### PR TITLE
Añade resplandor verde oscuro al total de premios

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -167,8 +167,9 @@
     #premios-titulo,#info-cartones-titulo{font-size:1.1rem;text-align:center;font-family:'Bangers',cursive;}
     #premios-modal .modal-content,#info-cartones-modal .modal-content{align-items:center;}
     #info-cartones-aceptar,#premios-aceptar{font-size:1.2rem;padding:8px 20px;}
-    .text-premio-total{font-family:'Bangers',cursive;color:white;font-size:1.5rem;text-align:center;text-shadow:none;}
-    .valor-total{font-size:3rem;}
+    .text-premio-total{font-family:'Bangers',cursive;color:white;font-size:1.5rem;text-align:center;}
+    .text-premio-total div{ text-shadow:0 0 4px darkgreen; }
+    .valor-total{font-size:3rem;text-shadow:0 0 4px darkgreen;}
     .premio-row{display:flex;justify-content:center;align-items:center;gap:10px;font-family:'Bangers',cursive;font-weight:bold;margin-bottom:4px;}
     .premio-row .premio-valor{font-size:1.4rem;}
     .premio-row .cartones-valor{font-size:1.2rem;}


### PR DESCRIPTION
## Resumen
- Agrega resplandor verde oscuro de 4px a los textos de créditos totales en la ventana de premios.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a657b789f08326b66b869ce65aa6b6