### PR TITLE
Parametrizar endpoint de subida en nuevosorteo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Luego inicie el servicio con:
 npm start
 ```
 
+El formulario de nuevo sorteo obtiene la URL de este servicio desde la
+variable `UPLOAD_ENDPOINT` exportada en `config.js`. Por defecto apunta a
+`http://localhost:3000/upload`. Para entornos distintos a localhost puede
+definirse la variable de entorno `UPLOAD_ENDPOINT` o asignarse
+`window.UPLOAD_ENDPOINT` antes de cargar los scripts.
+
 ## Despliegue estático
 
 El archivo `index.html` contiene toda la lógica de la aplicación. Sólo es necesario servirlo desde cualquier servidor web estático. El inicio de sesión se realiza con cuentas de Google y se redirige automáticamente al menú correspondiente según el rol almacenado en Firestore.

--- a/config.js
+++ b/config.js
@@ -7,3 +7,11 @@ export const firebaseConfig = {
   messagingSenderId: "455917034653",
   appId: "1:455917034653:web:ef3f7a1d14be86a1580874"
 };
+
+// Endpoint para la subida de imágenes. Se puede sobrescribir mediante la
+// variable de entorno UPLOAD_ENDPOINT o definiendo window.UPLOAD_ENDPOINT
+// antes de cargar los scripts.
+export const UPLOAD_ENDPOINT =
+  (typeof window !== 'undefined' && window.UPLOAD_ENDPOINT) ||
+  (typeof process !== 'undefined' && process.env && process.env.UPLOAD_ENDPOINT) ||
+  'http://localhost:3000/upload';

--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -193,9 +193,9 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="auth.js"></script>
-  <script>
+  <script type="module">
+  import { UPLOAD_ENDPOINT } from './config.js';
   ensureAuth('Administrador');
-  const UPLOAD_ENDPOINT='http://localhost:3000/upload';
   const LOGO_URL='https://i.imgur.com/twjhNtZ.png';
   const preloadLogo=new Image();
   preloadLogo.src=LOGO_URL;


### PR DESCRIPTION
## Resumen
- mover `UPLOAD_ENDPOINT` a `config.js` con valor por defecto y posibilidad de sobrescribirlo por variable de entorno
- importar el endpoint en `nuevosorteo.html`
- documentar cómo ajustar `UPLOAD_ENDPOINT` para despliegues fuera de localhost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b8f8e0d888326b02f5c884efdefed