### PR TITLE
Ajustes en retiros y modales de transacciones

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -701,6 +701,7 @@
       const data = {
         tipotrans:'retiro',
         bancoreceptor: docB.exists?(docB.data().banco||''):'' ,
+        MontoSolicitado: monto,
         Monto: montoFinal,
         referencia:'',
         comentario: document.getElementById('comentario-retiro').value.trim(),

--- a/transacciones.html
+++ b/transacciones.html
@@ -275,17 +275,109 @@
         <div><span style="color:black;">Alias:</span> <span style="color:#006400;">${u.alias||''}</span></div>
         <div><span style="color:black;">Cédula:</span> <span style="color:#FF8C00;">${b.cedula||''}</span></div>
         <div><span style="color:black;">Pago Movil:</span> <span style="color:#0000FF;">${b.pagomovil||''}</span></div>
+        <div><span style="color:black;">Banco:</span> <span style="color:#800080;">${b.banco||''}</span></div>
+        <div><span style="color:black;">Cuenta:</span> <span style="color:#A52A2A;">${b.cuenta||''}</span></div>
         <div><span style="color:black;">Créditos:</span> <span style="color:#800080;">${b.creditos||0}</span></div>
         <div><span style="color:black;">Cartones gratis:</span> <span style="color:#008000;">${b.CartonesGratis||0}</span></div>
       `;
       const btn=document.createElement('button');btn.textContent='Cerrar';btn.addEventListener('click',()=>document.body.removeChild(overlay));box.appendChild(btn);
     }
+    function mostrarDatosTransaccion(t){
+      const overlay=document.createElement('div');
+      Object.assign(overlay.style,{position:'fixed',top:0,left:0,right:0,bottom:0,background:'rgba(0,0,0,0.5)',display:'flex',alignItems:'center',justifyContent:'center'});
+      const box=document.createElement('div');
+      Object.assign(box.style,{background:'#fff',padding:'15px',borderRadius:'8px',display:'flex',flexDirection:'column',gap:'8px',minWidth:'260px',fontFamily:'Calibri, Arial, sans-serif',fontWeight:'bold'});
+      overlay.appendChild(box);document.body.appendChild(overlay);
+      const fs=formatearFecha(t.fechasolicitud||'');
+      const hs=formatearHora(t.horasolicitud||'');
+      const fg=formatearFecha(t.fechagestion||'');
+      const hg=formatearHora(t.horagestion||'');
+      box.innerHTML=`<div style="color:black;font-weight:normal;">Datos Transacción</div>`+
+        `<div style="color:#00008B;">Referencia: ${t.referencia||''}</div>`+
+        `<div style="color:orange;">Fecha de solicitud: ${fs}</div>`+
+        `<div style="color:orange;">Hora de solicitud: ${hs}</div>`+
+        `<div style="color:green;">Fecha de gestión: ${fg}</div>`+
+        `<div style="color:green;">Hora de gestión: ${hg}</div>`+
+        `<div style="color:#555;font-weight:bold;">Usuario Gestor: ${t.usuariogestor||''}</div>`;
+      const btn=document.createElement('button');btn.textContent='Cerrar';btn.addEventListener('click',()=>document.body.removeChild(overlay));box.appendChild(btn);
+    }
     function formatearFecha(f){if(!f)return '';if(f.includes('-')){const[y,m,d]=f.split('-');return `${d.padStart(2,'0')}/${m.padStart(2,'0')}/${y}`;}const[d,m,y]=f.split('/');return `${d.padStart(2,'0')}/${m.padStart(2,'0')}/${y}`;}
     function parseFecha(f){if(!f)return 0;if(f.includes('-')){const[y,m,d]=f.split('-');return new Date(`${y}-${m}-${d}`).getTime();}const[d,m,y]=f.split('/');return new Date(`${y}-${m}-${d}`).getTime();}
+    function aHora24(str){if(!str) return '00:00';str=str.toLowerCase().replace(/\./g,'').replace(/\s+/g,'');const m=str.match(/(\d{1,2}):(\d{2})(?::(\d{2}))?(a|p)?m?/);if(!m) return str;let h=parseInt(m[1],10);const min=m[2];const ap=m[4];if(ap==='p'&&h<12)h+=12;if(ap==='a'&&h===12)h=0;return `${String(h).padStart(2,'0')}:${min}`;}
+    function formatearHora(str){if(!str) return '';const [h24,min]=aHora24(str).split(':');let h=parseInt(h24,10);const ampm=h>=12?'pm':'am';h=h%12;if(h===0)h=12;return `${h}:${min} ${ampm}`;}
     function sortTrans(a,b){if(a.estado==='PENDIENTE'&&b.estado!=='PENDIENTE')return -1;if(a.estado!=='PENDIENTE'&&b.estado==='PENDIENTE')return 1;return parseFecha(a.fechasolicitud)-parseFecha(b.fechasolicitud);}
     function actualizarBotonRet(){const btn=document.getElementById('aprobar-ret');const icon=btn.querySelector('.icon');const txt=btn.querySelector('span:last-child');if(Object.keys(editRefs).length){icon.innerHTML='&#9998;';icon.style.color='blue';txt.textContent='Editar';}else{icon.innerHTML='&#10004;';icon.style.color='green';txt.textContent='Aprobar';}}
-    function renderRec(){const tb=document.querySelector('#tabla-recargas tbody');tb.innerHTML='';let i=1;datosRec.forEach(t=>{const cond=t.Condicion||'VISIBLE';if(mostrarRecArch?cond!=='ARCHIVADA':cond==='ARCHIVADA')return;const fecha=formatearFecha(t.fechasolicitud);if(filtrosRec.monto&& !t.Monto.toString().includes(filtrosRec.monto))return;if(filtrosRec.nombre&& !abreviar(t.IDbilletera).toLowerCase().includes(filtrosRec.nombre))return;if(filtrosRec.banco&& (t.bancoreceptor||'')!==filtrosRec.banco)return;if(filtrosRec.ref&& !(t.referencia||'').toString().includes(filtrosRec.ref))return;if(filtrosRec.fecha&& fecha!==filtrosRec.fecha)return;if(filtrosRec.estado&& t.estado!==filtrosRec.estado)return;const tr=document.createElement('tr');tr.innerHTML=`<td>${i}</td><td style='color:#4b0082;'>${t.Monto}</td><td class='gmail' data-mail='${t.IDbilletera}'>${abreviar(t.IDbilletera)}</td><td>${t.bancoreceptor||''}</td><td style='color:#4b0082;'>${t.referencia}</td><td style='color:#A52A2A;'>${fecha}</td><td>${t.estado}</td><td style='text-align:center;'><input type='checkbox' data-id='${t.id}' data-estado='${t.estado}'></td>`;const estadoTd=tr.children[6];if(t.estado==='ANULADO'){tr.classList.add('anulado');}else{estadoTd.style.color=estadoColor(t.estado);}if(t.nota){estadoTd.classList.add('nota-estado');estadoTd.addEventListener('click',e=>{e.stopPropagation();alert(t.nota);});}const mailTd=tr.children[2];mailTd.style.cursor='pointer';mailTd.addEventListener('click',()=>mostrarInfoGmail(t.IDbilletera));tb.appendChild(tr);i++;});}
-    function renderRet(){const tb=document.querySelector('#tabla-retiros tbody');tb.innerHTML='';let i=1;datosRet.forEach(t=>{const cond=t.Condicion||'VISIBLE';if(mostrarRetArch?cond!=='ARCHIVADA':cond==='ARCHIVADA')return;const fecha=formatearFecha(t.fechasolicitud);if(filtrosRet.monto&& !t.Monto.toString().includes(filtrosRet.monto))return;if(filtrosRet.nombre&& !abreviar(t.IDbilletera).toLowerCase().includes(filtrosRet.nombre))return;if(filtrosRet.banco&& (t.bancoreceptor||'')!==filtrosRet.banco)return;if(filtrosRet.ref&& !(t.referencia||'').toString().includes(filtrosRet.ref))return;if(filtrosRet.fecha&& fecha!==filtrosRet.fecha)return;if(filtrosRet.estado&& t.estado!==filtrosRet.estado)return;const tr=document.createElement('tr');tr.innerHTML=`<td>${i}</td><td style='color:#4b0082;'>${t.Monto}</td><td class='gmail' data-mail='${t.IDbilletera}'>${abreviar(t.IDbilletera)}</td><td>${(t.bancoreceptor||'').split(':')[0]}</td><td style='color:#4b0082;' contenteditable='false' inputmode='numeric' oninput="this.textContent=this.textContent.replace(/[^0-9]/g,'').slice(0,5);">${t.referencia||''}</td><td style='color:#A52A2A;'>${fecha}</td><td>${t.estado}</td><td style='text-align:center;'><input type='checkbox' data-id='${t.id}' data-estado='${t.estado}'></td>`;const estadoTd=tr.children[6];if(t.estado==='ANULADO'){tr.classList.add('anulado');}else{estadoTd.style.color=estadoColor(t.estado);}if(t.nota){estadoTd.classList.add('nota-estado');estadoTd.addEventListener('click',e=>{e.stopPropagation();alert(t.nota);});}const chk=tr.querySelector('input[type=checkbox]');const refTd=tr.children[4];refTd.dataset.original=t.referencia||'';chk.addEventListener('change',()=>{actualizarEditable();});refTd.addEventListener('input',()=>{refTd.textContent=refTd.textContent.replace(/[^0-9]/g,'').slice(0,5);if(t.estado==='APROBADO'){const nuevo=refTd.textContent.trim();const orig=refTd.dataset.original||'';if(nuevo!==orig)editRefs[t.id]=nuevo;else delete editRefs[t.id];actualizarBotonRet();}});const mailTd=tr.children[2];mailTd.style.cursor='pointer';mailTd.addEventListener('click',()=>mostrarInfoGmail(t.IDbilletera));tb.appendChild(tr);i++;});}
+    function renderRec(){
+      const tb=document.querySelector('#tabla-recargas tbody');
+      tb.innerHTML='';
+      let i=1;
+      datosRec.forEach(t=>{
+        const cond=t.Condicion||'VISIBLE';
+        if(mostrarRecArch?cond!=='ARCHIVADA':cond==='ARCHIVADA')return;
+        const fecha=formatearFecha(t.fechasolicitud);
+        if(filtrosRec.monto&& !t.Monto.toString().includes(filtrosRec.monto))return;
+        if(filtrosRec.nombre&& !abreviar(t.IDbilletera).toLowerCase().includes(filtrosRec.nombre))return;
+        if(filtrosRec.banco&& (t.bancoreceptor||'')!==filtrosRec.banco)return;
+        if(filtrosRec.ref&& !(t.referencia||'').toString().includes(filtrosRec.ref))return;
+        if(filtrosRec.fecha&& fecha!==filtrosRec.fecha)return;
+        if(filtrosRec.estado&& t.estado!==filtrosRec.estado)return;
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${i}</td><td style='color:#4b0082;'>${t.Monto}</td><td class='gmail' data-mail='${t.IDbilletera}'>${abreviar(t.IDbilletera)}</td><td>${t.bancoreceptor||''}</td><td style='color:#4b0082;'>${t.referencia}</td><td style='color:#A52A2A;'>${fecha}</td><td>${t.estado}</td><td style='text-align:center;'><input type='checkbox' data-id='${t.id}' data-estado='${t.estado}'></td>`;
+        const estadoTd=tr.children[6];
+        if(t.estado==='ANULADO'){tr.classList.add('anulado');}else{estadoTd.style.color=estadoColor(t.estado);}
+        if(t.nota){estadoTd.classList.add('nota-estado');estadoTd.addEventListener('click',e=>{e.stopPropagation();alert(t.nota);});}
+        const mailTd=tr.children[2];
+        mailTd.style.cursor='pointer';
+        mailTd.addEventListener('click',()=>mostrarInfoGmail(t.IDbilletera));
+        const fechaTd=tr.children[5];
+        fechaTd.style.cursor='pointer';
+        fechaTd.addEventListener('click',()=>mostrarDatosTransaccion(t));
+        tb.appendChild(tr);
+        i++;
+      });
+    }
+    function renderRet(){
+      const tb=document.querySelector('#tabla-retiros tbody');
+      tb.innerHTML='';
+      let i=1;
+      datosRet.forEach(t=>{
+        const cond=t.Condicion||'VISIBLE';
+        if(mostrarRetArch?cond!=='ARCHIVADA':cond==='ARCHIVADA')return;
+        const fecha=formatearFecha(t.fechasolicitud);
+        if(filtrosRet.monto&& !t.Monto.toString().includes(filtrosRet.monto))return;
+        if(filtrosRet.nombre&& !abreviar(t.IDbilletera).toLowerCase().includes(filtrosRet.nombre))return;
+        if(filtrosRet.banco&& (t.bancoreceptor||'')!==filtrosRet.banco)return;
+        if(filtrosRet.ref&& !(t.referencia||'').toString().includes(filtrosRet.ref))return;
+        if(filtrosRet.fecha&& fecha!==filtrosRet.fecha)return;
+        if(filtrosRet.estado&& t.estado!==filtrosRet.estado)return;
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${i}</td><td style='color:#4b0082;'>${t.Monto}</td><td class='gmail' data-mail='${t.IDbilletera}'>${abreviar(t.IDbilletera)}</td><td>${(t.bancoreceptor||'').split(':')[0]}</td><td style='color:#4b0082;' contenteditable='false' inputmode='numeric' oninput="this.textContent=this.textContent.replace(/[^0-9]/g,'').slice(0,5);">${t.referencia||''}</td><td style='color:#A52A2A;'>${fecha}</td><td>${t.estado}</td><td style='text-align:center;'><input type='checkbox' data-id='${t.id}' data-estado='${t.estado}'></td>`;
+        const estadoTd=tr.children[6];
+        if(t.estado==='ANULADO'){tr.classList.add('anulado');}else{estadoTd.style.color=estadoColor(t.estado);}
+        if(t.nota){estadoTd.classList.add('nota-estado');estadoTd.addEventListener('click',e=>{e.stopPropagation();alert(t.nota);});}
+        const chk=tr.querySelector('input[type=checkbox]');
+        const refTd=tr.children[4];
+        refTd.dataset.original=t.referencia||'';
+        chk.addEventListener('change',()=>{actualizarEditable();});
+        refTd.addEventListener('input',()=>{
+          refTd.textContent=refTd.textContent.replace(/[^0-9]/g,'').slice(0,5);
+          if(t.estado==='APROBADO'){
+            const nuevo=refTd.textContent.trim();
+            const orig=refTd.dataset.original||'';
+            if(nuevo!==orig)editRefs[t.id]=nuevo; else delete editRefs[t.id];
+            actualizarBotonRet();
+          }
+        });
+        const mailTd=tr.children[2];
+        mailTd.style.cursor='pointer';
+        mailTd.addEventListener('click',()=>mostrarInfoGmail(t.IDbilletera));
+        const fechaTd=tr.children[5];
+        fechaTd.style.cursor='pointer';
+        fechaTd.addEventListener('click',()=>mostrarDatosTransaccion(t));
+        tb.appendChild(tr);
+        i++;
+      });
+    }
 
     function actualizarEditable(){
       const checks=Array.from(document.querySelectorAll('#tabla-retiros tbody input[type=checkbox]'));
@@ -324,7 +416,7 @@
             const cred=bdoc.exists?(bdoc.data().creditos||0):0;
             let nuevo=cred;
             if(data.tipotrans==='deposito') nuevo+=parseFloat(data.Monto)||0;
-            else if(data.tipotrans==='retiro') nuevo-=parseFloat(data.Monto)||0;
+            else if(data.tipotrans==='retiro') nuevo-=parseFloat(data.MontoSolicitado ?? data.Monto)||0;
             t.set(billeteraRef,{creditos:nuevo},{merge:true});
           });
         }


### PR DESCRIPTION
## Resumen
- Guardar monto solicitado y monto neto al registrar retiros
- Mostrar banco y cuenta en el modal de datos de usuario
- Añadir modal de detalle de transacción y usar monto solicitado al aprobar retiros

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c49c275c8326b127372bbbc35e80