### PR TITLE
feat: mejora interfaz de jugar cartón

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -6,183 +6,154 @@
   <title>Jugar Cartón</title>
   <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
   <style>
-      body {
-          font-family: 'Poppins', sans-serif;
-          background: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
-                      url('https://img.freepik.com/vetores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
-          background-repeat: repeat;
-          background-size: auto;
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          min-height: 100vh;
-          text-align: center;
-      }
-      table {
-            margin: 20px auto;
-            border-collapse: collapse;
-            background: rgba(255, 255, 255, 0.9);
-            border-radius: 15px;
-            border: 15px solid #004d00;
-            padding: 10px;
-            box-shadow: 0 0 10px rgba(0,0,0,0.5);
-      }
-      th {
-          font-size: 2rem;
-          color: #ff6600;
-          text-shadow: 2px 2px 4px #000;
-      }
-      th, td {
-            border: 2px solid black;
-            width: 60px;
-            height: 60px;
-            text-align: center;
-            font-weight: bold;
-      }
-      #bingo-board select {
-          width: 100%;
-          font-size: 2rem;
-          font-weight: bold;
-          padding: 5px;
-          text-align: center;
-          border: none;
-          background: transparent;
-          outline: none;
-          -webkit-appearance: none;
-          -moz-appearance: none;
-          appearance: none;
-      }
-      #select-sorteo {
-          width: 220px;
-          font-size: 1.1rem;
-          padding: 5px 10px;
-          text-align: center;
-          border: 1px solid #333;
-          border-radius: 5px;
-          background: #fff;
-      }
-      .sorteo-info, #valor-carton, #creditos-info {
-          margin:5px 0;
-          font-family:'Poppins', sans-serif;
-          font-size:1rem;
-          color:#000;
-      }
-      .sorteo-info {
-          display:flex;
-          align-items:center;
-          justify-content:center;
-          gap:10px;
-      }
-      #info-carton {
-          display:flex;
-          align-items:center;
-          justify-content:center;
-          gap:10px;
-          margin:5px 0;
-      }
-      #info-text { display:flex; flex-direction:column; text-align:left; }
-      #creditos-info { display:flex; align-items:center; gap:5px; }
-      #fecha-hora-sorteo { display:flex; flex-direction:column; text-align:left; }
-      #ir-billetera-btn {
-          font-family: 'Bangers', cursive;
-          background: linear-gradient(#0a8800, #ffffff);
-          color: white;
-          border: 3px solid #FFD700;
-          border-radius: 8px;
-          text-shadow: 2px 2px 4px #000;
-          font-size: 1.2rem;
-          width: 200px;
-          cursor: pointer;
-      }
-      .free { background-color:#ffcc00; font-weight:bold; }
-      .menu-btn {
-          width: 250px;
-          height: 60px;
-          font-family: 'Bangers', cursive;
-          font-size: 1.4rem;
-          background: rgba(0, 170, 255, 0.8);
-          color: white;
-          border: 4px solid #FFD700;
-          border-radius: 10px;
-          text-shadow: 2px 2px 4px #000;
-          text-transform: uppercase;
-          cursor: pointer;
-          transition: transform 0.3s, box-shadow 0.3s, background 0.3s;
-      }
-      .menu-btn:hover {
-          transform: scale(1.05);
-          box-shadow: 0 0 15px rgba(255, 215, 0, 0.8);
-      }
-      .menu-btn:active {
-          transform: scale(0.95);
-          box-shadow: 0 0 5px rgba(255, 215, 0, 0.8);
-      }
-      .back-btn {
-          position: fixed;
-          top: 5px;
-          left: 5px;
-          width: 120px;
-          height: 40px;
-          font-family: 'Bangers', cursive;
-          font-size: 1.2rem;
-          background: orange;
-          color: white;
-          border: 4px solid #FFD700;
-          border-radius: 10px;
-          text-shadow: 2px 2px 4px #000;
-          text-transform: uppercase;
-          display:flex;
-          align-items:center;
-          justify-content:center;
-          gap:5px;
-      }
-      #login-footer { margin-top:20px; }
-      #fecha-hora, #derechos { font-size:0.7rem; text-align:center; color:#000; }
-      #derechos { font-size:0.6rem; }
+    body {
+      font-family: 'Poppins', sans-serif;
+      background: linear-gradient(rgba(255,255,255,0.7), rgba(255,255,255,0.7)),
+                  url('https://img.freepik.com/vetores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
+      background-repeat: repeat;
+      background-size: auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      min-height: 100vh;
+      text-align: center;
+      padding-top: 50px;
+    }
+    h1#titulo{
+      font-family:'Bangers',cursive;
+      color:white;
+      text-shadow:2px 2px 4px orange;
+      margin-bottom:10px;
+      font-size:2rem;
+    }
+    .menu-btn{
+      width:250px;
+      height:60px;
+      font-family:'Bangers',cursive;
+      font-size:1.4rem;
+      background:rgba(0,170,255,0.8);
+      color:white;
+      border:4px solid #FFD700;
+      border-radius:10px;
+      text-shadow:2px 2px 4px #000;
+      text-transform:uppercase;
+      cursor:pointer;
+      transition:transform 0.3s,box-shadow 0.3s,background 0.3s;
+    }
+    .menu-btn:hover{ transform:scale(1.05); box-shadow:0 0 15px rgba(255,215,0,0.8); }
+    .menu-btn:active{ transform:scale(0.95); box-shadow:0 0 5px rgba(255,215,0,0.8); }
+    .back-btn{
+      position:fixed;
+      top:5px;
+      left:5px;
+      width:120px;
+      height:40px;
+      background:orange;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap:5px;
+      font-size:1.2rem;
+    }
+    @media (orientation:portrait){
+      #volver-btn{width:40px;}
+      #volver-btn .label{display:none;}
+    }
+    #select-sorteo{
+      width:220px;
+      font-size:1.1rem;
+      padding:5px 10px;
+      text-align:center;
+      border:1px solid #333;
+      border-radius:5px;
+      background:#fff;
+    }
+    .sorteo-info{display:flex;align-items:center;justify-content:center;gap:10px;}
+    .datos-sorteo{display:flex;gap:10px;justify-content:center;margin-top:5px;flex-wrap:wrap;}
+    .datos-sorteo div{font-weight:bold;font-size:0.9rem;}
+    #valor-carton{color:green;}
+    #cartones-jugando{color:purple;}
+    #premio-repartir{color:orange;}
+    #wallet-section{display:flex;align-items:center;gap:10px;justify-content:center;margin:10px 0;flex-wrap:wrap;}
+    #wallet-section div{font-size:0.9rem;}
+    .action-btn{
+      font-family:'Bangers',cursive;
+      background:linear-gradient(#0a8800,#ffffff);
+      color:white;
+      border:3px solid #FFD700;
+      border-radius:8px;
+      text-shadow:2px 2px 4px #000;
+      cursor:pointer;
+    }
+    #ir-billetera-btn{width:60px;height:60px;font-size:1.5rem;display:flex;align-items:center;justify-content:center;}
+    #jugar-carton-btn{width:200px;height:60px;font-size:1.2rem;display:flex;align-items:center;justify-content:center;margin-top:10px;}
+    .carton-box{display:flex;justify-content:center;margin:8px auto;perspective:1000px;}
+    .carton{margin:0;border-collapse:separate;border-spacing:0;background:linear-gradient(#ffffff,#cccccc);border-radius:16px;border:2px solid gray;table-layout:fixed;}
+    .carton th,.carton td{background:transparent;border:2px solid gray;width:60px;height:60px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0;margin:0;box-sizing:border-box;}
+    .carton th{font-size:2rem;color:#ff6600;background:linear-gradient(#cccccc,#ffffff);text-shadow:2px 2px 0 #000;}
+    .carton td{cursor:pointer;}
+    .carton td.free{background-color:#ffcc00;display:flex;align-items:center;justify-content:center;}
+    .carton td.error{border:2px solid red;}
+    .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;}
+    .modal-content{background:#fff;padding:10px;border-radius:10px;display:grid;grid-template-columns:repeat(5,60px);gap:5px;}
+    .modal-content div{width:60px;height:60px;display:flex;align-items:center;justify-content:center;font-weight:bold;font-size:1.5rem;color:blue;cursor:pointer;}
+    #login-footer{margin-top:20px;}
+    #fecha-hora,#derechos{font-size:0.7rem;text-align:center;color:#000;}
+    #derechos{font-size:0.6rem;}
   </style>
 </head>
 <body>
-  <button id="volver-btn" class="menu-btn back-btn">&#9664; Volver</button>
-  <div class="sorteo-info">
-    <select id="select-sorteo">
-      <option value="" disabled selected>Selecciona Sorteo</option>
-      <option value="demo" data-fecha="2025-07-13" data-hora="22:00" data-valor="120">Sorteo de Prueba</option>
-    </select>
-    <div id="fecha-hora-sorteo">
-      <div id="fecha-sorteo"></div>
-      <div id="hora-sorteo"></div>
+  <button id="volver-btn" class="menu-btn back-btn"><span class="tri">&#9664;</span><span class="label">Volver</span></button>
+  <h1 id="titulo">JUGAR CARTÓN</h1>
+  <section id="sorteo-section">
+    <div class="sorteo-info">
+      <select id="select-sorteo">
+        <option value="" disabled selected>Selecciona Sorteo</option>
+      </select>
+      <div id="fecha-hora-sorteo">
+        <div id="fecha-sorteo"></div>
+        <div id="hora-sorteo"></div>
+      </div>
     </div>
-  </div>
-  <div id="info-carton">
-    <div id="info-text">
+    <div class="datos-sorteo">
       <div id="valor-carton"></div>
-      <div id="creditos-info">Créditos disponibles: <span id="creditos-label">0</span></div>
+      <div id="cartones-jugando"></div>
+      <div id="premio-repartir"></div>
     </div>
-    <button id="ir-billetera-btn" onclick="window.location.href='billetera.html'">Recargar Billetera</button>
-  </div>
-  <input type="text" id="alias-jugador" readonly placeholder="Alias" style="font-size:1.5rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:200px;display:block;margin:10px auto;color:orange;">
-  <div style="font-size:0.6rem;margin-top:-8px;">Si deseas cambiar tu alias dirigite a Perfil &gt; Alias</div>
-  <table>
-    <thead>
-      <tr><th>B</th><th>I</th><th>N</th><th>G</th><th>O</th></tr>
-    </thead>
-    <tbody id="bingo-board"></tbody>
-  </table>
-  <label style="display:block;margin:10px 0;"><input type="checkbox" id="guardar-carton"> Guardar como plantilla</label>
-  <div id="nombre-carton-div" style="display:none;">
-    <input type="text" id="nombre-carton" placeholder="Nombre de plantilla" style="font-size:1rem;padding:5px;text-align:center;">
-  </div>
-  <select id="plantilla-select" style="width:180px;margin-top:10px;font-size:1rem;padding:5px;text-align:center;">
-    <option value="">Mis Plantillas</option>
-  </select>
-  <button id="jugar-carton-btn" class="menu-btn" style="margin-top:10px;">Jugar Cartón</button>
-
+  </section>
+  <section id="wallet-section">
+    <div>Créditos disponibles: <span id="creditos-label">0</span></div>
+    <div>Cartones gratis: <span id="gratis-label">0</span></div>
+    <button id="ir-billetera-btn" class="action-btn" onclick="window.location.href='billetera.html'"><span class="icon">&#128179;</span></button>
+  </section>
+  <section id="alias-section">
+    <input type="text" id="alias-jugador" readonly placeholder="Alias" style="font-size:1.2rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:180px;display:block;margin:10px auto;color:orange;">
+    <div style="font-size:0.6rem;margin-top:-8px;">Si deseas cambiar tu alias dirigite a Perfil &gt; Alias</div>
+    <div class="carton-box">
+      <table class="carton">
+        <thead>
+          <tr><th>B</th><th>I</th><th>N</th><th>G</th><th>O</th></tr>
+        </thead>
+        <tbody id="bingo-board"></tbody>
+      </table>
+    </div>
+    <label style="display:block;margin:10px 0;"><input type="checkbox" id="guardar-carton"> Guardar cartón</label>
+    <div id="nombre-carton-div" style="display:none;">
+      <input type="text" id="nombre-carton" placeholder="Nombre de cartón" style="font-size:1rem;padding:5px;text-align:center;">
+    </div>
+    <select id="plantilla-select" style="width:180px;margin-top:10px;font-size:1rem;padding:5px;text-align:center;">
+      <option value="">Mis Cartones</option>
+    </select>
+    <button id="jugar-carton-btn" class="action-btn">JUGAR CARTÓN</button>
+  </section>
   <div id="login-footer">
     <div id="fecha-hora"></div>
     <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
   </div>
-
+  <div id="number-modal" class="modal" onclick="this.style.display='none'">
+    <div id="number-grid" class="modal-content" onclick="event.stopPropagation();"></div>
+  </div>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -190,25 +161,26 @@
   <script>
   ensureAuth();
 
-  const board = document.getElementById('bingo-board');
-  const ranges = [[1,15],[16,30],[31,45],[46,60],[61,75]];
+  const ranges=[[1,15],[16,30],[31,45],[46,60],[61,75]];
+  const board=document.getElementById('bingo-board');
+  let currentCell=null;
+  let sorteoInterval=null;
+  let currentSorteo=null;
 
   function createBoard(){
     for(let r=0;r<5;r++){
       const tr=document.createElement('tr');
       for(let c=0;c<5;c++){
         const td=document.createElement('td');
-        if(r===2 && c===2){ td.classList.add('free'); td.textContent='★'; }
-        else {
-          const select=document.createElement('select');
-          select.dataset.row=r; select.dataset.col=c;
-          const def=document.createElement('option');
-          def.value=''; def.textContent=''; def.selected=true; select.appendChild(def);
-          for(let i=ranges[c][0]; i<=ranges[c][1]; i++){
-            const opt=document.createElement('option'); opt.value=i; opt.textContent=i; select.appendChild(opt);
-          }
-          select.addEventListener('change',validateBoard);
-          td.appendChild(select);
+        td.dataset.row=r; td.dataset.col=c;
+        if(r===2 && c===2){
+          td.classList.add('free');
+          const span=document.createElement('span');
+          span.id='carton-num';
+          span.textContent='0';
+          td.appendChild(span);
+        }else{
+          td.addEventListener('click',()=>openModal(td));
         }
         tr.appendChild(td);
       }
@@ -216,44 +188,187 @@
     }
   }
 
+  function openModal(cell){
+    currentCell=cell;
+    const col=parseInt(cell.dataset.col);
+    const [start,end]=ranges[col];
+    const grid=document.getElementById('number-grid');
+    grid.innerHTML='';
+    for(let i=start;i<=end;i++){
+      const div=document.createElement('div');
+      div.textContent=i;
+      div.addEventListener('click',()=>selectNumber(i));
+      grid.appendChild(div);
+    }
+    document.getElementById('number-modal').style.display='flex';
+  }
+
+  function selectNumber(num){
+    if(!currentCell) return;
+    currentCell.textContent=num;
+    currentCell.dataset.value=num;
+    document.getElementById('number-modal').style.display='none';
+    validateBoard();
+  }
+
   function validateBoard(){
     let cols=[[],[],[],[],[]];
     let ok=true;
-    document.querySelectorAll('select[data-col]').forEach(sel=>{
-      const col=parseInt(sel.dataset.col); const val=sel.value;
-      if(val===''||cols[col].includes(val)){ sel.style.border='2px solid red'; ok=false; }
-      else{ sel.style.border='none'; cols[col].push(val); }
+    document.querySelectorAll('#bingo-board td').forEach(td=>{
+      const col=parseInt(td.dataset.col);
+      if(td.classList.contains('free')) return;
+      const val=td.dataset.value||'';
+      if(val===''||cols[col].includes(val)){
+        td.classList.add('error');
+        ok=false;
+      }else{
+        td.classList.remove('error');
+        cols[col].push(val);
+      }
     });
     return ok;
   }
+
   function limpiarcarton(){
-    document.querySelectorAll('select[data-col]').forEach(s=>{s.value='';s.style.border='none';});
-  }
-  function setBoard(carton){
-    document.querySelectorAll('select[data-row]').forEach(sel=>{
-      const r=parseInt(sel.dataset.row);
-      const c=parseInt(sel.dataset.col);
-      sel.value=carton[r][c]||'';
+    document.querySelectorAll('#bingo-board td').forEach(td=>{
+      if(td.classList.contains('free')) return;
+      td.dataset.value='';
+      td.textContent='';
+      td.classList.remove('error');
     });
   }
+
+  function setBoard(carton){
+    document.querySelectorAll('#bingo-board td').forEach(td=>{
+      if(td.classList.contains('free')) return;
+      const r=parseInt(td.dataset.row);
+      const c=parseInt(td.dataset.col);
+      const val=carton[r][c]||'';
+      td.dataset.value=val;
+      td.textContent=val;
+    });
+    validateBoard();
+  }
+
+  async function actualizarDatosSorteo(){
+    if(!currentSorteo) return;
+    const sorteoRef=db.collection('sorteos').doc(currentSorteo);
+    const doc=await sorteoRef.get();
+    if(!doc.exists) return;
+    const data=doc.data();
+    const valor=data.valorCarton||0;
+    const jug=data.cartonesjugando||0;
+    const premio=data.totalPremios||0;
+    document.getElementById('valor-carton').textContent=`Valor de Cartón: ${valor}`;
+    document.getElementById('cartones-jugando').textContent=`Cartones Jugando: ${jug}`;
+    document.getElementById('premio-repartir').textContent=`Premio a Repartir: ${premio}`;
+    const numEl=document.getElementById('carton-num');
+    if(numEl) numEl.textContent=jug+1;
+  }
+
+  function iniciarIntervalo(){
+    if(sorteoInterval) clearInterval(sorteoInterval);
+    sorteoInterval=setInterval(actualizarDatosSorteo,10000);
+    actualizarDatosSorteo();
+  }
+
+  function formatearFecha(f){ if(!f) return ''; const [y,m,d]=f.split('-'); return `${d}/${m}/${y}`; }
+  function formatearHora(h){ if(!h) return ''; const [hh,mm]=h.split(':'); let n=parseInt(hh); const ampm=n>=12?'pm':'am'; n=n%12||12; return `${n}:${mm} ${ampm}`; }
+
+  function actualizarInfoSorteo(){
+    const opt=document.getElementById('select-sorteo').selectedOptions[0];
+    if(!opt) return;
+    currentSorteo=opt.value;
+    document.getElementById('fecha-sorteo').textContent=`Fecha: ${formatearFecha(opt.dataset.fecha)}`;
+    document.getElementById('hora-sorteo').textContent=`Hora: ${formatearHora(opt.dataset.hora)}`;
+    iniciarIntervalo();
+  }
+
+  async function cargarSorteosActivos(){
+    const sel=document.getElementById('select-sorteo');
+    try{
+      sel.innerHTML='<option value="" disabled selected>Selecciona Sorteo</option>';
+      const snap=await db.collection('sorteos').where('estado','==','Activo').get();
+      snap.forEach(doc=>{
+        const d=doc.data();
+        const opt=document.createElement('option');
+        opt.value=doc.id;
+        opt.textContent=d.nombre;
+        opt.dataset.fecha=d.fecha;
+        opt.dataset.hora=d.hora;
+        sel.appendChild(opt);
+      });
+    }catch(e){ console.warn('No se pudieron cargar sorteos'); }
+    actualizarInfoSorteo();
+  }
+
   async function enviarDatos(){
     const alias=document.getElementById('alias-jugador').value.trim();
     const user=auth.currentUser;
-    if(alias===''||!user){ alert('Por favor, ingresa tu Alias antes de enviar el cartón.'); return; }
-    if(!validateBoard()){ alert('Corrige los errores antes de enviar. Asegúrate de seleccionar todos los valores y no repetir valores en las columnas.'); return; }
-    let carton=[[],[],[],[],[]];
-    document.querySelectorAll('select[data-row]').forEach(sel=>{ carton[parseInt(sel.dataset.row)][parseInt(sel.dataset.col)]=sel.value||''; });
-    const dataJuego={
+    if(alias===''||!user){ alert('Por favor, ingresa tu Alias.'); return; }
+    if(!validateBoard()){ alert('Corrige los errores antes de enviar.'); return; }
+    if(!currentSorteo){ alert('Selecciona un sorteo.'); return; }
+
+    const billeteraRef=db.collection('Billetera').doc(user.email);
+    const billeteraDoc=await billeteraRef.get();
+    let creditos=billeteraDoc.data().creditos||0;
+    let gratis=billeteraDoc.data().cartonesGratis||0;
+
+    const sorteoRef=db.collection('sorteos').doc(currentSorteo);
+    const sorteoDoc=await sorteoRef.get();
+    const sorteoData=sorteoDoc.data();
+    const valor=Number(sorteoData.valorCarton||0);
+    const vars=await db.collection('Variablesglobales').doc('Parametros').get();
+    const porcentaje=Number(vars.data().porcentaje||0);
+    const porcentajesu=Number(vars.data().porcentajesu||0);
+    let jugarGratis=false;
+    if(gratis>0){
+      gratis--;
+      jugarGratis=true;
+      await billeteraRef.update({cartonesGratis:gratis});
+    }else if(creditos>=valor){
+      creditos-=valor;
+      await billeteraRef.update({creditos});
+      const porcentajeVal=valor*porcentaje/100;
+      const porcentajeSuVal=valor*porcentajesu/100;
+      const paraPremio=valor-porcentajeVal-porcentajeSuVal;
+      await sorteoRef.update({
+        cartonesjugando: firebase.firestore.FieldValue.increment(1),
+        totalPremios: firebase.firestore.FieldValue.increment(paraPremio),
+        totalporcentaje: firebase.firestore.FieldValue.increment(porcentajeVal),
+        totalporcentajesu: firebase.firestore.FieldValue.increment(porcentajeSuVal)
+      });
+    }else{
+      alert('No tienes créditos suficientes.');
+      return;
+    }
+    if(jugarGratis){
+      await sorteoRef.update({
+        cartonesjugando: firebase.firestore.FieldValue.increment(1)
+      });
+    }
+    const carton=[[],[],[],[],[]];
+    document.querySelectorAll('#bingo-board td').forEach(td=>{
+      const r=parseInt(td.dataset.row);
+      const c=parseInt(td.dataset.col);
+      carton[r][c]=td.dataset.value||'';
+    });
+    await db.collection('CartonJugado').add({
       userEmail:user.email,
       alias:alias,
-      sorteoId:document.getElementById('select-sorteo').value,
+      sorteoId:currentSorteo,
       carton:carton,
-      timestamp:Date.now()
-    };
-    await db.collection('CartonJuego').add(dataJuego);
+      fecha:new Date().toLocaleDateString('es-ES'),
+      hora:new Date().toLocaleTimeString('es-ES')
+    });
     if(document.getElementById('guardar-carton').checked){
       const nombre=document.getElementById('nombre-carton').value.trim();
-      await db.collection('CartonPlantilla').add({...dataJuego,nombre});
+      await db.collection('CartonesPlantilla').add({
+        userEmail:user.email,
+        alias:alias,
+        carton:carton,
+        nombre:nombre
+      });
       await cargarPlantillas();
     }
     alert('Jugada de Cartón enviada correctamente.');
@@ -265,16 +380,16 @@
     const user=auth.currentUser;
     if(!user) return;
     const sel=document.getElementById('plantilla-select');
-    sel.innerHTML='<option value="">Mis Plantillas</option>';
+    sel.innerHTML='<option value="">Mis Cartones</option>';
     plantillas={};
-    const snap=await db.collection('CartonPlantilla').where('userEmail','==',user.email).get();
+    const snap=await db.collection('CartonesPlantilla').where('userEmail','==',user.email).get();
     let idx=1;
     snap.forEach(doc=>{
       const d=doc.data();
       plantillas[doc.id]=d.carton;
       const opt=document.createElement('option');
       opt.value=doc.id;
-      opt.textContent=d.nombre||`Plantilla ${idx++}`;
+      opt.textContent=d.nombre||`Cartón ${idx++}`;
       sel.appendChild(opt);
     });
   }
@@ -283,26 +398,6 @@
     const ahora=new Date();
     const opciones={year:'numeric',month:'long',day:'numeric',hour:'2-digit',minute:'2-digit'};
     document.getElementById('fecha-hora').textContent=ahora.toLocaleString('es-ES',opciones);
-  }
-
-  async function cargarSorteosActivos(){
-    const sel=document.getElementById('select-sorteo');
-    try{
-      sel.innerHTML='<option value="" disabled selected>Selecciona Sorteo</option>';
-      const snap=await db.collection('sorteos').where('estado','==','Activo').get();
-      snap.forEach(doc=>{const d=doc.data();const opt=document.createElement('option');opt.value=doc.id;opt.textContent=d.nombre;opt.dataset.fecha=d.fecha;opt.dataset.hora=d.hora;opt.dataset.valor=d.valorCarton;sel.appendChild(opt);});
-      if(sel.options.length>1) sel.selectedIndex=1;
-    }catch(e){ console.warn('No se pudieron cargar sorteos desde Firestore'); }
-    actualizarInfoSorteo();
-  }
-  function formatearFecha(f){ if(!f) return ''; const [y,m,d]=f.split('-'); return `${d}/${m}/${y}`; }
-  function formatearHora(h){ if(!h) return ''; const [hh,mm]=h.split(':'); let n=parseInt(hh); const ampm=n>=12?'pm':'am'; n=n%12||12; return `${n}:${mm} ${ampm}`; }
-  function actualizarInfoSorteo(){
-    const opt=document.getElementById('select-sorteo').selectedOptions[0];
-    if(!opt) return;
-    document.getElementById('fecha-sorteo').textContent=`Fecha: ${formatearFecha(opt.dataset.fecha)}`;
-    document.getElementById('hora-sorteo').textContent=`Hora: ${formatearHora(opt.dataset.hora)}`;
-    document.getElementById('valor-carton').textContent=`Valor de Carton: ${opt.dataset.valor}`;
   }
 
   document.getElementById('select-sorteo').addEventListener('change',actualizarInfoSorteo);
@@ -324,9 +419,17 @@
       }
       const billeteraRef=db.collection('Billetera').doc(user.email);
       const billeteraDoc=await billeteraRef.get();
-      if(billeteraDoc.exists){ document.getElementById('creditos-label').textContent=billeteraDoc.data().creditos||0; }
-      else { await billeteraRef.set({creditos:0}); document.getElementById('creditos-label').textContent='0'; }
-    } else { window.location.href='index.html'; }
+      if(billeteraDoc.exists){
+        document.getElementById('creditos-label').textContent=billeteraDoc.data().creditos||0;
+        document.getElementById('gratis-label').textContent=billeteraDoc.data().cartonesGratis||0;
+      }else{
+        await billeteraRef.set({creditos:0,cartonesGratis:0});
+        document.getElementById('creditos-label').textContent='0';
+        document.getElementById('gratis-label').textContent='0';
+      }
+    }else{
+      window.location.href='index.html';
+    }
     cargarSorteosActivos();
     await cargarPlantillas();
   });
@@ -337,3 +440,4 @@
   </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Resumen
- Reestructura jugarcartones.html con nuevo título y diseño adaptado
- Agrega selección de números mediante ventana modal y cálculo dinámico de sorteo
- Integra manejo de billetera, cartones gratis y guardado de cartones

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c0dc3150c83268c5d235ce4605e0a