### PR TITLE
Mostrar cartones en ventana dedicada

### DIFF
--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -110,7 +110,7 @@
       text-shadow:2px 2px 4px #000;
       cursor:pointer;
     }
-    #info-cartones-pdf{background:linear-gradient(purple,#00008b);}
+    #info-cartones-ver{background:linear-gradient(purple,#00008b);}
     #jugados-btn-container{position:absolute;bottom:5px;right:50px;}
     #ver-jugados-btn{width:40px;height:40px;display:flex;align-items:center;justify-content:center;background:linear-gradient(purple,#ffffff);border:3px solid #FFD700;border-radius:8px;cursor:pointer;position:relative;}
     #jugados-count{position:absolute;top:-8px;left:-8px;background:purple;color:white;border-radius:50%;width:20px;height:20px;display:flex;align-items:center;justify-content:center;font-size:0.8rem;font-family:'Bangers',cursive;z-index:10;}
@@ -293,7 +293,7 @@
           <div id="info-cartones-jugando" class="info-line"></div>
           <div id="info-cartones-gratis" class="info-line"></div>
           <div class="modal-buttons">
-            <button id="info-cartones-pdf" class="action-btn">PDF Jugadas</button>
+            <button id="info-cartones-ver" class="action-btn">Ver Cartones</button>
             <button id="info-cartones-aceptar" class="action-btn">Aceptar</button>
           </div>
       </div>
@@ -312,7 +312,6 @@
   <script src="auth.js"></script>
   <script src="scripts/timezone.js"></script>
   <script src="scripts/estadoSorteos.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script>
   ensureAuth();
   initServerTime();
@@ -1005,9 +1004,9 @@ function toggleForma(idx){
     cj.innerHTML=`Cartones jugando: <strong style="color:purple;">${cartonesJugando}</strong>`;
     const cg=document.getElementById('info-cartones-gratis');
     cg.innerHTML=`Cartones Gratis jugando: <strong style="color:#00008b;">${cartonesGratisJugando}</strong>`;
-    const pdfBtn=document.getElementById('info-cartones-pdf');
+    const verBtn=document.getElementById('info-cartones-ver');
     const s=sorteosActivos.find(x=>x.id===currentSorteo);
-    if(s && (s.estado==='Sellado' || s.estado==='Jugando')) pdfBtn.style.display='inline-block'; else pdfBtn.style.display='none';
+    if(s && (s.estado==='Sellado' || s.estado==='Jugando')) verBtn.style.display='inline-block'; else verBtn.style.display='none';
     document.getElementById('info-cartones-modal').style.display='flex';
   }
 
@@ -1022,84 +1021,11 @@ function toggleForma(idx){
     document.getElementById('premios-modal').style.display='flex';
   }
 
-  async function generarPDFJugadas(){
+  async function verCartonesJugadas(){
     const s=sorteosActivos.find(x=>x.id===currentSorteo);
     if(!s) return;
-    const snap=await db.collection('CartonJugado').where('sorteoId','==',currentSorteo).get();
-    const docs=[]; snap.forEach(d=>docs.push(d.data()));
-    docs.sort((a,b)=>a.cartonNum-b.cartonNum);
-    const { jsPDF } = window.jspdf;
-    const doc=new jsPDF('p','mm','a4');
-    async function toDataURL(url){
-      const res=await fetch(url); const blob=await res.blob();
-      return await new Promise(r=>{const reader=new FileReader(); reader.onload=()=>r(reader.result); reader.readAsDataURL(blob);});
-    }
-    const logo=await toDataURL('https://i.imgur.com/twjhNtZ.png');
-    doc.addImage(logo,'PNG',10,10,15,15);
-    doc.setFontSize(16); doc.text('BingOnline',105,18,{align:'center'});
-    doc.setFontSize(10); doc.text('📅 '+s.fecha,190,12,{align:'right'}); doc.text('🕒 '+s.hora,190,18,{align:'right'});
-    const tipoColor=s.tipo==='Sorteo Especial'?[255,165,0]:[0,128,0];
-    doc.setFontSize(12); doc.setTextColor(0,0,0);
-    doc.text('Tipo de sorteo:',105,26,{align:'center'});
-    doc.setTextColor(tipoColor[0],tipoColor[1],tipoColor[2]); doc.text(`${s.tipo} Sorteo: ${s.nombre}`,105,32,{align:'center'});
-    doc.setTextColor(0,0,0);
-    const cont=document.createElement('div');
-    cont.style.display='flex';
-    cont.style.flexWrap='wrap';
-    cont.style.width='190mm';
-    cont.style.position='fixed';
-    cont.style.left='-10000px';
-    docs.forEach(d=>{
-      const wrapper=document.createElement('div');
-      wrapper.style.width='30mm';
-      wrapper.style.height='38mm';
-      wrapper.style.margin='2mm';
-      wrapper.style.borderRadius='10px';
-      wrapper.style.padding='1mm';
-      wrapper.style.background=d.tipocarton==='gratis'? 'linear-gradient(#0000ff,#ffff00)':'linear-gradient(#008000,#ffff00)';
-      wrapper.style.boxShadow='0 0 5px rgba(0,0,0,0.5)';
-      const mini=document.createElement('div');
-      wrapper.appendChild(mini);
-      const top=document.createElement('div');
-      top.textContent=`${d.tipocarton==='gratis'?'Gratis':'Pagado'} ${String(d.cartonNum).padStart(4,'0')}`;
-      top.style.textAlign='center';
-      top.style.fontSize='6px';
-      top.style.color='white';
-      mini.appendChild(top);
-      const alias=document.createElement('div');
-      alias.textContent=d.alias||'';
-      alias.style.textAlign='center';
-      alias.style.fontSize='5px';
-      alias.style.color='black';
-      mini.appendChild(alias);
-      const table=document.createElement('table');
-      table.style.width='100%';
-      table.style.borderCollapse='collapse';
-      table.style.background='linear-gradient(#ffffff,#cccccc)';
-      for(let r=0;r<5;r++){
-        const tr=document.createElement('tr');
-        for(let c=0;c<5;c++){
-          const td=document.createElement('td');
-          td.style.border='0.2mm solid #555';
-          td.style.width='20%';
-          td.style.height='6mm';
-          td.style.fontSize='5px';
-          td.style.textAlign='center';
-          const pos=(d.posiciones||[]).find(p=>p.r===r&&p.c===c);
-          td.textContent=pos?pos.valor:'';
-          tr.appendChild(td);
-        }
-        table.appendChild(tr);
-      }
-      mini.appendChild(table);
-      cont.appendChild(wrapper);
-    });
-    document.body.appendChild(cont);
-    await new Promise(res=>doc.html(cont,{x:10,y:40,width:190,callback:res}));
-    document.body.removeChild(cont);
-    const pages=doc.getNumberOfPages();
-    for(let i=1;i<=pages;i++){ doc.setPage(i); const pw=doc.internal.pageSize.getWidth(); const ph=doc.internal.pageSize.getHeight(); doc.setFontSize(8); doc.setTextColor(128); doc.text(`página ${i} de ${pages}`, pw-30, ph-5); }
-    doc.save('jugadas-'+s.nombre+'.pdf');
+    const url=`sorteosellado.html?s=${currentSorteo}&n=${encodeURIComponent(s.nombre)}&t=${encodeURIComponent(s.tipo)}&f=${encodeURIComponent(s.fecha)}&h=${encodeURIComponent(s.hora)}`;
+    window.open(url,'_blank');
     document.getElementById('info-cartones-modal').style.display='none';
   }
 
@@ -1339,7 +1265,7 @@ document.getElementById('gratis-label').addEventListener('click',()=>{
   document.getElementById('cartones-gratis-jugando').addEventListener('click',mostrarCartonesJugandoModal);
   document.getElementById('premio-valor').addEventListener('click',mostrarPremiosModal);
   document.getElementById('info-cartones-aceptar').addEventListener('click',()=>{document.getElementById('info-cartones-modal').style.display='none';});
-  document.getElementById('info-cartones-pdf').addEventListener('click',generarPDFJugadas);
+  document.getElementById('info-cartones-ver').addEventListener('click',verCartonesJugadas);
   document.getElementById('premios-aceptar').addEventListener('click',()=>{document.getElementById('premios-modal').style.display='none';});
   document.getElementById('limpiar-btn').addEventListener('click',async()=>{if(await confirm('¿Deseas limpiar todas las jugadas del carton?')) limpiarcarton();});
   document.getElementById('azar-btn').addEventListener('click',async()=>{if(await confirm('¿Quieres cargar jugadas al azar?')) cargarAzar();});

--- a/sorteosellado.html
+++ b/sorteosellado.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sorteo Sellado</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <style>
+    body{
+      font-family:'Poppins',sans-serif;
+      background:linear-gradient(rgba(255,255,255,0.7), rgba(255,255,255,0.7)),
+                 url('https://img.freepik.com/vetores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
+      background-repeat:repeat;
+      background-size:auto;
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      justify-content:flex-start;
+      min-height:100vh;
+      text-align:center;
+      padding:5px;
+    }
+    h1{font-family:'Bangers',cursive;color:purple;text-shadow:0 0 10px #fff;margin:5px 0;}
+    #info{font-family:'Bangers',cursive;font-size:1rem;color:#000;margin-bottom:10px;}
+    #cartones-container{display:flex;flex-wrap:wrap;justify-content:center;gap:5px;width:100%;}
+    .mini-carton-box{display:flex;flex-direction:column;align-items:center;}
+    .mini-index,.mini-num{padding:1px 3px;background:rgba(255,255,255,0.8);border-radius:3px;font-weight:bold;font-size:0.7rem;margin:2px 0;text-align:center;}
+    .mini-index{color:#000;}
+    .mini-num{color:purple;}
+    .mini-carton-wrapper{background:linear-gradient(green,yellow);padding:3px;border-radius:10px;box-shadow:0 0 5px rgba(0,0,0,0.5);}
+    .mini-carton-wrapper.gratis{background:linear-gradient(#0000ff,yellow);}
+    .mini-carton{border-collapse:separate;border-spacing:0;background:linear-gradient(#ffffff,#cccccc);border-radius:8px;}
+    .mini-carton th,.mini-carton td{border:1px solid gray;width:20px;height:20px;text-align:center;font-weight:bold;font-size:0.6rem;aspect-ratio:1/1;}
+    .mini-carton th{font-size:0.8rem;color:#ff6600;background:radial-gradient(circle,#ffffff,#ffffff 60%,#00aa00);text-shadow:1px 1px 0 #000;}
+    .mini-carton-wrapper.gratis .mini-carton th{background:radial-gradient(circle,#ffffff,#ffffff 60%,#0000ff);}
+    @media (orientation:landscape){#cartones-container{justify-content:flex-start;}}
+  </style>
+</head>
+<body>
+  <h1 id="titulo"></h1>
+  <div id="info"></div>
+  <div id="cartones-container"></div>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
+  <script src="auth.js"></script>
+  <script>
+  ensureAuth();
+  async function cargar(){
+    const params=new URLSearchParams(location.search);
+    const sorteoId=params.get('s');
+    const nombre=params.get('n')||'';
+    const tipo=params.get('t')||'';
+    const fecha=params.get('f')||'';
+    const hora=params.get('h')||'';
+    document.getElementById('titulo').textContent=nombre;
+    document.getElementById('info').textContent=`${tipo} - ${fecha} ${hora}`;
+    const snap=await db.collection('CartonJugado').where('sorteoId','==',sorteoId).get();
+    const docs=[]; snap.forEach(d=>docs.push(d.data()));
+    docs.sort((a,b)=> (b.alias||'').localeCompare(a.alias||''));
+    const cont=document.getElementById('cartones-container');
+    docs.forEach(d=>{
+      const box=document.createElement('div');
+      box.className='mini-carton-box';
+      const idx=document.createElement('div');
+      idx.className='mini-index';
+      idx.textContent=`${d.tipocarton==='gratis'?'Gratis':'Pagado'} ${String(d.cartonNum).padStart(4,'0')}`;
+      box.appendChild(idx);
+      const wrap=document.createElement('div');
+      wrap.className='mini-carton-wrapper';
+      if(d.tipocarton==='gratis') wrap.classList.add('gratis');
+      wrap.appendChild(crearMiniCarton(d.posiciones||[]));
+      box.appendChild(wrap);
+      const alias=document.createElement('div');
+      alias.className='mini-num';
+      alias.textContent=d.alias||'';
+      box.appendChild(alias);
+      cont.appendChild(box);
+    });
+  }
+  function crearMiniCarton(posiciones){
+    const table=document.createElement('table');
+    table.className='mini-carton';
+    const head=document.createElement('thead');
+    const trh=document.createElement('tr');
+    ['B','I','N','G','O'].forEach(l=>{const th=document.createElement('th');th.textContent=l;trh.appendChild(th);});
+    head.appendChild(trh);table.appendChild(head);
+    const tbody=document.createElement('tbody');
+    for(let r=0;r<5;r++){
+      const tr=document.createElement('tr');
+      for(let c=0;c<5;c++){
+        const td=document.createElement('td');
+        if(r===2&&c===2){td.innerHTML='<span style="color:orange;">★</span>';}else{
+          const found=posiciones.find(p=>p.r===r&&p.c===c);
+          if(found) td.textContent=found.valor;
+        }
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    return table;
+  }
+  cargar();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Resumen
- Reemplazar generación de PDF por apertura de ventana `sorteosellado.html`
- Añadir página `sorteosellado.html` con miniaturas de cartones y orden por alias

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0c911a5883269a48ae2ea9cbe24a