### PR TITLE
fix: mostrar nombre del sorteo al seleccionar

### DIFF
--- a/__tests__/jugarcartones.test.js
+++ b/__tests__/jugarcartones.test.js
@@ -38,3 +38,44 @@ test('al seleccionar un sorteo se actualiza el botón', () => {
 
   expect(document.getElementById('sorteo-btn').textContent).toBe('Sorteo Demo');
 });
+
+test('cargarSorteosActivos crea botones que actualizan el sorteo', async () => {
+  const html = fs.readFileSync('jugarcartones.html', 'utf8');
+  const dom = new JSDOM(html, {runScripts: 'outside-only'});
+  const {window} = dom;
+  const document = window.document;
+
+  window.ensureAuth = () => {};
+  window.auth = {onAuthStateChanged: () => {}};
+  window.db = {
+    collection: () => ({
+      where: () => ({
+        async get() {
+          return {
+            forEach(cb) {
+              cb({id:'s1', data: () => ({nombre:'Sorteo Demo',fecha:'2024-01-01',hora:'12:00',tipo:'Sorteo Diario'})});
+            }
+          };
+        }
+      })
+    })
+  };
+  window.sorteosModal = {close: () => {}, showModal: () => {}};
+  window.setInterval = () => {};
+  window.alert = () => {};
+
+  const script = html.match(/<script>([\s\S]*)<\/script>\s*<\/body>/)[1];
+  window.eval(script);
+
+  window.resetForma = () => {};
+  window.iniciarIntervalo = () => {};
+  window.actualizarCartonesJugador = () => {};
+  window.cargarFormasSorteo = () => {};
+  window.formatearFecha = f => f;
+  window.formatearHora = h => h;
+
+  await window.cargarSorteosActivos();
+  const item = document.querySelector('#sorteos-list .sorteo-item');
+  item.click();
+  expect(document.getElementById('sorteo-btn').textContent).toBe('Sorteo Demo');
+});

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -556,8 +556,10 @@ function toggleForma(idx){
         sorteosActivos.push({id:doc.id,nombre:d.nombre,fecha:d.fecha,hora:d.hora,tipo:d.tipo});
         const item=document.createElement('button');
         item.className='sorteo-item';
+        item.type='button';
         item.textContent=d.nombre;
-        item.addEventListener('click',()=>{
+        item.addEventListener('click',e=>{
+          e.preventDefault();
           seleccionarSorteo({id:doc.id,nombre:d.nombre,fecha:d.fecha,hora:d.hora,tipo:d.tipo});
           sorteosModal.close();
         });


### PR DESCRIPTION
## Resumen
- Evita que el selector de sorteos recargue la página al pulsar un botón
- Añade prueba que valida la actualización del botón al elegir un sorteo

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e5d4aca5083269b1ea5849873dffd