### PR TITLE
Improve login error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,8 +305,13 @@
   createBoard();
 
   // Manejar autenticación
-  document.getElementById("login-btn").addEventListener("click", () => {
-    signInWithPopup(auth, provider).catch(console.error);
+  document.getElementById("login-btn").addEventListener("click", async () => {
+    try {
+      await signInWithPopup(auth, provider);
+    } catch (err) {
+      console.error("Google sign-in failed:", err);
+      alert("No se pudo iniciar sesión con Google. Revisa la configuración de Firebase.");
+    }
   });
 
   document.getElementById("logout-btn").addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- add try/catch with alert when the Google sign-in popup fails

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686963fa2fb08326af2dabfccd2d142f