### PR TITLE
feat: gestionar sorteo seleccionado en jugarcartones

### DIFF
--- a/__tests__/jugarcartones.test.js
+++ b/__tests__/jugarcartones.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const {JSDOM} = require('jsdom');
 
 test('auth.onAuthStateChanged espera cargarSorteosActivos', () => {
   const html = fs.readFileSync('jugarcartones.html', 'utf8');
@@ -8,4 +9,32 @@ test('auth.onAuthStateChanged espera cargarSorteosActivos', () => {
 test('abrirSorteosModal carga sorteos si lista vacía', () => {
   const html = fs.readFileSync('jugarcartones.html', 'utf8');
   expect(html).toMatch(/async function abrirSorteosModal\(\)[\s\S]*const list=document.getElementById\('sorteos-list'\);[\s\S]*if\(!list.querySelector\('input\[type="radio"\]'\)\)[\s\S]*await cargarSorteosActivos\(\);/);
+});
+
+test('al seleccionar un sorteo se actualiza el botón', () => {
+  const html = fs.readFileSync('jugarcartones.html', 'utf8');
+  const dom = new JSDOM(html, {runScripts: 'outside-only'});
+  const {window} = dom;
+  const document = window.document;
+
+  window.ensureAuth = () => {};
+  window.auth = {onAuthStateChanged: () => {}};
+  window.db = {};
+  window.sorteosModal = {close: () => {}, showModal: () => {}};
+  window.setInterval = () => {};
+  window.alert = () => {};
+
+  const script = html.match(/<script>([\s\S]*)<\/script>\s*<\/body>/)[1];
+  window.eval(script);
+
+  window.resetForma = () => {};
+  window.iniciarIntervalo = () => {};
+  window.actualizarCartonesJugador = () => {};
+  window.cargarFormasSorteo = () => {};
+  window.formatearFecha = f => f;
+  window.formatearHora = h => h;
+
+  window.seleccionarSorteo({id:'s1',nombre:'Sorteo Demo',fecha:'2024-01-01',hora:'12:00',tipo:'Sorteo Diario'});
+
+  expect(document.getElementById('sorteo-btn').textContent).toBe('Sorteo Demo');
 });

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -265,6 +265,7 @@ const board=document.getElementById('bingo-board');
 let currentCell=null;
 let sorteoInterval=null;
 let currentSorteo=null;
+let sorteoSeleccionado=null;
 let cartonesGuardados={};
 let sorteosActivos=[];
 let seleccionadoJugado=null;
@@ -576,6 +577,10 @@ function toggleForma(idx){
         input.dataset.premios=premioVal;
         input.dataset.tipo=d.tipo;
 
+        input.addEventListener('change',()=>{
+          sorteoSeleccionado={id:doc.id,nombre:d.nombre,fecha:d.fecha,hora:d.hora,tipo:d.tipo};
+        });
+
         const info=document.createElement('div');
         info.className='sorteo-item-info';
         const nombre=document.createElement('div');
@@ -855,18 +860,8 @@ function toggleForma(idx){
   }
 
   document.getElementById('seleccionar-sorteo-btn').addEventListener('click',()=>{
-    console.log('click en seleccionar sorteo');
-    const chk=document.querySelector('#sorteos-list input[name="sorteoSeleccion"]:checked');
-    console.log('radio seleccionado:',chk?chk.dataset.nombre:null);
-    if(!chk){ alert('Selecciona un sorteo'); return; }
-    const s={
-      id:chk.value,
-      nombre:chk.dataset.nombre,
-      fecha:chk.dataset.fecha,
-      hora:chk.dataset.hora,
-      tipo:chk.dataset.tipo
-    };
-    seleccionarSorteo(s);
+    if(!sorteoSeleccionado){ alert('Selecciona un sorteo'); return; }
+    seleccionarSorteo(sorteoSeleccionado);
     sorteosModal.close();
   });
   document.getElementById('jugar-carton-btn').addEventListener('click',enviarDatos);


### PR DESCRIPTION
## Resumen
- Manejo global del sorteo seleccionado y actualización del botón tras elegir.
- Listener de radios guarda los datos del sorteo en `sorteoSeleccionado`.
- Prueba unitaria que simula la selección y verifica el nombre mostrado.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e46ed11f883269b8b64b1918c9f17