### PR TITLE
Ajusta ancho de campos de premio y cartones gratis

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -66,9 +66,11 @@
     .row{display:flex;justify-content:center;gap:5px;width:calc(100% - 12px);margin:3px 6px;}
     .row input{flex:1;width:100%;}
     .premio-row{display:flex;justify-content:center;align-items:center;width:calc(100% - 12px);gap:5px;margin:3px 6px;font-weight:bold;}
-    .premio-row input{flex:0 0 35%;width:auto;margin:0;font-weight:bold;}
+    .premio-row input{flex:0 0 25%;width:auto;margin:0;font-weight:bold;}
     .premio-row span{flex:0 0 15%;text-align:center;font-weight:bold;}
     .porcentaje-forma{color:green;}
+    .porcentaje-forma::placeholder,
+    .cartones-forma::placeholder{font-size:0.8rem;}
     .porcentaje-restante{color:#006400;}
     .cartones-total{color:purple;}
     #nombre-sorteo{font-weight:bold;color:purple;}


### PR DESCRIPTION
## Resumen
- Reduce el ancho de los campos "% Premio" y "Cartones gratis" dentro de las pestañas
- Ajusta el tamaño de la fuente de los textos de ayuda cuando los campos están vacíos

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b497cf6048326b9fd0a9cd29ec1b7