### PR TITLE
Actualizar info de cartón sin tabla

### DIFF
--- a/player.html
+++ b/player.html
@@ -87,6 +87,18 @@
           justify-content: center;
           gap: 10px;
       }
+      #info-carton {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 10px;
+          margin: 5px 0;
+      }
+      #info-text {
+          display: flex;
+          flex-direction: column;
+          text-align: left;
+      }
       #creditos-info {
           display: flex;
           align-items: center;
@@ -333,17 +345,13 @@
         <div id="hora-sorteo"></div>
       </div>
     </div>
-    <table id="info-carton" style="border-collapse:collapse;margin:auto;">
-      <tr>
-        <td id="valor-carton"></td>
-        <td rowspan="2" style="padding-left:10px;">
-          <button id="ir-billetera-btn" onclick="window.location.href='billetera.html'">Recargar Billetera</button>
-        </td>
-      </tr>
-      <tr>
-        <td id="creditos-info">Créditos disponibles: <span id="creditos-label">0</span></td>
-      </tr>
-    </table>
+    <div id="info-carton">
+      <div id="info-text" style="display:flex;flex-direction:column;">
+        <div id="valor-carton"></div>
+        <div id="creditos-info">Créditos disponibles: <span id="creditos-label">0</span></div>
+      </div>
+      <button id="ir-billetera-btn" onclick="window.location.href='billetera.html'">Recargar Billetera</button>
+    </div>
     <input type="text" id="alias-jugador" readonly placeholder="Alias" style="font-size: 1.5rem; padding: 5px; text-align: center; border-radius: 5px; border: 1px solid #ccc; width: 200px; display: block; margin: 10px auto; color: orange;">
     <div style="font-size:0.6rem;margin-top:-8px;">Si deseas cambiar tu alias dirigite a Perfil &gt; Alias</div>
     <table>


### PR DESCRIPTION
## Resumen
- reemplazo de la tabla que mostraba el valor del cartón y créditos disponibles
- creación de contenedores `div` para alinear estos datos y el botón de recarga
- nuevos estilos para `#info-carton` y `#info-text`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687865c9a1988326a9b6033cad6d43ef