### PR TITLE
feat: confirmaciones y detalle de montos

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -580,10 +580,13 @@
         if(estado && t.estado!==estado) return;
         const estadoColor=t.estado==='PENDIENTE'?'orange':t.estado==='ANULADO'?'red':t.estado==='APROBADO'?'green':'black';
         const tr=document.createElement('tr');
-        tr.innerHTML=`<td>${n}</td><td style="color:${t.tipotrans==='deposito'?'green':'red'}">${t.tipotrans.toUpperCase()}</td><td style="color:${t.tipotrans==='deposito'?'green':'red'}">${t.Monto}</td><td class="celda-fecha">${f}</td><td style="color:${estadoColor}">${t.estado}</td>`;
+        tr.innerHTML=`<td>${n}</td><td style="color:${t.tipotrans==='deposito'?'green':'red'}">${t.tipotrans.toUpperCase()}</td><td class="celda-monto" style="color:${t.tipotrans==='deposito'?'green':'red'}">${t.Monto}</td><td class="celda-fecha">${f}</td><td style="color:${estadoColor}">${t.estado}</td>`;
         const fechaTd=tr.querySelector('.celda-fecha');
         fechaTd.style.cursor='pointer';
         fechaTd.addEventListener('click',()=>mostrarDetalle(t));
+        const montoTd=tr.querySelector('.celda-monto');
+        montoTd.style.cursor='pointer';
+        montoTd.addEventListener('click',()=>mostrarDetalleMonto(t));
         const estadoTd=tr.lastElementChild;
         if(t.estado==='ANULADO' && t.nota){
           estadoTd.classList.add('nota-estado');
@@ -605,6 +608,23 @@
         `<div style="color:green;">Fecha de gestión: ${fg}</div>`+
         `<div style="color:green;">Hora de gestión: ${hg}</div>`+
         `<button id="modal-ok">Aceptar</button>`;
+        const modal=document.getElementById('modal-detalle');
+        modal.style.display='flex';
+        document.getElementById('modal-ok').addEventListener('click',()=>{modal.style.display='none';},{once:true});
+      }
+
+      function mostrarDetalleMonto(t){
+        const solicitado=t.tipotrans==='retiro'?parseFloat(t.MontoSolicitado||t.Monto):parseFloat(t.Monto);
+        const comB=t.tipotrans==='retiro'?solicitado*porcentajeRetiro/100:0;
+        const comG=t.tipotrans==='retiro'?solicitado*porcentajeAdministra/100:0;
+        const total=parseFloat(t.Monto);
+        const cont=document.querySelector('#modal-detalle .contenido');
+        cont.innerHTML=
+          `<div style="font-weight:bold;color:#333;">Monto solicitado: ${solicitado.toFixed(2)}</div>`+
+          `<div>Comisión Bancaria: ${comB.toFixed(2)}</div>`+
+          `<div>Comisión Gestión: ${comG.toFixed(2)}</div>`+
+          `<div>Total recibido: ${total.toFixed(2)}</div>`+
+          `<button id='modal-ok'>Aceptar</button>`;
         const modal=document.getElementById('modal-detalle');
         modal.style.display='flex';
         document.getElementById('modal-ok').addEventListener('click',()=>{modal.style.display='none';},{once:true});
@@ -697,6 +717,7 @@
       if(monto>creditos){ alert('El monto supera los créditos disponibles'); return; }
       const montoFinal = monto - (monto*porcentajeRetiro/100) - (monto*porcentajeAdministra/100);
       document.getElementById('monto-retiro-neto').value = montoFinal>0 ? montoFinal.toFixed(2) : '';
+      if(!confirm(`¿Confirmas la solicitud de retiro por ${montoFinal.toFixed(2)}?`)) return;
       const docB=await db.collection('Billetera').doc(user.email).get();
       const data = {
         tipotrans:'retiro',

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -590,31 +590,36 @@ function toggleForma(idx){
     const porcentaje=Number(vars.data().porcentaje||0);
     const porcentajesu=Number(vars.data().porcentajesu||0);
     let jugarGratis=false;
+    let nuevoCreditos=creditos;
+    let nuevoGratis=gratis;
+    let porcentajeVal=0, porcentajeSuVal=0, paraPremio=0;
     if(gratis>0){
-      gratis--;
       jugarGratis=true;
-      await billeteraRef.update({CartonesGratis:gratis});
-      document.getElementById('gratis-label').textContent=gratis;
+      nuevoGratis=gratis-1;
     }else if(creditos>=valor){
-      creditos-=valor;
-      await billeteraRef.update({creditos});
-      document.getElementById('creditos-label').textContent=creditos;
-      const porcentajeVal=valor*porcentaje/100;
-      const porcentajeSuVal=valor*porcentajesu/100;
-      const paraPremio=valor-porcentajeVal-porcentajeSuVal;
+      nuevoCreditos=creditos-valor;
+      porcentajeVal=valor*porcentaje/100;
+      porcentajeSuVal=valor*porcentajesu/100;
+      paraPremio=valor-porcentajeVal-porcentajeSuVal;
+    }else{
+      alert('No tienes créditos suficientes.');
+      return;
+    }
+    if(!confirm('¿Estas seguro de comprar el carton jugado?')) return;
+    if(jugarGratis){
+      await billeteraRef.update({CartonesGratis:nuevoGratis});
+      document.getElementById('gratis-label').textContent=nuevoGratis;
+      await sorteoRef.update({
+        cartonesjugando: firebase.firestore.FieldValue.increment(1)
+      });
+    }else{
+      await billeteraRef.update({creditos:nuevoCreditos});
+      document.getElementById('creditos-label').textContent=nuevoCreditos;
       await sorteoRef.update({
         cartonesjugando: firebase.firestore.FieldValue.increment(1),
         totalPremios: firebase.firestore.FieldValue.increment(paraPremio),
         totalporcentaje: firebase.firestore.FieldValue.increment(porcentajeVal),
         totalporcentajesu: firebase.firestore.FieldValue.increment(porcentajeSuVal)
-      });
-    }else{
-      alert('No tienes créditos suficientes.');
-      return;
-    }
-    if(jugarGratis){
-      await sorteoRef.update({
-        cartonesjugando: firebase.firestore.FieldValue.increment(1)
       });
     }
     const posiciones=[];


### PR DESCRIPTION
## Resumen
- Muestra un modal con detalle de comisiones y total al pulsar el monto de una transacción.
- Solicita confirmación antes de enviar solicitud de retiro y al comprar un cartón jugado.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4dc9606c0832692d2670b33638432