### PR TITLE
Añadir selector de país y hora servidor

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
       left: 0;
       right: 0;
       font-size: 0.7rem;
+      text-align: center;
     }
     .back-btn {
       position: fixed;
@@ -93,6 +94,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="auth.js"></script>
+  <script src="scripts/timezone.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       if(typeof firebase === 'undefined'){
@@ -101,6 +103,7 @@
       }
       initFirebase();
       handleRedirect();
+      initFechaHora('fecha-hora');
       const termsContainer=document.getElementById('terms-container');
       const registerContainer=document.getElementById('register-container');
       document.getElementById('login-btn').addEventListener('click', () => {
@@ -126,14 +129,6 @@
         });
       }
       document.getElementById('terms-link').addEventListener('click', e => { e.preventDefault(); window.location.href='terminos.html'; });
-    function actualizarFechaHora(){
-      const ahora = new Date();
-      const opciones = { year:'numeric', month:'long', day:'numeric', hour:'2-digit', minute:'2-digit' };
-      document.getElementById('fecha-hora').textContent = ahora.toLocaleString('es-ES', opciones);
-    }
-    actualizarFechaHora();
-    setInterval(actualizarFechaHora, 60000);
-
     auth.onAuthStateChanged(async user => {
       if(user){
         const doc = await db.collection('users').doc(user.email).get();

--- a/juegoactivo.html
+++ b/juegoactivo.html
@@ -57,16 +57,10 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="auth.js"></script>
+  <script src="scripts/timezone.js"></script>
   <script>
   ensureAuth();
-
-  function actualizarFechaHora(){
-    const ahora=new Date();
-    const opciones={year:'numeric',month:'long',day:'numeric',hour:'2-digit',minute:'2-digit'};
-    document.getElementById('fecha-hora').textContent=ahora.toLocaleString('es-ES',opciones);
-  }
-  actualizarFechaHora();
-  setInterval(actualizarFechaHora,60000);
+  initFechaHora('fecha-hora');
 
   document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='player.html';});
   </script>

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -284,6 +284,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="auth.js"></script>
+  <script src="scripts/timezone.js"></script>
   <script>
   ensureAuth();
 
@@ -1030,13 +1031,7 @@ function toggleForma(idx){
     setBoard(carton);
   }
 
-  function actualizarFechaHora(){
-    const ahora=new Date();
-    const opciones={year:'numeric',month:'long',day:'numeric',hour:'2-digit',minute:'2-digit'};
-    document.getElementById('fecha-hora').textContent=ahora.toLocaleString('es-ES',opciones);
-  }
-
-document.getElementById('sorteo-btn').addEventListener('click',abrirSorteosModal);
+  document.getElementById('sorteo-btn').addEventListener('click',abrirSorteosModal);
 document.getElementById('jugar-carton-btn').addEventListener('click',confirmarCompra);
 document.getElementById('gratis-label').addEventListener('click',()=>{
   const gl=document.getElementById('gratis-label');
@@ -1068,6 +1063,8 @@ document.getElementById('gratis-label').addEventListener('click',()=>{
     if(!show) document.getElementById('nombre-carton').value='';
   });
 
+  initFechaHora('fecha-hora');
+
   auth.onAuthStateChanged(async user=>{
     if(user){
       const doc=await db.collection('users').doc(user.email).get();
@@ -1097,8 +1094,6 @@ document.getElementById('gratis-label').addEventListener('click',()=>{
   document.querySelectorAll('.carton th').forEach((th,i)=>{
     th.addEventListener('click',()=>toggleForma(i+1));
   });
-  actualizarFechaHora();
-  setInterval(actualizarFechaHora,60000);
   </script>
 </body>
 </html>

--- a/parametros.html
+++ b/parametros.html
@@ -165,7 +165,7 @@
     <div class="form-row small-row">
       <div class="field">
         <label for="pais">País:</label>
-        <input type="text" id="pais" placeholder="País" />
+        <select id="pais"></select>
       </div>
       <div class="field">
         <label for="porcentaje">Porcentaje Agencia:</label>
@@ -197,6 +197,30 @@
   <script src="auth.js"></script>
   <script>
     ensureAuth('Superadmin');
+
+    async function cargarPaises(){
+      try{
+        const resp = await fetch('https://restcountries.com/v3.1/all?fields=name,translations,timezones');
+        const paises = await resp.json();
+        paises.sort((a,b)=>{
+          const nA = (a.translations?.spa?.common || a.name.common);
+          const nB = (b.translations?.spa?.common || b.name.common);
+          return nA.localeCompare(nB);
+        });
+        const sel = document.getElementById('pais');
+        paises.forEach(p=>{
+          const nombre = p.translations?.spa?.common || p.name.common;
+          const opt = document.createElement('option');
+          opt.value = nombre;
+          opt.textContent = nombre;
+          opt.dataset.timezone = p.timezones[0];
+          sel.appendChild(opt);
+        });
+      }catch(e){
+        console.error('Error cargando países', e);
+      }
+    }
+
     async function solicitarPassword(){
       const pwd = await prompt('Ingresa tu contraseña');
       if(!pwd){ window.location.href='super.html'; return; }
@@ -224,7 +248,7 @@
       document.getElementById('emailA').value = data.EmailA || '';
       document.getElementById('nombreAgencia').value = data.NombreAgencia || '';
       document.getElementById('direccion').value = data.Direccion || '';
-      document.getElementById('pais').value = data.Pais || '';
+      if(data.Pais){ document.getElementById('pais').value = data.Pais; }
       document.getElementById('porcentaje').value = data.porcentaje || '';
       document.getElementById('porcentajesu').value = data.porcentajesu || '';
       document.getElementById('porcentajeretiro').value = data.porcentajeretiro || '';
@@ -232,7 +256,7 @@
       toggleEdicion(true);
     }
     function toggleEdicion(disabled){
-      document.querySelectorAll('#parametros-form input').forEach(inp=>inp.disabled = disabled);
+      document.querySelectorAll('#parametros-form input, #parametros-form select').forEach(inp=>inp.disabled = disabled);
       document.getElementById('editar-btn').style.display = disabled ? 'block':'none';
       document.getElementById('guardar-btn').style.display = disabled ? 'none':'block';
     }
@@ -247,6 +271,7 @@
         NombreAgencia: document.getElementById('nombreAgencia').value.trim(),
         Direccion: document.getElementById('direccion').value.trim(),
         Pais: document.getElementById('pais').value.trim(),
+        ZonaHoraria: document.getElementById('pais').selectedOptions[0]?.dataset.timezone || '',
         porcentaje: parseFloat(document.getElementById('porcentaje').value)||0,
         porcentajesu: parseFloat(document.getElementById('porcentajesu').value)||0,
         porcentajeretiro: parseFloat(document.getElementById('porcentajeretiro').value)||0,
@@ -265,7 +290,7 @@
         if(logout){logout.addEventListener('click',e=>{e.preventDefault();logout();});}
       }
     });
-    solicitarPassword();
+    (async()=>{ await cargarPaises(); await solicitarPassword(); })();
   </script>
 </body>
 </html>

--- a/perfil.html
+++ b/perfil.html
@@ -116,16 +116,10 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="auth.js"></script>
+  <script src="scripts/timezone.js"></script>
   <script>
   ensureAuth();
-
-  function actualizarFechaHora(){
-    const ahora=new Date();
-    const opciones={year:'numeric',month:'long',day:'numeric',hour:'2-digit',minute:'2-digit'};
-    document.getElementById('fecha-hora').textContent=ahora.toLocaleString('es-ES',opciones);
-  }
-  actualizarFechaHora();
-  setInterval(actualizarFechaHora,60000);
+  initFechaHora('fecha-hora');
 
   document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='player.html';});
   document.getElementById('guardar-perfil-btn').addEventListener('click',guardarPerfil);

--- a/player.html
+++ b/player.html
@@ -158,6 +158,7 @@
       #login-footer {
           position: relative;
           margin-top: 20px;
+          text-align: center;
       }
       #login-btn {
           width: 220px;
@@ -346,6 +347,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="auth.js"></script>
+  <script src="scripts/timezone.js"></script>
 <script>
 ensureAuth();
 auth.onAuthStateChanged(async user=>{
@@ -358,13 +360,7 @@ auth.onAuthStateChanged(async user=>{
     }
   }
 });
-function actualizarFechaHora(){
-  const ahora=new Date();
-  const opciones={year:"numeric",month:"long",day:"numeric",hour:"2-digit",minute:"2-digit"};
-  document.getElementById("fecha-hora").textContent=ahora.toLocaleString("es-ES",opciones);
-}
-actualizarFechaHora();
-setInterval(actualizarFechaHora,60000);
+initFechaHora('fecha-hora');
 
 document.getElementById("carton-btn").addEventListener("click",()=>{window.location.href="jugarcartones.html";});
 document.getElementById("jugando-btn").addEventListener("click",()=>{window.location.href="juegoactivo.html";});

--- a/registrarse.html
+++ b/registrarse.html
@@ -56,7 +56,7 @@
     #cancelar{background:linear-gradient(orange,#ffffff);}
     #terms-container{margin:10px;font-size:0.8rem;display:flex;align-items:center;justify-content:center;gap:5px;}
     #terms-container label{display:flex;align-items:center;}
-    #login-footer{position:absolute;bottom:0;left:0;right:0;}
+    #login-footer{position:absolute;bottom:0;left:0;right:0;text-align:center;}
     #fecha-hora,#derechos{font-size:0.7rem;}
     #derechos{font-size:0.6rem;}
   </style>
@@ -80,6 +80,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="auth.js"></script>
+  <script src="scripts/timezone.js"></script>
   <script>
     ensureAuth();
     auth.onAuthStateChanged(user=>{
@@ -112,13 +113,7 @@
       window.location.href='player.html';
     });
     document.getElementById('cancelar').addEventListener('click', ()=>{ window.location.href='index.html'; });
-    function actualizarFechaHora(){
-      const ahora = new Date();
-      const opciones={year:'numeric',month:'long',day:'numeric',hour:'2-digit',minute:'2-digit'};
-      document.getElementById('fecha-hora').textContent=ahora.toLocaleString('es-ES',opciones);
-    }
-    actualizarFechaHora();
-    setInterval(actualizarFechaHora,60000);
+    initFechaHora('fecha-hora');
   </script>
 </body>
 </html>

--- a/scripts/timezone.js
+++ b/scripts/timezone.js
@@ -1,0 +1,25 @@
+async function initFechaHora(idElemento="fecha-hora"){
+  try{
+    const doc = await db.collection('Variablesglobales').doc('Parametros').get();
+    if(!doc.exists) return;
+    const { Pais, ZonaHoraria } = doc.data();
+    const el = document.getElementById(idElemento);
+    if(!el || !ZonaHoraria) return;
+    async function actualizar(){
+      try{
+        const resp = await fetch(`https://worldtimeapi.org/api/timezone/${encodeURIComponent(ZonaHoraria)}`);
+        const data = await resp.json();
+        const fecha = new Date(data.datetime);
+        const fechaStr = fecha.toLocaleDateString('es-ES',{timeZone:ZonaHoraria,year:'numeric',month:'long',day:'numeric'});
+        const horaStr = fecha.toLocaleString('en-US',{timeZone:ZonaHoraria,hour:'2-digit',minute:'2-digit',hour12:true}).toLowerCase();
+        el.textContent = `${Pais}, ${fechaStr}, ${horaStr}`;
+      }catch(err){
+        console.error('Error obteniendo hora del servidor', err);
+      }
+    }
+    await actualizar();
+    setInterval(actualizar,60000);
+  }catch(e){
+    console.error('Error obteniendo parámetros', e);
+  }
+}


### PR DESCRIPTION
## Resumen
- Incorporar lista desplegable de países y guardar zona horaria en parámetros globales
- Crear utilitario para obtener fecha y hora exacta desde worldtimeapi.org
- Mostrar país, fecha y hora centralizadas en los pies de página de la aplicación

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7294e16648326af0ff9da25546a16