### PR TITLE
Mejoras en visualización y estados de sorteos

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -76,6 +76,8 @@
     #sorteo-btn.especial{background:linear-gradient(#ff8800,#ffffff);}
     .sorteo-diario{color:green;}
     .sorteo-especial{color:orange;}
+    .sorteo-sellado{color:gray;}
+    .sorteo-jugando{color:purple;}
     .sorteo-info{display:flex;align-items:center;justify-content:center;gap:10px;}
     .datos-sorteo{display:flex;flex-direction:column;align-items:center;gap:4px;justify-content:center;margin-top:2px;flex-wrap:wrap;font-family:'Bangers',cursive;}
     #sorteo-section{margin-bottom:5px;}
@@ -130,8 +132,8 @@
     .carton-back img{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:80%;height:auto;opacity:0.15;object-fit:contain;pointer-events:none;z-index:0;}
     .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;z-index:1000;}
     .modal-content{background:#fff;padding:10px;border-radius:10px;display:flex;flex-direction:column;align-items:flex-start;gap:5px;width:max-content;}
-    #sorteos-list div{display:block;font-weight:bold;font-size:1rem;color:#000;cursor:pointer;font-family:'Poppins',sans-serif;position:relative;padding-bottom:8px;}
-    #sorteos-list div .sorteo-detalle{position:absolute;left:0;top:100%;margin-top:-2px;font-size:0.6rem;font-weight:normal;pointer-events:none;color:#000;font-family:'Poppins',sans-serif;}
+    #sorteos-list div{display:block;font-weight:bold;font-size:1rem;cursor:pointer;font-family:'Poppins',sans-serif;margin-bottom:2px;}
+    #sorteos-list div .sorteo-detalle{display:block;font-size:0.6rem;font-weight:normal;pointer-events:none;color:inherit;font-family:'Poppins',sans-serif;margin-top:-2px;}
     #number-modal-title{font-size:0.8rem;text-align:center;width:100%;text-shadow:0 0 5px blue;margin-bottom:5px;font-family:'Poppins',sans-serif;}
     #number-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:5px;justify-items:center;}
     #number-grid div{width:60px;height:60px;display:flex;align-items:center;justify-content:center;font-size:1.8rem;text-shadow:0 0 5px green;cursor:pointer;}
@@ -620,6 +622,8 @@ function toggleForma(idx){
     btn.style.fontSize = s.nombre.length>20?'0.8rem':'1.1rem';
     document.getElementById('fecha-sorteo').innerHTML=`<span class="cal-icon">📅</span> ${formatearFecha(s.fecha)}`;
     document.getElementById('hora-sorteo').innerHTML=`<span class="clock-icon">⏰</span> ${formatearHora(s.hora)}`;
+    const jugarBtn=document.getElementById('jugar-carton-btn');
+    if(s.estado==='Sellado' || s.estado==='Jugando') jugarBtn.disabled=true; else jugarBtn.disabled=false;
     actualizarFondoCarton();
     await cargarFormasSorteo();
     await actualizarDatosSorteo();
@@ -632,16 +636,22 @@ function toggleForma(idx){
     list.innerHTML='';
     sorteosActivos.forEach((s,i)=>{
       const div=document.createElement('div');
+      div.className = s.estado==='Sellado' ? 'sorteo-sellado'
+                    : s.estado==='Jugando' ? 'sorteo-jugando'
+                    : (s.tipo==='Sorteo Diario' ? 'sorteo-diario' : 'sorteo-especial');
+      const indexSpan=document.createElement('span');
+      indexSpan.textContent=`${i+1}- `;
+      div.appendChild(indexSpan);
       const nombreSpan=document.createElement('span');
-      nombreSpan.textContent=`${i+1}- ${s.nombre}`;
-      nombreSpan.className=s.tipo==='Sorteo Diario'?'sorteo-diario':'sorteo-especial';
+      nombreSpan.textContent=s.nombre;
       div.appendChild(nombreSpan);
-      const detalle=document.createElement('span');
+      list.appendChild(div);
+      const detalle=document.createElement('div');
       detalle.className='sorteo-detalle';
       detalle.innerHTML=`<span class="cal-icon">📅</span> ${formatearFecha(s.fecha)} <span class="clock-icon">⏰</span> ${formatearHora(s.hora)}`;
+      detalle.style.marginLeft=indexSpan.offsetWidth+'px';
       div.appendChild(detalle);
       div.addEventListener('click',()=>{seleccionarSorteo(s);document.getElementById('sorteos-modal').style.display='none';});
-      list.appendChild(div);
     });
     document.getElementById('sorteos-modal').style.display='flex';
   }
@@ -649,10 +659,10 @@ function toggleForma(idx){
   async function cargarSorteosActivos(){
     sorteosActivos=[];
     try{
-      const snap=await db.collection('sorteos').where('estado','==','Activo').get();
+      const snap=await db.collection('sorteos').where('estado','in',['Activo','Sellado','Jugando']).get();
       snap.forEach(doc=>{
         const d=doc.data();
-        sorteosActivos.push({id:doc.id,nombre:d.nombre,fecha:d.fecha,hora:d.hora,tipo:d.tipo});
+        sorteosActivos.push({id:doc.id,nombre:d.nombre,fecha:d.fecha,hora:d.hora,tipo:d.tipo,estado:d.estado});
       });
     }catch(e){ console.warn('No se pudieron cargar sorteos'); }
   }


### PR DESCRIPTION
## Resumen
- Ajuste de estilos en el modal de selección de sorteos, reduciendo márgenes y manteniendo colores consistentes.
- Inclusión de sorteos en estados Sellado y Jugando, con colores gris y morado respectivamente.
- Deshabilitar el botón **JUGAR CARTÓN** cuando el sorteo seleccionado está Sellado o Jugando.

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab907de8248326a198ef598ad5fd41