### PR TITLE
Mejoras visuales en nuevosorteo

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -66,7 +66,7 @@
     .row{display:flex;justify-content:center;gap:5px;width:calc(100% - 12px);margin:3px 6px;}
     .row input{flex:1;width:100%;}
     .premio-row{display:grid;grid-template-columns:repeat(4,1fr);align-items:center;width:calc(100% - 12px);gap:5px;font-weight:bold;}
-    .premio-row input,
+    .premio-row input{margin:0;text-align:center;font-weight:bold;width:100%;}
     .premio-row span{margin:0;text-align:center;font-weight:bold;}
     .porcentaje-forma{color:green;}
     .porcentaje-forma::placeholder,
@@ -103,8 +103,8 @@
     .carton-wrapper{position:relative;border-radius:23px;transform-style:preserve-3d;box-shadow:0 0 15px rgba(0,0,0,0.8);overflow:hidden;padding:10px;background:linear-gradient(#ffffff,#cccccc);}
     .carton-wrapper.flipped .carton{pointer-events:none;}
     .carton-wrapper.flipped .carton-back{pointer-events:auto;}
-    .carton{margin:0;border-collapse:separate;border-spacing:0;background:linear-gradient(#ffffff,#cccccc);border-radius:16px;border:2px solid black;backface-visibility:hidden;-webkit-backface-visibility:hidden;table-layout:fixed;box-sizing:border-box;overflow:hidden;}
-    .carton th,.carton td{background:transparent;border:2px solid black;width:50px;height:50px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0;margin:0;box-sizing:border-box;backface-visibility:hidden;-webkit-backface-visibility:hidden;}
+    .carton{margin:0;border-collapse:separate;border-spacing:0;background:linear-gradient(#ffffff,#cccccc);border-radius:16px;border:2px solid gray;backface-visibility:hidden;-webkit-backface-visibility:hidden;table-layout:fixed;box-sizing:border-box;overflow:hidden;}
+    .carton th,.carton td{background:transparent;border:2px solid gray;width:50px;height:50px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0;margin:0;box-sizing:border-box;backface-visibility:hidden;-webkit-backface-visibility:hidden;}
     .carton th{font-size:2rem;cursor:pointer;color:#ff6600;background:linear-gradient(#cccccc,#ffffff);text-shadow:2px 2px 0 #000;}
     .carton td{cursor:pointer;}
     .carton td.selected{background-color:orange;color:white;}


### PR DESCRIPTION
## Resumen
- Ajusta el tamaño de los campos de premio y cartones gratis para que se adapten mejor en móvil
- Cambia las líneas del cartón a color gris

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b771530e08326a68e6f66af23dc8e