### PR TITLE
Vincular selección de sorteo desde cada item

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -548,7 +548,6 @@ function toggleForma(idx){
     sorteosActivos.forEach((s,i)=>{
       const item=document.createElement('div');
       item.className='sorteo-item';
-      item.dataset.index=i;
 
       const nombre=document.createElement('div');
       nombre.className='sorteo-nombre';
@@ -577,6 +576,11 @@ function toggleForma(idx){
       tipo.textContent=s.tipo==='Sorteo Especial'?'ESPECIAL':'DIARIO';
       tipo.style.color=s.tipo==='Sorteo Especial'?'orange':'green';
       item.appendChild(tipo);
+
+      item.addEventListener('click',()=>{
+        seleccionarSorteo(s);
+        document.getElementById('sorteos-modal').style.display='none';
+      });
 
       list.appendChild(item);
     });
@@ -842,15 +846,6 @@ function toggleForma(idx){
   }
 
   document.getElementById('sorteo-btn').addEventListener('click',abrirSorteosModal);
-  document.getElementById('sorteos-list').addEventListener('click',e=>{
-    const item=e.target.closest('.sorteo-item');
-    if(!item) return;
-    const s=sorteosActivos[item.dataset.index];
-    if(s){
-      seleccionarSorteo(s);
-      document.getElementById('sorteos-modal').style.display='none';
-    }
-  });
   document.getElementById('jugar-carton-btn').addEventListener('click',enviarDatos);
   document.getElementById('guardar-carton-btn').addEventListener('click',guardarCarton);
   document.getElementById('mis-cartones-icon').addEventListener('click',abrirCartonesModal);


### PR DESCRIPTION
## Resumen
- Añadir manejador de clic a cada sorteo en `abrirSorteosModal` para seleccionar y cerrar modal.
- Eliminar listener global de `#sorteos-list` que ya no era necesario.

## Pruebas
- `npm test`
- Script de verificación de clic en sorteo con jsdom.

------
https://chatgpt.com/codex/tasks/task_e_689e323c1fb883268a193f16a6416353