### PR TITLE
Fix back button positioning

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -36,6 +36,7 @@
     }
     .view {
       position: relative;
+      width: 100%;
     }
     .menu-btn:hover {
       transform: scale(1.05);

--- a/collab.html
+++ b/collab.html
@@ -36,6 +36,7 @@
     }
     .view {
       position: relative;
+      width: 100%;
     }
     .menu-btn:hover {
       transform: scale(1.05);

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       right: 0;
       font-size: 0.7rem;
     }
-    #close-terms-btn {
+    .back-btn {
       position: absolute;
       top: 5px;
       left: 5px;
@@ -69,6 +69,10 @@
       border-radius: 10px;
       text-shadow: 2px 2px 4px #000;
       text-transform: uppercase;
+    }
+    #terms-container, #register-container {
+      position: relative;
+      width: 100%;
     }
   </style>
 </head>
@@ -86,7 +90,7 @@
   <div id="terms-container" style="display:none;">
     <h2>Términos y Condiciones</h2>
     <p>Al usar esta aplicación aceptas las reglas del juego.</p>
-    <button id="close-terms-btn">&#9664; Volver</button>
+    <button id="close-terms-btn" class="back-btn">&#9664; Volver</button>
   </div>
   <div id="register-container" style="display:none;">
     <h2>Registro de Jugador</h2>

--- a/player.html
+++ b/player.html
@@ -141,6 +141,7 @@
       }
       .view {
           position: relative;
+          width: 100%;
       }
       .menu-btn:hover {
           transform: scale(1.05);

--- a/super.html
+++ b/super.html
@@ -36,6 +36,7 @@
     }
     .view {
       position: relative;
+      width: 100%;
     }
     .menu-btn:hover {
       transform: scale(1.05);


### PR DESCRIPTION
## Summary
- ensure back buttons are top-left aligned by expanding `.view` containers to `width:100%`
- standardize back button styling and apply to terms/register screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68740ed93f9483268320a46c166958e0