### PR TITLE
Ajusta estilos en modales de premios y cartones

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -162,10 +162,12 @@
     #login-footer{margin-top:20px;}
     #fecha-hora,#derechos{font-size:0.7rem;text-align:center;color:#000;}
     #derechos{font-size:0.6rem;}
-    .info-line{font-family:'Bangers',cursive;font-size:1.5rem;}
-    .text-premio-total{font-family:'Bangers',cursive;color:white;text-shadow:0 0 5px green,-3px 0 3px #000,0 3px 3px #000,3px 0 3px #000,0 -3px 3px #000;}
-    .text-forma-premio{font-family:'Bangers',cursive;font-weight:bold;text-shadow:0 0 5px green,-3px 0 3px #000,0 3px 3px #000,3px 0 3px #000,0 -3px 3px #000;}
-    .text-forma-gratis{font-family:'Bangers',cursive;font-weight:bold;color:purple;}
+    .info-line{font-family:'Bangers',cursive;font-size:1.5rem;text-align:center;}
+    .text-premio-total{font-family:'Bangers',cursive;color:white;text-shadow:0 0 5px green;font-size:1.5rem;text-align:center;}
+    .text-forma-premio{font-family:'Bangers',cursive;font-weight:bold;text-shadow:0 0 5px green;font-size:1.2rem;text-align:center;}
+    .text-forma-gratis{font-family:'Bangers',cursive;font-weight:bold;color:purple;font-size:1.1rem;text-align:center;}
+    #premios-titulo,#info-cartones-titulo{font-size:0.9rem;text-align:center;}
+    #premios-modal .modal-content,#info-cartones-modal .modal-content{align-items:center;}
   </style>
 </head>
 <body>
@@ -841,7 +843,7 @@ function toggleForma(idx){
       return;
     }
     const titulo=document.getElementById('info-cartones-titulo');
-    titulo.textContent=`Cartones jugando en ${currentSorteoNombre}`;
+    titulo.innerHTML=`Cartones jugando<br>${currentSorteoNombre}`;
     titulo.style.color=currentSorteoTipo==='Sorteo Diario'?'green':'orange';
     const cj=document.getElementById('info-cartones-jugando');
     cj.innerHTML=`Cartones jugando: <strong style="color:purple;">${cartonesJugando}</strong>`;
@@ -857,7 +859,7 @@ function toggleForma(idx){
       return;
     }
     const titulo=document.getElementById('premios-titulo');
-    titulo.textContent=`PREMIOS A REPARTIR en: ${currentSorteoNombre}`;
+    titulo.innerHTML=`PREMIOS A REPARTIR<br>${currentSorteoNombre}`;
     titulo.style.color=currentSorteoTipo==='Sorteo Diario'?'green':'orange';
     document.getElementById('premios-total').textContent=`Creditos totales a repartir: ${Math.round(premioActual)}`;
     const cont=document.getElementById('premios-formas');


### PR DESCRIPTION
## Summary
- ajusta los títulos de los modales de premios y de cartones para mostrar el nombre del sorteo en una segunda línea con fuente reducida
- centra y aumenta las fuentes de la información de premios, eliminando sombras negras
## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a63823b008832687faeb0aefd5a5d9