### PR TITLE
Implementaciones en billetera y roles

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -103,6 +103,7 @@
     <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
   </div>
+  <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
   <div id="main-menu">
     <button id="gestionar-sorteos-btn" class="menu-btn">Gestionar Sorteos</button>
     <button id="publicar-resultados-btn" class="menu-btn">Publicar Resultados</button>
@@ -134,6 +135,15 @@
   <script src="auth.js"></script>
   <script>
   ensureAuth('Administrador');
+  auth.onAuthStateChanged(async user=>{
+    if(!user) return;
+    const role = await getUserRole(user);
+    if(role==='Superadmin'){
+      const btn=document.getElementById('salir-super-btn');
+      btn.style.display='flex';
+      btn.addEventListener('click',()=>{window.location.href='super.html';});
+    }
+  });
   function hideViews(){document.querySelectorAll('.view').forEach(v=>v.style.display='none');}
   async function cargarSorteosActivos(){
     const select=document.getElementById('sorteo-activo-select');

--- a/auth.js
+++ b/auth.js
@@ -107,10 +107,11 @@ function ensureAuth(roleExpected){
   auth.onAuthStateChanged(async user => {
     if(!user){ window.location.href='index.html'; return; }
     const role = await getUserRole(user);
-    if(roleExpected && role !== roleExpected){
+    if(roleExpected && role !== roleExpected && role !== 'Superadmin'){
       redirectByRole(role);
       return;
     }
+    window.currentRole = role;
     const nameEl = document.getElementById('user-name');
     if (nameEl) nameEl.textContent = user.displayName;
     const emailEl = document.getElementById('user-email');

--- a/billetera.html
+++ b/billetera.html
@@ -58,9 +58,10 @@
       margin-top: 20px;
     }
     .tab-buttons button {
-      padding: 10px 20px;
+      padding: 12px 24px;
       margin: 0 5px;
       font-family: 'Bangers', cursive;
+      font-size: 1.2rem;
       border: none;
       color: white;
       cursor: pointer;
@@ -84,12 +85,13 @@
     }
     #guardar-datos {
       font-family: 'Bangers', cursive;
-      font-size: 1rem;
+      font-size: 1.2rem;
       background: #0a8800;
       color: white;
       border: 3px solid #FFD700;
       border-radius: 8px;
       text-shadow: 2px 2px 4px #000;
+      width: 200px;
       cursor:pointer;
     }
     #btn-depositar {
@@ -99,6 +101,8 @@
       border: 3px solid #FFD700;
       border-radius: 8px;
       text-shadow:2px 2px 4px #000;
+      font-size:1.2rem;
+      width:200px;
       cursor:pointer;
     }
     #btn-retirar {
@@ -108,6 +112,8 @@
       border: 3px solid #FFD700;
       border-radius: 8px;
       text-shadow:2px 2px 4px #000;
+      font-size:1.2rem;
+      width:200px;
       cursor:pointer;
     }
   </style>
@@ -281,7 +287,9 @@
       alert('Solicitud enviada, una vez validada se transferirá a tu pago móvil');
     });
 
-    document.getElementById('volver-btn').addEventListener('click',()=>{window.history.back();});
+    document.getElementById('volver-btn').addEventListener('click',()=>{
+      window.location.href='player.html';
+    });
 
     cargarSelects();
   </script>

--- a/collab.html
+++ b/collab.html
@@ -103,6 +103,7 @@
     <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
   </div>
+  <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
   <div id="main-menu">
     <button id="ver-recargas-btn" class="menu-btn">Verificar Recargas</button>
     <button id="aprobar-retiros-btn" class="menu-btn">Aprobar Retiros</button>
@@ -132,6 +133,15 @@
   <script src="auth.js"></script>
   <script>
   ensureAuth('Colaborador');
+  auth.onAuthStateChanged(async user=>{
+    if(!user) return;
+    const role = await getUserRole(user);
+    if(role==='Superadmin'){
+      const btn=document.getElementById('salir-super-btn');
+      btn.style.display='flex';
+      btn.addEventListener('click',()=>{window.location.href='super.html';});
+    }
+  });
   function hideViews(){
     document.querySelectorAll('.view').forEach(v=>v.style.display='none');
   }

--- a/gestionarusuarios.html
+++ b/gestionarusuarios.html
@@ -119,7 +119,11 @@
     <input type="text" id="usu-apellido" placeholder="Apellido" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:5px auto;" />
     <input type="email" id="usu-correo" placeholder="Correo" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:5px auto;" />
     <input type="text" id="usu-alias" placeholder="Alias" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:5px auto;" />
-    <input type="text" id="usu-rol" placeholder="Rol" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:5px auto;" />
+    <select id="usu-rol" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:5px auto;">
+      <option value="Administrador">Administrador</option>
+      <option value="Colaborador">Colaborador</option>
+      <option value="Jugador">Jugador</option>
+    </select>
   </div>
 
   <button id="consultar-btn" class="menu-btn">Consultar</button>
@@ -139,6 +143,7 @@
       const snap = await db.collection('users').get();
       snap.forEach(doc=>{
         const d = doc.data();
+        if(d.role === 'Superadmin') return;
         const tr = document.createElement('tr');
         tr.innerHTML = `<td><input type="radio" name="seleccion" value="${doc.id}"></td><td>${d.name||''}</td><td>${d.apellido||''}</td><td>${doc.id}</td><td>${d.alias||''}</td><td>${d.role||''}</td>`;
         bodyTabla.appendChild(tr);

--- a/player.html
+++ b/player.html
@@ -259,6 +259,7 @@
       <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" style="width:40px;height:40px;border-radius:50%;">
       <a id="logout-link" href="#">Cerrar sesión</a>
   </div>
+  <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
 
   <div id="main-menu" class="view" style="display:none;">
     <div id="menu-buttons">
@@ -333,6 +334,15 @@
   <script src="auth.js"></script>
   <script>
 ensureAuth();
+auth.onAuthStateChanged(async user=>{
+  if(!user) return;
+  const role = await getUserRole(user);
+  if(role==='Superadmin'){
+    const btn=document.getElementById('salir-super-btn');
+    btn.style.display='flex';
+    btn.addEventListener('click',()=>{window.location.href='super.html';});
+  }
+});
 
   // Roles predefinidos para cuentas especiales
   const predefinedRoles = {


### PR DESCRIPTION
## Resumen
- Mejoras visuales en **billetera.html** para uso en móviles
- Dropdown de roles y exclusión de Superadmin en **gestionarusuarios.html**
- Ajuste de `ensureAuth` para permitir a superadmins navegar en todos los menús
- Botón **Salir** visible solo para superadmins en menús de administrador, colaborador y jugador

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877166081208326af7a3bf634e1403a