### PR TITLE
Mejoras de archivo e interfaz en sorteos y transacciones

### DIFF
--- a/gestionsorteos.html
+++ b/gestionsorteos.html
@@ -230,6 +230,23 @@
   const tbody=document.querySelector('#tabla-sorteos tbody');
   let mostrarArch=false;
 
+  function actualizarArchivarBtn(){
+    const btn=document.getElementById('archivar-btn');
+    const icon=btn.querySelector('.icon');
+    const txt=btn.querySelector('.txt');
+    if(mostrarArch){
+      txt.textContent='Desarchivar';
+      icon.innerHTML='&#128193;';
+      icon.style.color='blue';
+      txt.style.color='blue';
+    }else{
+      txt.textContent='Archivar';
+      icon.innerHTML='&#128194;';
+      icon.style.color='brown';
+      txt.style.color='brown';
+    }
+  }
+
   async function cargarDatos(){
     const [sorteosSnap, formasSnap] = await Promise.all([
       db.collection('sorteos').get(),
@@ -310,6 +327,7 @@
   document.getElementById('archivo-btn').addEventListener('click',()=>{
     mostrarArch=!mostrarArch;
     document.getElementById('archivo-btn').classList.toggle('archivo-activo',mostrarArch);
+    actualizarArchivarBtn();
     filtrar();
   });
 
@@ -330,19 +348,36 @@
   });
   document.getElementById('archivar-btn').addEventListener('click',async ()=>{
     const chks=document.querySelectorAll('#tabla-sorteos input[type=checkbox]:checked');
-    if(chks.length===0){alert('Debes seleccionar al menos un sorteo para poder archivarlo');return;}
-    const ids=[];let tieneActivo=false;
-    chks.forEach(c=>{
-      if(c.dataset.estado==='Activo'){tieneActivo=true;c.checked=false;}
-      else ids.push(c.dataset.id);
-    });
-    if(tieneActivo){alert('No pueden archivarse Sorteos Activos');}
-    if(!ids.length) return;
-    const batch=db.batch();
-    ids.forEach(id=>batch.update(db.collection('sorteos').doc(id),{condicion:'ARCHIVADO'}));
-    await batch.commit();
+    if(chks.length===0){alert('Debes seleccionar al menos un sorteo');return;}
+    if(mostrarArch){
+      const ids=[];
+      chks.forEach(c=>ids.push(c.dataset.id));
+      const batch=db.batch();
+      ids.forEach(id=>batch.update(db.collection('sorteos').doc(id),{condicion:'VISIBLE'}));
+      await batch.commit();
+    }else{
+      const ids=[];let tieneActivo=false;
+      chks.forEach(c=>{
+        if(c.dataset.estado==='Activo'){tieneActivo=true;c.checked=false;}
+        else ids.push(c.dataset.id);
+      });
+      if(tieneActivo){alert('No pueden archivarse Sorteos Activos');}
+      if(!ids.length) return;
+      const batch=db.batch();
+      ids.forEach(id=>batch.update(db.collection('sorteos').doc(id),{condicion:'ARCHIVADO'}));
+      await batch.commit();
+    }
     cargarDatos();
   });
+
+  function formatoHora12(h){
+    if(!h) return '';
+    const [hh,mm]=h.split(':');
+    let hnum=parseInt(hh,10);
+    const ampm=hnum>=12?'PM':'AM';
+    hnum=hnum%12; if(hnum===0) hnum=12;
+    return `${hnum}:${mm} ${ampm}`;
+  }
 
   function mostrarPremios(formas){
     const modal=document.getElementById('modal-premios');
@@ -377,7 +412,7 @@
     const cont=document.getElementById('modal-info-content');
     cont.innerHTML=`<div style="font-weight:bold;color:darkgreen;">Tipo de Sorteo: ${d.tipo||''}</div>`+
                    `<div style="font-weight:bold;color:darkblue;">Valor Cartón: ${d.valorCarton||''}</div>`+
-                   `<div style="font-weight:bold;color:darkorange;">Hora Sorteo: ${d.hora||''}</div>`+
+                   `<div style="font-weight:bold;color:darkorange;">Hora Sorteo: ${formatoHora12(d.hora)}</div>`+
                    `<div style="font-weight:bold;color:darkorange;">Minutos cierre: ${d.cierreMinutos||''}</div>`;
     modal.style.display='flex';
   }
@@ -391,6 +426,7 @@
   });
 
   document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='admin.html';});
+  actualizarArchivarBtn();
   cargarDatos();
   </script>
 </body>

--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -18,7 +18,7 @@
       min-height: 100vh;
       text-align: center;
       font-family: 'Bangers', cursive;
-      padding-top: 20px;
+      padding-top: 5px;
     }
     .menu-btn {
       width: 250px;
@@ -72,30 +72,30 @@
     #estado-group button.active[data-value="Activo"]{background:linear-gradient(#00a000,#ffffff);}
     #estado-group button.active[data-value="Inactivo"]{background:linear-gradient(#ff0000,#ffffff);}
     #estado-group button.active[data-value="Archivado"]{background:linear-gradient(#8b4513,#ffffff);}
-    .tabs{width:calc(100% - 30px);max-width:600px;margin:10px auto;}
+    .tabs{width:calc(100% - 30px);max-width:600px;margin:5px auto;}
     .tab-buttons{display:flex;justify-content:center;}
-    .tab-buttons button{flex:1;padding:6px 0;margin:0 2px;font-family:'Bangers',cursive;font-size:1rem;border:1px solid #333;border-bottom:none;border-radius:10px 10px 0 0;color:white;cursor:pointer;background:#808080;text-shadow:1px 1px 2px #333;}
+    .tab-buttons button{flex:1;padding:6px 0;margin:0 2px;font-family:'Bangers',cursive;font-size:1rem;border:1px solid #333;border-bottom:none;border-radius:0;color:white;cursor:pointer;background:#808080;text-shadow:1px 1px 2px #333;}
     .tab-buttons button.active{filter:brightness(1.1);position:relative;top:1px;text-shadow:1px 1px 2px #000;}
-    .tab-content{display:none;border:1px solid #333;border-radius:20px;padding:10px;position:relative;overflow:hidden;}
+    .tab-content{display:none;border:1px solid #333;border-radius:0 0 20px 20px;padding:10px;position:relative;overflow:hidden;gap:5px;}
     .tab-content.active{display:flex;flex-direction:column;align-items:center;}
+    .tab-content input,.tab-content .row,.tab-content .imagen-wrapper,.tab-content .ver-imagen{margin:0;}
     .tab-buttons button.active[data-tab="forma1"], .forma-item1{background:linear-gradient(#90ee90,#ffffff);}
     .tab-buttons button.active[data-tab="forma2"], .forma-item2{background:linear-gradient(#fffacd,#ffffff);}
     .tab-buttons button.active[data-tab="forma3"], .forma-item3{background:linear-gradient(#add8e6,#ffffff);}
     .tab-buttons button.active[data-tab="forma4"], .forma-item4{background:linear-gradient(#d8b0ff,#ffffff);}
     .tab-buttons button.active[data-tab="forma5"], .forma-item5{background:linear-gradient(#ffcc99,#ffffff);}
     .forma-label{position:absolute;left:-35px;top:50%;transform:translateY(-50%);writing-mode:vertical-rl;text-orientation:upright;font-weight:bold;font-size:0.8rem;}
-    .carton-box{border:2px solid #004d00;border-radius:20px;padding:5px;display:flex;justify-content:center;margin:5px auto;overflow:hidden;}
-    .carton-wrapper{display:inline-block;perspective:1000px;border-radius:20px;overflow:hidden;}
-    .carton-inner{position:relative;transition:transform 0.6s;transform-style:preserve-3d;border-radius:20px;}
-    .carton-wrapper.flipped .carton-inner{transform:rotateY(180deg);}
-    .carton{margin:0;border-collapse:collapse;background:linear-gradient(#ffffff,#cccccc);border-radius:20px;border:6px solid #004d00;padding:2px;box-shadow:0 0 15px rgba(0,0,0,0.6);backface-visibility:hidden;table-layout:fixed;box-sizing:border-box;}
-    .carton th,.carton td{background:transparent;border:2px solid black;width:60px;height:60px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0;margin:0;box-sizing:border-box;}
+    .carton-box{display:flex;justify-content:center;margin:5px auto;perspective:1000px;}
+    .carton-wrapper{position:relative;border-radius:20px;transition:transform 0.6s;transform-style:preserve-3d;box-shadow:0 0 15px rgba(0,0,0,0.8);overflow:hidden;}
+    .carton-wrapper.flipped{transform:rotateY(180deg);}
+    .carton{margin:0;border-collapse:collapse;background:linear-gradient(#ffffff,#cccccc);border-radius:20px;backface-visibility:hidden;table-layout:fixed;box-sizing:border-box;}
+    .carton th,.carton td{background:transparent;border:2px solid black;width:50px;height:50px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0;margin:0;box-sizing:border-box;}
     .carton th{font-size:2rem;cursor:pointer;color:#ff6600;background:linear-gradient(#cccccc,#ffffff);text-shadow:2px 2px 0 #000;}
     .carton td{cursor:pointer;}
     .carton td.selected{background-color:orange;color:white;}
     .carton td.free{background-color:#ffcc00;}
-    .carton-back{position:absolute;top:0;left:0;width:100%;height:100%;backface-visibility:hidden;transform:rotateY(180deg);display:flex;align-items:center;justify-content:center;background:linear-gradient(#ffffff,#cccccc);border:6px solid #004d00;border-radius:20px;box-shadow:0 0 15px rgba(0,0,0,0.6);padding:2px;box-sizing:border-box;}
-    .carton-back img{width:70%;opacity:0.3;}
+    .carton-back{position:absolute;top:0;left:0;width:100%;height:100%;backface-visibility:hidden;transform:rotateY(180deg);display:flex;align-items:center;justify-content:center;background:linear-gradient(#ffffff,#cccccc);}
+    .carton-back img{width:100%;height:100%;opacity:0.3;object-fit:cover;}
     .carton th:first-child{border-top-left-radius:10px;}
     .carton th:last-child{border-top-right-radius:10px;}
     .carton tbody tr:last-child td:first-child{border-bottom-left-radius:10px;}
@@ -107,26 +107,51 @@
     .input-wrapper{display:flex;align-items:center;}
     .label-left{font-weight:bold;font-size:0.8rem;margin-right:3px;text-shadow:0 0 3px #fff;}
     .label-right{font-weight:bold;font-size:0.8rem;margin-left:3px;text-shadow:0 0 3px #fff;}
+    #fecha-label{font-size:1rem;color:#4b0082;text-shadow:1px 1px 2px #000;}
+    #fecha-sorteo{color:#4b0082;font-weight:bold;}
+    #hora-label{font-size:1rem;color:#00008b;text-shadow:1px 1px 2px #000;}
+    #hora-sorteo{color:#00008b;font-weight:bold;}
+    #minutos-label{font-size:1rem;color:#ff8c00;text-shadow:1px 1px 2px #000;}
+    #cierre-minutos{color:#ff8c00;font-weight:bold;}
+    #valor-label{font-size:1rem;color:#006400;text-shadow:1px 1px 2px #000;}
+    #valor-carton{color:#006400;font-weight:bold;}
     .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;}
     .modal img{max-width:90%;max-height:90%;}
     .modal span{position:absolute;top:10px;right:20px;font-size:2rem;color:#fff;cursor:pointer;}
+    @media (orientation:portrait){
+      #volver-btn{width:40px;}
+      #volver-btn .label{display:none;}
+    }
+
+    #guardar-sorteo-btn{
+      font-family:'Bangers',cursive;
+      font-size:1.2rem;
+      background:#0a8800;
+      color:white;
+      border:3px solid #FFD700;
+      border-radius:8px;
+      text-shadow:2px 2px 4px #000;
+      width:200px;
+      cursor:pointer;
+      margin:5px auto;
+    }
   </style>
 </head>
 <body>
-  <button id="volver-btn" class="menu-btn back-btn">&#9664; Volver</button>
-  <h2>Nuevo Sorteo</h2>
+  <button id="volver-btn" class="menu-btn back-btn"><span class="icon">&#9664;</span><span class="label">Volver</span></button>
+  <h2 style="margin-top:0;">Nuevo Sorteo</h2>
   <input id="nombre-sorteo" maxlength="70" placeholder="Nombre de sorteo">
   <div id="tipo-sorteo-group" class="toggle-group">
     <button data-value="Sorteo Especial">Especial</button>
     <button data-value="Sorteo Diario">Diario</button>
   </div>
   <div class="row">
-    <div class="input-wrapper"><span class="label-left">Fecha</span><input id="fecha-sorteo" type="date"></div>
-    <div class="input-wrapper"><input id="hora-sorteo" type="time"><span class="label-right">Hora</span></div>
+    <div class="input-wrapper"><span class="label-left" id="fecha-label">Fecha</span><input id="fecha-sorteo" type="date"></div>
+    <div class="input-wrapper"><input id="hora-sorteo" type="time"><span class="label-right" id="hora-label">Hora</span></div>
   </div>
   <div class="row">
-    <div class="input-wrapper"><span class="label-left">Minutos</span><input id="cierre-minutos" type="number" placeholder="Minutos antes de cerrar jugadas"></div>
-    <div class="input-wrapper"><input id="valor-carton" type="number" placeholder="Valor del Cartón"><span class="label-right">Valor</span></div>
+    <div class="input-wrapper"><span class="label-left" id="minutos-label">MINUTOS CIERRE</span><input id="cierre-minutos" type="number" placeholder="Minutos antes de cerrar jugadas"></div>
+    <div class="input-wrapper"><input id="valor-carton" type="number" placeholder="Valor del Cartón"><span class="label-right" id="valor-label">VALOR CARTÓN</span></div>
   </div>
   <div id="estado-group" class="toggle-group">
     <button data-value="Activo">Activo</button>
@@ -135,7 +160,7 @@
   </div>
   <div id="forms-container"></div>
   <div id="image-modal" class="modal"><span id="close-modal">&times;</span><img id="modal-img" src="" alt="premio"></div>
-  <button id="guardar-sorteo-btn" class="menu-btn">Guardar Sorteo</button>
+  <button id="guardar-sorteo-btn">Guardar Sorteo</button>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -204,7 +229,7 @@
         <button type="button" class="subir-imagen">Subir</button></div>\
       <a class="ver-imagen">Ver imagen</a>\
       <input type="hidden" class="imagen-url">\
-      <div class="carton-box"><div class="carton-wrapper"><div class="carton-inner"><table class="carton" data-idx="${i}"></table><div class="carton-back"><img src="https://i.imgur.com/twjhNtZ.png" alt="logo"></div></div></div></div>`;
+      <div class="carton-box"><div class="carton-wrapper"><table class="carton" data-idx="${i}"></table><div class="carton-back"><img src="https://i.imgur.com/twjhNtZ.png" alt="logo"></div></div></div>`;
       tabs.appendChild(div);
       const wrapper=div.querySelector('.carton-wrapper');
       const table=wrapper.querySelector('table');
@@ -291,7 +316,7 @@
     const tipoBtn=document.querySelector('#tipo-sorteo-group button.active');
     const estadoBtn=document.querySelector('#estado-group button.active');
     const tipo=tipoBtn?tipoBtn.dataset.value:'';
-    const estado=estadoBtn?estadoBtn.dataset.value:'';
+    let estado=estadoBtn?estadoBtn.dataset.value:'';
     const fecha=fechaInput.value;
     const hora=horaInput.value;
     const cierreVal=cierreInput.value;
@@ -304,6 +329,8 @@
     if(!valorVal){alert('Coloca un valor para el cartón');valorInput.focus();return;}
     const cierre=parseInt(cierreVal);
     const valor=parseFloat(valorVal);
+    const condicion = estado==='Archivado'?'ARCHIVADO':'VISIBLE';
+    if(estado==='Archivado') estado='Inactivo';
     const formas=[];let total=0;let conPorcentaje=0;
     const divs=document.querySelectorAll('.tab-content');
     for(let i=0;i<divs.length;i++){
@@ -340,7 +367,7 @@
     }
     if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
-      const sorteoRef=await db.collection('sorteos').add({nombre,tipo,fecha,hora,cierreMinutos:cierre,valorCarton:valor,estado,condicion:'VISIBLE'});
+      const sorteoRef=await db.collection('sorteos').add({nombre,tipo,fecha,hora,cierreMinutos:cierre,valorCarton:valor,estado,condicion});
       const batch=db.batch();
       formas.forEach(f=>{const ref=db.collection('formas').doc();batch.set(ref,{sorteoId:sorteoRef.id,...f});});
       await batch.commit();

--- a/transacciones.html
+++ b/transacciones.html
@@ -164,6 +164,34 @@
     let editRefs={};
     let mostrarRecArch=false;
     let mostrarRetArch=false;
+    function actualizarArchivarRecBtn(){
+      const btn=document.getElementById('archivar-rec');
+      const icon=btn.querySelector('.icon');
+      const txt=btn.querySelector('span:last-child');
+      if(mostrarRecArch){
+        txt.textContent='Desarchivar';
+        icon.innerHTML='&#128193;';
+        icon.style.color='blue';
+      }else{
+        txt.textContent='Archivar';
+        icon.innerHTML='&#128194;';
+        icon.style.color='';
+      }
+    }
+    function actualizarArchivarRetBtn(){
+      const btn=document.getElementById('archivar-ret');
+      const icon=btn.querySelector('.icon');
+      const txt=btn.querySelector('span:last-child');
+      if(mostrarRetArch){
+        txt.textContent='Desarchivar';
+        icon.innerHTML='&#128193;';
+        icon.style.color='blue';
+      }else{
+        txt.textContent='Archivar';
+        icon.innerHTML='&#128194;';
+        icon.style.color='';
+      }
+    }
     const filtrosRec={monto:'',nombre:'',banco:'',ref:'',fecha:'',estado:''};
     const filtrosRet={monto:'',nombre:'',banco:'',ref:'',fecha:'',estado:''};
     function fecha(){const d=new Date();return d.toLocaleDateString('es-VE');}
@@ -336,8 +364,25 @@
       if(!motivo) return;
       actualizar(ids,'ANULADO',motivo);
     });
-    document.getElementById('archivar-rec').addEventListener('click',()=>{const checks=document.querySelectorAll('#tabla-recargas tbody input[type=checkbox]:checked');if(!checks.length)return;const ids=[];let pendiente=false;checks.forEach(ch=>{if(ch.dataset.estado==='PENDIENTE'){pendiente=true;ch.checked=false;}else ids.push(ch.dataset.id);});if(pendiente)alert('Las transacciones PENDIENTES no pueden archivarse');if(ids.length)actualizar(ids,null,null,null,'ARCHIVADA');});
-    document.getElementById('ver-arch-rec').addEventListener('click',()=>{mostrarRecArch=!mostrarRecArch;document.getElementById('ver-arch-rec').classList.toggle('archivo-activo',mostrarRecArch);renderRec();});
+    document.getElementById('archivar-rec').addEventListener('click',()=>{
+      const checks=document.querySelectorAll('#tabla-recargas tbody input[type=checkbox]:checked');
+      if(!checks.length)return;
+      const ids=[];let pendiente=false;
+      checks.forEach(ch=>{
+        if(ch.dataset.estado==='PENDIENTE'){pendiente=true;ch.checked=false;}
+        else ids.push(ch.dataset.id);
+      });
+      if(pendiente)alert('Las transacciones PENDIENTES no pueden archivarse');
+      if(!ids.length)return;
+      if(mostrarRecArch)actualizar(ids,null,null,null,'VISIBLE');
+      else actualizar(ids,null,null,null,'ARCHIVADA');
+    });
+    document.getElementById('ver-arch-rec').addEventListener('click',()=>{
+      mostrarRecArch=!mostrarRecArch;
+      document.getElementById('ver-arch-rec').classList.toggle('archivo-activo',mostrarRecArch);
+      actualizarArchivarRecBtn();
+      renderRec();
+    });
 
     document.getElementById('aprobar-ret').addEventListener('click',async()=>{
       if(Object.keys(editRefs).length){
@@ -395,8 +440,25 @@
       if(!nota.trim()){alert('Debes colocar un motivo para anulación');return;}
       actualizar(ids,'ANULADO',nota.trim());
     });
-    document.getElementById('archivar-ret').addEventListener('click',()=>{const checks=document.querySelectorAll('#tabla-retiros tbody input[type=checkbox]:checked');if(!checks.length)return;const ids=[];let pendiente=false;checks.forEach(ch=>{if(ch.dataset.estado==='PENDIENTE'){pendiente=true;ch.checked=false;}else ids.push(ch.dataset.id);});if(pendiente)alert('Las transacciones PENDIENTES no pueden archivarse');if(ids.length)actualizar(ids,null,null,null,'ARCHIVADA');});
-    document.getElementById('ver-arch-ret').addEventListener('click',()=>{mostrarRetArch=!mostrarRetArch;document.getElementById('ver-arch-ret').classList.toggle('archivo-activo',mostrarRetArch);renderRet();});
+    document.getElementById('archivar-ret').addEventListener('click',()=>{
+      const checks=document.querySelectorAll('#tabla-retiros tbody input[type=checkbox]:checked');
+      if(!checks.length)return;
+      const ids=[];let pendiente=false;
+      checks.forEach(ch=>{
+        if(ch.dataset.estado==='PENDIENTE'){pendiente=true;ch.checked=false;}
+        else ids.push(ch.dataset.id);
+      });
+      if(pendiente)alert('Las transacciones PENDIENTES no pueden archivarse');
+      if(!ids.length)return;
+      if(mostrarRetArch)actualizar(ids,null,null,null,'VISIBLE');
+      else actualizar(ids,null,null,null,'ARCHIVADA');
+    });
+    document.getElementById('ver-arch-ret').addEventListener('click',()=>{
+      mostrarRetArch=!mostrarRetArch;
+      document.getElementById('ver-arch-ret').classList.toggle('archivo-activo',mostrarRetArch);
+      actualizarArchivarRetBtn();
+      renderRet();
+    });
 
     function marcarTodos(id){const tb=document.getElementById(id);const checks=tb.querySelectorAll('tbody input[type=checkbox]');const all=Array.from(checks).every(c=>c.checked);checks.forEach(c=>{c.checked=!all;c.dispatchEvent(new Event('change'));});}
     document.getElementById('sel-rec').addEventListener('click',()=>marcarTodos('tabla-recargas'));
@@ -418,6 +480,8 @@
     actualizarPendientes();
     setInterval(actualizarPendientes,10000);
     document.getElementById('volver-btn').addEventListener('click',()=>{history.back();});
+    actualizarArchivarRecBtn();
+    actualizarArchivarRetBtn();
     cargarBancos();
     auth.onAuthStateChanged(()=>cargar());
   </script>


### PR DESCRIPTION
## Resumen
- Botones de archivar ahora permiten desarchivar registros con ícono azul tanto en gestión de sorteos como en transacciones.
- Detalles de sorteos muestran la hora en formato AM/PM.
- Vista de nuevo sorteo mejorada: etiquetas coloreadas, contenedor de formas sin bordes redondeados, flip del cartón en el contenedor y botón Guardar estilizado.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aa3af4fd48326a6927384f6bfb681