### PR TITLE
Ajusta margen de columnas de selección en gestionar usuarios

### DIFF
--- a/gestionarusuarios.html
+++ b/gestionarusuarios.html
@@ -119,9 +119,17 @@
     #tabla-usuarios th:nth-child(4), #tabla-usuarios td:nth-child(4){width:30%;}
     #tabla-usuarios th:nth-child(5), #tabla-usuarios td:nth-child(5){width:15%;}
     #tabla-usuarios th:nth-child(6), #tabla-usuarios td:nth-child(6){width:15%;}
-    #tabla-usuarios th:nth-child(7), #tabla-usuarios td:nth-child(7){width:calc(5% + 4px);padding:0;text-align:center;}
+    #tabla-usuarios th:nth-child(7),
+    #tabla-usuarios td:nth-child(7),
+    #tabla-persistentes th:nth-child(4),
+    #tabla-persistentes td:nth-child(4){
+      width:5%;
+      min-width:24px;
+      padding:3px;
+      text-align:center;
+      box-sizing:border-box;
+    }
     #tabla-persistentes th:nth-child(1), #tabla-persistentes td:nth-child(1){width:5%;}
-    #tabla-persistentes th:nth-child(4), #tabla-persistentes td:nth-child(4){width:calc(5% + 4px);padding:0;text-align:center;}
     #tabla-usuarios td:nth-child(7), #tabla-persistentes td:nth-child(4){display:flex;justify-content:center;align-items:center;}
     #tabla-usuarios td:nth-child(7) input, #tabla-persistentes td:nth-child(4) input{margin:0;}
     .gmail-cell{cursor:pointer;}


### PR DESCRIPTION
## Resumen
- Añade ancho mínimo y padding a las columnas de selección en tablas de gestionarusuarios para que los radios se vean completos.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fdfaded0083268d547d3baafb13b8