### PR TITLE
Mejoras visuales en formularios de sorteo

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -65,31 +65,45 @@
     .row{display:flex;justify-content:center;gap:5px;width:250px;margin:3px auto;}
     .row input{flex:1;width:100%;}
     .toggle-group{display:flex;justify-content:center;gap:5px;margin:3px 0;}
-    .toggle-group button{flex:1;max-width:120px;padding:5px 10px;border-radius:20px;border:1px solid #ccc;background:#ddd;font-family:'Bangers',cursive;font-size:0.9rem;cursor:pointer;text-shadow:1px 1px 2px #000;color:#000;}
-    .toggle-group button.active{background:#ff8c00;color:#fff;}
-    .tabs{width:95%;max-width:350px;margin-top:10px;}
+    .toggle-group button{flex:1;max-width:120px;padding:5px 10px;border-radius:20px;border:1px solid #ccc;font-family:'Bangers',cursive;font-size:0.9rem;cursor:pointer;text-shadow:1px 1px 2px #000;color:#000;}
+    #tipo-sorteo-group button[data-value="Sorteo Especial"]{background:linear-gradient(#ff8c00,#ffd9a5);}
+    #tipo-sorteo-group button[data-value="Sorteo Diario"]{background:linear-gradient(#bfbfbf,#ffffff);}
+    #estado-group button[data-value="Activo"]{background:linear-gradient(#00a000,#ffffff);}
+    #estado-group button[data-value="Inactivo"]{background:linear-gradient(#ff0000,#ffffff);}
+    #estado-group button[data-value="Archivado"]{background:linear-gradient(#8b4513,#ffffff);color:#fff;}
+    .toggle-group button.active{filter:brightness(1.2);}
+    .tabs{width:100%;max-width:600px;margin-top:10px;}
     .tab-buttons{display:flex;justify-content:center;}
-    .tab-buttons button{flex:1;padding:6px 0;margin:0 2px;font-family:'Bangers',cursive;font-size:0.9rem;border:1px solid #333;border-bottom:none;border-radius:10px 10px 0 0;color:white;cursor:pointer;text-shadow:2px 2px 4px #000;background:#007bff;}
-    .tab-buttons button.active{filter:brightness(1.2);position:relative;top:1px;}
-    .tab-content{display:none;border:1px solid #333;border-radius:0 10px 10px 10px;padding:5px;}
+    .tab-buttons button{flex:1;padding:6px 0;margin:0 2px;font-family:'Bangers',cursive;font-size:1rem;border:1px solid #333;border-bottom:none;border-radius:10px 10px 0 0;color:white;cursor:pointer;text-shadow:2px 2px 4px #000;}
+    .tab-buttons button.active{filter:brightness(1.1);position:relative;top:1px;}
+    .tab-content{display:none;border:1px solid #333;border-radius:0 10px 10px 10px;padding:10px;position:relative;overflow:hidden;}
     .tab-content.active{display:block;}
-    .carton{
-      margin:5px auto;
-      border-collapse:collapse;
-      background:#fff url('https://i.imgur.com/0XKQJ5N.png') center/cover no-repeat;
-      border-radius:20px;
-      padding:5px;
-      box-shadow:0 0 15px rgba(0,0,0,0.6);
-    }
-    .carton th,.carton td{border:2px solid black;width:40px;height:40px;text-align:center;font-weight:bold;}
+    .tab-buttons button[data-tab="forma1"], .forma-item1{background:linear-gradient(#90ee90,#ffffff);}
+    .tab-buttons button[data-tab="forma2"], .forma-item2{background:linear-gradient(#fffacd,#ffffff);}
+    .tab-buttons button[data-tab="forma3"], .forma-item3{background:linear-gradient(#add8e6,#ffffff);}
+    .tab-buttons button[data-tab="forma4"], .forma-item4{background:linear-gradient(#d8b0ff,#ffffff);}
+    .tab-buttons button[data-tab="forma5"], .forma-item5{background:linear-gradient(#ffcc99,#ffffff);}
+    .forma-item1::before,.forma-item2::before,.forma-item3::before,.forma-item4::before,.forma-item5::before{position:absolute;top:-20px;left:-20px;width:200%;height:200%;transform:rotate(-45deg);color:rgba(0,0,0,0.2);font-size:2rem;white-space:pre;pointer-events:none;}
+    .forma-item1::before{content:"Forma 1 Forma 1 Forma 1 Forma 1 Forma 1 Forma 1 ";}
+    .forma-item2::before{content:"Forma 2 Forma 2 Forma 2 Forma 2 Forma 2 Forma 2 ";}
+    .forma-item3::before{content:"Forma 3 Forma 3 Forma 3 Forma 3 Forma 3 Forma 3 ";}
+    .forma-item4::before{content:"Forma 4 Forma 4 Forma 4 Forma 4 Forma 4 Forma 4 ";}
+    .forma-item5::before{content:"Forma 5 Forma 5 Forma 5 Forma 5 Forma 5 Forma 5 ";}
+    .carton-wrapper{display:inline-block;perspective:1000px;margin:5px auto;}
+    .carton-inner{position:relative;transition:transform 0.6s;transform-style:preserve-3d;}
+    .carton-wrapper.flipped .carton-inner{transform:rotateY(180deg);}
+    .carton{margin:0;border-collapse:collapse;background:url('https://i.imgur.com/0XKQJ5N.png') center/cover no-repeat;border-radius:20px;border:15px solid #004d00;padding:5px;box-shadow:0 0 15px rgba(0,0,0,0.6);backface-visibility:hidden;}
+    .carton th,.carton td{background:transparent;border:2px solid black;width:60px;height:60px;text-align:center;font-weight:bold;}
+    .carton th{font-size:2rem;cursor:pointer;}
     .carton td{cursor:pointer;}
     .carton td.selected{background-color:orange;color:white;}
     .carton td.free{background-color:#ffcc00;}
-    .carton th{background:#f2f2f2;position:relative;perspective:600px;cursor:pointer;}
-    .carton th .flip{position:relative;width:100%;height:100%;transform-style:preserve-3d;transition:transform 0.6s;}
-    .carton th.flipped .flip{transform:rotateY(180deg);}
-    .carton th .front,.carton th .back{position:absolute;width:100%;height:100%;backface-visibility:hidden;display:flex;align-items:center;justify-content:center;font-size:1.2rem;}
-    .carton th .back{transform:rotateY(180deg);}
+    .carton-back{position:absolute;top:0;left:0;width:100%;height:100%;backface-visibility:hidden;transform:rotateY(180deg);display:flex;align-items:center;justify-content:center;background:url('https://i.imgur.com/0XKQJ5N.png') center/cover no-repeat;border:15px solid #004d00;border-radius:20px;box-shadow:0 0 15px rgba(0,0,0,0.6);}
+    .carton-back img{width:60%;opacity:0.3;}
+    .carton th:first-child{border-top-left-radius:10px;}
+    .carton th:last-child{border-top-right-radius:10px;}
+    .carton tbody tr:last-child td:first-child{border-bottom-left-radius:10px;}
+    .carton tbody tr:last-child td:last-child{border-bottom-right-radius:10px;}
     .imagen-wrapper{display:flex;justify-content:center;align-items:center;gap:5px;width:250px;margin:3px auto;}
     .imagen-wrapper input{flex:1;}
     .ver-imagen{display:none;margin-top:3px;font-size:0.9rem;color:#007bff;text-decoration:underline;cursor:pointer;}
@@ -136,8 +150,11 @@
     const htr=document.createElement('tr');
     letters.forEach(l=>{
       const th=document.createElement('th');
-      th.innerHTML=`<div class="flip"><span class="front">${l}</span><span class="back"><img src="https://i.imgur.com/twjhNtZ.png" alt="logo" style="width:30px;height:30px;"></span></div>`;
-      th.addEventListener('click',()=>{th.classList.toggle('flipped');});
+      th.textContent=l;
+      th.addEventListener('click',()=>{
+        const wrapper=table.closest('.carton-wrapper');
+        if(wrapper) wrapper.classList.toggle('flipped');
+      });
       htr.appendChild(th);
     });
     thead.appendChild(htr);
@@ -178,7 +195,7 @@
 
       const div=document.createElement('div');
       div.id=`forma${i}`;
-      div.className=`tab-content forma-item${i===1?' active':''}`;
+      div.className=`tab-content forma-item${i}${i===1?' active':''}`;
       div.innerHTML=`<input class="nombre-forma" placeholder="Nombre de forma">\
       <div class="row"><input type="number" class="porcentaje-forma" placeholder="% Premio">\
       <input type="number" class="cartones-forma" placeholder="Cartones gratis"></div>\
@@ -187,7 +204,7 @@
         <button type="button" class="subir-imagen">Subir</button></div>\
       <a class="ver-imagen">Ver imagen</a>\
       <input type="hidden" class="imagen-url">\
-      <table class="carton" data-idx="${i}"></table>`;
+      <div class="carton-wrapper"><div class="carton-inner"><table class="carton" data-idx="${i}"></table><div class="carton-back"><img src="https://i.imgur.com/twjhNtZ.png" alt="logo"></div></div></div>`;
       tabs.appendChild(div);
       const table=div.querySelector('table');
       crearTabla(table);


### PR DESCRIPTION
## Resumen
- Se estilizaron los toggles de tipo y estado con colores distintivos.
- Se ampliaron y personalizaron las pestañas de formas con degradados y texto diagonal.
- El cartón ahora muestra fondo visible, bordes redondeados y efecto de volteo completo con logo central.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898160351548326be41835e80cc9b01