### PR TITLE
feat: soportar premios variados en formas

### DIFF
--- a/editarsorte.html
+++ b/editarsorte.html
@@ -233,15 +233,11 @@
         div.querySelector('.carton').scrollIntoView({behavior:'smooth'});
         return;
       }
-      formas.push({
-        idx:i+1,
-        nombre:nom,
-        porcentaje:!isNaN(por)?por:0,
-        cartonesGratis:!isNaN(cart)?cart:0,
-        premioImagen:img,
-        posiciones:pos
-      });
-      if(!isNaN(por)&&por>0){ total+=por; conPorcentaje++; }
+      const obj={idx:i+1,nombre:nom,posiciones:pos};
+      if(!isNaN(por)&&por>0){obj.porcentaje=por;total+=por;conPorcentaje++;}
+      if(!isNaN(cart)&&cart>0){obj.cartonesGratis=cart;}
+      if(img){obj.premioImagen=img;}
+      formas.push(obj);
     }
     if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{

--- a/gestionsorteos.html
+++ b/gestionsorteos.html
@@ -159,29 +159,30 @@
   </div>
   <table id="tabla-sorteos">
     <thead>
-      <tr>
-        <th>N°</th>
-        <th><input type="text" id="filtro-nombre" placeholder="Nombre de sorteo" style="width:100%;box-sizing:border-box;"></th>
-        <th>
-          <div class="fecha-container">
-            <input type="date" id="filtro-fecha" style="width:100%;">
-            <span class="fecha-placeholder">Fecha</span>
-          </div>
-        </th>
-        <th>
-          <select id="filtro-estado" style="width:100%;">
-            <option value="">Estado</option>
-            <option value="Activo">Activo</option>
-            <option value="Inactivo">Inactivo</option>
-            <option value="Finalizado">Finalizado</option>
-            <option value="Archivado">Archivado</option>
-          </select>
-        </th>
-        <th style="text-align:center;">&#10004;</th>
-      </tr>
-    </thead>
-    <tbody></tbody>
-  </table>
+        <tr>
+          <th>N°</th>
+          <th><input type="text" id="filtro-nombre" placeholder="Nombre de sorteo" style="width:100%;box-sizing:border-box;"></th>
+          <th>
+            <div class="fecha-container">
+              <input type="date" id="filtro-fecha" style="width:100%;">
+              <span class="fecha-placeholder">Fecha</span>
+            </div>
+          </th>
+          <th>
+            <select id="filtro-estado" style="width:100%;">
+              <option value="">Estado</option>
+              <option value="Activo">Activo</option>
+              <option value="Inactivo">Inactivo</option>
+              <option value="Finalizado">Finalizado</option>
+              <option value="Archivado">Archivado</option>
+            </select>
+          </th>
+          <th>Premios</th>
+          <th style="text-align:center;">&#10004;</th>
+        </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -192,9 +193,23 @@
   const tbody=document.querySelector('#tabla-sorteos tbody');
 
   async function cargarDatos(){
-    const snap=await db.collection('sorteos').get();
+    const [sorteosSnap, formasSnap] = await Promise.all([
+      db.collection('sorteos').get(),
+      db.collection('formas').get()
+    ]);
+    const mapaFormas={};
+    formasSnap.forEach(f=>{
+      const d=f.data();
+      const sid=d.sorteoId;
+      if(!mapaFormas[sid]) mapaFormas[sid]=[];
+      mapaFormas[sid].push(d);
+    });
     datos.length=0;
-    snap.forEach(doc=>datos.push({id:doc.id,...doc.data()}));
+    sorteosSnap.forEach(doc=>{
+      const info={id:doc.id,...doc.data()};
+      info.formas=mapaFormas[doc.id]||[];
+      datos.push(info);
+    });
     datos.sort((a,b)=>{const fa=a.fecha||'';const fb=b.fecha||'';return fa>fb?-1:fa<fb?1:0;});
     filtrar();
   }
@@ -205,8 +220,14 @@
     lista.forEach(d=>{
       let fecha=d.fecha||'';
       if(fecha.includes('-')) fecha=fecha.split('-').reverse().join('/');
+      const premios=(d.formas||[]).map(f=>{
+        if(f.porcentaje) return `${f.nombre}: ${f.porcentaje}%`;
+        if(f.cartonesGratis) return `${f.nombre}: ${f.cartonesGratis} cartones`;
+        if(f.premioImagen) return `${f.nombre}: imagen`;
+        return '';
+      }).filter(Boolean).join('<br>');
       const tr=document.createElement('tr');
-      tr.innerHTML=`<td>${idx++}</td><td>${d.nombre}</td><td>${fecha}</td><td>${d.estado}</td><td style="text-align:center;"><input type="checkbox" data-id="${d.id}"></td>`;
+      tr.innerHTML=`<td>${idx++}</td><td>${d.nombre}</td><td>${fecha}</td><td>${d.estado}</td><td>${premios}</td><td style="text-align:center;"><input type="checkbox" data-id="${d.id}"></td>`;
       const color=d.estado==='Activo'?'green':
                    d.estado==='Inactivo'?'red':
                    d.estado==='Archivado'?'brown':

--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -172,7 +172,7 @@
     if(!valorVal){alert('Coloca un valor para el cart\u00f3n');valorInput.focus();return;}
     const cierre=parseInt(cierreVal);
     const valor=parseFloat(valorVal);
-    const formas=[];let total=0;
+    const formas=[];let total=0;let conPorcentaje=0;
     const divs=document.querySelectorAll('.forma-item');
     for(let i=0;i<divs.length;i++){
       const div=divs[i];
@@ -200,17 +200,13 @@
         div.querySelector('.carton').scrollIntoView({behavior:'smooth'});
         return;
       }
-      formas.push({
-        idx:i+1,
-        nombre:nom,
-        porcentaje:!isNaN(por)?por:0,
-        cartonesGratis:!isNaN(cart)?cart:0,
-        premioImagen:img,
-        posiciones:pos
-      });
-      if(!isNaN(por)&&por>0) total+=por;
+      const obj={idx:i+1,nombre:nom,posiciones:pos};
+      if(!isNaN(por)&&por>0){obj.porcentaje=por;total+=por;conPorcentaje++;}
+      if(!isNaN(cart)&&cart>0){obj.cartonesGratis=cart;}
+      if(img){obj.premioImagen=img;}
+      formas.push(obj);
     }
-    if(total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
+    if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
       const sorteoRef=await db.collection('sorteos').add({nombre,tipo,fecha,hora,cierreMinutos:cierre,valorCarton:valor,estado});
       const batch=db.batch();


### PR DESCRIPTION
## Resumen
- Permite registrar porcentajes opcionales, cartones gratis e imágenes de premio para cada forma de sorteo.
- Ajusta la edición y creación de sorteos para almacenar solo los campos de premio definidos.
- Muestra un resumen de premios en la tabla de administración de sorteos.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896967c5b0083269e1f5bc5a01a424f