### PR TITLE
Mejoras visuales en billetera

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -48,8 +48,8 @@
     #creditos-container{margin:10px auto;}
     #creditos-title,#creditos-valor{font-family:"Bangers",cursive;color:#fff;}
     #creditos-title{font-size:2rem;text-shadow:0 0 8px #ff8c00;animation:pulse 1s infinite;}
+    #creditos-valor{font-size:2.4rem;animation:pulse 1s infinite;}
     #creditos-info{display:flex;align-items:center;justify-content:center;gap:15px;}
-    #creditos-valor{font-size:2.4rem;}
     #cartones-gratis{font-family:"Bangers",cursive;color:#fff;font-size:2rem;text-shadow:0 0 8px #00008B;animation:pulse 1s infinite;display:flex;align-items:center;gap:3px;}
     #carton-icon{width:24px;height:24px;}
     #creditos-valor.verde{text-shadow:0 0 5px #006600;}
@@ -66,6 +66,12 @@
       padding: 4px 8px;
       font-size:0.8rem;
       word-break:break-word;
+    }
+    #tabla-bancos th,#tabla-bancos td{
+      font-weight:bold;
+      color:#00008B;
+      text-shadow:0 0 4px #fff;
+      text-align:center;
     }
     .tabs {
       margin-top:20px;
@@ -172,7 +178,7 @@
     <div id="creditos-info">
       <div id="creditos-valor" class="rojo">0</div>
       <div id="cartones-gratis">
-        <img id="carton-icon" src="https://cdn-icons-png.flaticon.com/32/9424/9424875.png" alt="Cartón">
+        <img id="carton-icon" src="https://cdn-icons-png.flaticon.com/32/5065/5065890.png" alt="Ticket">
         <span id="cartones-valor">0</span>
       </div>
     </div>
@@ -204,7 +210,7 @@
       <h3>Bancos habilitados para depósitos</h3>
       <table id="tabla-bancos">
         <thead>
-          <tr><th>Banco</th><th>Número de pago móvil</th><th>Cédula</th></tr>
+          <tr><th>Banco</th><th>N° Pago Móvil</th><th>Cédula</th></tr>
         </thead>
         <tbody></tbody>
       </table>


### PR DESCRIPTION
## Summary
- actualicé el ícono de cartones gratis por un ticket
- animé el valor de créditos
- ajusté el encabezado de la tabla de depósitos
- apliqué estilo azul con resplandor blanco en la tabla

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c3364087483268a6380ca188efb4f