### PR TITLE
fix: remove checkbox terms validation

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -26,10 +26,6 @@ async function loginGoogle(){
       return;
     }
   }
-  if(!document.getElementById('accept-terms').checked){
-    alert('Debes aceptar los términos y condiciones');
-    return;
-  }
   try {
     await auth.signInWithPopup(provider);
   } catch(err) {


### PR DESCRIPTION
## Summary
- allow Google login without requiring nonexistent terms checkbox

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f5f6e37248326b0b3b9b19d2e3ca6