### PR TITLE
Ajustes de diseño en registro e inicio

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
       justify-content: center;
       min-height: 100vh;
       text-align: center;
+      margin:0;
     }
     #login-container {
       position: relative;
@@ -50,7 +51,7 @@
     }
     #login-footer {
       position: absolute;
-      bottom: 10px;
+      bottom: 0;
       left: 0;
       right: 0;
       font-size: 0.7rem;

--- a/registrarse.html
+++ b/registrarse.html
@@ -15,6 +15,8 @@
       justify-content:center;
       min-height:100vh;
       text-align:center;
+      margin:0;
+      position:relative;
     }
     h2{
       font-family:'Bangers',cursive;
@@ -33,7 +35,7 @@
     }
     #alias{color:#ff6600;}
     #email{margin:10px;font-weight:bold;color:#006400;}
-    #user-photo{width:80px;height:80px;border-radius:50%;margin-top:10px;}
+    #logo-bingo{width:200px;margin-bottom:5px;}
     .action-btn{
       font-family:'Bangers',cursive;
       background:linear-gradient(#0a8800,#ffffff);
@@ -51,19 +53,18 @@
       margin:5px auto;
     }
     #cancelar{background:linear-gradient(orange,#ffffff);}
-    #terms-container{margin:10px;font-size:0.8rem;}
-    #login-footer{margin-top:20px;}
+    #terms-container{margin:10px;font-size:0.8rem;display:flex;align-items:center;justify-content:center;gap:5px;}
+    #login-footer{position:absolute;bottom:0;left:0;right:0;}
     #fecha-hora,#derechos{font-size:0.7rem;}
     #derechos{font-size:0.6rem;}
   </style>
 </head>
 <body>
-  <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" style="width:80px;margin-bottom:5px;" />
+  <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" />
   <h2>Registro de Jugador</h2>
   <input type="text" id="nombre" placeholder="Nombre">
   <input type="text" id="apellido" placeholder="Apellido">
   <input type="text" id="alias" placeholder="Alias">
-  <img id="user-photo" src="" alt="foto perfil" />
   <div id="email"></div>
   <div id="terms-container"><input type="checkbox" id="accept-terms"> <label for="accept-terms">Acepto <a href="terminos.html" target="_blank">términos y condiciones</a></label></div>
   <button id="registrar" class="action-btn">Registrarse</button>
@@ -82,7 +83,6 @@
     auth.onAuthStateChanged(user=>{
       if(!user) return;
       document.getElementById('email').textContent = user.email;
-      document.getElementById('user-photo').src = user.photoURL;
     });
     function validarTexto(txt,max){
       return txt && txt.length<=max && /^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/.test(txt);


### PR DESCRIPTION
## Resumen
- Ampliado el logo en la página de registro y eliminado la foto de cuenta de Google.
- Alineado el checkbox de términos y anclado el footer al final en registrarse.html.
- Eliminado el margen superior del índice y fijado su footer al borde inferior.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f5d61dfac8326a9e8b2da6787c111