### PR TITLE
Ajustes visuales en jugarcartones

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -92,6 +92,7 @@
     #creditos-label,#gratis-label{font-family:'Bangers',cursive;font-size:1.5rem;text-shadow:0 0 5px green;display:inline-block;animation:pulse 1s infinite;}
     #gratis-label{color:#4b0082;text-shadow:0 0 5px #fff;}
     #creditos-label{color:#333;text-shadow:0 0 5px green;}
+    .credit-icon{color:white;font-weight:bold;text-shadow:0 0 5px lime;}
     .action-btn{
       font-family:'Bangers',cursive;
       background:linear-gradient(#0a8800,#ffffff);
@@ -121,7 +122,7 @@
     .carton td.error{border:2px solid red;}
     .carton-back{position:absolute;top:0;left:0;right:0;bottom:0;border-radius:10px;backface-visibility:hidden;transform:rotateY(180deg);background:linear-gradient(gray,white);display:flex;align-items:center;justify-content:center;}
     .carton-back img{width:80%;height:80%;opacity:0.3;object-fit:contain;}
-    .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;}
+    .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;z-index:1000;}
     .modal-content{background:#fff;padding:10px;border-radius:10px;display:flex;flex-direction:column;align-items:flex-start;gap:5px;width:max-content;}
     #cartones-list div,#sorteos-list div{display:block;font-weight:bold;font-size:1rem;color:#000;cursor:pointer;font-family:'Poppins',sans-serif;white-space:nowrap;}
     #number-modal-title{font-size:0.8rem;text-align:center;width:100%;text-shadow:0 0 5px blue;margin-bottom:5px;font-family:'Poppins',sans-serif;}
@@ -132,9 +133,9 @@
     .close-icon{position:absolute;top:5px;right:5px;cursor:pointer;font-size:1.2rem;}
     .mini-carton-box{position:relative;display:flex;align-items:center;justify-content:center;cursor:pointer;aspect-ratio:1/1;width:100%;}
     .mini-carton-box.selected{outline:3px solid blue;}
-    .mini-index,.mini-num{position:absolute;left:4px;padding:1px 3px;background:rgba(255,255,255,0.8);border-radius:3px;font-weight:bold;font-size:0.7rem;}
+    .mini-index,.mini-num{position:absolute;left:50%;transform:translateX(-50%);padding:1px 3px;background:rgba(255,255,255,0.8);border-radius:3px;font-weight:bold;font-size:0.7rem;}
     .mini-index{top:4px;}
-    .mini-num{bottom:4px;color:purple;text-align:left;}
+    .mini-num{bottom:4px;color:purple;}
     .mini-carton-wrapper{background:linear-gradient(green,yellow);padding:3px;border-radius:10px;box-shadow:0 0 5px rgba(0,0,0,0.5);transform:scale(0.7);}
     .mini-carton{border-collapse:separate;border-spacing:0;background:linear-gradient(#ffffff,#cccccc);border-radius:8px;}
     .mini-carton th,.mini-carton td{border:1px solid gray;width:30px;height:30px;text-align:center;font-weight:bold;font-size:0.8rem;aspect-ratio:1/1;}
@@ -180,7 +181,7 @@
         <input type="text" id="alias-jugador" readonly placeholder="Alias">
         <button id="editar-alias" onclick="window.location.href='perfil.html'">&#9998;</button>
       </div>
-        <div class="wallet-row"><strong><img src="https://api.iconify.design/mdi/sack-dollar.svg" class="carton-icon" alt="Créditos"> Créditos:</strong> <span id="creditos-label">0</span></div>
+        <div class="wallet-row"><strong><span class="credit-icon">$</span> Créditos:</strong> <span id="creditos-label">0</span></div>
         <div class="wallet-row"><strong><img src="https://cdn-icons-png.flaticon.com/32/5065/5065890.png" class="carton-icon" alt="Cartón"> gratis:</strong> <span id="gratis-label">0</span></div>
         <button id="azar-btn" class="action-btn" title="Cargar jugadas al azar"><img src="https://api.iconify.design/mdi/dice-5.svg" class="carton-icon" alt="Azar"></button>
         <button id="limpiar-btn" class="action-btn" title="Limpiar cartón"><img src="https://api.iconify.design/mdi/broom.svg" class="carton-icon" alt="Limpiar"></button>
@@ -622,7 +623,7 @@ function loadFromCookie(){
       });
       const num=document.createElement('div');
       num.className='mini-index';
-      num.textContent=++idx;
+      num.textContent=`N° ${++idx}`;
       box.appendChild(num);
       const wrap=document.createElement('div');
       wrap.className='mini-carton-wrapper';
@@ -631,7 +632,7 @@ function loadFromCookie(){
       const bnum=document.createElement('div');
       const cn=data.cartonNum!==undefined?data.cartonNum.toString().padStart(4,'0'):'----';
       bnum.className='mini-num';
-      bnum.textContent=`Carton: ${cn}`;
+      bnum.textContent=`Cartón: ${cn}`;
       box.appendChild(bnum);
       grid.appendChild(box);
     });


### PR DESCRIPTION
## Resumen
- Simplifica la etiqueta de créditos y agrega símbolo `$` con resplandor verde.
- Asegura que la notificación morada no se superponga a las ventanas modales.
- Mejora la visualización de cartones jugados con numeración superior e inferior.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d56461ce88326b2a687d3df9adeb8