### PR TITLE
Agregar gestión de transacciones

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -251,15 +251,44 @@
         <option value="" disabled selected>Banco donde transferiste</option>
       </select>
       <input type="number" id="monto-deposito" placeholder="Monto">
-        <input type="number" id="referencia" placeholder="Referencia de pago" inputmode="numeric" pattern="\d*" oninput="this.value=this.value.replace(/\D/g,'');">
+        <input type="text" id="referencia" placeholder="Referencia (últimos 5 dígitos)" inputmode="numeric" pattern="\d*" maxlength="5" oninput="this.value=this.value.replace(/\D/g,"");">
       <textarea id="comentario-deposito" placeholder="Comentario (opcional)"></textarea>
-      <button id="btn-depositar">Depositar</button>
+      <button id="btn-depositar">Solicitar Depósito</button>
     </div>
     <div id="retirar" class="tab-content">
       <label id="banco-retiro"></label>
       <input type="number" id="monto-retiro" placeholder="Monto">
       <textarea id="comentario-retiro" placeholder="Comentario (opcional)"></textarea>
       <button id="btn-retirar">Retirar</button>
+    </div>
+  </div>
+  <div id="transacciones-section">
+    <div style="display:flex;align-items:center;justify-content:center;gap:10px;">
+      <h3 style="margin:0;">Mis transacciones</h3>
+      <label class="switch">
+        <input type="checkbox" id="toggle-transacciones">
+        <span class="slider"></span>
+      </label>
+    </div>
+    <div id="transacciones-content">
+      <table id="tabla-transacciones">
+        <thead>
+          <tr>
+            <th>N°</th>
+            <th>
+              <select id="filtro-tipo">
+                <option value="">TIPO</option>
+                <option value="deposito">Deposito</option>
+                <option value="retiro">Retiro</option>
+              </select>
+            </th>
+            <th><input id="filtro-monto" type="number" placeholder="MONTO"></th>
+            <th><input id="filtro-fecha" type="date"></th>
+            <th>Estado</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
     </div>
   </div>
 
@@ -269,6 +298,7 @@
   <script src="auth.js"></script>
   <script>
     ensureAuth();
+    const transacciones=[];
 
     function cargarBancosBilletera(){
       db.collection('Bancos').where('categoria','==','Jugadores').where('estado','==','Activo').onSnapshot(snap=>{
@@ -340,6 +370,7 @@
         document.getElementById('cartones-valor').textContent='0';
         document.getElementById('banco-retiro').textContent='Banco donde recibirás:';
       }
+      cargarTransacciones();
     });
 
     document.getElementById('guardar-datos').addEventListener('click', async () => {
@@ -364,22 +395,71 @@
       alert('Datos guardados');
     });
 
+    function fechaActual(){
+      const d=new Date();
+      return d.toLocaleDateString('es-VE');
+    }
+    function horaActual(){
+      const d=new Date();
+      return d.toLocaleTimeString('es-VE',{hour:'2-digit',minute:'2-digit'});
+    }
+
+    async function cargarTransacciones(){
+      const user=auth.currentUser;
+      const snap=await db.collection('transacciones').where('IDbilletera','==',user.email).get();
+      transacciones.length=0;
+      snap.forEach(doc=>transacciones.push({id:doc.id,...doc.data()}));
+      filtrarTransacciones();
+    }
+
+    function filtrarTransacciones(){
+      const tipo=document.getElementById('filtro-tipo').value;
+      const monto=document.getElementById('filtro-monto').value.trim();
+      const fecha=document.getElementById('filtro-fecha').value;
+      const tbody=document.querySelector('#tabla-transacciones tbody');
+      tbody.innerHTML='';
+      let n=1;
+      transacciones.forEach(t=>{
+        if(t.estado==='ARCHIVADO') return;
+        if(tipo && t.tipotrans!==tipo) return;
+        if(monto && parseFloat(t.Monto)!=parseFloat(monto)) return;
+        const f=t.estado==='PENDIENTE'?t.fechasolicitud:t.fechagestion;
+        if(fecha && f!==fecha) return;
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${n}</td><td style="color:${t.tipotrans==='deposito'?'green':'red'}">${t.tipotrans.toUpperCase()}</td><td style="color:${t.tipotrans==='deposito'?'green':'red'}">${t.Monto}</td><td style="color:${t.estado==='PENDIENTE'?'orange':'green'}">${f}</td><td style="color:${t.estado==='REALIZADO'?'green':t.estado==='ANULADO'?'orange':'black'}">${t.estado}</td>`;
+        if(t.estado==='ANULADO' && t.nota){tr.addEventListener('click',()=>alert(t.nota));}
+        tbody.appendChild(tr);n++;});
+    }
+
+    document.getElementById('filtro-tipo').addEventListener('change',filtrarTransacciones);
+    document.getElementById('filtro-monto').addEventListener('input',filtrarTransacciones);
+    document.getElementById('filtro-fecha').addEventListener('change',filtrarTransacciones);
+
     document.getElementById('btn-depositar').addEventListener('click', async () => {
       const user = auth.currentUser;
+      const ref=document.getElementById('referencia').value.trim();
+      if(!/^[0-9]{1,5}$/.test(ref)){ alert('Coloca solo los últimos 5 dígitos de la referencia'); return; }
       const data = {
-        billeteraId: user.email,
-        banco: document.getElementById('banco-deposito').value,
-        monto: parseFloat(document.getElementById('monto-deposito').value) || 0,
-        referencia: document.getElementById('referencia').value.trim(),
+        tipotrans:'deposito',
+        bancoreceptor: document.getElementById('banco-deposito').value,
+        Monto: parseFloat(document.getElementById('monto-deposito').value) || 0,
+        referencia: ref,
         comentario: document.getElementById('comentario-deposito').value.trim(),
-        tipo: 'Deposito',
-        fecha: new Date()
+        estado:'PENDIENTE',
+        IDbilletera: user.email,
+        fechasolicitud: fechaActual(),
+        horasolicitud: horaActual(),
+        usuariogestor:'',
+        rolusuario:'',
+        fechagestion:'',
+        horagestion:'',
+        nota:''
       };
-      if(!data.banco){ alert('Seleccione el banco'); return; }
-      if(data.monto<=0){ alert('Monto inválido'); return; }
-      if(!data.referencia){ alert('Ingrese referencia'); return; }
-      await db.collection('Transacciones').add(data);
+      if(!data.bancoreceptor){ alert('Seleccione el banco'); return; }
+      if(data.Monto<=0){ alert('Monto inválido'); return; }
+      await db.collection('transacciones').add(data);
       alert('Bien, recibimos tu solicitud, una vez verificado el pago se recargará tu billetera');
+      cargarTransacciones();
     });
 
     document.getElementById('btn-retirar').addEventListener('click', async () => {
@@ -387,15 +467,26 @@
       const monto = parseFloat(document.getElementById('monto-retiro').value) || 0;
       const creditos = parseFloat(document.getElementById('creditos-valor').textContent) || 0;
       if(monto>creditos){ alert('El monto supera los créditos disponibles'); return; }
+      const docB=await db.collection('Billetera').doc(user.email).get();
       const data = {
-        billeteraId: user.email,
-        monto: monto,
+        tipotrans:'retiro',
+        bancoreceptor: docB.exists?(docB.data().banco||''):'' ,
+        Monto: monto,
+        referencia:'',
         comentario: document.getElementById('comentario-retiro').value.trim(),
-        tipo: 'Retiro',
-        fecha: new Date()
+        estado:'PENDIENTE',
+        IDbilletera:user.email,
+        fechasolicitud:fechaActual(),
+        horasolicitud:horaActual(),
+        usuariogestor:'',
+        rolusuario:'',
+        fechagestion:'',
+        horagestion:'',
+        nota:''
       };
-      await db.collection('Transacciones').add(data);
+      await db.collection('transacciones').add(data);
       alert('Solicitud enviada, una vez validada se transferirá a tu pago móvil');
+      cargarTransacciones();
     });
 
     document.getElementById('volver-btn').addEventListener('click',()=>{
@@ -409,6 +500,14 @@
     }
     toggle.addEventListener('change',actualizarVisibilidad);
     actualizarVisibilidad();
+
+    const toggleT=document.getElementById('toggle-transacciones');
+    const transDiv=document.getElementById('transacciones-content');
+    function visTrans(){
+      transDiv.style.display=toggleT.checked?'block':'none';
+    }
+    toggleT.addEventListener('change',visTrans);
+    visTrans();
 
   </script>
 </body>

--- a/collab.html
+++ b/collab.html
@@ -106,7 +106,7 @@
   </div>
   <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
   <div id="main-menu">
-    <button id="ver-recargas-btn" class="menu-btn">Verificar Recargas</button>
+    <button id="ver-recargas-btn" class="menu-btn">Gestionar transferencias</button>
     <button id="aprobar-retiros-btn" class="menu-btn">Aprobar Retiros</button>
     <button class="menu-btn">Gestión Jugadores</button>
   </div>
@@ -194,7 +194,7 @@
     alert('Envio completado exitosamente');
     retiroActual=null; await cargarRetiros(); document.getElementById('detalle-retiro').innerHTML=''; }
 
-  document.getElementById('ver-recargas-btn').addEventListener('click',()=>{hideViews();document.getElementById('verificar-recargas-screen').style.display='block';cargarRecargas();});
+  document.getElementById('ver-recargas-btn').addEventListener('click',()=>{window.location.href='transacciones.html';});
   document.getElementById('aprobar-retiros-btn').addEventListener('click',()=>{hideViews();document.getElementById('aprobar-retiros-screen').style.display='block';cargarRetiros();});
   document.getElementById('ver-recargas-back').addEventListener('click',()=>{hideViews();document.getElementById('main-menu').style.display='block';});
   document.getElementById('retiros-back').addEventListener('click',()=>{hideViews();document.getElementById('main-menu').style.display='block';});

--- a/transacciones.html
+++ b/transacciones.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Transacciones</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
+  <style>
+    body {background: linear-gradient(rgba(255,255,255,0.7),rgba(255,255,255,0.7)), url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg'); background-repeat: repeat; text-align:center; font-family: 'Bangers', cursive; padding:20px;}
+    .menu-btn{width:120px;height:40px;background:orange;border:4px solid #FFD700;border-radius:10px;color:#fff;text-shadow:2px 2px 4px #000;font-size:1rem;display:flex;align-items:center;justify-content:center;gap:5px;}
+    table{margin:10px auto;border-collapse:collapse;width:100%;font-size:0.8rem;}
+    th,td{border:1px solid #ccc;padding:4px 6px;word-break:break-word;}
+    th{font-weight:bold;}
+    .switch{position:relative;display:inline-block;width:42px;height:24px;}
+    .switch input{display:none;}
+    .slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background-color:#ccc;transition:.4s;border-radius:24px;}
+    .slider:before{position:absolute;content:"";height:18px;width:18px;left:3px;bottom:3px;background-color:white;transition:.4s;border-radius:50%;}
+    input:checked + .slider{background-color:#4caf50;}
+    input:checked + .slider:before{transform:translateX(18px);}
+    .acciones{margin:5px;}
+  </style>
+</head>
+<body>
+  <button id="volver-btn" class="menu-btn">&#9664; Volver</button>
+  <h2>Gestionar transferencias</h2>
+  <div id="recargas-section">
+    <div style="display:flex;align-items:center;justify-content:center;gap:10px;">
+      <h3 style="margin:0;">Gestionar Recargas</h3>
+      <label class="switch"><input type="checkbox" id="toggle-recargas"><span class="slider"></span></label>
+    </div>
+    <div id="recargas-content">
+      <div class="acciones">
+        <button id="aprobar-rec" class="menu-btn">Aprobar</button>
+        <button id="anular-rec" class="menu-btn">Anular</button>
+        <button id="archivar-rec" class="menu-btn">Archivar</button>
+      </div>
+      <table id="tabla-recargas">
+        <thead>
+          <tr>
+            <th>N°</th>
+            <th style="color:#4b0082;">Monto</th>
+            <th>Nombre</th>
+            <th>Banco</th>
+            <th style="color:#4b0082;">Referencia</th>
+            <th style="color:#A52A2A;">Fecha</th>
+            <th>Estado</th>
+            <th><input type="checkbox" id="sel-all-rec"></th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+  <div id="retiros-section">
+    <div style="display:flex;align-items:center;justify-content:center;gap:10px;">
+      <h3 style="margin:0;">Gestionar Retiros</h3>
+      <label class="switch"><input type="checkbox" id="toggle-retiros"><span class="slider"></span></label>
+    </div>
+    <div id="retiros-content">
+      <div class="acciones">
+        <input type="text" id="ref-retiro" placeholder="Referencia" maxlength="5" style="width:100px;">
+        <button id="aprobar-ret" class="menu-btn">Aprobar</button>
+        <button id="anular-ret" class="menu-btn">Anular</button>
+        <button id="archivar-ret" class="menu-btn">Archivar</button>
+      </div>
+      <table id="tabla-retiros">
+        <thead>
+          <tr>
+            <th>N°</th>
+            <th style="color:#4b0082;">Monto</th>
+            <th>Nombre</th>
+            <th>Banco receptor</th>
+            <th style="color:#4b0082;">Referencia</th>
+            <th style="color:#A52A2A;">Fecha</th>
+            <th>Estado</th>
+            <th><input type="checkbox" id="sel-all-ret"></th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
+  <script src="auth.js"></script>
+  <script>
+    ensureAuth('Colaborador');
+    const transRef=db.collection('transacciones');
+    const datosRec=[];const datosRet=[];
+    function fecha(){const d=new Date();return d.toLocaleDateString('es-VE');}
+    function hora(){const d=new Date();return d.toLocaleTimeString('es-VE',{hour:'2-digit',minute:'2-digit'});}
+
+    function toggleView(id,content){document.getElementById(id).addEventListener('change',()=>{content.style.display=document.getElementById(id).checked?'block':'none';});content.style.display='none';}
+    toggleView('toggle-recargas',document.getElementById('recargas-content'));
+    toggleView('toggle-retiros',document.getElementById('retiros-content'));
+
+    async function cargar(){
+      const snap=await transRef.get();
+      datosRec.length=0;datosRet.length=0;
+      snap.forEach(d=>{const dt={id:d.id,...d.data()};
+        if(dt.tipotrans==='deposito')datosRec.push(dt); else datosRet.push(dt);});
+      renderRec();renderRet();
+    }
+    function abreviar(mail){return mail.split('@')[0];}
+    function estadoColor(e){return e==='REALIZADO'?'green':e==='ANULADO'?'orange':e==='ARCHIVADO'?'brown':'orange';}
+    function renderRec(){const tb=document.querySelector('#tabla-recargas tbody');tb.innerHTML='';let i=1;datosRec.forEach(t=>{if(t.estado!=='ARCHIVADO'){const tr=document.createElement('tr');tr.innerHTML=`<td>${i}</td><td style='color:#4b0082;'>${t.Monto}</td><td>${abreviar(t.IDbilletera)}</td><td>${(t.bancoreceptor||'').split(':')[0]}</td><td style='color:#4b0082;'>${t.referencia}</td><td style='color:#A52A2A;'>${t.fechasolicitud}</td><td style='color:${estadoColor(t.estado)}'>${t.estado}</td><td><input type='checkbox' data-id='${t.id}'></td>`;tb.appendChild(tr);i++;}});}
+    function renderRet(){const tb=document.querySelector('#tabla-retiros tbody');tb.innerHTML='';let i=1;datosRet.forEach(t=>{if(t.estado!=='ARCHIVADO'){const tr=document.createElement('tr');tr.innerHTML=`<td>${i}</td><td style='color:#4b0082;'>${t.Monto}</td><td>${abreviar(t.IDbilletera)}</td><td>${(t.bancoreceptor||'').split(':')[0]}</td><td style='color:#4b0082;'>${t.referencia||''}</td><td style='color:#A52A2A;'>${t.fechasolicitud}</td><td style='color:${estadoColor(t.estado)}'>${t.estado}</td><td><input type='checkbox' data-id='${t.id}'></td>`;tb.appendChild(tr);i++;}});}
+
+    function seleccionados(tb){return Array.from(tb.querySelectorAll('input[type=checkbox]:checked')).map(c=>c.dataset.id);}
+
+    async function actualizar(ids,estado,nota,ref){for(const id of ids){const upd={estado,usuariogestor:auth.currentUser.email,rolusuario:window.currentRole,fechagestion:fecha(),horagestion:hora()};if(nota)upd.nota=nota;if(ref)upd.referencia=ref;await transRef.doc(id).update(upd);}cargar();}
+
+    document.getElementById('aprobar-rec').addEventListener('click',()=>{const ids=seleccionados(document.getElementById('tabla-recargas'));if(ids.length)actualizar(ids,'REALIZADO');});
+    document.getElementById('anular-rec').addEventListener('click',()=>{const ids=seleccionados(document.getElementById('tabla-recargas'));if(ids.length){const nota=prompt('Motivo');actualizar(ids,'ANULADO',nota);}});
+    document.getElementById('archivar-rec').addEventListener('click',()=>{const ids=seleccionados(document.getElementById('tabla-recargas'));if(ids.length)actualizar(ids,'ARCHIVADO');});
+
+    document.getElementById('aprobar-ret').addEventListener('click',()=>{const ids=seleccionados(document.getElementById('tabla-retiros'));const ref=document.getElementById('ref-retiro').value.trim();if(!ref){alert('Ingrese la referencia');return;}if(ids.length)actualizar(ids,'REALIZADO',null,ref);});
+    document.getElementById('anular-ret').addEventListener('click',()=>{const ids=seleccionados(document.getElementById('tabla-retiros'));if(ids.length){const nota=prompt('Motivo');actualizar(ids,'ANULADO',nota);}});
+    document.getElementById('archivar-ret').addEventListener('click',()=>{const ids=seleccionados(document.getElementById('tabla-retiros'));if(ids.length)actualizar(ids,'ARCHIVADO');});
+
+    document.getElementById('volver-btn').addEventListener('click',()=>{history.back();});
+    auth.onAuthStateChanged(()=>cargar());
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Resumen
- registrar depósitos y retiros en la colección **transacciones**
- mostrar historial de transacciones con filtros en `billetera.html`
- cambiar el botón en `collab.html` y redirigir a `transacciones.html`
- crear nueva pantalla `transacciones.html` para aprobar, anular o archivar

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881889a19348326bdae7e69d2f144cb