### PR TITLE
Ajustes UI billetera

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -213,7 +213,7 @@
     <div style="display:flex;align-items:center;justify-content:center;gap:10px;">
       <h3 style="margin:0;">Mis datos bancarios</h3>
       <label class="switch">
-        <input type="checkbox" id="toggle-datos" checked>
+        <input type="checkbox" id="toggle-datos">
         <span class="slider"></span>
       </label>
     </div>
@@ -251,7 +251,7 @@
         <option value="" disabled selected>Banco donde transferiste</option>
       </select>
       <input type="number" id="monto-deposito" placeholder="Monto">
-      <input type="text" id="referencia" placeholder="Referencia de pago">
+        <input type="number" id="referencia" placeholder="Referencia de pago" inputmode="numeric" pattern="\d*" oninput="this.value=this.value.replace(/\D/g,'');">
       <textarea id="comentario-deposito" placeholder="Comentario (opcional)"></textarea>
       <button id="btn-depositar">Depositar</button>
     </div>


### PR DESCRIPTION
## Resumen
- desactivar por defecto el switch de datos bancarios
- permitir solo números en la referencia de pago

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c3b8524d883268fa3f594a6d9fa6f