### PR TITLE
Add fallback to Google sign‑in redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -612,6 +612,11 @@
     }
     auth.signInWithPopup(provider).catch(err => {
       console.error("Google sign-in failed:", err);
+      if (err.code === "auth/popup-blocked" || err.code === "auth/popup-closed-by-user") {
+        // Si el popup fue bloqueado, intentar con redirección
+        auth.signInWithRedirect(provider);
+        return;
+      }
       alert("No se pudo iniciar sesión con Google. Revisa la configuración de Firebase.");
     });
   }


### PR DESCRIPTION
## Summary
- use `signInWithRedirect` when the popup is blocked or closed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b0122e99c832686cb36c4275147ca