### PR TITLE
Reducir tamaño de celdas del cartón en nuevos sorteos

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -85,16 +85,16 @@
     .tab-buttons button.active[data-tab="forma5"], .forma-item5{background:linear-gradient(#ffcc99,#ffffff);}
     .forma-label{position:absolute;left:-35px;top:50%;transform:translateY(-50%);writing-mode:vertical-rl;text-orientation:upright;font-weight:bold;font-size:0.8rem;}
     .carton-box{border:2px solid #004d00;border-radius:20px;padding:5px;display:flex;justify-content:center;margin:5px auto;overflow:hidden;}
-    .carton-wrapper{display:inline-block;perspective:1000px;}
-    .carton-inner{position:relative;transition:transform 0.6s;transform-style:preserve-3d;}
+    .carton-wrapper{display:inline-block;perspective:1000px;border-radius:20px;overflow:hidden;}
+    .carton-inner{position:relative;transition:transform 0.6s;transform-style:preserve-3d;border-radius:20px;}
     .carton-wrapper.flipped .carton-inner{transform:rotateY(180deg);}
-    .carton{margin:0;border-collapse:collapse;background:linear-gradient(#ffffff,#cccccc);border-radius:20px;border:8px solid #004d00;padding:3px;box-shadow:0 0 15px rgba(0,0,0,0.6);backface-visibility:hidden;table-layout:fixed;box-sizing:border-box;}
-    .carton th,.carton td{background:transparent;border:2px solid black;width:80px;height:80px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0;box-sizing:border-box;}
-    .carton th{font-size:2.5rem;cursor:pointer;color:#ff6600;background:linear-gradient(#cccccc,#ffffff);text-shadow:2px 2px 0 #000;}
+    .carton{margin:0;border-collapse:collapse;background:linear-gradient(#ffffff,#cccccc);border-radius:20px;border:6px solid #004d00;padding:2px;box-shadow:0 0 15px rgba(0,0,0,0.6);backface-visibility:hidden;table-layout:fixed;box-sizing:border-box;}
+    .carton th,.carton td{background:transparent;border:2px solid black;width:60px;height:60px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0;margin:0;box-sizing:border-box;}
+    .carton th{font-size:2rem;cursor:pointer;color:#ff6600;background:linear-gradient(#cccccc,#ffffff);text-shadow:2px 2px 0 #000;}
     .carton td{cursor:pointer;}
     .carton td.selected{background-color:orange;color:white;}
     .carton td.free{background-color:#ffcc00;}
-    .carton-back{position:absolute;top:0;left:0;width:100%;height:100%;backface-visibility:hidden;transform:rotateY(180deg);display:flex;align-items:center;justify-content:center;background:linear-gradient(#ffffff,#cccccc);border:8px solid #004d00;border-radius:20px;box-shadow:0 0 15px rgba(0,0,0,0.6);padding:3px;box-sizing:border-box;}
+    .carton-back{position:absolute;top:0;left:0;width:100%;height:100%;backface-visibility:hidden;transform:rotateY(180deg);display:flex;align-items:center;justify-content:center;background:linear-gradient(#ffffff,#cccccc);border:6px solid #004d00;border-radius:20px;box-shadow:0 0 15px rgba(0,0,0,0.6);padding:2px;box-sizing:border-box;}
     .carton-back img{width:70%;opacity:0.3;}
     .carton th:first-child{border-top-left-radius:10px;}
     .carton th:last-child{border-top-right-radius:10px;}


### PR DESCRIPTION
## Resumen
- Ajuste de estilos para que el cartón tenga celdas cuadradas reducidas al 75%.
- Redondeo de bordes en todos los contenedores del cartón al voltearse.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68982ae9b8948326840b83e8106f0da1