### PR TITLE
Ajusta estilos y tamaño del cartón en Nuevo Sorteo

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -65,25 +65,25 @@
     .row{display:flex;justify-content:center;gap:5px;width:250px;margin:3px auto;}
     .row input{flex:1;width:100%;}
     .toggle-group{display:flex;justify-content:center;gap:5px;margin:3px 0;}
-    .toggle-group button{flex:1;max-width:120px;padding:5px 10px;border-radius:20px;border:1px solid #ccc;font-family:'Bangers',cursive;font-size:0.9rem;cursor:pointer;text-shadow:1px 1px 2px #000;color:#000;}
-    #tipo-sorteo-group button[data-value="Sorteo Especial"]{background:linear-gradient(#ff8c00,#ffd9a5);}
-    #tipo-sorteo-group button[data-value="Sorteo Diario"]{background:linear-gradient(#bfbfbf,#ffffff);}
-    #estado-group button[data-value="Activo"]{background:linear-gradient(#00a000,#ffffff);}
-    #estado-group button[data-value="Inactivo"]{background:linear-gradient(#ff0000,#ffffff);}
-    #estado-group button[data-value="Archivado"]{background:linear-gradient(#8b4513,#ffffff);color:#fff;}
-    .toggle-group button.active{filter:brightness(1.2);}
+    .toggle-group button{flex:1;max-width:120px;padding:5px 10px;border-radius:20px;border:1px solid #ccc;font-family:'Bangers',cursive;font-size:0.9rem;cursor:pointer;background:#808080;color:#fff;text-shadow:1px 1px 2px #333;}
+    .toggle-group button.active{filter:brightness(1.2);text-shadow:1px 1px 2px #000;}
+    #tipo-sorteo-group button.active[data-value="Sorteo Especial"]{background:linear-gradient(#ff8c00,#ffd9a5);}
+    #tipo-sorteo-group button.active[data-value="Sorteo Diario"]{background:linear-gradient(#bfbfbf,#ffffff);}
+    #estado-group button.active[data-value="Activo"]{background:linear-gradient(#00a000,#ffffff);}
+    #estado-group button.active[data-value="Inactivo"]{background:linear-gradient(#ff0000,#ffffff);}
+    #estado-group button.active[data-value="Archivado"]{background:linear-gradient(#8b4513,#ffffff);}
     .tabs{width:100%;max-width:600px;margin-top:10px;}
     .tab-buttons{display:flex;justify-content:center;}
-    .tab-buttons button{flex:1;padding:6px 0;margin:0 2px;font-family:'Bangers',cursive;font-size:1rem;border:1px solid #333;border-bottom:none;border-radius:10px 10px 0 0;color:white;cursor:pointer;text-shadow:2px 2px 4px #000;}
-    .tab-buttons button.active{filter:brightness(1.1);position:relative;top:1px;}
+    .tab-buttons button{flex:1;padding:6px 0;margin:0 2px;font-family:'Bangers',cursive;font-size:1rem;border:1px solid #333;border-bottom:none;border-radius:10px 10px 0 0;color:white;cursor:pointer;background:#808080;text-shadow:1px 1px 2px #333;}
+    .tab-buttons button.active{filter:brightness(1.1);position:relative;top:1px;text-shadow:1px 1px 2px #000;}
     .tab-content{display:none;border:1px solid #333;border-radius:0 10px 10px 10px;padding:10px;position:relative;overflow:hidden;}
     .tab-content.active{display:block;}
-    .tab-buttons button[data-tab="forma1"], .forma-item1{background:linear-gradient(#90ee90,#ffffff);}
-    .tab-buttons button[data-tab="forma2"], .forma-item2{background:linear-gradient(#fffacd,#ffffff);}
-    .tab-buttons button[data-tab="forma3"], .forma-item3{background:linear-gradient(#add8e6,#ffffff);}
-    .tab-buttons button[data-tab="forma4"], .forma-item4{background:linear-gradient(#d8b0ff,#ffffff);}
-    .tab-buttons button[data-tab="forma5"], .forma-item5{background:linear-gradient(#ffcc99,#ffffff);}
-    .forma-item1::before,.forma-item2::before,.forma-item3::before,.forma-item4::before,.forma-item5::before{position:absolute;top:-20px;left:-20px;width:200%;height:200%;transform:rotate(-45deg);color:rgba(0,0,0,0.2);font-size:2rem;white-space:pre;pointer-events:none;}
+    .tab-buttons button.active[data-tab="forma1"], .forma-item1{background:linear-gradient(#90ee90,#ffffff);}
+    .tab-buttons button.active[data-tab="forma2"], .forma-item2{background:linear-gradient(#fffacd,#ffffff);}
+    .tab-buttons button.active[data-tab="forma3"], .forma-item3{background:linear-gradient(#add8e6,#ffffff);}
+    .tab-buttons button.active[data-tab="forma4"], .forma-item4{background:linear-gradient(#d8b0ff,#ffffff);}
+    .tab-buttons button.active[data-tab="forma5"], .forma-item5{background:linear-gradient(#ffcc99,#ffffff);}
+    .forma-item1::before,.forma-item2::before,.forma-item3::before,.forma-item4::before,.forma-item5::before{position:absolute;top:-20px;left:-20px;width:200%;height:200%;transform:rotate(-45deg);color:rgba(0,0,0,0.12);font-size:1rem;white-space:pre;pointer-events:none;}
     .forma-item1::before{content:"Forma 1 Forma 1 Forma 1 Forma 1 Forma 1 Forma 1 ";}
     .forma-item2::before{content:"Forma 2 Forma 2 Forma 2 Forma 2 Forma 2 Forma 2 ";}
     .forma-item3::before{content:"Forma 3 Forma 3 Forma 3 Forma 3 Forma 3 Forma 3 ";}
@@ -92,14 +92,14 @@
     .carton-wrapper{display:inline-block;perspective:1000px;margin:5px auto;}
     .carton-inner{position:relative;transition:transform 0.6s;transform-style:preserve-3d;}
     .carton-wrapper.flipped .carton-inner{transform:rotateY(180deg);}
-    .carton{margin:0;border-collapse:collapse;background:url('https://i.imgur.com/0XKQJ5N.png') center/cover no-repeat;border-radius:20px;border:15px solid #004d00;padding:5px;box-shadow:0 0 15px rgba(0,0,0,0.6);backface-visibility:hidden;}
-    .carton th,.carton td{background:transparent;border:2px solid black;width:60px;height:60px;text-align:center;font-weight:bold;}
-    .carton th{font-size:2rem;cursor:pointer;}
+    .carton{margin:0;border-collapse:collapse;background:linear-gradient(#ffffff,#cccccc);border-radius:20px;border:8px solid #004d00;padding:3px;box-shadow:0 0 15px rgba(0,0,0,0.6);backface-visibility:hidden;}
+    .carton th,.carton td{background:transparent;border:2px solid black;width:40px;height:40px;text-align:center;font-weight:bold;}
+    .carton th{font-size:1.5rem;cursor:pointer;}
     .carton td{cursor:pointer;}
     .carton td.selected{background-color:orange;color:white;}
     .carton td.free{background-color:#ffcc00;}
-    .carton-back{position:absolute;top:0;left:0;width:100%;height:100%;backface-visibility:hidden;transform:rotateY(180deg);display:flex;align-items:center;justify-content:center;background:url('https://i.imgur.com/0XKQJ5N.png') center/cover no-repeat;border:15px solid #004d00;border-radius:20px;box-shadow:0 0 15px rgba(0,0,0,0.6);}
-    .carton-back img{width:60%;opacity:0.3;}
+    .carton-back{position:absolute;top:0;left:0;width:100%;height:100%;backface-visibility:hidden;transform:rotateY(180deg);display:flex;align-items:center;justify-content:center;background:linear-gradient(#ffffff,#cccccc);border:8px solid #004d00;border-radius:20px;box-shadow:0 0 15px rgba(0,0,0,0.6);}
+    .carton-back img{width:50%;opacity:0.3;}
     .carton th:first-child{border-top-left-radius:10px;}
     .carton th:last-child{border-top-right-radius:10px;}
     .carton tbody tr:last-child td:first-child{border-bottom-left-radius:10px;}
@@ -206,8 +206,12 @@
       <input type="hidden" class="imagen-url">\
       <div class="carton-wrapper"><div class="carton-inner"><table class="carton" data-idx="${i}"></table><div class="carton-back"><img src="https://i.imgur.com/twjhNtZ.png" alt="logo"></div></div></div>`;
       tabs.appendChild(div);
-      const table=div.querySelector('table');
+      const wrapper=div.querySelector('.carton-wrapper');
+      const table=wrapper.querySelector('table');
       crearTabla(table);
+      wrapper.querySelector('.carton-back').addEventListener('click',()=>{
+        wrapper.classList.toggle('flipped');
+      });
     }
 
     tabs.querySelectorAll('.tab-buttons button').forEach(btn=>{


### PR DESCRIPTION
## Resumen
- Los botones de alternancia ahora solo muestran su color cuando están activos y usan texto blanco con sombras adecuadas.
- Se reemplazaron las imágenes del cartón por un degradado blanco a gris y se redujeron sus dimensiones para evitar desbordes.
- El reverso del cartón vuelve a la vista frontal al tocarse y cada pestaña muestra "Forma" de fondo con 12% de opacidad.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68981a6047e08326abd1aaac08450d0d