### PR TITLE
Mejoras visuales en jugarcartones y corrección de cartones gratis

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -70,13 +70,13 @@
       background:#fff;
     }
     .sorteo-info{display:flex;align-items:center;justify-content:center;gap:10px;}
-    .datos-sorteo{display:flex;gap:10px;justify-content:center;margin-top:5px;flex-wrap:wrap;font-family:'Bangers',cursive;}
+    .datos-sorteo{display:flex;flex-direction:column;align-items:center;gap:10px;justify-content:center;margin-top:5px;flex-wrap:wrap;font-family:'Bangers',cursive;}
     .datos-sorteo div{font-weight:bold;font-size:1.2rem;}
     #valor-carton span,#cartones-jugando span{font-size:1.5rem;}
+    #valor-carton-valor,#premio-valor{animation:pulse 1s infinite;display:inline-block;}
     #valor-carton{color:green;}
     #cartones-jugando{color:purple;}
     #premio-repartir{color:white;font-family:'Bangers',cursive;font-size:1.8rem;text-shadow:0 0 10px #004400;}
-    #premio-valor{animation:pulse 1s infinite;display:inline-block;}
     .wallet-row{display:flex;align-items:center;gap:5px;margin:3px 0;font-size:1rem;font-weight:bold;}
     #creditos-label,#gratis-label{font-family:'Bangers',cursive;font-size:1.5rem;text-shadow:0 0 5px green;display:inline-block;animation:pulse 1s infinite;}
     #gratis-label{color:#4b0082;text-shadow:0 0 5px #fff;}
@@ -90,7 +90,7 @@
       text-shadow:2px 2px 4px #000;
       cursor:pointer;
     }
-    #ir-billetera-btn{width:40px;height:40px;font-size:1.2rem;display:flex;align-items:center;justify-content:center;}
+    #ir-billetera-btn{width:40px;height:40px;font-size:1.2rem;display:flex;align-items:center;justify-content:center;margin-left:15px;}
     #jugar-carton-btn{width:200px;height:40px;font-size:1.2rem;display:flex;align-items:center;justify-content:center;margin:10px auto;}
     .carton-box{display:flex;justify-content:center;margin:8px auto;perspective:1000px;}
     .carton-wrapper{position:relative;transform-style:preserve-3d;transition:transform 0.6s;border-radius:16px;padding:6px;background:linear-gradient(green,yellow);box-shadow:0 0 15px rgba(0,0,0,0.5);}
@@ -101,7 +101,7 @@
     .carton th,.carton td{background:transparent;border:2px solid gray;width:60px;height:60px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0 3px;margin:0;box-sizing:border-box;}
     .carton th{font-size:2.5rem;color:#ff6600;background:radial-gradient(circle,#ffffff,#ffffff 60%,#00aa00);text-shadow:2px 2px 0 #000;}
     .carton td{cursor:pointer;font-size:1.8rem;text-shadow:0 0 3px green;}
-    .carton td.free{background:radial-gradient(circle,#ffffff,#ffff00);display:flex;align-items:center;justify-content:center;}
+    .carton td.free{background:radial-gradient(circle,#ffffff,#ffff00);display:flex;align-items:center;justify-content:center;font-size:1.2rem;color:#4B0082;}
     .carton td.error{border:2px solid red;}
     .carton-back{position:absolute;top:0;left:0;right:0;bottom:0;border-radius:10px;backface-visibility:hidden;transform:rotateY(180deg);background:linear-gradient(gray,white);display:flex;align-items:center;justify-content:center;}
     .carton-back img{width:80%;height:80%;opacity:0.3;object-fit:contain;}
@@ -110,7 +110,6 @@
     .modal-content div{width:60px;height:60px;display:flex;align-items:center;justify-content:center;font-weight:bold;font-size:1.8rem;color:#000;cursor:pointer;text-shadow:0 0 3px green;font-family:'Bangers',cursive;}
     @keyframes pulse{0%{transform:scale(1);}50%{transform:scale(1.2);}100%{transform:scale(1);}}
     #player-container{position:relative;border:2px solid green;border-radius:10px;background:linear-gradient(gray,white);padding:10px;margin-top:10px;}
-    #player-title{position:absolute;top:2px;left:5px;font-size:0.6rem;color:green;font-weight:bold;text-shadow:0 0 3px #fff;}
     #alias-row{display:flex;align-items:center;justify-content:center;gap:5px;}
     #alias-jugador{font-size:1.2rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:180px;color:orange;}
     #editar-alias{background:none;border:none;color:blue;font-size:1.2rem;cursor:pointer;}
@@ -137,14 +136,13 @@
       </div>
     </div>
     <div class="datos-sorteo">
+      <div id="premio-repartir">Premio a Repartir: <span id="premio-valor">0</span></div>
       <div id="valor-carton">Valor de Cartón: <span id="valor-carton-valor">0</span></div>
       <div id="cartones-jugando">Cartones Jugando: <span id="cartones-jugando-valor">0</span></div>
-      <div id="premio-repartir">Premio a Repartir: <span id="premio-valor">0</span></div>
     </div>
   </section>
   <section id="alias-section">
     <div id="player-container">
-      <span id="player-title">Mis datos</span>
       <div id="alias-row">
         <input type="text" id="alias-jugador" readonly placeholder="Alias">
         <button id="editar-alias" onclick="window.location.href='perfil.html'">&#9998;</button>
@@ -163,7 +161,7 @@
         <div class="carton-back"><img src="https://i.imgur.com/twjhNtZ.png" alt="logo"></div>
       </div>
     </div>
-    <div class="wallet-row"><label><input type="checkbox" id="guardar-check"> Guardar cartón</label><input type="text" id="nombre-carton" placeholder="Nombra el Cartón"><button id="guardar-carton-btn" title="Guardar cartón">💾</button></div>
+    <div class="wallet-row"><label><input type="checkbox" id="guardar-check"><span id="guardar-titulo"> Guardar cartón</span></label><input type="text" id="nombre-carton" placeholder="Nombra el Cartón"><button id="guardar-carton-btn" title="Guardar cartón">💾</button></div>
     <button id="mis-cartones-btn">Mis Cartones</button>
     <button id="jugar-carton-btn" class="action-btn">JUGAR CARTÓN</button>
   </section>
@@ -358,7 +356,7 @@
     const billeteraRef=db.collection('Billetera').doc(user.email);
     const billeteraDoc=await billeteraRef.get();
     let creditos=billeteraDoc.data().creditos||0;
-    let gratis=billeteraDoc.data().cartonesGratis||0;
+    let gratis=billeteraDoc.data().CartonesGratis||0;
 
     const sorteoRef=db.collection('sorteos').doc(currentSorteo);
     const sorteoDoc=await sorteoRef.get();
@@ -371,7 +369,7 @@
     if(gratis>0){
       gratis--;
       jugarGratis=true;
-      await billeteraRef.update({cartonesGratis:gratis});
+      await billeteraRef.update({CartonesGratis:gratis});
       document.getElementById('gratis-label').textContent=gratis;
     }else if(creditos>=valor){
       creditos-=valor;
@@ -474,6 +472,7 @@
     const show=e.target.checked;
     document.getElementById('nombre-carton').style.display=show?'inline-block':'none';
     document.getElementById('guardar-carton-btn').style.display=show?'inline-block':'none';
+    document.getElementById('guardar-titulo').style.display=show?'none':'inline';
     if(!show) document.getElementById('nombre-carton').value='';
   });
 
@@ -487,9 +486,9 @@
       const billeteraDoc=await billeteraRef.get();
       if(billeteraDoc.exists){
         document.getElementById('creditos-label').textContent=billeteraDoc.data().creditos||0;
-        document.getElementById('gratis-label').textContent=billeteraDoc.data().cartonesGratis||0;
+        document.getElementById('gratis-label').textContent=billeteraDoc.data().CartonesGratis||0;
       }else{
-        await billeteraRef.set({creditos:0,cartonesGratis:0});
+        await billeteraRef.set({creditos:0,CartonesGratis:0});
         document.getElementById('creditos-label').textContent='0';
         document.getElementById('gratis-label').textContent='0';
       }


### PR DESCRIPTION
## Resumen
- Reorganiza información del sorteo colocando el premio primero y añade animaciones de acercamiento.
- Ajusta separación del botón de recarga y elimina la etiqueta “Mis datos”.
- Corrige la lectura de `CartonesGratis` en la billetera y mejora estilos del cartón.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf700d8bc832697357c4dc03dde3f