### PR TITLE
Add collaborator and admin UI screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,14 +266,28 @@
       <button id="perfil-btn" class="menu-btn">Perfil</button>
     </div>
   </div>
-  <div id="collab-menu" style="display:none;">
-    <p>Menú de Colaborador</p>
+  <div id="collab-menu" class="view" style="display:none;">
+    <button id="collab-back" class="menu-btn back-btn">Volver</button>
+    <h3>Menú de Colaborador</h3>
+    <button id="ver-recargas-btn" class="menu-btn">Verificar Recargas</button>
+    <button id="aprobar-retiros-btn" class="menu-btn">Aprobar Retiros</button>
+    <h4>Gestión de Jugadores</h4>
+    <button id="gestion-jugadores-btn" class="menu-btn">Gestión Jugadores</button>
   </div>
-  <div id="admin-menu" style="display:none;">
-    <p>Menú de Administrador</p>
+  <div id="admin-menu" class="view" style="display:none;">
+    <button id="admin-back" class="menu-btn back-btn">Volver</button>
+    <h3>Menú de Administrador</h3>
+    <button id="gestionar-sorteos-btn" class="menu-btn">Gestionar Sorteos</button>
+    <button id="publicar-resultados-btn" class="menu-btn">Publicar Resultados</button>
+    <button id="gestionar-usuarios-btn" class="menu-btn">Gestionar Usuarios</button>
+    <button id="monitoreo-btn" class="menu-btn">Monitoreo en Tiempo Real</button>
   </div>
-  <div id="super-menu" style="display:none;">
-    <p>Menú de Superadmin</p>
+  <div id="super-menu" class="view" style="display:none;">
+    <button id="super-back" class="menu-btn back-btn">Volver</button>
+    <h3>Menú de Superadmin</h3>
+    <button id="crear-admin-btn" class="menu-btn">Crear Administrador</button>
+    <button id="privilegios-btn" class="menu-btn">Asignar Privilegios</button>
+    <button id="reportes-btn" class="menu-btn">Reportes Generales</button>
   </div>
 
   <div id="carton-screen" class="view" style="display:none;">
@@ -327,12 +341,88 @@
   <div id="perfil-screen" class="view" style="display:none;">
     <button id="perfil-back" class="menu-btn back-btn">Volver</button>
     <h3>Perfil del Jugador</h3>
+    <h4>Tus Datos Personales</h4>
     <input type="text" id="perfil-nombre" placeholder="Nombre" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
     <input type="text" id="perfil-apellido" placeholder="Apellido" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
     <input type="text" id="perfil-alias" placeholder="Alias" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
-    <input type="text" id="perfil-telefono" placeholder="Teléfono" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
-    <input type="text" id="perfil-direccion" placeholder="Dirección (opcional)" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
+    <h4>Tus Datos Bancarios</h4>
+    <select id="perfil-banco" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;">
+      <option value="" selected disabled>Selecciona Banco</option>
+      <option value="Banco Mercantil">Banco Mercantil</option>
+      <option value="Banco de Venezuela">Banco de Venezuela</option>
+      <option value="Banesco">Banesco</option>
+    </select>
+    <input type="text" id="perfil-pagomovil" placeholder="Número Pago móvil" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
+    <input type="text" id="perfil-cedula" placeholder="Número de Cédula" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
     <button id="guardar-perfil-btn" class="menu-btn" style="width:150px;">Guardar</button>
+  </div>
+
+  <div id="verificar-recargas-screen" class="view" style="display:none;">
+    <button id="ver-recargas-back" class="menu-btn back-btn">Volver</button>
+    <h3 style="color:orange;text-shadow:1px 1px 2px black;">Solicitudes Recargas Actuales: <span id="recargas-pendientes">0</span> Solicitudes</h3>
+    <table id="tabla-recargas" style="width:90%;font-size:0.8rem;"></table>
+    <button id="cargar-recarga-btn" class="menu-btn">Cargar solicitud</button>
+    <div id="detalle-recarga" style="margin-top:10px;text-align:left;font-size:0.9rem;"></div>
+    <button id="verificar-recarga-btn" class="menu-btn">Verificar</button>
+  </div>
+
+  <div id="aprobar-retiros-screen" class="view" style="display:none;">
+    <button id="retiros-back" class="menu-btn back-btn">Volver</button>
+    <h3 style="color:orange;text-shadow:1px 1px 2px black;">Solicitudes Retiros Actuales: <span id="retiros-pendientes">0</span> Retiros</h3>
+    <table id="tabla-retiros" style="width:90%;font-size:0.8rem;"></table>
+    <button id="cargar-retiro-btn" class="menu-btn">Cargar solicitud</button>
+    <div id="detalle-retiro" style="margin-top:10px;text-align:left;font-size:0.9rem;"></div>
+    <button id="enviar-retiro-btn" class="menu-btn">Enviar</button>
+  </div>
+
+  <div id="gestionar-sorteos-screen" class="view" style="display:none;">
+    <button id="sorteos-back" class="menu-btn back-btn">Volver</button>
+    <h3>Sorteos Actuales y Programados</h3>
+    <table id="tabla-sorteos" style="width:90%;font-size:0.8rem;"></table>
+    <button id="nuevo-sorteo-btn" class="menu-btn">Nuevo Sorteo</button>
+  </div>
+
+  <div id="publicar-resultados-screen" class="view" style="display:none;">
+    <button id="resultados-admin-back" class="menu-btn back-btn">Volver</button>
+    <h3>Resultados del Sorteo</h3>
+    <select id="sorteo-activo-select" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;"></select>
+    <input type="text" id="numeros-sorteados" placeholder="Números (1-75 separados por coma)" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
+    <button id="publicar-resultados-btn2" class="menu-btn" style="width:180px;">Publicar Resultados</button>
+  </div>
+
+  <div id="gestionar-usuarios-screen" class="view" style="display:none;">
+    <button id="usuarios-back" class="menu-btn back-btn">Volver</button>
+    <h3>Gestionar Usuarios</h3>
+    <table id="tabla-usuarios" style="width:90%;font-size:0.8rem;"></table>
+  </div>
+
+  <div id="monitoreo-screen" class="view" style="display:none;">
+    <button id="monitoreo-back" class="menu-btn back-btn">Detener Monitoreo</button>
+    <h3>Monitoreo en Tiempo Real</h3>
+    <div id="monitoreo-contenido"></div>
+  </div>
+
+  <div id="crear-admin-screen" class="view" style="display:none;">
+    <button id="crear-admin-back" class="menu-btn back-btn">Volver</button>
+    <h3>Crear Administrador</h3>
+    <input type="text" id="admin-nombre" placeholder="Nombre" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
+    <input type="text" id="admin-apellido" placeholder="Apellido" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
+    <input type="email" id="admin-correo" placeholder="Correo Gmail" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
+    <input type="text" id="admin-alias" placeholder="Alias" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
+    <button id="crear-admin-confirm" class="menu-btn">Crear</button>
+  </div>
+
+  <div id="privilegios-screen" class="view" style="display:none;">
+    <button id="privilegios-back" class="menu-btn back-btn">Volver</button>
+    <h3>Asignar Privilegios</h3>
+    <table id="tabla-privilegios" style="width:90%;font-size:0.8rem;"></table>
+    <button id="guardar-privilegios-btn" class="menu-btn">Guardar Cambios</button>
+  </div>
+
+  <div id="reportes-screen" class="view" style="display:none;">
+    <button id="reportes-back" class="menu-btn back-btn">Volver</button>
+    <h3>Reportes Generales</h3>
+    <div id="contenido-reportes"></div>
   </div>
 
   <!-- Importar el SDK de Firebase (compatibilidad para evitar problemas de CORS al abrir el archivo localmente) -->
@@ -597,6 +687,258 @@
     }
     alert("Bien, recibimos tu solicitud, una vez verificada te transferimos a tu banco");
   });
+
+  document.getElementById("guardar-perfil-btn").addEventListener("click", async () => {
+    const user = auth.currentUser;
+    const data = {
+      name: document.getElementById("perfil-nombre").value.trim(),
+      apellido: document.getElementById("perfil-apellido").value.trim(),
+      alias: document.getElementById("perfil-alias").value.trim(),
+      banco: document.getElementById("perfil-banco").value,
+      pagomovil: document.getElementById("perfil-pagomovil").value.trim(),
+      cedula: document.getElementById("perfil-cedula").value.trim(),
+      email: user.email,
+      photoURL: user.photoURL,
+      role: "Jugador"
+    };
+    if(!data.banco || !data.pagomovil || !data.cedula){
+      alert("Completa los campos obligatorios");
+      return;
+    }
+    await db.collection("users").doc(user.email).set(data, { merge: true });
+    document.getElementById("alias-jugador").value = data.alias || user.displayName || user.email;
+    alert("Datos guardados correctamente");
+  });
+
+  let recargaActual = null;
+  async function cargarRecargas() {
+    const tabla = document.getElementById("tabla-recargas");
+    tabla.innerHTML = "<tr><th>N° Recarga</th><th>Nombre</th><th>Monto</th><th>Banco Origen</th><th>Referencia</th><th>Fecha</th><th>Estatus</th></tr>";
+    const snap = await db.collection("recargas").orderBy("timestamp", "desc").get();
+    let pendientes = 0;
+    snap.forEach(doc => {
+      const d = doc.data();
+      const tr = document.createElement("tr");
+      tr.dataset.id = doc.id;
+      tr.innerHTML = `<td>${doc.id}</td><td>${d.nombre || ''} ${d.apellido || ''}</td><td>${d.monto || ''}</td><td>${d.banco_origen || ''}</td><td>${d.referencia || ''}</td><td>${d.fecha || ''}</td><td>${d.estatus}</td>`;
+      tabla.appendChild(tr);
+      if (d.estatus === 'PENDIENTE') pendientes++;
+    });
+    document.getElementById("recargas-pendientes").textContent = pendientes;
+  }
+
+  async function cargarRecargaSeleccion() {
+    const snap = await db.collection("recargas").where("estatus", "==", "PENDIENTE").limit(1).get();
+    if (snap.empty) { alert("No hay solicitudes pendientes"); return; }
+    const doc = snap.docs[0];
+    recargaActual = doc.id;
+    const d = doc.data();
+    document.getElementById("detalle-recarga").innerHTML = `Banco origen: ${d.banco_origen || ''}<br>Banco destino: ${d.banco_destino || ''}<br>Monto: ${d.monto}<br>Referencia de pago: ${d.referencia}<br>Comentario: ${d.comentario || ''}`;
+  }
+
+  async function verificarRecarga() {
+    if (!recargaActual) return;
+    await db.collection("recargas").doc(recargaActual).update({
+      estatus: "VERIFICADA",
+      colaborador: auth.currentUser.email,
+      gestion: firebase.firestore.FieldValue.serverTimestamp()
+    });
+    alert("Verificacion completada exitosamente");
+    recargaActual = null;
+    await cargarRecargas();
+    document.getElementById("detalle-recarga").innerHTML = "";
+  }
+
+  let retiroActual = null;
+  async function cargarRetiros() {
+    const tabla = document.getElementById("tabla-retiros");
+    tabla.innerHTML = "<tr><th>N° Retiro</th><th>Nombre</th><th>Monto</th><th>Banco Destino</th><th>Fecha</th><th>Estatus</th></tr>";
+    const snap = await db.collection("retiros").orderBy("timestamp", "desc").get();
+    let pendientes = 0;
+    snap.forEach(doc => {
+      const d = doc.data();
+      const tr = document.createElement("tr");
+      tr.dataset.id = doc.id;
+      tr.innerHTML = `<td>${doc.id}</td><td>${d.nombre || ''} ${d.apellido || ''}</td><td>${d.monto || ''}</td><td>${d.banco_destino || ''}</td><td>${d.fecha || ''}</td><td>${d.estatus}</td>`;
+      tabla.appendChild(tr);
+      if (d.estatus === 'PENDIENTE') pendientes++;
+    });
+    document.getElementById("retiros-pendientes").textContent = pendientes;
+  }
+
+  async function cargarRetiroSeleccion() {
+    const snap = await db.collection("retiros").where("estatus", "==", "PENDIENTE").limit(1).get();
+    if (snap.empty) { alert("No hay retiros pendientes"); return; }
+    const doc = snap.docs[0];
+    retiroActual = doc.id;
+    const d = doc.data();
+    document.getElementById("detalle-retiro").innerHTML = `Banco origen: ${d.banco_origen || ''}<br>Banco destino: ${d.banco_destino || ''}<br>Monto: ${d.monto}<br>Referencia de pago: ${d.referencia || ''}<br>Comentario: ${d.comentario || ''}`;
+  }
+
+  async function enviarRetiro() {
+    if (!retiroActual) return;
+    await db.collection("retiros").doc(retiroActual).update({
+      estatus: "RETIRADO",
+      colaborador: auth.currentUser.email,
+      gestion: firebase.firestore.FieldValue.serverTimestamp()
+    });
+    alert("Envio completado exitosamente");
+    retiroActual = null;
+    await cargarRetiros();
+    document.getElementById("detalle-retiro").innerHTML = "";
+  }
+
+  async function cargarSorteos() {
+    const tabla = document.getElementById("tabla-sorteos");
+    tabla.innerHTML = "<tr><th>N° Sorteo</th><th>Fecha</th><th>Nombre</th><th>Estado</th></tr>";
+    const snap = await db.collection("sorteos").orderBy("fecha", "desc").get();
+    snap.forEach(doc => {
+      const d = doc.data();
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td>${doc.id}</td><td>${d.fecha}</td><td>${d.nombre}</td><td>${d.estado}</td>`;
+      tabla.appendChild(tr);
+    });
+  }
+
+  async function cargarSorteosActivos() {
+    const select = document.getElementById("sorteo-activo-select");
+    select.innerHTML = '<option value="" selected disabled>Seleccione Sorteo</option>';
+    const snap = await db.collection("sorteos").where("estado","==","Activo").get();
+    snap.forEach(doc => {
+      const opt = document.createElement("option");
+      opt.value = doc.id;
+      opt.textContent = doc.data().nombre;
+      select.appendChild(opt);
+    });
+  }
+
+  document.getElementById("cargar-recarga-btn").addEventListener("click", cargarRecargaSeleccion);
+  document.getElementById("verificar-recarga-btn").addEventListener("click", verificarRecarga);
+  document.getElementById("cargar-retiro-btn").addEventListener("click", cargarRetiroSeleccion);
+  document.getElementById("enviar-retiro-btn").addEventListener("click", enviarRetiro);
+
+  document.getElementById("collab-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("main-menu").style.display = "block";
+  });
+  document.getElementById("admin-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("main-menu").style.display = "block";
+  });
+  document.getElementById("super-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("main-menu").style.display = "block";
+  });
+
+  document.getElementById("ver-recargas-btn").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("verificar-recargas-screen").style.display = "block";
+    cargarRecargas();
+  });
+  document.getElementById("aprobar-retiros-btn").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("aprobar-retiros-screen").style.display = "block";
+    cargarRetiros();
+  });
+  document.getElementById("ver-recargas-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("collab-menu").style.display = "block";
+  });
+  document.getElementById("retiros-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("collab-menu").style.display = "block";
+  });
+
+  document.getElementById("gestionar-sorteos-btn").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("gestionar-sorteos-screen").style.display = "block";
+    cargarSorteos();
+  });
+  document.getElementById("publicar-resultados-btn").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("publicar-resultados-screen").style.display = "block";
+    cargarSorteosActivos();
+  });
+  document.getElementById("gestionar-usuarios-btn").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("gestionar-usuarios-screen").style.display = "block";
+  });
+  document.getElementById("monitoreo-btn").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("monitoreo-screen").style.display = "block";
+  });
+  document.getElementById("sorteos-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("admin-menu").style.display = "block";
+  });
+  document.getElementById("resultados-admin-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("admin-menu").style.display = "block";
+  });
+  document.getElementById("usuarios-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("admin-menu").style.display = "block";
+  });
+  document.getElementById("monitoreo-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("admin-menu").style.display = "block";
+  });
+
+  document.getElementById("nuevo-sorteo-btn").addEventListener("click", async () => {
+    const nombre = prompt("Nombre del sorteo");
+    const fecha = prompt("Fecha del sorteo (DD/MM/YYYY)");
+    if(!nombre || !fecha) return;
+    await db.collection("sorteos").add({nombre, fecha, estado:"Pendiente"});
+    cargarSorteos();
+  });
+
+  document.getElementById("publicar-resultados-btn2").addEventListener("click", async () => {
+    const sorteoId = document.getElementById("sorteo-activo-select").value;
+    const numeros = document.getElementById("numeros-sorteados").value.split(',').map(n => parseInt(n.trim())).filter(n => n>=1 && n<=75);
+    if(!sorteoId || numeros.length===0){ alert("Datos inválidos"); return; }
+    await db.collection("sorteos").doc(sorteoId).update({resultados:numeros, estado:"Finalizado"});
+    alert("Resultados publicados");
+  });
+
+  document.getElementById("crear-admin-confirm").addEventListener("click", async () => {
+    const correo = document.getElementById("admin-correo").value.trim();
+    if(!correo) {alert("Correo requerido"); return;}
+    const data = {
+      name: document.getElementById("admin-nombre").value.trim(),
+      apellido: document.getElementById("admin-apellido").value.trim(),
+      alias: document.getElementById("admin-alias").value.trim(),
+      role: "Administrador"
+    };
+    const doc = await db.collection("users").doc(correo).get();
+    if(doc.exists){ alert("El correo ya existe"); return; }
+    await db.collection("users").doc(correo).set(data);
+    alert("Administrador creado exitosamente");
+  });
+
+  document.getElementById("crear-admin-btn").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("crear-admin-screen").style.display = "block";
+  });
+  document.getElementById("privilegios-btn").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("privilegios-screen").style.display = "block";
+  });
+  document.getElementById("reportes-btn").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("reportes-screen").style.display = "block";
+  });
+  document.getElementById("crear-admin-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("super-menu").style.display = "block";
+  });
+  document.getElementById("privilegios-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("super-menu").style.display = "block";
+  });
+  document.getElementById("reportes-back").addEventListener("click", () => {
+    hideViews();
+    document.getElementById("super-menu").style.display = "block";
+  });
   document.getElementById("terms-link").addEventListener("click", (e) => {
     e.preventDefault();
     document.getElementById("login-container").style.display = "none";
@@ -636,8 +978,9 @@
         document.getElementById("perfil-nombre").value = doc.data().name || user.displayName || "";
         document.getElementById("perfil-alias").value = doc.data().alias || "";
         document.getElementById("perfil-apellido").value = doc.data().apellido || "";
-        document.getElementById("perfil-telefono").value = doc.data().telefono || "";
-        document.getElementById("perfil-direccion").value = doc.data().direccion || "";
+        document.getElementById("perfil-banco").value = doc.data().banco || "";
+        document.getElementById("perfil-pagomovil").value = doc.data().pagomovil || "";
+        document.getElementById("perfil-cedula").value = doc.data().cedula || "";
       } else {
         document.getElementById("register-container").style.display = "block";
       }


### PR DESCRIPTION
## Summary
- extend profile screen with bank details and save handler
- add collaborator menu with screens to verify recargas and retiros
- add administrator and superadmin menus
- implement basic Firestore operations for recargas, retiros and sorteos

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686afe796a348326b51c0cdc5e245811