### PR TITLE
feat: personalize dialog titles

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -18,7 +18,7 @@ function initFirebase(){
 
 initFirebase();
 initAppName();
-overrideAlert();
+overrideDialogs();
 
 async function initAppName(){
   try{
@@ -31,8 +31,8 @@ async function initAppName(){
   }
 }
 
-function overrideAlert(){
-  window.alert = function(message){
+function overrideDialogs(){
+  const createOverlay = message => {
     const overlay = document.createElement('div');
     overlay.style.position = 'fixed';
     overlay.style.top = '0';
@@ -60,16 +60,58 @@ function overrideAlert(){
     const msg = document.createElement('p');
     msg.textContent = message;
 
+    box.appendChild(title);
+    box.appendChild(msg);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+    return { overlay, box };
+  };
+
+  window.alert = function(message){
+    const { overlay, box } = createOverlay(message);
     const btn = document.createElement('button');
     btn.textContent = 'Aceptar';
     btn.style.marginTop = '10px';
     btn.addEventListener('click', () => overlay.remove());
-
-    box.appendChild(title);
-    box.appendChild(msg);
     box.appendChild(btn);
-    overlay.appendChild(box);
-    document.body.appendChild(overlay);
+  };
+
+  window.confirm = function(message){
+    return new Promise(resolve => {
+      const { overlay, box } = createOverlay(message);
+      const btnOk = document.createElement('button');
+      btnOk.textContent = 'Aceptar';
+      btnOk.style.margin = '10px';
+      btnOk.addEventListener('click', () => { overlay.remove(); resolve(true); });
+      const btnCancel = document.createElement('button');
+      btnCancel.textContent = 'Cancelar';
+      btnCancel.style.margin = '10px';
+      btnCancel.addEventListener('click', () => { overlay.remove(); resolve(false); });
+      box.appendChild(btnOk);
+      box.appendChild(btnCancel);
+    });
+  };
+
+  window.prompt = function(message, def=''){
+    return new Promise(resolve => {
+      const { overlay, box } = createOverlay(message);
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.style.marginTop = '10px';
+      input.value = def;
+      const btnOk = document.createElement('button');
+      btnOk.textContent = 'Aceptar';
+      btnOk.style.margin = '10px';
+      btnOk.addEventListener('click', () => { const val = input.value; overlay.remove(); resolve(val); });
+      const btnCancel = document.createElement('button');
+      btnCancel.textContent = 'Cancelar';
+      btnCancel.style.margin = '10px';
+      btnCancel.addEventListener('click', () => { overlay.remove(); resolve(null); });
+      box.appendChild(input);
+      box.appendChild(btnOk);
+      box.appendChild(btnCancel);
+      input.focus();
+    });
   };
 }
 

--- a/configuraciones.html
+++ b/configuraciones.html
@@ -371,7 +371,7 @@
     document.getElementById('borrar-btn').addEventListener('click', async ()=>{
       const chk=document.querySelector('input[name="select-banco"]:checked');
       if(!chk){ alert('Elije un banco para editar o borrar'); return; }
-      if(confirm(`¿Confirma borrar el banco ${chk.dataset.nombre}?`)){
+      if(await confirm(`¿Confirma borrar el banco ${chk.dataset.nombre}?`)){
         await db.collection('Bancos').doc(chk.dataset.id).delete();
         document.getElementById('banco-id').value='';
         document.getElementById('banco-nombre').value='';

--- a/gestionarusuarios.html
+++ b/gestionarusuarios.html
@@ -246,7 +246,7 @@
       const docu = await db.collection('users').doc(correo).get();
       if(!docu.exists){ alert('Usuario no encontrado'); return; }
       const alias = docu.data().alias || '';
-      if(!confirm(`¿Esta seguro que desea eliminar el usuario ${correo} Alias: ${alias}?`)) return;
+      if(!await confirm(`¿Esta seguro que desea eliminar el usuario ${correo} Alias: ${alias}?`)) return;
       await db.collection('users').doc(correo).delete();
       alert('Usuario eliminado');
       cargarDatos();

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -706,9 +706,9 @@ function toggleForma(idx){
     document.getElementById('cartones-modal').style.display='flex';
   }
 
-  function cargarCartonGuardado(){
+  async function cargarCartonGuardado(){
     if(!seleccionadoGuardado) return;
-    if(confirm('¿Desea cargar el cartón seleccionado? Se sobreescribirán las jugadas actuales.')){
+    if(await confirm('¿Desea cargar el cartón seleccionado? Se sobreescribirán las jugadas actuales.')){
       setBoardFromPosiciones(seleccionadoGuardado.posiciones);
       document.getElementById('cartones-modal').style.display='none';
       saveToCookie();
@@ -784,9 +784,9 @@ function toggleForma(idx){
     return table;
   }
 
-  function cargarCartonJugado(){
+  async function cargarCartonJugado(){
     if(!seleccionadoJugado) return;
-    if(confirm('¿Desea cargar el cartón seleccionado? Se sobreescribirán los datos actuales.')){
+    if(await confirm('¿Desea cargar el cartón seleccionado? Se sobreescribirán los datos actuales.')){
       setBoardFromPosiciones(seleccionadoJugado.posiciones);
       const numEl=document.getElementById('carton-num');
       if(seleccionadoJugado.cartonNum!==undefined){
@@ -819,8 +819,8 @@ function toggleForma(idx){
   document.getElementById('jugados-close').addEventListener('click',()=>{document.getElementById('jugados-modal').style.display='none';});
   document.getElementById('cargar-guardado-btn').addEventListener('click',cargarCartonGuardado);
   document.getElementById('cartones-close').addEventListener('click',()=>{document.getElementById('cartones-modal').style.display='none';});
-  document.getElementById('limpiar-btn').addEventListener('click',()=>{if(confirm('¿Deseas limpiar todas las jugadas del carton?')) limpiarcarton();});
-  document.getElementById('azar-btn').addEventListener('click',()=>{if(confirm('¿Quieres cargar jugadas al azar?')) cargarAzar();});
+  document.getElementById('limpiar-btn').addEventListener('click',async()=>{if(await confirm('¿Deseas limpiar todas las jugadas del carton?')) limpiarcarton();});
+  document.getElementById('azar-btn').addEventListener('click',async()=>{if(await confirm('¿Quieres cargar jugadas al azar?')) cargarAzar();});
   document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='player.html';});
   document.getElementById('guardar-check').addEventListener('change',e=>{
     const show=e.target.checked;

--- a/parametros.html
+++ b/parametros.html
@@ -198,7 +198,7 @@
   <script>
     ensureAuth('Superadmin');
     async function solicitarPassword(){
-      const pwd = prompt('Ingresa tu contraseña');
+      const pwd = await prompt('Ingresa tu contraseña');
       if(!pwd){ window.location.href='super.html'; return; }
       try{
         const doc = await db.collection('Variablesglobales').doc('Parametros').get();

--- a/transacciones.html
+++ b/transacciones.html
@@ -435,7 +435,7 @@
         actualizarEditable();
         return;
       }
-      const nota=prompt('Motivo');
+      const nota=await prompt('Motivo');
       if(nota===null) return;
       if(!nota.trim()){alert('Debes colocar un motivo para anulación');return;}
       actualizar(ids,'ANULADO',nota.trim());


### PR DESCRIPTION
## Summary
- override alert/confirm/prompt to display app title from Firestore
- adapt prompts and confirmations across pages to await custom dialogs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f7867fe4483269f25a737bdad2b11