### PR TITLE
Ajusta estilo del botón Volver y radios en gestionar usuarios

### DIFF
--- a/gestionarusuarios.html
+++ b/gestionarusuarios.html
@@ -87,14 +87,15 @@
       position: fixed;
       top: 5px;
       left: 5px;
-      width: 120px;
+      width: 40px;
       height: 40px;
       background: orange;
       display:flex;
       align-items:center;
       justify-content:center;
-      gap:5px;
+      gap:0;
     }
+    #volver-btn .volver-text { display:none; }
     table {
       background: rgba(255,255,255,0.9);
       border-collapse: collapse;
@@ -118,9 +119,11 @@
     #tabla-usuarios th:nth-child(4), #tabla-usuarios td:nth-child(4){width:30%;}
     #tabla-usuarios th:nth-child(5), #tabla-usuarios td:nth-child(5){width:15%;}
     #tabla-usuarios th:nth-child(6), #tabla-usuarios td:nth-child(6){width:15%;}
-    #tabla-usuarios th:nth-child(7), #tabla-usuarios td:nth-child(7){width:5%;padding:2px;text-align:center;}
+    #tabla-usuarios th:nth-child(7), #tabla-usuarios td:nth-child(7){width:calc(5% + 4px);padding:0;text-align:center;}
     #tabla-persistentes th:nth-child(1), #tabla-persistentes td:nth-child(1){width:5%;}
-    #tabla-persistentes th:nth-child(4), #tabla-persistentes td:nth-child(4){width:5%;padding:2px;text-align:center;}
+    #tabla-persistentes th:nth-child(4), #tabla-persistentes td:nth-child(4){width:calc(5% + 4px);padding:0;text-align:center;}
+    #tabla-usuarios td:nth-child(7), #tabla-persistentes td:nth-child(4){display:flex;justify-content:center;align-items:center;}
+    #tabla-usuarios td:nth-child(7) input, #tabla-persistentes td:nth-child(4) input{margin:0;}
     .gmail-cell{cursor:pointer;}
     input, select { font-family: Calibri, Arial, sans-serif; font-size:0.75rem; }
     #formulario-usuario input { font-weight:bold; }
@@ -147,7 +150,6 @@
     .slider:before{position:absolute;content:"";height:18px;width:18px;left:3px;bottom:3px;background-color:white;transition:.4s;border-radius:50%;}
     input:checked + .slider{background-color:#4caf50;}
     input:checked + .slider:before{transform:translateX(18px);}
-    @media (orientation:portrait){#volver-btn .volver-text{display:none;}}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Resumen
- Botón **Volver** reducido a formato cuadrado y sin texto.
- Mayor ancho y centrado de columnas con radio botones en tablas.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fdde78370832683d611d5095d9930