### PR TITLE
Fix null element error in fecha display

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,6 +474,7 @@
   // Función para mostrar la fecha actual
   function mostrarFechaActual() {
     const fechaElemento = document.getElementById("fecha-actual");
+    if (!fechaElemento) return; // Evita errores si el elemento no existe
     const hoy = new Date();
     const opciones = { year: 'numeric', month: 'long', day: 'numeric' };
     fechaElemento.textContent = hoy.toLocaleDateString('es-ES', opciones);


### PR DESCRIPTION
## Summary
- avoid crash when `#fecha-actual` element is missing

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b09c3fca88326af29c94d05abd690