### PR TITLE
Actualiza imagen del reverso del cartón en nuevosorteo

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -336,11 +336,14 @@
     const tipo=tipoVal==='Sorteo Especial'?'ESPECIAL':(tipoVal==='Sorteo Diario'?'DIARIO':'');
     const fecha=document.getElementById('fecha-sorteo').value;
     const hora=document.getElementById('hora-sorteo').value;
+    const imagenUrl=tab.querySelector('.imagen-url').value.trim();
     const content=wrapper.querySelector('.back-content');
+    const img=content.querySelector('img');
     const nombreDiv=content.querySelector('.back-nombre');
     const tipoDiv=content.querySelector('.back-tipo');
     const fechaSpan=content.querySelector('.back-fecha');
     const horaSpan=content.querySelector('.back-hora');
+    img.src=imagenUrl||LOGO_URL;
     nombreDiv.textContent=nombre;
     nombreDiv.style.display=nombre? 'block':'none';
     if(tipo){


### PR DESCRIPTION
## Resumen
- Se amplía `updateCartonBack` para cargar la imagen del formulario y usar `LOGO_URL` cuando falta.
- Se asegura que los campos de nombre, tipo, fecha y hora se actualicen antes de aplicar la clase `flipped`.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b69a57404832684fd75ffbb42b3a2