### PR TITLE
Corrección de visibilidad del menú de jugador

### DIFF
--- a/player.html
+++ b/player.html
@@ -260,7 +260,7 @@
   </div>
   <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
 
-  <div id="main-menu" class="view" style="display:none;">
+  <div id="main-menu" class="view">
     <div id="menu-buttons">
       <img id="menu-logo" src="https://i.imgur.com/twjhNtZ.png" />
       <h3>Menú Jugador</h3>


### PR DESCRIPTION
## Resumen
- quitar el `display:none` del contenedor principal del menú en *player.html* para que la interfaz de jugador se muestre siempre

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687846cfbf0083268c30e0c025ba7823