### PR TITLE
Ajustar mini-cartones en modal de jugados

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -136,10 +136,10 @@
     .mini-index,.mini-num{position:absolute;left:50%;transform:translateX(-50%);padding:1px 3px;background:rgba(255,255,255,0.8);border-radius:3px;font-weight:bold;font-size:0.7rem;}
     .mini-index{top:4px;}
     .mini-num{bottom:4px;color:purple;}
-    .mini-carton-wrapper{background:linear-gradient(green,yellow);padding:3px;border-radius:10px;box-shadow:0 0 5px rgba(0,0,0,0.5);transform:scale(0.7);}
+    .mini-carton-wrapper{background:linear-gradient(green,yellow);padding:3px;border-radius:10px;box-shadow:0 0 5px rgba(0,0,0,0.5);}
     .mini-carton{border-collapse:separate;border-spacing:0;background:linear-gradient(#ffffff,#cccccc);border-radius:8px;}
-    .mini-carton th,.mini-carton td{border:1px solid gray;width:30px;height:30px;text-align:center;font-weight:bold;font-size:0.8rem;aspect-ratio:1/1;}
-    .mini-carton th{font-size:1rem;color:#ff6600;background:radial-gradient(circle,#ffffff,#ffffff 60%,#00aa00);text-shadow:1px 1px 0 #000;}
+    .mini-carton th,.mini-carton td{border:1px solid gray;width:20px;height:20px;text-align:center;font-weight:bold;font-size:0.6rem;aspect-ratio:1/1;}
+    .mini-carton th{font-size:0.8rem;color:#ff6600;background:radial-gradient(circle,#ffffff,#ffffff 60%,#00aa00);text-shadow:1px 1px 0 #000;}
     @keyframes pulse{0%{transform:scale(1);}50%{transform:scale(1.2);}100%{transform:scale(1);}}
     @keyframes float{0%{transform:translateY(0);}50%{transform:translateY(-5px);}100%{transform:translateY(0);}}
     #player-container{position:relative;border:2px solid green;border-radius:10px;background:linear-gradient(gray,white);padding:10px;margin-top:10px;}


### PR DESCRIPTION
## Resumen
- Eliminar el `transform: scale` de los mini-cartones para evitar espacios excesivos
- Reducir el tamaño de celdas y fuentes en mini-cartones para que entren tres por fila

## Pruebas
- `npm test` *(falla: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de87434e08326bd2dafca33cb36f7