### PR TITLE
Alinear texto de términos junto a checkbox

### DIFF
--- a/registrarse.html
+++ b/registrarse.html
@@ -54,6 +54,7 @@
     }
     #cancelar{background:linear-gradient(orange,#ffffff);}
     #terms-container{margin:10px;font-size:0.8rem;display:flex;align-items:center;justify-content:center;gap:5px;}
+    #terms-container label{display:flex;align-items:center;}
     #login-footer{position:absolute;bottom:0;left:0;right:0;}
     #fecha-hora,#derechos{font-size:0.7rem;}
     #derechos{font-size:0.6rem;}


### PR DESCRIPTION
## Resumen
- Alineado vertical del texto de aceptación de términos junto al checkbox en `registrarse.html`.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f6b75b7548326987d663d6093fce5