### PR TITLE
Mejoras en visualización de transacciones en billetera

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -88,6 +88,29 @@
       text-align:center;
     }
     #banco-retiro{font-weight:bold;color:#00008B;text-shadow:0 0 4px #fff;}
+    td.nota-estado{position:relative;cursor:pointer;}
+    td.nota-estado::before{
+      content:'';
+      position:absolute;
+      top:0;
+      left:0;
+      width:0;
+      height:0;
+      border-top:8px solid red;
+      border-right:8px solid transparent;
+    }
+    #modal-detalle{
+      position:fixed;
+      top:0;left:0;width:100%;height:100%;
+      background:rgba(0,0,0,0.5);
+      display:none;align-items:center;justify-content:center;
+      z-index:2000;
+    }
+    #modal-detalle .contenido{
+      background:#fff;padding:15px;border-radius:8px;
+      font-family:Calibri, Arial, sans-serif;font-weight:bold;text-align:left;
+    }
+    #modal-detalle button{margin-top:10px;font-weight:bold;}
     @media (max-width:480px) and (orientation:portrait){
       body{padding:2px;}
       #tabla-transacciones{margin:2px 0;width:100%;}
@@ -348,6 +371,8 @@
     </div>
   </div>
 
+  <div id="modal-detalle"><div class="contenido"></div></div>
+
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -480,6 +505,38 @@
       return `${d.padStart(2,'0')}/${m.padStart(2,'0')}/${a}`;
     }
 
+    function aHora24(str){
+      if(!str) return '00:00';
+      str=str.toLowerCase();
+      const m=str.match(/(\d{1,2}):(\d{2})(?:\s*(a|p)\.?m\.?)?/);
+      if(!m) return str;
+      let h=parseInt(m[1],10);const min=m[2];const ap=m[3];
+      if(ap){
+        if(ap==='p'&&h<12)h+=12;
+        if(ap==='a'&&h===12)h=0;
+      }
+      return `${String(h).padStart(2,'0')}:${min}`;
+    }
+
+    function parseFechaHora(f,h){
+      const [d,m,a]=f.split('/');
+      return new Date(`${a}-${m}-${d}T${aHora24(h)}:00`);
+    }
+
+    function formatearHora(str){
+      if(!str) return '';
+      str=str.toLowerCase();
+      const m=str.match(/(\d{1,2}):(\d{2})(?:\s*(a|p)\.?m\.?)?/);
+      if(!m) return str;
+      let h=parseInt(m[1],10);const min=m[2];const ap=m[3];
+      if(ap){
+        return `${h}:${min} ${ap}m`;
+      }
+      const ampm=h>=12?'pm':'am';
+      h=h%12; if(h===0) h=12;
+      return `${h}:${min} ${ampm}`;
+    }
+
     async function cargarTransacciones(){
       const user=auth.currentUser;
       const snap=await db.collection('transacciones').where('IDbilletera','==',user.email).get();
@@ -491,10 +548,8 @@
         transacciones.push({id:doc.id,...data});
       });
       transacciones.sort((a,b)=>{
-        const fa=a.fechagestion||a.fechasolicitud;
-        const fb=b.fechagestion||b.fechasolicitud;
-        const da=new Date(fa.split('/').reverse().join('-'));
-        const db=new Date(fb.split('/').reverse().join('-'));
+        const da=parseFechaHora(a.fechagestion||a.fechasolicitud,a.horagestion||a.horasolicitud);
+        const db=parseFechaHora(b.fechagestion||b.fechasolicitud,b.horagestion||b.horasolicitud);
         return db-da;
       });
       filtrarTransacciones();
@@ -516,14 +571,40 @@
         const f=formatearFecha(t.estado==='PENDIENTE'?t.fechasolicitud:t.fechagestion);
         if(fecha && f!==fecha) return;
         if(estado && t.estado!==estado) return;
+        const estadoColor=t.estado==='PENDIENTE'?'orange':t.estado==='ANULADO'?'red':t.estado==='APROBADO'?'green':'black';
         const tr=document.createElement('tr');
-        tr.innerHTML=`<td>${n}</td><td style="color:${t.tipotrans==='deposito'?'green':'red'}">${t.tipotrans.toUpperCase()}</td><td style="color:${t.tipotrans==='deposito'?'green':'red'}">${t.Monto}</td><td>${f}</td><td style="color:${t.estado==='PENDIENTE'?'orange':t.estado==='ANULADO'?'red':t.estado==='APROBADO'?'green':'black'}">${t.estado}</td>`;
-        if(t.estado==='ANULADO' && t.nota){tr.addEventListener('click',()=>alert(t.nota));}
+        tr.innerHTML=`<td>${n}</td><td style="color:${t.tipotrans==='deposito'?'green':'red'}">${t.tipotrans.toUpperCase()}</td><td style="color:${t.tipotrans==='deposito'?'green':'red'}">${t.Monto}</td><td class="celda-fecha">${f}</td><td style="color:${estadoColor}">${t.estado}</td>`;
+        const fechaTd=tr.querySelector('.celda-fecha');
+        fechaTd.style.cursor='pointer';
+        fechaTd.addEventListener('click',()=>mostrarDetalle(t));
+        const estadoTd=tr.lastElementChild;
+        if(t.estado==='ANULADO' && t.nota){
+          estadoTd.classList.add('nota-estado');
+          estadoTd.addEventListener('click',e=>{e.stopPropagation();alert(t.nota);});
+        }
         tbody.appendChild(tr);n++;});
-    }
+      }
 
-    document.getElementById('filtro-tipo').addEventListener('change',filtrarTransacciones);
-    document.getElementById('filtro-monto').addEventListener('input',filtrarTransacciones);
+      function mostrarDetalle(t){
+        const ref=t.referencia||'';
+        const fs=formatearFecha(t.fechasolicitud||'');
+        const hs=formatearHora(t.horasolicitud||'');
+        const fg=formatearFecha(t.fechagestion||'');
+        const hg=formatearHora(t.horagestion||'');
+        const cont=document.querySelector('#modal-detalle .contenido');
+        cont.innerHTML=`<div style="color:#00008B;">Referencia: ${ref}</div>`+
+        `<div style="color:orange;">Fecha de solicitud: ${fs}</div>`+
+        `<div style="color:orange;">Hora de solicitud: ${hs}</div>`+
+        `<div style="color:green;">Fecha de gestión: ${fg}</div>`+
+        `<div style="color:green;">Hora de gestión: ${hg}</div>`+
+        `<button id="modal-ok">Aceptar</button>`;
+        const modal=document.getElementById('modal-detalle');
+        modal.style.display='flex';
+        document.getElementById('modal-ok').addEventListener('click',()=>{modal.style.display='none';},{once:true});
+      }
+
+      document.getElementById('filtro-tipo').addEventListener('change',filtrarTransacciones);
+      document.getElementById('filtro-monto').addEventListener('input',filtrarTransacciones);
     document.getElementById('filtro-fecha').addEventListener('change',filtrarTransacciones);
     document.getElementById('filtro-estado').addEventListener('change',filtrarTransacciones);
 


### PR DESCRIPTION
## Resumen
- Ordena las transacciones por fecha y hora de solicitud para una cronología más precisa.
- Muestra indicador rojo con nota de anulación sólo al pulsar la celda de estado.
- Despliega ventana emergente con datos detallados al pulsar la fecha de cada transacción.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68952d5416bc83269bf98d25f061d97d