### PR TITLE
Agregar carga dinámica de bancos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 node initUsers.js
 node initBanks.js
 ```
-Este segundo script poblará las colecciones `BancosBilletera` y `BancosBingo` con los bancos iniciales.
+Este segundo script poblará la colección `Bancos` con los bancos iniciales.
 
 Debe disponer de un archivo `serviceAccountKey.json` con las credenciales de Firebase o definir la variable `GOOGLE_APPLICATION_CREDENTIALS` apuntando al archivo de claves.
 

--- a/billetera.html
+++ b/billetera.html
@@ -219,38 +219,40 @@
   <script>
     ensureAuth();
 
-    async function cargarBancosBilletera(){
-      const snap=await db.collection('BancosBilletera').get();
-      const sel=document.getElementById('banco');
-      sel.innerHTML='<option value="" disabled selected>Banco</option>';
-      snap.forEach(doc=>{
-        const nombre=doc.data().nombre||doc.id;
-        const opt=document.createElement('option');
-        opt.value=nombre;
-        opt.textContent=nombre;
-        sel.appendChild(opt);
+    function cargarBancosBilletera(){
+      db.collection('Bancos').onSnapshot(snap=>{
+        const sel=document.getElementById('banco');
+        sel.innerHTML='<option value="" disabled selected>Banco</option>';
+        snap.forEach(doc=>{
+          const nombre=doc.data().nombre||doc.id;
+          const opt=document.createElement('option');
+          opt.value=nombre;
+          opt.textContent=nombre;
+          sel.appendChild(opt);
+        });
       });
     }
 
-    async function cargarBancosBingo(){
-      const snap=await db.collection('BancosBingo').get();
+    function cargarBancosBingo(){
+      db.collection('Bancos').onSnapshot(snap=>{
       const tbody=document.querySelector('#tabla-bancos tbody');
       const sel=document.getElementById('banco-deposito');
       sel.innerHTML='<option value="" disabled selected>Banco donde transferiste</option>';
       const permitidos=['0172 - Banco Bancamiga','0102 - Banco de Venezuela'];
       tbody.innerHTML='';
       snap.forEach(doc=>{
-        const d=doc.data();
+        const nombre=doc.data().nombre||doc.id;
         const tr=document.createElement('tr');
-        tr.innerHTML=`<td>${d.banco}</td><td>${d.pagomovil}</td><td>${d.cedula}</td>`;
+        tr.innerHTML=`<td>${nombre}</td><td>${doc.data().pagomovil||''}</td><td>${doc.data().cedula||''}</td>`;
         tbody.appendChild(tr);
-        if(permitidos.includes(d.banco)){
+        if(permitidos.includes(nombre)){
           const opt=document.createElement('option');
-          opt.value=d.banco;
-          opt.textContent=d.banco;
+          opt.value=nombre;
+          opt.textContent=nombre;
           sel.appendChild(opt);
         }
       });
+    });
     }
 
     document.querySelectorAll('.tab-buttons button').forEach(btn => {

--- a/initBanks.js
+++ b/initBanks.js
@@ -14,7 +14,7 @@ admin.initializeApp({
 const db = admin.firestore();
 
 async function main() {
-  const billetera = [
+  const bancos = [
     '0102 - Banco de Venezuela',
     '0105 - Banco Mercantil',
     '0108 - Banco Provincial',
@@ -46,44 +46,8 @@ async function main() {
     '0193 - Banco Fintec'
   ];
 
-  for (const nombre of billetera) {
-    await db.collection('BancosBilletera').doc(nombre).set({ nombre });
-  }
-
-  const bingo = [
-    '0102 - Banco de Venezuela',
-    '0105 - Banco Mercantil',
-    '0108 - Banco Provincial',
-    '0134 - Banesco Banco Universal',
-    '0116 - Banco Occidental de Descuento',
-    '0191 - Banco Nacional de Crédito',
-    '0163 - Banco del Tesoro',
-    '0115 - Banco Exterior',
-    '0128 - Banco Caroní',
-    '0151 - Banco Fondo Común',
-    '0138 - Banco Plaza',
-    '0175 - Banco Bicentenario',
-    '0137 - Banco Sofitasa',
-    '0171 - Banco Activo',
-    '0104 - Banco Venezolano de Crédito',
-    '0166 - Banco Agrícola de Venezuela',
-    '0174 - Banplus Banco Universal',
-    '0114 - Banco del Caribe',
-    '0156 - 100% Banco',
-    '0106 - Banco Industrial de Venezuela',
-    '0177 - Banco BANFANB',
-    '0168 - Banco Mi Banco',
-    '0146 - Banco del Pueblo Soberano',
-    '0121 - Banco Provincial de Crédito',
-    '0132 - Banco Guayana',
-    '0190 - Citibank',
-    '0187 - Banco de Exportación y Comercio',
-    '0172 - Banco Bancamiga',
-    '0193 - Banco Fintec'
-  ];
-
-  for (const banco of bingo) {
-    await db.collection('BancosBingo').doc(banco).set({ banco });
+  for (const nombre of bancos) {
+    await db.collection('Bancos').doc(nombre).set({ nombre });
   }
 
   console.log('Bancos inicializados');

--- a/perfil.html
+++ b/perfil.html
@@ -55,9 +55,6 @@
   <h4>Tus Datos Bancarios</h4>
   <select id="perfil-banco">
     <option value="" selected disabled>Selecciona Banco</option>
-    <option value="Banco Mercantil">Banco Mercantil</option>
-    <option value="Banco de Venezuela">Banco de Venezuela</option>
-    <option value="Banesco">Banesco</option>
   </select>
   <input type="text" id="perfil-pagomovil" placeholder="Número Pago móvil" />
   <input type="text" id="perfil-cedula" placeholder="Número de Cédula" />
@@ -83,8 +80,25 @@
   actualizarFechaHora();
   setInterval(actualizarFechaHora,60000);
 
+  function cargarBancosPerfil(){
+    db.collection('Bancos').onSnapshot(snap=>{
+      const sel=document.getElementById('perfil-banco');
+      const actual=sel.value;
+      sel.innerHTML='<option value="" selected disabled>Selecciona Banco</option>';
+      snap.forEach(doc=>{
+        const nombre=doc.data().nombre||doc.id;
+        const opt=document.createElement('option');
+        opt.value=nombre;
+        opt.textContent=nombre;
+        sel.appendChild(opt);
+      });
+      if(actual) sel.value=actual;
+    });
+  }
+
   document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='player.html';});
   document.getElementById('guardar-perfil-btn').addEventListener('click',guardarPerfil);
+  cargarBancosPerfil();
 
   async function guardarPerfil(){
     const user = auth.currentUser;
@@ -119,6 +133,7 @@
         document.getElementById('perfil-pagomovil').value=d.pagomovil||'';
         document.getElementById('perfil-cedula').value=d.cedula||'';
       }
+      cargarBancosPerfil();
     } else { window.location.href='index.html'; }
   });
   </script>


### PR DESCRIPTION
## Resumen
- almacenar todos los bancos en una sola colección `Bancos`
- actualizar `billetera.html` y `perfil.html` para que las listas de bancos se llenen en tiempo real desde Firestore
- modificar `initBanks.js` para poblar la nueva colección
- ajustar el README con la instrucción correcta

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b0aafd9ec8326968cc94d139d91aa