### PR TITLE
Fix menu reload and remove back buttons

### DIFF
--- a/player.html
+++ b/player.html
@@ -261,7 +261,7 @@
       <a id="logout-link" href="#">Cerrar sesión</a>
   </div>
 
-  <div id="main-menu" class="view" style="display:block;">
+  <div id="main-menu" class="view" style="display:none;">
     <div id="menu-buttons">
       <img id="menu-logo" src="https://i.imgur.com/twjhNtZ.png" />
       <h3>Menú Jugador</h3>
@@ -272,7 +272,6 @@
     </div>
   </div>
   <div id="collab-menu" class="view" style="display:none;">
-    <button id="collab-back" class="menu-btn back-btn">Volver</button>
     <h3>Menú de Colaborador</h3>
     <button id="ver-recargas-btn" class="menu-btn">Verificar Recargas</button>
     <button id="aprobar-retiros-btn" class="menu-btn">Aprobar Retiros</button>
@@ -280,7 +279,6 @@
     <button id="gestion-jugadores-btn" class="menu-btn">Gestión Jugadores</button>
   </div>
   <div id="admin-menu" class="view" style="display:none;">
-    <button id="admin-back" class="menu-btn back-btn">Volver</button>
     <h3>Menú de Administrador</h3>
     <button id="gestionar-sorteos-btn" class="menu-btn">Gestionar Sorteos</button>
     <button id="publicar-resultados-btn" class="menu-btn">Publicar Resultados</button>
@@ -288,7 +286,6 @@
     <button id="monitoreo-btn" class="menu-btn">Monitoreo en Tiempo Real</button>
   </div>
   <div id="super-menu" class="view" style="display:none;">
-    <button id="super-back" class="menu-btn back-btn">Volver</button>
     <h3>Menú de Superadmin</h3>
     <button id="crear-admin-btn" class="menu-btn">Crear Administrador</button>
     <button id="privilegios-btn" class="menu-btn">Asignar Privilegios</button>
@@ -797,18 +794,7 @@ ensureAuth();
   document.getElementById("cargar-retiro-btn").addEventListener("click", cargarRetiroSeleccion);
   document.getElementById("enviar-retiro-btn").addEventListener("click", enviarRetiro);
 
-  document.getElementById("collab-back").addEventListener("click", () => {
-    hideViews();
-    document.getElementById("main-menu").style.display = "block";
-  });
-  document.getElementById("admin-back").addEventListener("click", () => {
-    hideViews();
-    document.getElementById("main-menu").style.display = "block";
-  });
-  document.getElementById("super-back").addEventListener("click", () => {
-    hideViews();
-    document.getElementById("main-menu").style.display = "block";
-  });
+  // Botones de retorno para pantallas internas
 
   document.getElementById("ver-recargas-btn").addEventListener("click", () => {
     hideViews();


### PR DESCRIPTION
## Summary
- hide the player menu by default to prevent showing the player view during reload
- remove back buttons from top-level role menus (collab, admin, super)
- clean up JS listeners accordingly

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687068b919808326996eb2165dd43210