### PR TITLE
Fix Google profile picture and style session info

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -56,12 +56,18 @@
       align-items: flex-end;
       margin-right: 5px;
     }
+    #user-name, #user-email {
+      font-family: Calibri, Arial, sans-serif;
+      color: #333;
+    }
+
     #user-pic {
       width: 40px;
       height: 40px;
       border-radius: 50%;
     }
     #logout-link {
+      font-family: Calibri, Arial, sans-serif;
       margin-left: 5px;
       font-size: 0.7rem;
       color: #007bff;
@@ -77,7 +83,7 @@
       <div id="user-name"></div>
       <div id="user-email"></div>
     </div>
-    <img id="user-pic" src="" alt="Usuario" />
+    <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
   </div>
   <div>

--- a/collab.html
+++ b/collab.html
@@ -56,12 +56,18 @@
       align-items: flex-end;
       margin-right: 5px;
     }
+    #user-name, #user-email {
+      font-family: Calibri, Arial, sans-serif;
+      color: #333;
+    }
+
     #user-pic {
       width: 40px;
       height: 40px;
       border-radius: 50%;
     }
     #logout-link {
+      font-family: Calibri, Arial, sans-serif;
       margin-left: 5px;
       font-size: 0.7rem;
       color: #007bff;
@@ -77,7 +83,7 @@
       <div id="user-name"></div>
       <div id="user-email"></div>
     </div>
-    <img id="user-pic" src="" alt="Usuario" />
+    <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
   </div>
   <div>

--- a/player.html
+++ b/player.html
@@ -188,6 +188,7 @@
           font-size: 1.2rem;
       }
       #logout-link {
+          font-family: Calibri, Arial, sans-serif;
           color: #007bff;
           text-decoration: underline;
           cursor: pointer;
@@ -210,9 +211,9 @@
           margin-right: 5px;
       }
       #user-name, #user-email {
-          color: black;
+          color: #333;
           text-shadow: 1px 1px 2px #0000;
-          font-family: Arial, sans-serif;
+          font-family: Calibri, Arial, sans-serif;
           font-size: 0.7rem;
       }
       #fecha-hora, #derechos {
@@ -255,7 +256,7 @@
         <div id="user-name"></div>
         <div id="user-email"></div>
       </div>
-      <img id="user-pic" src="" alt="Usuario" style="width:40px;height:40px;border-radius:50%;">
+      <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" style="width:40px;height:40px;border-radius:50%;">
       <a id="logout-link" href="#">Cerrar sesión</a>
   </div>
 

--- a/super.html
+++ b/super.html
@@ -56,12 +56,18 @@
       align-items: flex-end;
       margin-right: 5px;
     }
+    #user-name, #user-email {
+      font-family: Calibri, Arial, sans-serif;
+      color: #333;
+    }
+
     #user-pic {
       width: 40px;
       height: 40px;
       border-radius: 50%;
     }
     #logout-link {
+      font-family: Calibri, Arial, sans-serif;
       margin-left: 5px;
       font-size: 0.7rem;
       color: #007bff;
@@ -77,7 +83,7 @@
       <div id="user-name"></div>
       <div id="user-email"></div>
     </div>
-    <img id="user-pic" src="" alt="Usuario" />
+    <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
   </div>
   <div>


### PR DESCRIPTION
## Summary
- ensure Google profile images load by adding `referrerpolicy="no-referrer"` and `crossorigin="anonymous"`
- use Calibri font in user session info and darken text color
- apply same style to logout link

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c804dddec83269f62dad5f30ba0c1