### PR TITLE
Mostrar cartones en modal en filas de a dos

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -129,13 +129,13 @@
     #number-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;}
     #number-grid div{width:60px;height:60px;display:flex;align-items:center;justify-content:center;font-size:1.8rem;text-shadow:0 0 5px green;cursor:pointer;}
     #jugados-content{width:max-content;max-width:100%;margin:auto;max-height:80vh;overflow-y:auto;align-items:center;position:relative;padding:5px;box-sizing:border-box;}
-    #jugados-grid{display:grid;grid-template-columns:repeat(3,auto);gap:2px;justify-items:center;}
+    #jugados-grid{display:grid;grid-template-columns:repeat(2,auto);gap:8px;justify-items:center;}
     .close-icon{position:absolute;top:5px;right:5px;cursor:pointer;font-size:1.2rem;}
-    .mini-carton-box{position:relative;display:flex;align-items:center;justify-content:center;cursor:pointer;aspect-ratio:1/1;}
+    .mini-carton-box{display:flex;flex-direction:column;align-items:center;cursor:pointer;}
     .mini-carton-box.selected{outline:3px solid blue;}
-    .mini-index,.mini-num{position:absolute;left:50%;transform:translateX(-50%);padding:1px 3px;background:rgba(255,255,255,0.8);border-radius:3px;font-weight:bold;font-size:0.7rem;}
-    .mini-index{top:4px;}
-    .mini-num{bottom:4px;color:purple;}
+    .mini-index,.mini-num{padding:1px 3px;background:rgba(255,255,255,0.8);border-radius:3px;font-weight:bold;font-size:0.7rem;margin:2px 0;text-align:center;}
+    .mini-index{color:#000;}
+    .mini-num{color:purple;}
     .mini-carton-wrapper{background:linear-gradient(green,yellow);padding:3px;border-radius:10px;box-shadow:0 0 5px rgba(0,0,0,0.5);}
     .mini-carton{border-collapse:separate;border-spacing:0;background:linear-gradient(#ffffff,#cccccc);border-radius:8px;}
     .mini-carton th,.mini-carton td{border:1px solid gray;width:20px;height:20px;text-align:center;font-weight:bold;font-size:0.6rem;aspect-ratio:1/1;}


### PR DESCRIPTION
## Resumen
- Ajustar rejilla del modal de cartones jugados para mostrar dos cartones por fila.
- Reubicar números de índice y número de cartón fuera de la miniatura, arriba y abajo respectivamente.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689def7e376c83269a1323f4b38aa7a3