### PR TITLE
feat: limitar cartones gratis por sorteo

### DIFF
--- a/editarsorte.html
+++ b/editarsorte.html
@@ -134,6 +134,8 @@
     #hora-sorteo{color:purple;font-weight:bold;}
     #minutos-label{font-size:1rem;color:#ff8c00;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #cierre-minutos{color:#ff8c00;font-weight:bold;}
+    #max-carton-gratis{width:40px;text-align:center;font-weight:bold;}
+    #max-carton-gratis::placeholder{font-size:0.6rem;}
     #valor-label{font-size:1rem;color:#006400;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #valor-carton{color:#006400;font-weight:bold;}
     .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;}
@@ -180,7 +182,8 @@
     <div class="input-wrapper"><input id="hora-sorteo" type="time"><span class="label-right" id="hora-label">Hora</span></div>
   </div>
   <div class="row">
-    <div class="input-wrapper"><span class="label-left" id="minutos-label">MINUTOS CIERRE</span><input id="cierre-minutos" type="number" placeholder="Minutos antes de cerrar jugadas"></div>
+    <div class="input-wrapper"><span class="label-left" id="minutos-label">MINUTOS</span><input id="cierre-minutos" type="number" placeholder="Minutos antes de cerrar jugadas"></div>
+    <div class="input-wrapper"><input id="max-carton-gratis" type="number" min="0" max="99" placeholder="Max CG" style="width:40px;text-align:center;"></div>
     <div class="input-wrapper"><input id="valor-carton" type="number" placeholder="Valor del Cartón"><span class="label-right" id="valor-label">VALOR CARTÓN</span></div>
   </div>
   <div id="estado-group" class="toggle-group">
@@ -215,11 +218,12 @@
     const fecha=document.getElementById('fecha-sorteo').value;
     const hora=document.getElementById('hora-sorteo').value;
     const cierre=document.getElementById('cierre-minutos').value;
+    const maxcg=document.getElementById('max-carton-gratis').value;
     const valor=document.getElementById('valor-carton').value;
     const tipoBtn=document.querySelector('#tipo-sorteo-group button.active');
     const estadoBtn=document.querySelector('#estado-group button.active');
     const data={
-      nombre,tipo:tipoBtn?tipoBtn.dataset.value:'',fecha,hora,cierre,valor,
+      nombre,tipo:tipoBtn?tipoBtn.dataset.value:'',fecha,hora,cierre,maxcg,valor,
       estado:estadoBtn?estadoBtn.dataset.value:'',
       formas:[]
     };
@@ -250,6 +254,7 @@
       document.getElementById('fecha-sorteo').value=data.fecha||'';
       document.getElementById('hora-sorteo').value=data.hora||'';
       document.getElementById('cierre-minutos').value=data.cierre||'';
+      document.getElementById('max-carton-gratis').value=data.maxcg||'';
       document.getElementById('valor-carton').value=data.valor||'';
       if(data.tipo){
         document.querySelectorAll('#tipo-sorteo-group button').forEach(b=>b.classList.remove('active'));
@@ -303,6 +308,7 @@
     document.getElementById('fecha-sorteo').addEventListener('input',saveState);
     document.getElementById('hora-sorteo').addEventListener('input',saveState);
     document.getElementById('cierre-minutos').addEventListener('input',saveState);
+    document.getElementById('max-carton-gratis').addEventListener('input',saveState);
     document.getElementById('valor-carton').addEventListener('input',saveState);
     document.querySelectorAll('.tab-content .nombre-forma,.tab-content .porcentaje-forma,.tab-content .cartones-forma,.tab-content .imagen-url').forEach(i=>i.addEventListener('input',e=>{
       saveState();
@@ -323,7 +329,7 @@
     const d=doc.data();
     let est=d.estado||'';
     if(d.condicion==='ARCHIVADO') est='Archivado';
-    const data={nombre:d.nombre||'',tipo:d.tipo||'',fecha:d.fecha||'',hora:d.hora||'',cierre:d.cierreMinutos||'',valor:d.valorCarton||'',estado:est,formas:[]};
+    const data={nombre:d.nombre||'',tipo:d.tipo||'',fecha:d.fecha||'',hora:d.hora||'',cierre:d.cierreMinutos||'',maxcg:d.maxcartongratis||'',valor:d.valorCarton||'',estado:est,formas:[]};
     const snap=await db.collection('formas').where('sorteoId','==',sorteoId).get();
     const arr=[];snap.forEach(s=>arr.push(s.data()));
     arr.sort((a,b)=>(a.idx||0)-(b.idx||0));
@@ -598,6 +604,7 @@ firebase.auth().onAuthStateChanged(u=>{
     const fechaInput=document.getElementById('fecha-sorteo');
     const horaInput=document.getElementById('hora-sorteo');
     const cierreInput=document.getElementById('cierre-minutos');
+    const maxcgInput=document.getElementById('max-carton-gratis');
     const valorInput=document.getElementById('valor-carton');
     const nombre=nombreInput.value.trim();
     const tipoBtn=document.querySelector('#tipo-sorteo-group button.active');
@@ -607,6 +614,7 @@ firebase.auth().onAuthStateChanged(u=>{
     const fecha=fechaInput.value;
     const hora=horaInput.value;
     const cierreVal=cierreInput.value;
+    const maxcgVal=maxcgInput.value;
     const valorVal=valorInput.value;
     if(!nombre){alert('Asigna un nombre al Sorteo');nombreInput.focus();return;}
     if(!tipo){alert('Elije un tipo de sorteo');return;}
@@ -615,6 +623,7 @@ firebase.auth().onAuthStateChanged(u=>{
     if(!cierreVal){alert('Elije una cantidad de minutos para cierre previo de Jugadas');cierreInput.focus();return;}
     if(!valorVal){alert('Coloca un valor para el cartón');valorInput.focus();return;}
     const cierre=parseInt(cierreVal);
+    const maxcartongratis=parseInt(maxcgVal)||0;
     const valor=parseFloat(valorVal);
     const condicion = estado==='Archivado'?'ARCHIVADO':'VISIBLE';
     if(estado==='Archivado') estado='Inactivo';
@@ -656,7 +665,7 @@ firebase.auth().onAuthStateChanged(u=>{
     }
     if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
-      await db.collection('sorteos').doc(sorteoId).update({nombre,tipo,fecha,hora,cierreMinutos:cierre,valorCarton:valor,estado,condicion});
+      await db.collection('sorteos').doc(sorteoId).update({nombre,tipo,fecha,hora,cierreMinutos:cierre,maxcartongratis:maxcartongratis,valorCarton:valor,estado,condicion});
       const snap=await db.collection('formas').where('sorteoId','==',sorteoId).get();
       const batch=db.batch();
       snap.forEach(d=>batch.delete(db.collection('formas').doc(d.id)));

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -82,9 +82,10 @@
     .datos-sorteo div{font-weight:bold;font-size:1.2rem;}
     #valor-carton span,#cartones-jugando span{font-size:1.5rem;}
     #valor-carton-valor,#premio-valor{animation:pulse 1s infinite;display:inline-block;}
-    #cartones-jugando-valor,#carton-num{animation:float 1s infinite;display:inline-block;}
+    #cartones-jugando-valor,#carton-num,#gratis-plus,#cartones-gratis-jugando{animation:wiggle 1s infinite;display:inline-block;}
     #valor-carton{color:green;display:flex;align-items:center;gap:5px;}
     #cartones-jugando{color:purple;display:flex;align-items:center;gap:5px;}
+    #gratis-plus{font-weight:bold;color:black;font-family:'Bangers',cursive;}
     #stats-row{display:flex;justify-content:center;align-items:center;gap:20px;}
     .billete-icon{font-size:1.5rem;}
     .carton-icon{width:24px;height:24px;}
@@ -145,7 +146,7 @@
     .mini-carton th,.mini-carton td{border:1px solid gray;width:20px;height:20px;text-align:center;font-weight:bold;font-size:0.6rem;aspect-ratio:1/1;}
     .mini-carton th{font-size:0.8rem;color:#ff6600;background:radial-gradient(circle,#ffffff,#ffffff 60%,#00aa00);text-shadow:1px 1px 0 #000;}
     @keyframes pulse{0%{transform:scale(1);}50%{transform:scale(1.2);}100%{transform:scale(1);}}
-    @keyframes float{0%{transform:translateY(0);}50%{transform:translateY(-5px);}100%{transform:translateY(0);}}
+    @keyframes wiggle{0%{transform:translateX(0);}33%{transform:translateX(5px);}66%{transform:translateX(-5px);}100%{transform:translateX(0);}}
     #player-container{position:relative;border:2px solid green;border-radius:10px;background:linear-gradient(gray,white);padding:10px;margin-top:5px;}
     #alias-row{display:flex;align-items:center;justify-content:center;gap:5px;}
     #alias-jugador{font-size:1.2rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:220px;color:orange;}
@@ -177,7 +178,7 @@
       <div id="premio-repartir"><span id="premio-label">Premio a Repartir:</span> <span id="premio-valor">0</span></div>
       <div id="stats-row">
         <div id="valor-carton"><span class="billete-icon">💵</span> Cartón: <span id="valor-carton-valor">0</span></div>
-        <div id="cartones-jugando"><img src="https://cdn-icons-png.flaticon.com/32/5065/5065890.png" class="carton-icon" alt="Cartón"> Jugando: <span id="cartones-jugando-valor">0</span></div>
+        <div id="cartones-jugando"><img src="https://cdn-icons-png.flaticon.com/32/5065/5065890.png" class="carton-icon" alt="Cartón"> Jugando: <span id="cartones-jugando-valor">0</span> <span id="gratis-plus">+</span> <span id="cartones-gratis-jugando">0</span></div>
       </div>
     </div>
   </section>
@@ -262,6 +263,8 @@ let cookieKey='';
 let formasSorteo=[];
 let formaActiva=0;
 let premioActual=0;
+let maxCartonesGratis=0;
+let avisoMaxGratisMostrado=false;
 const formColors=['#90ee90','#fffacd','#add8e6','#d8b0ff','#ffcc99'];
 const formGlows=['#006400','#b8860b','#00008b','#4b0082','#8b4513'];
 
@@ -487,10 +490,19 @@ function toggleForma(idx){
     const data=doc.data();
   const valor=data.valorCarton||0;
   const jug=data.cartonesjugando||0;
+  const gratisJug=data.cartonesgratisjugando||0;
+  maxCartonesGratis=parseInt(data.maxcartongratis||0);
   const premio=data.totalPremios||0;
   premioActual=premio;
   document.getElementById('valor-carton-valor').textContent=valor;
   document.getElementById('cartones-jugando-valor').textContent=jug;
+  document.getElementById('cartones-gratis-jugando').textContent=gratisJug;
+  const gratisLabel=document.getElementById('gratis-label');
+  if(gratisJug>=maxCartonesGratis && maxCartonesGratis>0 && parseInt(gratisLabel.textContent)>0){
+    gratisLabel.style.color='red';
+  }else{
+    gratisLabel.style.color='';
+  }
   const pv=document.getElementById('premio-valor');
   if(formaActiva>0){
     const f=formasSorteo.find(x=>x.idx===formaActiva);
@@ -585,6 +597,8 @@ function toggleForma(idx){
   const sorteoData=sorteoDoc.data();
   const valor=Number(sorteoData.valorCarton||0);
   const jugActual=sorteoData.cartonesjugando||0;
+  const gratisJugando=sorteoData.cartonesgratisjugando||0;
+  const maxGratis=sorteoData.maxcartongratis||0;
   const cartonNum=jugActual+1;
   const vars=await db.collection('Variablesglobales').doc('Parametros').get();
     const porcentaje=Number(vars.data().porcentaje||0);
@@ -594,8 +608,23 @@ function toggleForma(idx){
     let nuevoGratis=gratis;
     let porcentajeVal=0, porcentajeSuVal=0, paraPremio=0;
     if(gratis>0){
-      jugarGratis=true;
-      nuevoGratis=gratis-1;
+      if(gratisJugando < maxGratis){
+        jugarGratis=true;
+        nuevoGratis=gratis-1;
+        document.getElementById('gratis-label').style.color='';
+      }else{
+        if(!avisoMaxGratisMostrado){alert(`Solo se pueden jugar un máximo de: ${maxGratis}`);avisoMaxGratisMostrado=true;}
+        document.getElementById('gratis-label').style.color='red';
+        if(creditos>=valor){
+          nuevoCreditos=creditos-valor;
+          porcentajeVal=valor*porcentaje/100;
+          porcentajeSuVal=valor*porcentajesu/100;
+          paraPremio=valor-porcentajeVal-porcentajeSuVal;
+        }else{
+          alert('No tienes créditos suficientes.');
+          return;
+        }
+      }
     }else if(creditos>=valor){
       nuevoCreditos=creditos-valor;
       porcentajeVal=valor*porcentaje/100;
@@ -609,7 +638,8 @@ function toggleForma(idx){
       await billeteraRef.update({CartonesGratis:nuevoGratis});
       document.getElementById('gratis-label').textContent=nuevoGratis;
       await sorteoRef.update({
-        cartonesjugando: firebase.firestore.FieldValue.increment(1)
+        cartonesjugando: firebase.firestore.FieldValue.increment(1),
+        cartonesgratisjugando: firebase.firestore.FieldValue.increment(1)
       });
     }else{
       await billeteraRef.update({creditos:nuevoCreditos});

--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -134,6 +134,8 @@
     #hora-sorteo{color:purple;font-weight:bold;}
     #minutos-label{font-size:1rem;color:#ff8c00;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #cierre-minutos{color:#ff8c00;font-weight:bold;}
+    #max-carton-gratis{width:40px;text-align:center;font-weight:bold;}
+    #max-carton-gratis::placeholder{font-size:0.6rem;}
     #valor-label{font-size:1rem;color:#006400;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #valor-carton{color:#006400;font-weight:bold;}
     .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;}
@@ -180,7 +182,8 @@
     <div class="input-wrapper"><input id="hora-sorteo" type="time"><span class="label-right" id="hora-label">Hora</span></div>
   </div>
   <div class="row">
-    <div class="input-wrapper"><span class="label-left" id="minutos-label">MINUTOS CIERRE</span><input id="cierre-minutos" type="number" placeholder="Minutos antes de cerrar jugadas"></div>
+    <div class="input-wrapper"><span class="label-left" id="minutos-label">MINUTOS</span><input id="cierre-minutos" type="number" placeholder="Minutos antes de cerrar jugadas"></div>
+    <div class="input-wrapper"><input id="max-carton-gratis" type="number" min="0" max="99" placeholder="Max CG" style="width:40px;text-align:center;"></div>
     <div class="input-wrapper"><input id="valor-carton" type="number" placeholder="Valor del Cartón"><span class="label-right" id="valor-label">VALOR CARTÓN</span></div>
   </div>
   <div id="estado-group" class="toggle-group">
@@ -212,11 +215,12 @@
     const fecha=document.getElementById('fecha-sorteo').value;
     const hora=document.getElementById('hora-sorteo').value;
     const cierre=document.getElementById('cierre-minutos').value;
+    const maxcg=document.getElementById('max-carton-gratis').value;
     const valor=document.getElementById('valor-carton').value;
     const tipoBtn=document.querySelector('#tipo-sorteo-group button.active');
     const estadoBtn=document.querySelector('#estado-group button.active');
     const data={
-      nombre,tipo:tipoBtn?tipoBtn.dataset.value:'',fecha,hora,cierre,valor,
+      nombre,tipo:tipoBtn?tipoBtn.dataset.value:'',fecha,hora,cierre,maxcg,valor,
       estado:estadoBtn?estadoBtn.dataset.value:'',
       formas:[]
     };
@@ -247,6 +251,7 @@
       document.getElementById('fecha-sorteo').value=data.fecha||'';
       document.getElementById('hora-sorteo').value=data.hora||'';
       document.getElementById('cierre-minutos').value=data.cierre||'';
+      document.getElementById('max-carton-gratis').value=data.maxcg||'';
       document.getElementById('valor-carton').value=data.valor||'';
       if(data.tipo){
         document.querySelectorAll('#tipo-sorteo-group button').forEach(b=>b.classList.remove('active'));
@@ -300,6 +305,7 @@
     document.getElementById('fecha-sorteo').addEventListener('input',saveState);
     document.getElementById('hora-sorteo').addEventListener('input',saveState);
     document.getElementById('cierre-minutos').addEventListener('input',saveState);
+    document.getElementById('max-carton-gratis').addEventListener('input',saveState);
     document.getElementById('valor-carton').addEventListener('input',saveState);
     document.querySelectorAll('.tab-content .nombre-forma,.tab-content .porcentaje-forma,.tab-content .cartones-forma,.tab-content .imagen-url').forEach(i=>i.addEventListener('input',e=>{
       saveState();
@@ -579,6 +585,7 @@
     const fechaInput=document.getElementById('fecha-sorteo');
     const horaInput=document.getElementById('hora-sorteo');
     const cierreInput=document.getElementById('cierre-minutos');
+    const maxcgInput=document.getElementById('max-carton-gratis');
     const valorInput=document.getElementById('valor-carton');
     const nombre=nombreInput.value.trim();
     const tipoBtn=document.querySelector('#tipo-sorteo-group button.active');
@@ -588,6 +595,7 @@
     const fecha=fechaInput.value;
     const hora=horaInput.value;
     const cierreVal=cierreInput.value;
+    const maxcgVal=maxcgInput.value;
     const valorVal=valorInput.value;
     if(!nombre){alert('Asigna un nombre al Sorteo');nombreInput.focus();return;}
     if(!tipo){alert('Elije un tipo de sorteo');return;}
@@ -596,6 +604,7 @@
     if(!cierreVal){alert('Elije una cantidad de minutos para cierre previo de Jugadas');cierreInput.focus();return;}
     if(!valorVal){alert('Coloca un valor para el cartón');valorInput.focus();return;}
     const cierre=parseInt(cierreVal);
+    const maxcartongratis=parseInt(maxcgVal)||0;
     const valor=parseFloat(valorVal);
     const condicion = estado==='Archivado'?'ARCHIVADO':'VISIBLE';
     if(estado==='Archivado') estado='Inactivo';
@@ -637,7 +646,7 @@
     }
     if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
-      const sorteoRef=await db.collection('sorteos').add({nombre,tipo,fecha,hora,cierreMinutos:cierre,valorCarton:valor,estado,condicion});
+      const sorteoRef=await db.collection('sorteos').add({nombre,tipo,fecha,hora,cierreMinutos:cierre,maxcartongratis:maxcartongratis,cartonesgratisjugando:0,valorCarton:valor,estado,condicion});
       const batch=db.batch();
       formas.forEach(f=>{const ref=db.collection('formas').doc();batch.set(ref,{sorteoId:sorteoRef.id,...f});});
         await batch.commit();


### PR DESCRIPTION
## Resumen
- Permite definir un máximo de cartones gratis por sorteo y guardarlo en Firestore
- Muestra y controla el uso de cartones gratis en la pantalla de juego con nueva animación y contador
- Ajusta la validación al jugar para respetar el límite y descontar créditos cuando se excede

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5377a29cc8326b93d89df8b4f1c77