### PR TITLE
chore: set full upload endpoint

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -195,7 +195,7 @@
   <script src="auth.js"></script>
   <script>
   ensureAuth('Administrador');
-  const UPLOAD_ENDPOINT='/upload';
+  const UPLOAD_ENDPOINT='http://localhost:3000/upload';
   const LOGO_URL='https://i.imgur.com/twjhNtZ.png';
   const preloadLogo=new Image();
   preloadLogo.src=LOGO_URL;


### PR DESCRIPTION
## Summary
- use full URL for `UPLOAD_ENDPOINT` to support cross-domain uploads

## Testing
- `npm start`
- `curl -X POST -H "Authorization: Bearer fake-token" -F "file=@package.json" http://localhost:3000/upload`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7f2a5e9483268ceb3e5f8fd711f4