### PR TITLE
Corrige rotación de reverso del cartón en nuevosorteo

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -100,18 +100,18 @@
     .tab-buttons button.active[data-tab="forma5"], .forma-item5{background:linear-gradient(#ffcc99,#ffffff);}
     .forma-label{position:absolute;left:-35px;top:50%;transform:translateY(-50%);writing-mode:vertical-rl;text-orientation:upright;font-weight:bold;font-size:0.8rem;}
     .carton-box{display:flex;justify-content:center;margin:8px auto;perspective:1000px;}
-    .carton-wrapper{position:relative;border-radius:23px;transform-style:preserve-3d;box-shadow:0 0 15px rgba(0,0,0,0.8);overflow:hidden;padding:10px;background:linear-gradient(#ffffff,#cccccc);}
+    .carton-wrapper{position:relative;border-radius:23px;transform-style:preserve-3d;perspective:1000px;box-shadow:0 0 15px rgba(0,0,0,0.8);overflow:hidden;padding:10px;background:linear-gradient(#ffffff,#cccccc);}
     .carton-wrapper.flipped .carton{pointer-events:none;}
     .carton-wrapper.flipped .carton-back{pointer-events:auto;}
-    .carton{margin:0;border-collapse:separate;border-spacing:0;background:linear-gradient(#ffffff,#cccccc);border-radius:16px;border:2px solid black;backface-visibility:hidden;-webkit-backface-visibility:hidden;table-layout:fixed;box-sizing:border-box;overflow:hidden;}
+    .carton{position:absolute;inset:0;transform:rotateY(0deg);margin:0;border-collapse:separate;border-spacing:0;background:linear-gradient(#ffffff,#cccccc);border-radius:16px;border:2px solid black;backface-visibility:hidden;-webkit-backface-visibility:hidden;table-layout:fixed;box-sizing:border-box;overflow:hidden;}
     .carton th,.carton td{background:transparent;border:2px solid black;width:50px;height:50px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0;margin:0;box-sizing:border-box;backface-visibility:hidden;-webkit-backface-visibility:hidden;}
     .carton th{font-size:2rem;cursor:pointer;color:#ff6600;background:linear-gradient(#cccccc,#ffffff);text-shadow:2px 2px 0 #000;}
     .carton td{cursor:pointer;}
     .carton td.selected{background-color:orange;color:white;}
     .carton td.free{background-color:#ffcc00;display:flex;align-items:center;justify-content:center;}
     .carton td.free img{width:80%;height:80%;object-fit:contain;}
-    .carton-back{position:absolute;top:10px;left:10px;right:10px;bottom:10px;border-radius:16px;pointer-events:none;}
-    .carton-back .back-content{position:absolute;inset:0;transform:rotateY(180deg);backface-visibility:hidden;-webkit-backface-visibility:hidden;display:flex;align-items:center;justify-content:center;background:linear-gradient(#808080,#ffffff);border-radius:16px;}
+    .carton-back{position:absolute;inset:10px;transform:rotateY(180deg);backface-visibility:hidden;border-radius:16px;pointer-events:none;}
+    .carton-back .back-content{position:absolute;inset:0;backface-visibility:hidden;-webkit-backface-visibility:hidden;display:flex;align-items:center;justify-content:center;background:linear-gradient(#808080,#ffffff);border-radius:16px;}
     .carton-back .back-content img{position:absolute;inset:0;width:100%;height:100%;object-fit:contain;opacity:0.3;}
     .carton-back .back-info{position:relative;display:flex;flex-direction:column;align-items:center;text-align:center;gap:5px;width:100%;}
     .back-nombre{font-family:'Bangers',cursive;font-size:1.5rem;color:purple;text-shadow:0 0 5px #fff;font-weight:bold;animation:pulse 1s infinite;}


### PR DESCRIPTION
## Resumen
- Ajusta `.carton` y `.carton-back` para posicionamiento absoluto y rotaciones correctas
- Quita rotación redundante de `.carton-back .back-content`
- Añade `perspective` a `.carton-wrapper` para mantener efecto 3D

## Pruebas
- `npm test`
- Script de Playwright en modo escritorio y móvil verificando orientaciones


------
https://chatgpt.com/codex/tasks/task_e_689b6b0731b48326a1e5c36d5ab4e075