### PR TITLE
Fija encabezado y botón en modal de cartones jugados

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -128,8 +128,9 @@
     #number-modal-title{font-size:0.8rem;text-align:center;width:100%;text-shadow:0 0 5px blue;margin-bottom:5px;font-family:'Poppins',sans-serif;}
     #number-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;}
     #number-grid div{width:60px;height:60px;display:flex;align-items:center;justify-content:center;font-size:1.8rem;text-shadow:0 0 5px green;cursor:pointer;}
-    #jugados-content{width:max-content;max-width:100%;margin:auto;max-height:80vh;overflow-y:auto;align-items:center;position:relative;padding:5px;box-sizing:border-box;}
-    #jugados-grid{display:grid;grid-template-columns:repeat(2,auto);gap:8px;justify-items:center;}
+    #jugados-content{width:max-content;max-width:100%;margin:auto;max-height:80vh;align-items:center;position:relative;padding:5px;box-sizing:border-box;display:flex;flex-direction:column;}
+    #jugados-grid{display:grid;grid-template-columns:repeat(2,auto);gap:8px;justify-items:center;overflow-y:auto;flex-grow:1;min-height:0;}
+    #jugados-nombre-sorteo,#cargar-jugado-btn{flex-shrink:0;}
     .close-icon{position:absolute;top:5px;right:5px;cursor:pointer;font-size:1.2rem;}
     .mini-carton-box{display:flex;flex-direction:column;align-items:center;cursor:pointer;}
     .mini-carton-box.selected{outline:3px solid blue;}


### PR DESCRIPTION
## Resumen
- Mantiene visibles el nombre del sorteo y el botón Cargar cartón en el modal de cartones jugados.
- Permite desplazarse por la lista de cartones sin ocultar controles clave.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689df630c05c83269bc4434af1d66731