### PR TITLE
Carga de sorteos antes de abrir modal

### DIFF
--- a/__tests__/jugarcartones.test.js
+++ b/__tests__/jugarcartones.test.js
@@ -7,5 +7,5 @@ test('auth.onAuthStateChanged espera cargarSorteosActivos', () => {
 
 test('abrirSorteosModal carga sorteos si lista vacía', () => {
   const html = fs.readFileSync('jugarcartones.html', 'utf8');
-  expect(html).toMatch(/async function abrirSorteosModal\(\)[\s\S]*if\(sorteosActivos.length===0\)[\s\S]*await cargarSorteosActivos\(\);/);
+  expect(html).toMatch(/async function abrirSorteosModal\(\)[\s\S]*const list=document.getElementById\('sorteos-list'\);[\s\S]*if\(!list.querySelector\('input\[type="radio"\]'\)\)[\s\S]*await cargarSorteosActivos\(\);/);
 });

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -545,12 +545,6 @@ function toggleForma(idx){
     cargarFormasSorteo();
   }
 
-  async function abrirSorteosModal(){
-    if(sorteosActivos.length===0){
-      await cargarSorteosActivos();
-    }
-    sorteosModal.showModal();
-  }
 
   async function cargarSorteosActivos(){
     const list=document.getElementById('sorteos-list');
@@ -846,7 +840,6 @@ function toggleForma(idx){
     document.getElementById('fecha-hora').textContent=ahora.toLocaleString('es-ES',opciones);
   }
 
-  document.getElementById('sorteo-btn').addEventListener('click',abrirSorteosModal);
   document.getElementById('sorteos-list').addEventListener('change',e=>{
     if(e.target.name==='sorteoSeleccion'){
       const {value,dataset}=e.target;
@@ -876,6 +869,15 @@ function toggleForma(idx){
   });
 
   auth.onAuthStateChanged(async user=>{
+    async function abrirSorteosModal(){
+      const list=document.getElementById('sorteos-list');
+      if(!list.querySelector('input[type="radio"]')){
+        await cargarSorteosActivos();
+      }
+      if(list.querySelector('input[type="radio"]')){
+        sorteosModal.showModal();
+      }
+    }
     if(user){
       const doc=await db.collection('users').doc(user.email).get();
       if(doc.exists){
@@ -898,6 +900,7 @@ function toggleForma(idx){
     }
     await cargarSorteosActivos();
     await cargarCartonesGuardados();
+    document.getElementById('sorteo-btn').addEventListener('click',abrirSorteosModal);
   });
 
   createBoard();


### PR DESCRIPTION
## Summary
- Se define `abrirSorteosModal` como función asíncrona dentro de `auth.onAuthStateChanged` y se asegura que solo abra el modal cuando existan sorteos cargados.
- Se actualiza el listener del botón para registrarlo después de la carga inicial y se ajusta la prueba correspondiente.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e3789133c8326a1e6520082daa9ec