### PR TITLE
Mostrar fecha y hora de sorteo en modal

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -130,7 +130,8 @@
     .carton-back img{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:80%;height:auto;opacity:0.15;object-fit:contain;pointer-events:none;z-index:0;}
     .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;z-index:1000;}
     .modal-content{background:#fff;padding:10px;border-radius:10px;display:flex;flex-direction:column;align-items:flex-start;gap:5px;width:max-content;}
-    #sorteos-list div{display:block;font-weight:bold;font-size:1rem;color:#000;cursor:pointer;font-family:'Poppins',sans-serif;white-space:nowrap;}
+    #sorteos-list div{display:block;font-weight:bold;font-size:1rem;color:#000;cursor:pointer;font-family:'Poppins',sans-serif;position:relative;padding-bottom:8px;}
+    #sorteos-list div .sorteo-detalle{position:absolute;left:0;top:100%;margin-top:-2px;font-size:0.6rem;font-weight:normal;pointer-events:none;color:#000;font-family:'Poppins',sans-serif;}
     #number-modal-title{font-size:0.8rem;text-align:center;width:100%;text-shadow:0 0 5px blue;margin-bottom:5px;font-family:'Poppins',sans-serif;}
     #number-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;}
     #number-grid div{width:60px;height:60px;display:flex;align-items:center;justify-content:center;font-size:1.8rem;text-shadow:0 0 5px green;cursor:pointer;}
@@ -631,8 +632,14 @@ function toggleForma(idx){
     list.innerHTML='';
     sorteosActivos.forEach((s,i)=>{
       const div=document.createElement('div');
-      div.textContent=`${i+1}- ${s.nombre}`;
-      div.className=s.tipo==='Sorteo Diario'?'sorteo-diario':'sorteo-especial';
+      const nombreSpan=document.createElement('span');
+      nombreSpan.textContent=`${i+1}- ${s.nombre}`;
+      nombreSpan.className=s.tipo==='Sorteo Diario'?'sorteo-diario':'sorteo-especial';
+      div.appendChild(nombreSpan);
+      const detalle=document.createElement('span');
+      detalle.className='sorteo-detalle';
+      detalle.innerHTML=`<span class="cal-icon">📅</span> ${formatearFecha(s.fecha)} <span class="clock-icon">⏰</span> ${formatearHora(s.hora)}`;
+      div.appendChild(detalle);
       div.addEventListener('click',()=>{seleccionarSorteo(s);document.getElementById('sorteos-modal').style.display='none';});
       list.appendChild(div);
     });


### PR DESCRIPTION
## Resumen
- Añade estilos para detalles de sorteo dentro del modal.
- Muestra fecha y hora bajo cada sorteo con íconos en el modal de selección.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8bd3803883268ef4807a3f380520