### PR TITLE
Agregar cartones gratis e imagen de premio a formas de sorteo

### DIFF
--- a/editarsorte.html
+++ b/editarsorte.html
@@ -140,6 +140,8 @@
       div.innerHTML=`<h3>Forma ${i}</h3>
       <input class="nombre-forma" placeholder="Nombre de forma">
       <input type="number" class="porcentaje-forma" placeholder="% Premio">
+      <input type="number" class="cartones-forma" placeholder="Cartones gratis">
+      <input class="imagen-forma" placeholder="Imagen del premio">
       <table class="carton" data-idx="${i}"><tbody></tbody></table>`;
       cont.appendChild(div);
       const tbody=div.querySelector('tbody');
@@ -170,6 +172,8 @@
         const div=forms[idx];
         div.querySelector('.nombre-forma').value=data.nombre||'';
         div.querySelector('.porcentaje-forma').value=data.porcentaje||0;
+        div.querySelector('.cartones-forma').value=data.cartonesGratis||'';
+        div.querySelector('.imagen-forma').value=data.premioImagen||'';
         data.posiciones.forEach(p=>{
           const td=div.querySelector(`td[data-row="${p.r}"][data-col="${p.c}"]`);
           if(td){ td.classList.add('selected'); td.textContent='\u2605'; }
@@ -207,25 +211,39 @@
       const div=divs[i];
       const nomInput=div.querySelector('.nombre-forma');
       const porInput=div.querySelector('.porcentaje-forma');
+      const cartInput=div.querySelector('.cartones-forma');
+      const imgInput=div.querySelector('.imagen-forma');
       const nom=nomInput.value.trim();
       const por=parseFloat(porInput.value);
+      const cart=parseInt(cartInput.value);
+      const img=imgInput.value.trim();
       const pos=[];
       div.querySelectorAll('td.selected').forEach(td=>{
         const r=parseInt(td.dataset.row); const c=parseInt(td.dataset.col);
         if(!(r===2&&c===2)) pos.push({r,c});
       });
       if(!nom){alert(`Asigna un nombre a la forma ${i+1}`);nomInput.focus();return;}
-      if(isNaN(por)||por<=0){alert(`Asigna un porcentaje a la forma ${i+1}`);porInput.focus();return;}
+      if((isNaN(por)||por<=0) && (isNaN(cart)||cart<=0) && !img){
+        alert(`Asigna un premio a la forma ${i+1}`);
+        porInput.focus();
+        return;
+      }
       if(pos.length===0){
         alert(`Debes elegir al menos una posicion en el carton para la forma ${i+1}`);
         div.querySelector('.carton').scrollIntoView({behavior:'smooth'});
         return;
       }
-      formas.push({idx:i+1,nombre:nom,porcentaje:por,posiciones:pos});
-      total+=por;
+      formas.push({
+        idx:i+1,
+        nombre:nom,
+        porcentaje:!isNaN(por)?por:0,
+        cartonesGratis:!isNaN(cart)?cart:0,
+        premioImagen:img,
+        posiciones:pos
+      });
+      if(!isNaN(por)&&por>0) total+=por;
     }
-    if(total>100){alert('La suma de porcentajes supera 100%');return;}
-    if(total<100){alert('Falta asignar porcentaje en las formas');return;}
+    if(total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
       await db.collection('sorteos').doc(sorteoId).update({nombre,tipo,fecha,hora,cierreMinutos:cierre,valorCarton:valor,estado});
       const snap = await db.collection('formas').where('sorteoId','==',sorteoId).get();

--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -140,6 +140,8 @@
       div.innerHTML=`<h3>Forma ${i}</h3>
       <input class="nombre-forma" placeholder="Nombre de forma">
       <input type="number" class="porcentaje-forma" placeholder="% Premio">
+      <input type="number" class="cartones-forma" placeholder="Cartones gratis">
+      <input class="imagen-forma" placeholder="Imagen del premio">
       <table class="carton" data-idx="${i}"><tbody></tbody></table>`;
       cont.appendChild(div);
       const tbody=div.querySelector('tbody');
@@ -176,25 +178,39 @@
       const div=divs[i];
       const nomInput=div.querySelector('.nombre-forma');
       const porInput=div.querySelector('.porcentaje-forma');
+      const cartInput=div.querySelector('.cartones-forma');
+      const imgInput=div.querySelector('.imagen-forma');
       const nom=nomInput.value.trim();
       const por=parseFloat(porInput.value);
+      const cart=parseInt(cartInput.value);
+      const img=imgInput.value.trim();
       const pos=[];
       div.querySelectorAll('td.selected').forEach(td=>{
         const r=parseInt(td.dataset.row); const c=parseInt(td.dataset.col);
         if(!(r===2&&c===2)) pos.push({r,c});
       });
       if(!nom){alert(`Asigna un nombre a la forma ${i+1}`);nomInput.focus();return;}
-      if(isNaN(por)||por<=0){alert(`Asigna un porcentaje a la forma ${i+1}`);porInput.focus();return;}
+      if((isNaN(por)||por<=0) && (isNaN(cart)||cart<=0) && !img){
+        alert(`Asigna un premio a la forma ${i+1}`);
+        porInput.focus();
+        return;
+      }
       if(pos.length===0){
         alert(`Debes elegir al menos una posicion en el carton para la forma ${i+1}`);
         div.querySelector('.carton').scrollIntoView({behavior:'smooth'});
         return;
       }
-      formas.push({idx:i+1,nombre:nom,porcentaje:por,posiciones:pos});
-      total+=por;
+      formas.push({
+        idx:i+1,
+        nombre:nom,
+        porcentaje:!isNaN(por)?por:0,
+        cartonesGratis:!isNaN(cart)?cart:0,
+        premioImagen:img,
+        posiciones:pos
+      });
+      if(!isNaN(por)&&por>0) total+=por;
     }
-    if(total>100){alert('La suma de porcentajes supera 100%');return;}
-    if(total<100){alert('Falta asignar porcentaje en las formas');return;}
+    if(total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
       const sorteoRef=await db.collection('sorteos').add({nombre,tipo,fecha,hora,cierreMinutos:cierre,valorCarton:valor,estado});
       const batch=db.batch();


### PR DESCRIPTION
## Resumen
- Añadir campos de Cartones gratis e Imagen del premio en nuevos y existentes sorteos.
- Guardar porcentaje, cartonesGratis y premioImagen en Firestore con validaciones actualizadas.
- Requerir al menos un tipo de premio por forma y que los porcentajes sumen 100.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68969080309083268a55a743c24cb3b2