### PR TITLE
Añadir switch para mostrar datos bancarios en billetera

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -132,6 +132,31 @@
     #tipo-cuenta{display:flex;justify-content:center;gap:5px;}
     #tipo-cuenta label{display:flex;align-items:center;gap:3px;}
     #tipo-cuenta input{width:auto;margin:0;}
+    .switch{
+      position:relative;
+      display:inline-block;
+      width:42px;
+      height:24px;
+    }
+    .switch input{display:none;}
+    .slider{
+      position:absolute;
+      cursor:pointer;
+      top:0;left:0;right:0;bottom:0;
+      background-color:#ccc;
+      transition:.4s;
+      border-radius:24px;
+    }
+    .slider:before{
+      position:absolute;
+      content:"";
+      height:18px;width:18px;left:3px;bottom:3px;
+      background-color:white;
+      transition:.4s;
+      border-radius:50%;
+    }
+    input:checked + .slider{background-color:#4caf50;}
+    input:checked + .slider:before{transform:translateX(18px);}
     #guardar-datos {
       font-family: 'Bangers', cursive;
       font-size: 1.2rem;
@@ -185,20 +210,28 @@
   </div>
 
   <div id="mis-datos">
-    <h3>Mis datos bancarios</h3>
-    <select id="banco">
-      <option value="" disabled selected>Banco</option>
-    </select>
-    <input type="number" id="cuenta" placeholder="N° Cuenta Bancaria" inputmode="numeric" pattern="\d*" oninput="this.value=this.value.replace(/\D/g,'');">
-    <div id="tipo-cuenta">
-      <label><input type="radio" name="tipo-cuenta" value="Ahorro"> Ahorro</label>
-      <label><input type="radio" name="tipo-cuenta" value="Corriente"> Corriente</label>
+    <div style="display:flex;align-items:center;justify-content:center;gap:10px;">
+      <h3 style="margin:0;">Mis datos bancarios</h3>
+      <label class="switch">
+        <input type="checkbox" id="toggle-datos" checked>
+        <span class="slider"></span>
+      </label>
     </div>
-    <div id="datos-pm">
-      <input type="number" id="cedula" placeholder="Cédula" inputmode="numeric" pattern="\d*" oninput="this.value=this.value.replace(/\D/g,'');">
-      <input type="number" id="pagomovil" placeholder="Número Pago móvil" inputmode="numeric" pattern="\d*" oninput="this.value=this.value.replace(/\D/g,'');">
+    <div id="datos-content">
+      <select id="banco">
+        <option value="" disabled selected>Banco</option>
+      </select>
+      <input type="number" id="cuenta" placeholder="N° Cuenta Bancaria" inputmode="numeric" pattern="\d*" oninput="this.value=this.value.replace(/\D/g,'');">
+      <div id="tipo-cuenta">
+        <label><input type="radio" name="tipo-cuenta" value="Ahorro"> Ahorro</label>
+        <label><input type="radio" name="tipo-cuenta" value="Corriente"> Corriente</label>
+      </div>
+      <div id="datos-pm">
+        <input type="number" id="cedula" placeholder="Cédula" inputmode="numeric" pattern="\d*" oninput="this.value=this.value.replace(/\D/g,'');">
+        <input type="number" id="pagomovil" placeholder="Número Pago móvil" inputmode="numeric" pattern="\d*" oninput="this.value=this.value.replace(/\D/g,'');">
+      </div>
+      <button id="guardar-datos">Guardar Datos</button>
     </div>
-    <button id="guardar-datos">Guardar Datos</button>
   </div>
 
   <div class="tabs">
@@ -368,6 +401,14 @@
     document.getElementById('volver-btn').addEventListener('click',()=>{
       window.location.href='player.html';
     });
+
+    const toggle=document.getElementById('toggle-datos');
+    const datos=document.getElementById('datos-content');
+    function actualizarVisibilidad(){
+      datos.style.display=toggle.checked?'block':'none';
+    }
+    toggle.addEventListener('change',actualizarVisibilidad);
+    actualizarVisibilidad();
 
   </script>
 </body>


### PR DESCRIPTION
## Summary
- agregar estilos y estructura de switch para mostrar u ocultar la seccion de datos bancarios
- encapsular los campos de banco, cuenta, tipo de cuenta, cedula y pago movil
- añadir codigo JS para controlar la visibilidad mediante el interruptor

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c395df59883269f9e8745e74262f1