### PR TITLE
Usar hora del país en registros

### DIFF
--- a/billetera.html
+++ b/billetera.html
@@ -389,8 +389,10 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="auth.js"></script>
+  <script src="scripts/timezone.js"></script>
   <script>
     ensureAuth();
+    initServerTime();
     const transacciones=[];
     let porcentajeRetiro=0, porcentajeAdministra=0;
 
@@ -498,15 +500,10 @@
     });
 
     function fechaActual(){
-      const d=new Date();
-      const dia=String(d.getDate()).padStart(2,'0');
-      const mes=String(d.getMonth()+1).padStart(2,'0');
-      const anio=d.getFullYear();
-      return `${dia}/${mes}/${anio}`;
+      return fechaServidor();
     }
     function horaActual(){
-      const d=new Date();
-      return d.toLocaleTimeString('es-VE',{hour:'2-digit',minute:'2-digit'});
+      return horaServidor();
     }
 
     function formatearFecha(str){
@@ -678,6 +675,7 @@
 
     document.getElementById('btn-depositar').addEventListener('click', async () => {
       if(!await validarDatosBancarios()) return;
+      await initServerTime();
       const user = auth.currentUser;
       const banco=document.getElementById('banco-deposito').value;
       if(!banco){alert('Seleccione el banco donde transferiste');document.getElementById('banco-deposito').focus();return;}
@@ -710,6 +708,7 @@
 
     async function ejecutarRetiro(monto,montoFinal){
       const user=auth.currentUser;
+      await initServerTime();
       const docB=await db.collection('Billetera').doc(user.email).get();
       const data={
         tipotrans:'retiro',

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -309,6 +309,7 @@
   <script src="scripts/timezone.js"></script>
   <script>
   ensureAuth();
+  initServerTime();
 
   const ranges=[[1,15],[16,30],[31,45],[46,60],[61,75]];
 const board=document.getElementById('bingo-board');
@@ -765,6 +766,7 @@ function toggleForma(idx){
       alert('Este número de cartón ya fue jugado en este sorteo.');
       return;
     }
+    await initServerTime();
     await db.collection('CartonJugado').add({
       userId:user.uid,
       alias:alias,
@@ -773,8 +775,8 @@ function toggleForma(idx){
       Ncarton:ncarton,
       tipocarton:jugarGratis?'gratis':'pagado',
       posiciones:posiciones,
-      fecha:new Date().toLocaleDateString('es-ES'),
-      hora:new Date().toLocaleTimeString('es-ES')
+      fecha:fechaServidor(),
+      hora:horaServidor()
     });
     await actualizarDatosSorteo();
     await actualizarCartonesJugador();

--- a/scripts/timezone.js
+++ b/scripts/timezone.js
@@ -1,13 +1,49 @@
-async function initFechaHora(idElemento = "fecha-hora") {
-  const el = document.getElementById(idElemento);
-  if (!el) return;
+// Datos globales de la hora del servidor
+const serverTime = {
+  Pais: '',
+  locale: 'es-ES',
+  zonaIana: '',
+  diferencia: 0
+};
 
+function parseZona(zona) {
+  const match = zona.match(/^UTC([+-])(\d{2}):(\d{2})$/);
+  if (match) {
+    const sign = match[1] === '-' ? '+' : '-';
+    const h = String(parseInt(match[2], 10));
+    return `Etc/GMT${sign}${h}`;
+  }
+  return zona;
+}
+
+async function sincronizarHora() {
+  if (!serverTime.zonaIana) {
+    serverTime.diferencia = 0;
+    return;
+  }
+  try {
+    const resp = await fetch(`https://worldtimeapi.org/api/timezone/${encodeURIComponent(serverTime.zonaIana)}`);
+    if (!resp.ok) throw new Error('Respuesta no válida');
+    const data = await resp.json();
+    const serverDate = new Date(data.datetime);
+    if (!isNaN(serverDate)) {
+      serverTime.diferencia = serverDate.getTime() - Date.now();
+    } else {
+      serverTime.diferencia = 0;
+    }
+  } catch (err) {
+    console.error('Error obteniendo hora del servidor', err);
+    serverTime.diferencia = 0;
+  }
+}
+
+async function initServerTime() {
+  if (serverTime.zonaIana) return; // ya inicializado
   try {
     const doc = await db.collection('Variablesglobales').doc('Parametros').get();
     if (!doc.exists) throw new Error('Documento Parametros no existe');
-
     const { Pais = '', ZonaHoraria = '' } = doc.data();
-
+    serverTime.Pais = Pais;
     const locales = {
       Venezuela: 'es-VE',
       España: 'es-ES',
@@ -15,63 +51,57 @@ async function initFechaHora(idElemento = "fecha-hora") {
       Colombia: 'es-CO',
       Argentina: 'es-AR'
     };
-    const locale = locales[Pais] || 'es-ES';
-
-    function parseZona(zona) {
-      const match = zona.match(/^UTC([+-])(\d{2}):(\d{2})$/);
-      if (match) {
-        const sign = match[1] === '-' ? '+' : '-';
-        const h = String(parseInt(match[2], 10));
-        return `Etc/GMT${sign}${h}`;
-      }
-      return zona;
-    }
-
-    const zonaIana = parseZona(ZonaHoraria);
-    let diferencia = 0;
-
-    async function sincronizar() {
-      if (!zonaIana) {
-        diferencia = 0;
-        return;
-      }
-      try {
-        const resp = await fetch(`https://worldtimeapi.org/api/timezone/${encodeURIComponent(zonaIana)}`);
-        if (!resp.ok) throw new Error('Respuesta no válida');
-        const data = await resp.json();
-        const serverDate = new Date(data.datetime);
-        if (!isNaN(serverDate)) {
-          diferencia = serverDate.getTime() - Date.now();
-        } else {
-          diferencia = 0;
-        }
-      } catch (err) {
-        console.error('Error obteniendo hora del servidor', err);
-        diferencia = 0;
-      }
-    }
-
-    function mostrar() {
-      const ahora = new Date(Date.now() + diferencia);
-      const opcionesFecha = { year: 'numeric', month: 'long', day: 'numeric', timeZone: zonaIana };
-      const opcionesHora = { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: zonaIana };
-      try {
-        const fechaStr = ahora.toLocaleDateString(locale, opcionesFecha);
-        let horaStr = ahora.toLocaleTimeString(locale, opcionesHora);
-        horaStr = horaStr.replace(' a. m.', ' am').replace(' p. m.', ' pm');
-        el.textContent = `${Pais}, ${fechaStr}, ${horaStr}`;
-      } catch (err) {
-        console.error('Error formateando fecha/hora', err);
-        el.textContent = '';
-      }
-    }
-
-    await sincronizar();
-    mostrar();
-    setInterval(mostrar, 1000);
-    setInterval(sincronizar, 3600000);
+    serverTime.locale = locales[Pais] || 'es-ES';
+    serverTime.zonaIana = parseZona(ZonaHoraria);
+    await sincronizarHora();
+    setInterval(sincronizarHora, 3600000);
   } catch (e) {
     console.error('Error obteniendo parámetros', e);
-    setTimeout(() => initFechaHora(idElemento), 60000);
   }
 }
+
+function obtenerFecha() {
+  const d = new Date(Date.now() + serverTime.diferencia);
+  const dia = String(d.getDate()).padStart(2, '0');
+  const mes = String(d.getMonth() + 1).padStart(2, '0');
+  const anio = d.getFullYear();
+  return `${dia}/${mes}/${anio}`;
+}
+
+function obtenerHora() {
+  const d = new Date(Date.now() + serverTime.diferencia);
+  return d.toLocaleTimeString(serverTime.locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: serverTime.zonaIana
+  });
+}
+
+async function initFechaHora(idElemento = "fecha-hora") {
+  await initServerTime();
+  const el = document.getElementById(idElemento);
+  if (!el) return;
+
+  function mostrar() {
+    const ahora = new Date(Date.now() + serverTime.diferencia);
+    const opcionesFecha = { year: 'numeric', month: 'long', day: 'numeric', timeZone: serverTime.zonaIana };
+    const opcionesHora = { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: serverTime.zonaIana };
+    try {
+      const fechaStr = ahora.toLocaleDateString(serverTime.locale, opcionesFecha);
+      let horaStr = ahora.toLocaleTimeString(serverTime.locale, opcionesHora);
+      horaStr = horaStr.replace(' a. m.', ' am').replace(' p. m.', ' pm');
+      el.textContent = `${serverTime.Pais}, ${fechaStr}, ${horaStr}`;
+    } catch (err) {
+      console.error('Error formateando fecha/hora', err);
+      el.textContent = '';
+    }
+  }
+
+  mostrar();
+  setInterval(mostrar, 1000);
+}
+
+window.initServerTime = initServerTime;
+window.fechaServidor = obtenerFecha;
+window.horaServidor = obtenerHora;
+window.initFechaHora = initFechaHora;

--- a/transacciones.html
+++ b/transacciones.html
@@ -163,8 +163,10 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="auth.js"></script>
+  <script src="scripts/timezone.js"></script>
   <script>
     ensureAuth('Colaborador');
+    initServerTime();
     const transRef=db.collection('transacciones');
     const datosRec=[];const datosRet=[];
     function loadRefCookies(){
@@ -208,8 +210,8 @@
     }
     const filtrosRec={monto:'',nombre:'',banco:'',ref:'',fecha:'',estado:''};
     const filtrosRet={monto:'',nombre:'',banco:'',ref:'',fecha:'',estado:''};
-    function fecha(){const d=new Date();return d.toLocaleDateString('es-VE');}
-    function hora(){const d=new Date();return d.toLocaleTimeString('es-VE',{hour:'2-digit',minute:'2-digit'});}
+    function fecha(){return fechaServidor();}
+    function hora(){return horaServidor();}
 
     function solicitarMotivo(){
       return new Promise(res=>{
@@ -414,6 +416,7 @@
     function seleccionados(tb){return Array.from(tb.querySelectorAll('input[type=checkbox]:checked')).map(c=>c.dataset.id);}
 
     async function actualizar(ids,estado,nota,ref,condicion){
+      await initServerTime();
       for(const id of ids){
         const doc=await transRef.doc(id).get();
         const data=doc.data();


### PR DESCRIPTION
## Resumen
- Centraliza la obtención de la hora del país y expone utilidades `fechaServidor` y `horaServidor`.
- Aplica hora del servidor al guardar solicitudes de depósito/retiro.
- Sella gestiones y jugadas de cartón con la hora del país.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde69f3ee08326873b729685ba0f7b