### PR TITLE
Muestra mensajes detallados de error en subida de imágenes

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -521,7 +521,7 @@
             ver.href=url;
             fileInput.value='';
             saveState();
-          }catch(e){console.error(e);alert('Error al subir imagen');}
+          }catch(e){console.error(e);alert('Error al subir imagen: '+e.message);}
         });
       });
 
@@ -541,8 +541,8 @@
     formData.append('file',file);
     const token=await auth.currentUser.getIdToken();
     const res=await fetch(UPLOAD_ENDPOINT,{method:'POST',headers:{Authorization:'Bearer '+token},body:formData});
-    if(!res.ok) throw new Error('upload fail');
     const data=await res.json();
+    if(!res.ok) throw new Error(data.message || data.error || 'Error al subir imagen');
     return data.url;
   }
 

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -49,7 +49,7 @@ app.post('/upload', verificarToken, upload.single('file'), async (req, res) => {
     res.json({ url });
   } catch (e) {
     console.error(e);
-    res.status(500).json({ error: 'Error al subir archivo' });
+    res.status(500).json({ error: 'Error al subir archivo', message: e.message });
   }
 });
 


### PR DESCRIPTION
## Resumen
- Añade el mensaje de excepción (`e.message`) en la respuesta JSON de `uploadServer.js` para facilitar el diagnóstico.
- En `nuevosorteo.html`, muestra al usuario el mensaje de error devuelto por el servidor cuando falla la subida de una imagen.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b910199e88326be89cb7bb84794ce