### PR TITLE
Modifica menú de categoría en gestión de bancos

### DIFF
--- a/configuraciones.html
+++ b/configuraciones.html
@@ -176,10 +176,13 @@
     <div id="bancos-content" style="display:none;margin-top:10px;">
     <input type="hidden" id="banco-id" />
     <input type="text" id="banco-nombre" placeholder="Nombre de banco" style="width:90%;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;" />
-    <select id="banco-categoria" style="width:90%;margin-top:5px;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;">
-      <option value="Jugadores">Jugadores</option>
-      <option value="Bingo">Bingo</option>
-    </select>
+    <div style="display:flex;align-items:center;width:90%;gap:5px;margin-top:5px;">
+        <label for="banco-categoria" style="flex:0 0 30%;text-align:right;">Banco Para:</label>
+        <select id="banco-categoria" style="flex:0 0 60%;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;">
+            <option value="Jugadores">Jugadores</option>
+            <option value="Bingo">Bingo</option>
+        </select>
+    </div>
     <div id="estado-container">
       <label><input type="radio" name="banco-estado" value="Activo" checked> Activo</label>
       <label><input type="radio" name="banco-estado" value="Inactivo"> Inactivo</label>


### PR DESCRIPTION
## Resumen
- Ajustar la interfaz de gestión de bancos
- Reducir tamaño del menú *Categoría* y agregar la etiqueta *Banco Para* alineada en la misma línea

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c15584c848326a62487298dcbb80f