### PR TITLE
feat: mejorar interfaz nuevosorteo

### DIFF
--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -71,8 +71,8 @@
     .porcentaje-forma{color:green;}
     .porcentaje-forma::placeholder,
     .cartones-forma::placeholder{font-size:0.8rem;}
-    .porcentaje-restante{color:#006400;}
-    .cartones-total{color:purple;}
+    .porcentaje-restante{color:#006400;font-size:1.2rem;}
+    .cartones-total{color:purple;font-size:1.2rem;}
     #nombre-sorteo{font-weight:bold;color:purple;}
     .toggle-group{display:flex;justify-content:center;gap:5px;margin:3px 0;}
     .toggle-group button{flex:1;max-width:120px;padding:5px 10px;border-radius:20px;border:1px solid #ccc;font-family:'Bangers',cursive;font-size:1rem;cursor:pointer;background:#808080;color:#fff;text-shadow:1px 1px 2px #333;}
@@ -106,18 +106,19 @@
     .carton th,.carton td{background:transparent;border:2px solid gray;width:60px;height:60px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0;margin:0;box-sizing:border-box;backface-visibility:hidden;-webkit-backface-visibility:hidden;font-family:'Poppins',sans-serif;}
     .carton th{font-size:2.5rem;color:#ff6600;background:radial-gradient(circle,#ffffff,#ffffff 60%,#00aa00);text-shadow:2px 2px 0 #000;}
     .carton td{cursor:pointer;font-size:1.8rem;text-shadow:0 0 3px green;}
+    .carton td.selected:not(.free){background:radial-gradient(circle,#ffffff,#ffffff 60%,#ffff00);}
     .carton td.selected .star{color:orange;}
     .carton td.free{background:radial-gradient(circle,#ffff00,#ffffff);display:flex;align-items:center;justify-content:center;}
     .carton td.free img{width:80%;height:80%;object-fit:contain;}
     .carton td .star{display:inline-block;animation:spinStar 10s linear infinite;}
     @keyframes spinStar{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}
     .carton-back{position:absolute;top:0;left:0;right:0;bottom:0;border-radius:10px;backface-visibility:hidden;transform:rotateY(180deg);background:linear-gradient(orange,white);display:flex;align-items:center;justify-content:center;}
-    .carton-back .back-content{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;}
+    .carton-back .back-content{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;}
     .carton-back .back-content img{width:80%;height:80%;object-fit:contain;}
     .carton-back .back-info{position:relative;display:flex;flex-direction:column;align-items:center;text-align:center;gap:5px;width:100%;}
     .back-nombre{font-family:'Bangers',cursive;font-size:1.5rem;color:purple;text-shadow:0 0 5px #fff;font-weight:bold;animation:pulse 1s infinite;}
     .back-tipo{font-family:'Bangers',cursive;font-size:1.3rem;text-shadow:0 0 5px #fff;font-weight:bold;animation:pulse 1s infinite;}
-    .back-fecha-hora{display:flex;gap:20px;font-family:'Bangers',cursive;font-size:1.2rem;color:blue;text-shadow:0 0 5px #fff;font-weight:bold;}
+    .back-fecha-hora{display:flex;gap:20px;font-family:'Bangers',cursive;font-size:1.2rem;color:purple;text-shadow:0 0 5px #fff;font-weight:bold;}
     .imagen-wrapper{display:flex;justify-content:center;align-items:center;gap:8px;flex-wrap:wrap;}
     .imagen-wrapper input{flex:1;min-width:120px;font-size:0.8rem;}
     .imagen-wrapper button{padding:3px 6px;font-size:0.8rem;}
@@ -129,8 +130,8 @@
     .label-right{font-weight:bold;font-size:0.8rem;margin-left:3px;text-shadow:0 0 3px #fff;}
     #fecha-label{font-size:1rem;color:#4b0082;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #fecha-sorteo{color:#4b0082;font-weight:bold;}
-    #hora-label{font-size:1rem;color:#00008b;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
-    #hora-sorteo{color:#00008b;font-weight:bold;}
+    #hora-label{font-size:1rem;color:purple;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
+    #hora-sorteo{color:purple;font-weight:bold;}
     #minutos-label{font-size:1rem;color:#ff8c00;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #cierre-minutos{color:#ff8c00;font-weight:bold;}
     #valor-label{font-size:1rem;color:#006400;text-shadow:0 0 1px #fff,1px 1px 1px #000;}


### PR DESCRIPTION
## Summary
- Aplica degradado radial amarillo-blanco a las celdas seleccionadas
- Centra las etiquetas traseras bajo el logo y colorea la hora de morado
- Aumenta el tamaño de letras para porcentajes restantes y cartones gratis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1ec8374c8326b09dd37513e09875