### PR TITLE
Arregla carga de bancos en billetera

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -266,6 +266,8 @@
 
     auth.onAuthStateChanged(async user => {
       if(!user) return;
+      cargarBancosBilletera();
+      cargarBancosBingo();
       const billeteraRef = db.collection('Billetera').doc(user.email);
       const doc = await billeteraRef.get();
       if(doc.exists){
@@ -349,8 +351,6 @@
       window.location.href='player.html';
     });
 
-    cargarBancosBilletera();
-    cargarBancosBingo();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Resumen
- los menús de selección de bancos se poblaban antes de que el usuario iniciara sesión
- ahora la lista de bancos se carga tras la autenticación

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b0ea6d7a08326becd4e96d1c09d9d