### PR TITLE
Mejoras visuales y guardado de cartones en jugarcartones

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -75,10 +75,9 @@
     #valor-carton span,#cartones-jugando span{font-size:1.5rem;}
     #valor-carton{color:green;}
     #cartones-jugando{color:purple;}
-    #premio-repartir{color:orange;font-family:'Bangers',cursive;text-shadow:0 0 5px green;}
+    #premio-repartir{color:white;font-family:'Bangers',cursive;font-size:1.8rem;text-shadow:0 0 10px #004400;}
     #premio-valor{animation:pulse 1s infinite;display:inline-block;}
-    #wallet-section{display:flex;flex-direction:column;align-items:center;gap:5px;justify-content:center;margin:10px 0;}
-    #wallet-section div{font-size:1rem;font-weight:bold;}
+    .wallet-row{display:flex;align-items:center;gap:5px;margin:3px 0;font-size:1rem;font-weight:bold;}
     #creditos-label,#gratis-label{font-family:'Bangers',cursive;font-size:1.5rem;text-shadow:0 0 5px green;display:inline-block;animation:pulse 1s infinite;}
     #gratis-label{color:#4b0082;text-shadow:0 0 5px #fff;}
     #creditos-label{color:#333;text-shadow:0 0 5px green;}
@@ -91,8 +90,8 @@
       text-shadow:2px 2px 4px #000;
       cursor:pointer;
     }
-    #ir-billetera-btn{width:180px;height:40px;font-size:1.1rem;display:flex;align-items:center;justify-content:center;}
-    #jugar-carton-btn{width:200px;height:40px;font-size:1.2rem;display:flex;align-items:center;justify-content:center;margin-top:10px;}
+    #ir-billetera-btn{width:40px;height:40px;font-size:1.2rem;display:flex;align-items:center;justify-content:center;}
+    #jugar-carton-btn{width:200px;height:40px;font-size:1.2rem;display:flex;align-items:center;justify-content:center;margin:10px auto;}
     .carton-box{display:flex;justify-content:center;margin:8px auto;perspective:1000px;}
     .carton-wrapper{position:relative;transform-style:preserve-3d;transition:transform 0.6s;border-radius:16px;padding:6px;background:linear-gradient(green,yellow);box-shadow:0 0 15px rgba(0,0,0,0.5);}
     .carton-wrapper.flipped{transform:rotateY(180deg);}
@@ -111,11 +110,12 @@
     .modal-content div{width:60px;height:60px;display:flex;align-items:center;justify-content:center;font-weight:bold;font-size:1.8rem;color:#000;cursor:pointer;text-shadow:0 0 3px green;font-family:'Bangers',cursive;}
     @keyframes pulse{0%{transform:scale(1);}50%{transform:scale(1.2);}100%{transform:scale(1);}}
     #player-container{position:relative;border:2px solid green;border-radius:10px;background:linear-gradient(gray,white);padding:10px;margin-top:10px;}
-    #player-title{position:absolute;top:2px;right:5px;font-size:0.6rem;color:green;font-weight:bold;}
+    #player-title{position:absolute;top:2px;left:5px;font-size:0.6rem;color:green;font-weight:bold;text-shadow:0 0 3px #fff;}
     #alias-row{display:flex;align-items:center;justify-content:center;gap:5px;}
     #alias-jugador{font-size:1.2rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:180px;color:orange;}
     #editar-alias{background:none;border:none;color:blue;font-size:1.2rem;cursor:pointer;}
-    #guardar-carton-btn{font-family:'Bangers',cursive;font-size:1.2rem;background:#0a8800;color:white;border:3px solid #FFD700;border-radius:8px;text-shadow:2px 2px 4px #000;width:200px;cursor:pointer;margin:10px auto;display:block;}
+    #guardar-carton-btn{font-family:'Bangers',cursive;font-size:1.2rem;background:#0a8800;color:white;border:3px solid #FFD700;border-radius:8px;text-shadow:2px 2px 4px #000;width:40px;cursor:pointer;margin-left:5px;display:none;}
+    #nombre-carton{display:none;padding:5px;border-radius:5px;border:1px solid #ccc;}
     #mis-cartones-btn{font-family:'Bangers',cursive;font-size:1.2rem;background:orange;color:white;border:3px solid #FFD700;border-radius:8px;text-shadow:2px 2px 4px #000;width:200px;cursor:pointer;margin:10px auto;display:block;}
     #carton-num{font-family:'Bangers',cursive;animation:pulse 1s infinite;text-shadow:0 0 5px green;}
     #login-footer{margin-top:20px;}
@@ -142,11 +142,6 @@
       <div id="premio-repartir">Premio a Repartir: <span id="premio-valor">0</span></div>
     </div>
   </section>
-  <section id="wallet-section">
-    <div><strong>Créditos disponibles:</strong> <span id="creditos-label">0</span></div>
-    <div><strong>Cartones gratis:</strong> <span id="gratis-label">0</span></div>
-    <button id="ir-billetera-btn" class="action-btn" onclick="window.location.href='billetera.html'">Recargar Billetera</button>
-  </section>
   <section id="alias-section">
     <div id="player-container">
       <span id="player-title">Mis datos</span>
@@ -154,6 +149,8 @@
         <input type="text" id="alias-jugador" readonly placeholder="Alias">
         <button id="editar-alias" onclick="window.location.href='perfil.html'">&#9998;</button>
       </div>
+      <div class="wallet-row"><strong>Créditos disponibles:</strong> <span id="creditos-label">0</span><button id="ir-billetera-btn" class="action-btn" onclick="window.location.href='billetera.html'" title="Recargar Billetera">💰</button></div>
+      <div class="wallet-row"><strong>Cartones gratis:</strong> <span id="gratis-label">0</span></div>
     </div>
     <div class="carton-box">
       <div class="carton-wrapper" id="carton-wrapper">
@@ -166,7 +163,7 @@
         <div class="carton-back"><img src="https://i.imgur.com/twjhNtZ.png" alt="logo"></div>
       </div>
     </div>
-    <button id="guardar-carton-btn">Guardar Cartón</button>
+    <div class="wallet-row"><label><input type="checkbox" id="guardar-check"> Guardar cartón</label><input type="text" id="nombre-carton" placeholder="Nombra el Cartón"><button id="guardar-carton-btn" title="Guardar cartón">💾</button></div>
     <button id="mis-cartones-btn">Mis Cartones</button>
     <button id="jugar-carton-btn" class="action-btn">JUGAR CARTÓN</button>
   </section>
@@ -229,6 +226,7 @@
       }
       board.appendChild(tr);
     }
+    document.querySelector('.carton-back').addEventListener('click',flipCard);
   }
 
   function openModal(cell){
@@ -310,9 +308,7 @@
     document.getElementById('premio-valor').textContent=premio;
     const numEl=document.getElementById('carton-num');
     if(numEl){
-      let base=(jug+1).toString();
-      while(base.length<4){base+='0';}
-      numEl.textContent=base;
+      numEl.textContent=(jug+1).toString().padStart(4,'0');
     }
   }
 
@@ -418,9 +414,13 @@
   }
 
   async function guardarCarton(){
+    const check=document.getElementById('guardar-check');
+    const nombre=document.getElementById('nombre-carton').value.trim();
+    if(!check.checked || nombre===''){
+      alert('Debes colocar un nombre para guardar tu cartón');
+      return;
+    }
     if(!validateBoard()){alert('Corrige los errores antes de guardar.');return;}
-    const nombre=prompt('Nombre del cartón');
-    if(!nombre) return;
     const user=auth.currentUser;
     const alias=document.getElementById('alias-jugador').value.trim();
     const posiciones=[];
@@ -470,6 +470,12 @@
   document.getElementById('guardar-carton-btn').addEventListener('click',guardarCarton);
   document.getElementById('mis-cartones-btn').addEventListener('click',abrirCartonesModal);
   document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='player.html';});
+  document.getElementById('guardar-check').addEventListener('change',e=>{
+    const show=e.target.checked;
+    document.getElementById('nombre-carton').style.display=show?'inline-block':'none';
+    document.getElementById('guardar-carton-btn').style.display=show?'inline-block':'none';
+    if(!show) document.getElementById('nombre-carton').value='';
+  });
 
   auth.onAuthStateChanged(async user=>{
     if(user){


### PR DESCRIPTION
## Resumen
- Resalta el premio a repartir con fuente mayor, color blanco y sombra verde
- Reubica datos de billetera y cartones gratis junto al alias con botón de recarga icónico
- Agrega checkbox con nombre e ícono para guardar cartones y corrige volteo y numeración del cartón

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cee5a8ae88326968d9bc284035861