### PR TITLE
Ajusta diseño de cartones jugados

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -128,10 +128,10 @@
     #number-modal-title{font-size:0.8rem;text-align:center;width:100%;text-shadow:0 0 5px blue;margin-bottom:5px;font-family:'Poppins',sans-serif;}
     #number-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;}
     #number-grid div{width:60px;height:60px;display:flex;align-items:center;justify-content:center;font-size:1.8rem;text-shadow:0 0 5px green;cursor:pointer;}
-    #jugados-content{width:100%;max-height:80vh;overflow:auto;align-items:center;position:relative;}
-    #jugados-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;overflow-y:auto;max-height:60vh;justify-items:center;}
+    #jugados-content{width:100%;max-height:80vh;overflow-y:auto;align-items:center;position:relative;padding:5px;box-sizing:border-box;}
+    #jugados-grid{display:grid;grid-template-columns:repeat(3,auto);gap:5px;justify-content:center;justify-items:center;}
     .close-icon{position:absolute;top:5px;right:5px;cursor:pointer;font-size:1.2rem;}
-    .mini-carton-box{position:relative;display:flex;align-items:center;justify-content:center;cursor:pointer;aspect-ratio:1/1;width:100%;}
+    .mini-carton-box{position:relative;display:flex;align-items:center;justify-content:center;cursor:pointer;aspect-ratio:1/1;}
     .mini-carton-box.selected{outline:3px solid blue;}
     .mini-index,.mini-num{position:absolute;left:50%;transform:translateX(-50%);padding:1px 3px;background:rgba(255,255,255,0.8);border-radius:3px;font-weight:bold;font-size:0.7rem;}
     .mini-index{top:4px;}


### PR DESCRIPTION
## Resumen
- Reduce márgenes en el modal de cartones jugados y centra los cartones en una grilla de tres columnas
- Ajusta el contenedor para permitir desplazamiento vertical con espacios de 5px

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dd9cb40348326bc7ec95dfc19e18c