### PR TITLE
Add user info header on role pages

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -42,13 +42,42 @@
       width: 250px;
       margin-bottom: 15px;
     }
+    #session-info {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      display: flex;
+      align-items: center;
+      font-size: 0.7rem;
+    }
+    #user-data {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      margin-right: 5px;
+    }
+    #user-pic {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+    }
+    #logout-link {
+      margin-left: 5px;
+      font-size: 0.7rem;
+      color: #007bff;
+      text-decoration: underline;
+    }
   </style>
 </head>
 <body>
   <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" alt="logo" />
-  <h2>Panel de Administrador</h2>
+  <h2>Menú Administrador</h2>
   <div id="session-info">
-    <span id="user-name"></span> - <span id="user-email"></span>
+    <div id="user-data">
+      <div id="user-name"></div>
+      <div id="user-email"></div>
+    </div>
+    <img id="user-pic" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
   </div>
   <div>

--- a/auth.js
+++ b/auth.js
@@ -101,6 +101,10 @@ function ensureAuth(roleExpected){
     if (nameEl) nameEl.textContent = user.displayName;
     const emailEl = document.getElementById('user-email');
     if (emailEl) emailEl.textContent = user.email;
+    const picEl = document.getElementById('user-pic');
+    if (picEl) picEl.src = user.photoURL;
+    const infoEl = document.getElementById('session-info');
+    if (infoEl) infoEl.style.display = 'flex';
     const logoutEl = document.getElementById('logout-link');
     if (logoutEl) {
       logoutEl.addEventListener('click', e => {

--- a/collab.html
+++ b/collab.html
@@ -42,13 +42,42 @@
       width: 250px;
       margin-bottom: 15px;
     }
+    #session-info {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      display: flex;
+      align-items: center;
+      font-size: 0.7rem;
+    }
+    #user-data {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      margin-right: 5px;
+    }
+    #user-pic {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+    }
+    #logout-link {
+      margin-left: 5px;
+      font-size: 0.7rem;
+      color: #007bff;
+      text-decoration: underline;
+    }
   </style>
 </head>
 <body>
   <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" alt="logo" />
-  <h2>Bienvenido Colaborador</h2>
+  <h2>Menú Colaborador</h2>
   <div id="session-info">
-    <span id="user-name"></span> - <span id="user-email"></span>
+    <div id="user-data">
+      <div id="user-name"></div>
+      <div id="user-email"></div>
+    </div>
+    <img id="user-pic" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
   </div>
   <div>

--- a/player.html
+++ b/player.html
@@ -160,6 +160,10 @@
           gap: 10px;
           align-items: center;
       }
+      #menu-buttons h3 {
+          margin: 0;
+          font-size: 1.5rem;
+      }
 
       #carton-screen {
           position: relative;
@@ -187,17 +191,23 @@
           color: #007bff;
           text-decoration: underline;
           cursor: pointer;
-          font-size: 0.8rem;
-          margin-top: 5px;
+          font-size: 0.7rem;
+          margin-left: 5px;
       }
       #session-info {
           position: fixed;
           top: 10px;
           right: 10px;
-          display: none;
-          flex-direction: column;
+          display: flex;
           align-items: center;
+          font-size: 0.7rem;
           z-index: 1000;
+      }
+      #user-data {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-end;
+          margin-right: 5px;
       }
       #user-name, #user-email {
           color: black;
@@ -241,15 +251,18 @@
   </div>
 
   <div id="session-info">
-      <img id="user-pic" src="" alt="Usuario" style="width:40px;height:40px;border-radius:50%;margin-bottom:5px;">
-      <div id="user-name"></div>
-      <div id="user-email"></div>
+      <div id="user-data">
+        <div id="user-name"></div>
+        <div id="user-email"></div>
+      </div>
+      <img id="user-pic" src="" alt="Usuario" style="width:40px;height:40px;border-radius:50%;">
       <a id="logout-link" href="#">Cerrar sesión</a>
   </div>
 
   <div id="main-menu" class="view" style="display:block;">
     <div id="menu-buttons">
       <img id="menu-logo" src="https://i.imgur.com/twjhNtZ.png" />
+      <h3>Menú Jugador</h3>
       <button id="carton-btn" class="menu-btn">Jugar Cartón</button>
       <button id="jugando-btn" class="menu-btn">Jugando</button>
       <button id="billetera-btn" class="menu-btn">Billetera</button>

--- a/super.html
+++ b/super.html
@@ -42,13 +42,42 @@
       width: 250px;
       margin-bottom: 15px;
     }
+    #session-info {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      display: flex;
+      align-items: center;
+      font-size: 0.7rem;
+    }
+    #user-data {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      margin-right: 5px;
+    }
+    #user-pic {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+    }
+    #logout-link {
+      margin-left: 5px;
+      font-size: 0.7rem;
+      color: #007bff;
+      text-decoration: underline;
+    }
   </style>
 </head>
 <body>
   <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" alt="logo" />
-  <h2>Panel de Superadmin</h2>
+  <h2>Menú Superadmin</h2>
   <div id="session-info">
-    <span id="user-name"></span> - <span id="user-email"></span>
+    <div id="user-data">
+      <div id="user-name"></div>
+      <div id="user-email"></div>
+    </div>
+    <img id="user-pic" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
   </div>
   <div>


### PR DESCRIPTION
## Summary
- display Google account picture, name and email on each role page
- rename panel titles to menu titles
- show user info with flex layout via `ensureAuth`
- small heading for player menu

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c7d75d6e8832682f6ef41edb3a772