### PR TITLE
Fix raffle filter and load forms on edit

### DIFF
--- a/editarsorte.html
+++ b/editarsorte.html
@@ -157,18 +157,18 @@
     document.getElementById('estado-sorteo').value = d.estado || '';
     const snap = await db.collection('formas').where('sorteoId','==',sorteoId).get();
     const forms = document.querySelectorAll('.forma-item');
-    let i=0;
-    snap.forEach(df=>{
-      if(i<forms.length){
-        const data=df.data();
-        const div=forms[i];
+    const datos=[];
+    snap.forEach(d=>datos.push({id:d.id,...d.data()}));
+    datos.sort((a,b)=>{const ia=a.idx||0, ib=b.idx||0;return ia-ib;});
+    datos.forEach((data,idx)=>{
+      if(idx<forms.length){
+        const div=forms[idx];
         div.querySelector('.nombre-forma').value=data.nombre||'';
         div.querySelector('.porcentaje-forma').value=data.porcentaje||0;
         data.posiciones.forEach(p=>{
           const td=div.querySelector(`td[data-row="${p.r}"][data-col="${p.c}"]`);
           if(td){ td.classList.add('selected'); td.textContent='\u2605'; }
         });
-        i++;
       }
     });
   }

--- a/gestionsorteos.html
+++ b/gestionsorteos.html
@@ -102,14 +102,16 @@
     tabla.innerHTML='<tr><th>N°</th><th>Nombre</th><th>Fecha</th><th>Estado</th><th></th></tr>';
     let q=db.collection('sorteos');
     if(estado!=='Todos') q=q.where('estado','==',estado);
-    const snap=await q.orderBy('fecha','desc').get();
+    const snap=await q.get();
+    const datos=[];
+    snap.forEach(doc=>datos.push({id:doc.id,...doc.data()}));
+    datos.sort((a,b)=>{const fa=a.fecha||'';const fb=b.fecha||'';return fa>fb?-1:fa<fb?1:0;});
     let idx=1;
-    snap.forEach(doc=>{
-      const d=doc.data();
+    datos.forEach(d=>{
       let fecha=d.fecha||'';
       if(fecha.includes('-')) fecha=fecha.split('-').reverse().join('/');
       const tr=document.createElement('tr');
-      tr.innerHTML=`<td>${idx++}</td><td>${d.nombre}</td><td>${fecha}</td><td>${d.estado}</td><td><input type="checkbox" data-id="${doc.id}"></td>`;
+      tr.innerHTML=`<td>${idx++}</td><td>${d.nombre}</td><td>${fecha}</td><td>${d.estado}</td><td><input type="checkbox" data-id="${d.id}"></td>`;
       tabla.appendChild(tr);
     });
   }


### PR DESCRIPTION
## Summary
- filter draws client-side so changing filter shows only matching rows
- load stored shapes when editing a draw and show star positions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687432e1dcd88326b3f52e059dc6a682