### PR TITLE
Limpiar campos de solicitud en billetera

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -537,6 +537,18 @@
       return false;
     }
 
+    function limpiarCamposTransaccion(tipo){
+      if(tipo==='deposito'){
+        document.getElementById('banco-deposito').selectedIndex=0;
+        document.getElementById('monto-deposito').value='';
+        document.getElementById('referencia').value='';
+        document.getElementById('comentario-deposito').value='';
+      }else if(tipo==='retiro'){
+        document.getElementById('monto-retiro').value='';
+        document.getElementById('comentario-retiro').value='';
+      }
+    }
+
     document.getElementById('btn-depositar').addEventListener('click', async () => {
       if(!await validarDatosBancarios()) return;
       const user = auth.currentUser;
@@ -565,6 +577,7 @@
       };
       await db.collection('transacciones').add(data);
       alert('Bien, recibimos tu solicitud, una vez verificado el pago se recargará tu billetera');
+      limpiarCamposTransaccion('deposito');
       cargarTransacciones();
     });
 
@@ -595,6 +608,7 @@
       };
       await db.collection('transacciones').add(data);
       alert('Solicitud enviada, una vez validada se transferirá a tu pago móvil');
+      limpiarCamposTransaccion('retiro');
       cargarTransacciones();
     });
 


### PR DESCRIPTION
## Resumen
- Añadida función `limpiarCamposTransaccion` para restablecer campos de depósito o retiro.
- Se invoca la limpieza después de enviar solicitudes de depósito y retiro, dejando el formulario listo para nuevas operaciones.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895124ced8083269eb51e38518b8140