### PR TITLE
Fix: ajustar switches y estilos de billetera

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -77,8 +77,10 @@
     #tabla-transacciones th:nth-child(5),#tabla-transacciones td:nth-child(5){width:120px;}
     #tabla-transacciones select,#tabla-transacciones input{font-size:0.9rem;width:100px;}
     #tabla-transacciones th:nth-child(3) input{width:100px;}
-    #transacciones-content{overflow-x:auto;}
+    #datos-content{display:none;}
+    #transacciones-content{overflow-x:auto;display:none;}
     #transacciones-section .switch{margin-top:4px;}
+    #tabla-bancos{background:rgba(255,255,255,0.95);}
     #tabla-bancos th,#tabla-bancos td{
       font-weight:bold;
       color:#00008B;
@@ -128,8 +130,8 @@
       width:260px;
     }
     #banco,#cuenta,#cedula,#pagomovil{font-weight:bold;}
-    #banco{color:#00008B;}
-    #cuenta{color:#006400;}
+    #banco{color:#00008B;width:100%;box-sizing:border-box;}
+    #cuenta{color:#006400;width:100%;box-sizing:border-box;}
     #cedula{color:#4B0082;}
     #pagomovil{color:#FF8C00;}
     .campo{display:flex;flex-direction:column;align-items:center;width:260px;margin:0 auto;}
@@ -594,22 +596,25 @@
       actualizar();
     });
 
-    const toggle=document.getElementById('toggle-datos');
-    const datos=document.getElementById('datos-content');
-    function actualizarVisibilidad(){
-      datos.style.display=toggle.checked?'block':'none';
-    }
-    toggle.addEventListener('change',actualizarVisibilidad);
-    actualizarVisibilidad();
+    </script>
+    <script>
+      document.addEventListener('DOMContentLoaded',()=>{
+      const toggle=document.getElementById('toggle-datos');
+      const datos=document.getElementById('datos-content');
+      const toggleT=document.getElementById('toggle-transacciones');
+      const transDiv=document.getElementById('transacciones-content');
 
-    const toggleT=document.getElementById('toggle-transacciones');
-    const transDiv=document.getElementById('transacciones-content');
-    function visTrans(){
-      transDiv.style.display=toggleT.checked?'block':'none';
-    }
-    toggleT.addEventListener('change',visTrans);
-    visTrans();
-
+      function actualizarVisibilidad(){
+        datos.style.display=toggle.checked?'block':'none';
+      }
+      function visTrans(){
+        transDiv.style.display=toggleT.checked?'block':'none';
+      }
+      toggle.addEventListener('change',actualizarVisibilidad);
+      toggleT.addEventListener('change',visTrans);
+      actualizarVisibilidad();
+      visTrans();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Resumen
- Oculta secciones de datos bancarios y transacciones hasta que el usuario active sus respectivos switches.
- Ajusta el ancho del selector de banco para igualarlo al campo de número de cuenta.
- Aplica un fondo blanco translúcido (95%) a la tabla de bancos habilitados para depósitos.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68941719cc348326a8d88d04449016df