### PR TITLE
Enable player menu font and unify page routing

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -80,12 +80,9 @@ async function getUserRole(user){
 }
 
 function redirectByRole(role){
-  switch(role){
-    case 'Superadmin': window.location.href='super.html'; break;
-    case 'Administrador': window.location.href='admin.html'; break;
-    case 'Colaborador': window.location.href='collab.html'; break;
-    default: window.location.href='player.html';
-  }
+  // Todas las funcionalidades se manejan en player.html,
+  // por lo que cualquier rol redirige a dicha página
+  window.location.href = 'player.html';
 }
 
 function ensureAuth(roleExpected){

--- a/player.html
+++ b/player.html
@@ -163,6 +163,7 @@
       #menu-buttons h3 {
           margin: 0;
           font-size: 1.5rem;
+          font-family: 'Bangers', cursive;
       }
 
       #carton-screen {


### PR DESCRIPTION
## Summary
- redirect all roles to `player.html` so every menu shows the same functionality
- style **Menú Jugador** heading using the same Bangers font as other screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c8451e9cc8326972a876067a6e007