### PR TITLE
Ajusta visibilidad del nombre de forma en el cartón

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -88,7 +88,7 @@
     .billete-icon{font-size:1.5rem;}
     .carton-icon{width:24px;height:24px;}
     #premio-repartir{color:white;font-family:'Bangers',cursive;font-size:1.8rem;text-shadow:0 0 10px #004400;position:relative;}
-    #forma-nombre{position:fixed;transform:translate(-50%,-100%);font-size:0.8rem;display:none;text-shadow:0 0 5px #004400;}
+    #forma-nombre{position:fixed;transform:translate(-50%,-100%);font-size:0.8rem;display:none;text-shadow:0 0 5px #004400;z-index:1000;}
     .wallet-row{display:flex;align-items:center;gap:5px;margin:3px 0;font-size:1rem;font-weight:bold;}
     #creditos-label,#gratis-label{font-family:'Bangers',cursive;font-size:1.5rem;text-shadow:0 0 5px green;display:inline-block;animation:pulse 1s infinite;}
     #gratis-label{color:#4b0082;text-shadow:0 0 5px #fff;}
@@ -334,8 +334,9 @@ function toggleForma(idx){
   pr.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
   pv.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
   nombre.textContent=forma.nombre||'';
-  nombre.style.display='block';
   nombre.style.textShadow=`0 0 5px ${formGlows[idx-1]}`;
+  const wrapper=document.getElementById('carton-wrapper');
+  nombre.style.display=wrapper.classList.contains('flipped')?'none':'block';
   const nCell=document.querySelector('.carton th:nth-child(3)');
   if(nCell){
     const rect=nCell.getBoundingClientRect();
@@ -357,6 +358,12 @@ function toggleForma(idx){
     ],{duration:600,easing:'ease-in-out'}).onfinish=()=>{
       wrapper.style.transform=`rotateY(${end}deg)`;
       wrapper.classList.toggle('flipped');
+      const nombre=document.getElementById('forma-nombre');
+      if(wrapper.classList.contains('flipped')||formaActiva===0){
+        nombre.style.display='none';
+      }else{
+        nombre.style.display='block';
+      }
     };
   }
 


### PR DESCRIPTION
## Resumen
- Muestra el nombre de la forma sobre el cartón con un `z-index` elevado.
- Oculta el nombre al voltear el cartón y lo muestra solo cuando está al frente y hay forma seleccionada.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e928be33083268f6ca88aa7d44f64