### PR TITLE
Agregar control de estados de sorteos y PDF de jugadas

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -101,15 +101,7 @@
     #gratis-label{color:#4b0082;text-shadow:0 0 5px #fff;}
     #creditos-label{color:#333;text-shadow:0 0 5px green;}
     .credit-icon{color:white;font-weight:bold;text-shadow:0 0 5px lime;}
-    .action-btn{
-      font-family:'Bangers',cursive;
-      background:linear-gradient(#0a8800,#ffffff);
-      color:white;
-      border:3px solid #FFD700;
-      border-radius:8px;
-      text-shadow:2px 2px 4px #000;
-      cursor:pointer;
-    }
+        #info-cartones-pdf{background:linear-gradient(purple,#00008b);}
     #jugados-btn-container{position:absolute;bottom:5px;right:50px;}
     #ver-jugados-btn{width:40px;height:40px;display:flex;align-items:center;justify-content:center;background:linear-gradient(purple,#ffffff);border:3px solid #FFD700;border-radius:8px;cursor:pointer;position:relative;}
     #jugados-count{position:absolute;top:-8px;left:-8px;background:purple;color:white;border-radius:50%;width:20px;height:20px;display:flex;align-items:center;justify-content:center;font-size:0.8rem;font-family:'Bangers',cursive;z-index:10;}
@@ -291,7 +283,10 @@
           <h2 id="info-cartones-titulo"></h2>
           <div id="info-cartones-jugando" class="info-line"></div>
           <div id="info-cartones-gratis" class="info-line"></div>
-          <button id="info-cartones-aceptar" class="action-btn">Aceptar</button>
+          <div class="modal-buttons">
+            <button id="info-cartones-pdf" class="action-btn">PDF Jugadas</button>
+            <button id="info-cartones-aceptar" class="action-btn">Aceptar</button>
+          </div>
       </div>
   </div>
   <div id="premios-modal" class="modal" onclick="this.style.display='none'">
@@ -307,9 +302,12 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="auth.js"></script>
   <script src="scripts/timezone.js"></script>
+  <script src="scripts/estadoSorteos.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script>
   ensureAuth();
   initServerTime();
+  iniciarControlSorteos();
 
   const ranges=[[1,15],[16,30],[31,45],[46,60],[61,75]];
 const board=document.getElementById('bingo-board');
@@ -667,6 +665,7 @@ function toggleForma(idx){
 
   async function cargarSorteosActivos(){
     sorteosActivos=[];
+    await actualizarEstadosSorteos();
     try{
       const snap=await db.collection('sorteos').where('estado','in',['Activo','Sellado','Jugando']).get();
       snap.forEach(doc=>{
@@ -997,6 +996,9 @@ function toggleForma(idx){
     cj.innerHTML=`Cartones jugando: <strong style="color:purple;">${cartonesJugando}</strong>`;
     const cg=document.getElementById('info-cartones-gratis');
     cg.innerHTML=`Cartones Gratis jugando: <strong style="color:#00008b;">${cartonesGratisJugando}</strong>`;
+    const pdfBtn=document.getElementById('info-cartones-pdf');
+    const s=sorteosActivos.find(x=>x.id===currentSorteo);
+    if(s && (s.estado==='Sellado' || s.estado==='Jugando')) pdfBtn.style.display='inline-block'; else pdfBtn.style.display='none';
     document.getElementById('info-cartones-modal').style.display='flex';
   }
 
@@ -1009,6 +1011,49 @@ function toggleForma(idx){
     renderPremios('premios');
     renderPremios('back-premios');
     document.getElementById('premios-modal').style.display='flex';
+  }
+
+  async function generarPDFJugadas(){
+    const s=sorteosActivos.find(x=>x.id===currentSorteo);
+    if(!s) return;
+    const snap=await db.collection('CartonJugado').where('sorteoId','==',currentSorteo).get();
+    const docs=[]; snap.forEach(d=>docs.push(d.data()));
+    docs.sort((a,b)=>a.cartonNum-b.cartonNum);
+    const { jsPDF } = window.jspdf;
+    const doc=new jsPDF('p','mm','a4');
+    async function toDataURL(url){
+      const res=await fetch(url); const blob=await res.blob();
+      return await new Promise(r=>{const reader=new FileReader(); reader.onload=()=>r(reader.result); reader.readAsDataURL(blob);});
+    }
+    const logo=await toDataURL('https://i.imgur.com/twjhNtZ.png');
+    doc.addImage(logo,'PNG',10,10,15,15);
+    doc.setFontSize(16); doc.text('BingOnline',105,18,{align:'center'});
+    doc.setFontSize(10); doc.text('📅 '+s.fecha,190,12,{align:'right'}); doc.text('🕒 '+s.hora,190,18,{align:'right'});
+    const tipoColor=s.tipo==='Sorteo Especial'?[255,165,0]:[0,128,0];
+    doc.setFontSize(12); doc.setTextColor(0,0,0);
+    doc.text('Tipo de sorteo:',105,26,{align:'center'});
+    doc.setTextColor(tipoColor[0],tipoColor[1],tipoColor[2]); doc.text(`${s.tipo} Sorteo: ${s.nombre}`,105,32,{align:'center'});
+    doc.setTextColor(0,0,0);
+    const cont=document.createElement('div');
+    cont.style.display='flex'; cont.style.flexWrap='wrap'; cont.style.width='190mm';
+    docs.forEach(d=>{
+      const mini=document.createElement('div');
+      mini.style.width='30mm'; mini.style.height='38mm'; mini.style.margin='2mm'; mini.style.border='1px solid #000';
+      const top=document.createElement('div');
+      top.textContent=`${d.tipocarton==='gratis'?'Gratis':'Pagado'} ${String(d.cartonNum).padStart(4,'0')}`;
+      top.style.textAlign='center'; top.style.fontSize='6px';
+      top.style.background=d.tipocarton==='gratis'? 'linear-gradient(#00008b,#ffff00)':'linear-gradient(#008000,#ffff00)';
+      top.style.color='white';
+      mini.appendChild(top);
+      const alias=document.createElement('div'); alias.textContent=d.alias||''; alias.style.textAlign='center'; alias.style.fontSize='5px'; alias.style.color='black'; mini.appendChild(alias);
+      const table=document.createElement('table'); table.style.width='100%'; table.style.borderCollapse='collapse';
+      for(let r=0;r<5;r++){ const tr=document.createElement('tr'); for(let c=0;c<5;c++){ const td=document.createElement('td'); td.style.border='0.2mm solid #555'; td.style.width='20%'; td.style.height='6mm'; td.style.fontSize='5px'; td.style.textAlign='center'; const pos=(d.posiciones||[]).find(p=>p.r===r&&p.c===c); td.textContent=pos?pos.valor:''; td.style.background=d.tipocarton==='gratis'?'#e0f0ff':'#e0ffe0'; tr.appendChild(td);} table.appendChild(tr);} mini.appendChild(table); cont.appendChild(mini); });
+    document.body.appendChild(cont);
+    await new Promise(res=>doc.html(cont,{x:10,y:40,width:190,callback:res}));
+    document.body.removeChild(cont);
+    const pages=doc.getNumberOfPages();
+    for(let i=1;i<=pages;i++){ doc.setPage(i); const pw=doc.internal.pageSize.getWidth(); const ph=doc.internal.pageSize.getHeight(); doc.setFontSize(8); doc.setTextColor(128); doc.text(`página ${i} de ${pages}`, pw-30, ph-5); }
+    doc.save('jugadas-'+s.nombre+'.pdf');
   }
 
   async function abrirJugadosModal(){
@@ -1247,6 +1292,7 @@ document.getElementById('gratis-label').addEventListener('click',()=>{
   document.getElementById('cartones-gratis-jugando').addEventListener('click',mostrarCartonesJugandoModal);
   document.getElementById('premio-valor').addEventListener('click',mostrarPremiosModal);
   document.getElementById('info-cartones-aceptar').addEventListener('click',()=>{document.getElementById('info-cartones-modal').style.display='none';});
+  document.getElementById('info-cartones-pdf').addEventListener('click',generarPDFJugadas);
   document.getElementById('premios-aceptar').addEventListener('click',()=>{document.getElementById('premios-modal').style.display='none';});
   document.getElementById('limpiar-btn').addEventListener('click',async()=>{if(await confirm('¿Deseas limpiar todas las jugadas del carton?')) limpiarcarton();});
   document.getElementById('azar-btn').addEventListener('click',async()=>{if(await confirm('¿Quieres cargar jugadas al azar?')) cargarAzar();});

--- a/scripts/estadoSorteos.js
+++ b/scripts/estadoSorteos.js
@@ -1,0 +1,33 @@
+async function actualizarEstadosSorteos(){
+  await initServerTime();
+  const ahora = new Date(Date.now() + serverTime.diferencia);
+  try{
+    const snap = await db.collection('sorteos').where('estado','in',['Activo','Sellado']).get();
+    const updates=[];
+    snap.forEach(doc=>{
+      const d=doc.data();
+      if(!d.fecha || !d.hora) return;
+      const [dia,mes,anio]=d.fecha.split('/').map(n=>parseInt(n,10));
+      const [hor,min]=d.hora.split(':').map(n=>parseInt(n,10));
+      const sorteoDate = new Date(anio,mes-1,dia,hor,min);
+      const cierre = parseInt(d.cierreMinutos||0,10);
+      const selladoDate = new Date(sorteoDate.getTime() - cierre*60000);
+      if(d.estado==='Activo' && ahora>=selladoDate){
+        updates.push(doc.ref.update({estado:'Sellado'}));
+      }else if(d.estado==='Sellado' && ahora>=sorteoDate){
+        updates.push(doc.ref.update({estado:'Jugando'}));
+      }
+    });
+    await Promise.all(updates);
+  }catch(e){
+    console.error('Error actualizando estados de sorteos',e);
+  }
+}
+
+async function iniciarControlSorteos(){
+  await actualizarEstadosSorteos();
+  setInterval(actualizarEstadosSorteos,60000);
+}
+
+window.actualizarEstadosSorteos=actualizarEstadosSorteos;
+window.iniciarControlSorteos=iniciarControlSorteos;


### PR DESCRIPTION
## Resumen
- Automatiza el cambio de estado de los sorteos de Activo a Sellado y Jugando según hora y fecha
- Añade botón **PDF Jugadas** en la ventana de cartones que genera un PDF con todas las jugadas

## Pruebas
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdf798ce8c832689cdd58291467185