### PR TITLE
Asegura carga previa de sorteos antes de abrir modal

### DIFF
--- a/__tests__/jugarcartones.test.js
+++ b/__tests__/jugarcartones.test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+
+test('auth.onAuthStateChanged espera cargarSorteosActivos', () => {
+  const html = fs.readFileSync('jugarcartones.html', 'utf8');
+  expect(html).toMatch(/auth\.onAuthStateChanged\(async user=>{[\s\S]*await cargarSorteosActivos\(\);/);
+});
+
+test('abrirSorteosModal carga sorteos si lista vacía', () => {
+  const html = fs.readFileSync('jugarcartones.html', 'utf8');
+  expect(html).toMatch(/async function abrirSorteosModal\(\)[\s\S]*if\(sorteosActivos.length===0\)[\s\S]*await cargarSorteosActivos\(\);/);
+});

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -542,9 +542,12 @@ function toggleForma(idx){
     cargarFormasSorteo();
   }
 
-  function abrirSorteosModal(){
+  async function abrirSorteosModal(){
     const list=document.getElementById('sorteos-list');
     list.innerHTML='';
+    if(sorteosActivos.length===0){
+      await cargarSorteosActivos();
+    }
     sorteosActivos.forEach((s,i)=>{
       const item=document.createElement('div');
       item.className='sorteo-item';
@@ -886,7 +889,7 @@ function toggleForma(idx){
     }else{
       window.location.href='index.html';
     }
-    cargarSorteosActivos();
+    await cargarSorteosActivos();
     await cargarCartonesGuardados();
   });
 


### PR DESCRIPTION
## Resumen
- Espera la carga de sorteos activos tras autenticación antes de permitir la interacción.
- Abre el modal de sorteos solo después de cargar la lista si está vacía.
- Agrega pruebas que verifican ambas condiciones.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e32eeade48326b3d42e3814bce624