### PR TITLE
Adjust digit limit messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,12 +357,12 @@
       alert("Por favor, selecciona el banco donde realizaste la transferencia.");
       return;
     }
-	 if (monto === "" || isNaN(monto) || monto.length > 5) {
-      alert("Por favor, ingresa un monto válido (solo números).");
+    if (monto === "" || isNaN(monto) || monto.length > 5) {
+      alert("Por favor, ingresa un monto válido (máximo 5 dígitos).");
       return;
     }
     if (referencia === "" || isNaN(referencia) || referencia.length > 5) {
-      alert("Por favor, ingresa un número de referencia válido (solo números, máximo 5 dígitos).");
+      alert("Por favor, ingresa un número de referencia válido (máximo 5 dígitos).");
       return;
     }
     if (!validateBoard()) {


### PR DESCRIPTION
## Summary
- clarify max digit limit for `monto` and `referencia` alerts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68699b4eb92c8326a9f5bb0535ffe3b5