### PR TITLE
Ensure actions wait for modal confirmation

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -742,7 +742,7 @@
       if(monto>creditos){ alert('El monto supera los créditos disponibles'); return; }
       const montoFinal=monto - (monto*porcentajeRetiro/100) - (monto*porcentajeAdministra/100);
       document.getElementById('monto-retiro-neto').value = montoFinal>0 ? montoFinal.toFixed(2) : '';
-      if(confirm(`¿Confirmas la solicitud de retiro por ${montoFinal.toFixed(2)}?`)){
+      if(await confirm(`¿Confirmas la solicitud de retiro por ${montoFinal.toFixed(2)}?`)){
         await ejecutarRetiro(monto,montoFinal);
       }
     });

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -649,9 +649,9 @@ function toggleForma(idx){
     limpiarcarton();
   }
 
-  function confirmarCompra(){
-    if(confirm('¿Estas seguro de comprar el carton jugado?')){
-      enviarDatos();
+  async function confirmarCompra(){
+    if(await confirm('¿Estas seguro de comprar el carton jugado?')){
+      await enviarDatos();
     }
   }
 


### PR DESCRIPTION
## Summary
- Asegura que la compra del cartón solo se ejecute tras confirmar la ventana modal
- Valida la solicitud de retiro únicamente después de la confirmación del usuario

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e891842c8326b03f7bf569172233