### PR TITLE
Ajustes móviles y mejora de volteo en nuevosorteo

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -74,7 +74,7 @@
     #estado-group button.active[data-value="Archivado"]{background:linear-gradient(#8b4513,#ffffff);}
     .tabs{width:calc(100% - 30px);max-width:600px;margin:5px auto;}
     .tab-buttons{display:flex;justify-content:center;}
-    .tab-buttons button{flex:1;padding:6px 0;margin:0 2px;font-family:'Bangers',cursive;font-size:1rem;border:1px solid #333;border-bottom:none;border-radius:0;color:white;cursor:pointer;background:#808080;text-shadow:1px 1px 2px #333;}
+    .tab-buttons button{flex:1;padding:6px 0;margin:0 2px;font-family:'Bangers',cursive;font-size:1rem;border:1px solid #333;border-bottom:none;border-radius:10px 10px 0 0;color:white;cursor:pointer;background:#808080;text-shadow:1px 1px 2px #333;}
     .tab-buttons button.active{filter:brightness(1.1);position:relative;top:1px;text-shadow:1px 1px 2px #000;}
     .tab-content{display:none;border:1px solid #333;border-radius:0 0 20px 20px;padding:10px;position:relative;overflow:hidden;gap:5px;}
     .tab-content.active{display:flex;flex-direction:column;align-items:center;}
@@ -86,20 +86,20 @@
     .tab-buttons button.active[data-tab="forma5"], .forma-item5{background:linear-gradient(#ffcc99,#ffffff);}
     .forma-label{position:absolute;left:-35px;top:50%;transform:translateY(-50%);writing-mode:vertical-rl;text-orientation:upright;font-weight:bold;font-size:0.8rem;}
     .carton-box{display:flex;justify-content:center;margin:5px auto;perspective:1000px;}
-    .carton-wrapper{position:relative;border-radius:20px;transition:transform 0.6s;transform-style:preserve-3d;box-shadow:0 0 15px rgba(0,0,0,0.8);overflow:hidden;}
+    .carton-wrapper{position:relative;border-radius:20px;transition:transform 0.6s;transform-style:preserve-3d;box-shadow:0 0 15px rgba(0,0,0,0.8);overflow:hidden;padding:7px;background:linear-gradient(#ffffff,#cccccc);}
     .carton-wrapper.flipped{transform:rotateY(180deg);}
-    .carton{margin:0;border-collapse:collapse;background:linear-gradient(#ffffff,#cccccc);border-radius:20px;backface-visibility:hidden;table-layout:fixed;box-sizing:border-box;}
+    .carton{margin:0;border-collapse:collapse;background:linear-gradient(#ffffff,#cccccc);border-radius:13px;backface-visibility:hidden;table-layout:fixed;box-sizing:border-box;}
     .carton th,.carton td{background:transparent;border:2px solid black;width:50px;height:50px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0;margin:0;box-sizing:border-box;}
     .carton th{font-size:2rem;cursor:pointer;color:#ff6600;background:linear-gradient(#cccccc,#ffffff);text-shadow:2px 2px 0 #000;}
     .carton td{cursor:pointer;}
     .carton td.selected{background-color:orange;color:white;}
     .carton td.free{background-color:#ffcc00;}
-    .carton-back{position:absolute;top:0;left:0;width:100%;height:100%;backface-visibility:hidden;transform:rotateY(180deg);display:flex;align-items:center;justify-content:center;background:linear-gradient(#ffffff,#cccccc);}
-    .carton-back img{width:100%;height:100%;opacity:0.3;object-fit:cover;}
-    .carton th:first-child{border-top-left-radius:10px;}
-    .carton th:last-child{border-top-right-radius:10px;}
-    .carton tbody tr:last-child td:first-child{border-bottom-left-radius:10px;}
-    .carton tbody tr:last-child td:last-child{border-bottom-right-radius:10px;}
+    .carton-back{position:absolute;top:7px;left:7px;right:7px;bottom:7px;backface-visibility:hidden;transform:rotateY(180deg);display:flex;align-items:center;justify-content:center;background:linear-gradient(#ffffff,#cccccc);border-radius:13px;}
+    .carton-back img{width:100%;height:100%;opacity:0.3;object-fit:cover;border-radius:13px;}
+    .carton th:first-child{border-top-left-radius:13px;}
+    .carton th:last-child{border-top-right-radius:13px;}
+    .carton tbody tr:last-child td:first-child{border-bottom-left-radius:13px;}
+    .carton tbody tr:last-child td:last-child{border-bottom-right-radius:13px;}
     .imagen-wrapper{display:flex;justify-content:center;align-items:center;gap:5px;width:250px;margin:3px auto;}
     .imagen-wrapper input{flex:none;width:120px;font-size:0.8rem;}
     .imagen-wrapper button{padding:3px 6px;font-size:0.8rem;}
@@ -107,17 +107,21 @@
     .input-wrapper{display:flex;align-items:center;}
     .label-left{font-weight:bold;font-size:0.8rem;margin-right:3px;text-shadow:0 0 3px #fff;}
     .label-right{font-weight:bold;font-size:0.8rem;margin-left:3px;text-shadow:0 0 3px #fff;}
-    #fecha-label{font-size:1rem;color:#4b0082;text-shadow:1px 1px 2px #000;}
+    #fecha-label{font-size:1rem;color:#4b0082;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #fecha-sorteo{color:#4b0082;font-weight:bold;}
-    #hora-label{font-size:1rem;color:#00008b;text-shadow:1px 1px 2px #000;}
+    #hora-label{font-size:1rem;color:#00008b;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #hora-sorteo{color:#00008b;font-weight:bold;}
-    #minutos-label{font-size:1rem;color:#ff8c00;text-shadow:1px 1px 2px #000;}
+    #minutos-label{font-size:1rem;color:#ff8c00;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #cierre-minutos{color:#ff8c00;font-weight:bold;}
-    #valor-label{font-size:1rem;color:#006400;text-shadow:1px 1px 2px #000;}
+    #valor-label{font-size:1rem;color:#006400;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #valor-carton{color:#006400;font-weight:bold;}
     .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;}
     .modal img{max-width:90%;max-height:90%;}
     .modal span{position:absolute;top:10px;right:20px;font-size:2rem;color:#fff;cursor:pointer;}
+    @media (max-width:600px){
+      body{align-items:stretch;padding:5px 20px;}
+      .menu-btn,input,select,.row,.toggle-group,.imagen-wrapper,.tabs{width:100%;max-width:none;margin-left:0;margin-right:0;}
+    }
     @media (orientation:portrait){
       #volver-btn{width:40px;}
       #volver-btn .label{display:none;}
@@ -190,12 +194,19 @@
       for(let c=0;c<5;c++){
         const td=document.createElement('td');
         td.dataset.row=r;td.dataset.col=c;
-        if(r===2&&c===2){ td.classList.add('free','selected'); td.textContent='\u2605'; }
-        td.addEventListener('click',()=>{
-          if(td.classList.contains('free')) return;
-          td.classList.toggle('selected');
-          td.textContent = td.classList.contains('selected') ? '\u2605' : '';
-        });
+        if(r===2&&c===2){
+          td.classList.add('free','selected');
+          td.textContent='\u2605';
+          td.addEventListener('click',()=>{
+            const wrapper=table.closest('.carton-wrapper');
+            if(wrapper) wrapper.classList.toggle('flipped');
+          });
+        }else{
+          td.addEventListener('click',()=>{
+            td.classList.toggle('selected');
+            td.textContent = td.classList.contains('selected') ? '\u2605' : '';
+          });
+        }
         tr.appendChild(td);
       }
       tbody.appendChild(tr);


### PR DESCRIPTION
## Resumen
- Reducción de márgenes laterales y botones de pestañas con bordes superiores redondeados en móviles.
- Sombras de etiquetas FECHA, HORA, MINUTOS CIERRE y VALOR CARTÓN ajustadas a 1px con resplandor blanco.
- Cartón de bingo con borde visible, reverso con logo y volteo también al pulsar la estrella central.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aaaf1301883269754f3d37cc89afb