### PR TITLE
Habilitar selección de país y uso global de zona horaria

### DIFF
--- a/parametros.html
+++ b/parametros.html
@@ -100,6 +100,10 @@
       text-align: left;
       background-color: #fff;
     }
+    /* El menú de selección de país debe verse con fondo blanco */
+    #pais {
+      background-color: #fff;
+    }
     .small-row {
       flex-wrap: wrap;
       gap: 10px;
@@ -253,7 +257,8 @@
       document.getElementById('porcentajesu').value = data.porcentajesu || '';
       document.getElementById('porcentajeretiro').value = data.porcentajeretiro || '';
       document.getElementById('porcentajeadministra').value = data.porcentajeadministra || '';
-      toggleEdicion(true);
+      /* Habilitar edición por defecto para permitir la selección inmediata del país */
+      toggleEdicion(false);
     }
     function toggleEdicion(disabled){
       document.querySelectorAll('#parametros-form input, #parametros-form select').forEach(inp=>inp.disabled = disabled);


### PR DESCRIPTION
## Resumen
- Habilita la edición inmediata de los parámetros globales y el menú de país
- Estiliza el selector de país con fondo blanco

## Pruebas
- `curl -s 'https://restcountries.com/v3.1/all?fields=name,translations,timezones' | jq -r '.[0].translations.spa.common'`
- `curl -s 'https://worldtimeapi.org/api/timezone/America/Bogota' | head -c 200`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a733156b78832685321a2f2478f208