### PR TITLE
Ampliar columna Gmail y modal de detalles en usuarios

### DIFF
--- a/gestionarusuarios.html
+++ b/gestionarusuarios.html
@@ -102,8 +102,24 @@
       margin-bottom: 10px;
       font-size:0.75rem;
       font-family: Calibri, Arial, sans-serif;
+      table-layout: fixed;
     }
-    th, td { border: 1px solid #ccc; padding: 4px; font-weight: normal; }
+    th, td {
+      border: 1px solid #ccc;
+      padding: 4px;
+      font-weight: normal;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    #tabla-usuarios th:nth-child(1), #tabla-usuarios td:nth-child(1){width:5%;}
+    #tabla-usuarios th:nth-child(2), #tabla-usuarios td:nth-child(2){width:15%;}
+    #tabla-usuarios th:nth-child(3), #tabla-usuarios td:nth-child(3){width:15%;}
+    #tabla-usuarios th:nth-child(4), #tabla-usuarios td:nth-child(4){width:30%;}
+    #tabla-usuarios th:nth-child(5), #tabla-usuarios td:nth-child(5){width:15%;}
+    #tabla-usuarios th:nth-child(6), #tabla-usuarios td:nth-child(6){width:15%;}
+    #tabla-usuarios th:nth-child(7), #tabla-usuarios td:nth-child(7){width:5%;}
+    .gmail-cell{cursor:pointer;}
     input, select { font-family: Calibri, Arial, sans-serif; font-size:0.75rem; }
     #formulario-usuario input { font-weight:bold; }
     #pers-correo { font-weight:bold; }
@@ -120,7 +136,7 @@
     select option[value="Superadmin"]{color:purple;font-weight:bold;}
     @media (max-width:600px){
       table{width:calc(100% - 6px);margin-left:3px;margin-right:3px;}
-      #tabla-usuarios th:nth-child(4),#tabla-usuarios td:nth-child(4){max-width:80px;word-break:break-all;}
+      #tabla-usuarios th:nth-child(4),#tabla-usuarios td:nth-child(4){max-width:120px;}
     }
     .switch{position:relative;display:inline-block;width:42px;height:24px;}
     .switch input{display:none;}
@@ -221,6 +237,17 @@
     </div>
   </div>
 
+  <div id="user-modal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;">
+    <div style="background:white;padding:15px;border-radius:8px;text-align:left;font-family:Calibri, Arial, sans-serif;font-size:0.9rem;">
+      <p id="modal-nombre" style="font-weight:bold;color:black;"></p>
+      <p id="modal-apellido" style="font-weight:bold;color:black;"></p>
+      <p id="modal-gmail" style="font-weight:bold;color:green;"></p>
+      <p id="modal-alias" style="font-weight:bold;color:orange;"></p>
+      <p id="modal-rol" style="font-weight:bold;"></p>
+      <div style="text-align:center;margin-top:10px;"><button id="modal-cerrar">Cerrar</button></div>
+    </div>
+  </div>
+
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -231,6 +258,24 @@
     const bodyTabla = document.getElementById('usuarios-body');
     const persistentes = [];
     const bodyPersist = document.getElementById('persistentes-body');
+    const modal = document.getElementById('user-modal');
+    const modalNombre = document.getElementById('modal-nombre');
+    const modalApellido = document.getElementById('modal-apellido');
+    const modalGmail = document.getElementById('modal-gmail');
+    const modalAlias = document.getElementById('modal-alias');
+    const modalRol = document.getElementById('modal-rol');
+    document.getElementById('modal-cerrar').addEventListener('click',()=>{modal.style.display='none';});
+
+    function mostrarModal(u){
+      modalNombre.textContent = `Nombre: ${u.name||''}`;
+      modalApellido.textContent = `Apellido: ${u.apellido||''}`;
+      modalGmail.textContent = `Gmail: ${u.id}`;
+      modalAlias.textContent = `Alias: ${u.alias||''}`;
+      modalRol.textContent = `Rol: ${u.role||''}`;
+      modalRol.className = '';
+      if(u.role) modalRol.classList.add('role-'+u.role.toLowerCase());
+      modal.style.display='flex';
+    }
 
     async function cargarDatos(){
       const snap = await db.collection('users').get();
@@ -250,7 +295,8 @@
         const tr=document.createElement('tr');
         const gmail=u.id.replace('@gmail.com','');
         const rolClase='role-'+(u.role||'').toLowerCase();
-        tr.innerHTML=`<td>${idx++}</td><td>${u.name||''}</td><td>${u.apellido||''}</td><td>${gmail}</td><td>${u.alias||''}</td><td class='${rolClase}'>${u.role||''}</td><td style="text-align:center;"><input type='radio' name='seleccion' data-correo='${u.id}' value='${u.id}'></td>`;
+        tr.innerHTML=`<td>${idx++}</td><td>${u.name||''}</td><td>${u.apellido||''}</td><td class='gmail-cell'>${gmail}</td><td>${u.alias||''}</td><td class='${rolClase}'>${u.role||''}</td><td style="text-align:center;"><input type='radio' name='seleccion' data-correo='${u.id}' value='${u.id}'></td>`;
+        tr.children[3].addEventListener('click',()=>mostrarModal(u));
         bodyTabla.appendChild(tr);
       });
     }


### PR DESCRIPTION
## Resumen
- Ajuste de anchos de columnas en la tabla de usuarios ampliando el espacio para la columna Gmail y usando texto elíptico.
- Nuevo modal al hacer clic sobre un Gmail que muestra nombre, apellido, correo, alias y rol con estilos de color.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fccfa39208326827f7ed3a1b07089