### PR TITLE
Ajustes de interfaz en parámetros globales

### DIFF
--- a/parametros.html
+++ b/parametros.html
@@ -18,6 +18,7 @@
       min-height: 100vh;
       text-align: center;
       font-family: 'Bangers', cursive;
+      padding-top: 60px;
     }
     .menu-btn {
       width: 250px;
@@ -78,6 +79,7 @@
       gap: 8px;
       font-family: Calibri, Arial, sans-serif;
       font-size: 0.9rem;
+      align-items: center;
     }
     .form-row {
       display: flex;
@@ -100,6 +102,7 @@
     .small-row {
       flex-wrap: wrap;
       gap: 10px;
+      justify-content: center;
     }
     .small-row .field {
       display: flex;
@@ -127,7 +130,7 @@
     <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
   </div>
-  <h2>Parámetros Globales</h2>
+  <h2 style="margin-top:20px;">Parámetros Globales</h2>
   <div id="parametros-form">
     <div class="form-row">
       <label for="aplicacion">Nombre de App:</label>


### PR DESCRIPTION
## Resumen
- Separar el contenido del borde superior para evitar que la flecha y la info de sesión se sobrepongan con el título.
- Centrar los campos finales de país y porcentajes junto con los botones de edición/guardado.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689504ac395883269fe92045472c539f