### PR TITLE
Ajustar visualización de cartones jugados en modal

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -129,7 +129,7 @@
     #number-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;}
     #number-grid div{width:60px;height:60px;display:flex;align-items:center;justify-content:center;font-size:1.8rem;text-shadow:0 0 5px green;cursor:pointer;}
     #jugados-content{width:90%;max-height:80vh;overflow:auto;align-items:center;position:relative;}
-    #jugados-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;overflow-y:auto;max-height:60vh;justify-items:center;}
+    #jugados-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:5px;overflow-y:auto;max-height:60vh;justify-items:center;}
     .close-icon{position:absolute;top:5px;right:5px;cursor:pointer;font-size:1.2rem;}
     .mini-carton-box{position:relative;display:flex;align-items:center;justify-content:center;cursor:pointer;aspect-ratio:1/1;width:100%;}
     .mini-carton-box.selected{outline:3px solid blue;}


### PR DESCRIPTION
## Resumen
- Compactar las columnas del modal de cartones jugados para mejorar su visualización.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d587d3a6883269caaf3e257c91266