### PR TITLE
Implementar nueva experiencia de canto de sorteo y PDF

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -134,16 +134,6 @@
     <button id="gestionar-sorteos-btn" class="menu-btn">Gestionar Sorteos</button>
     <button id="publicar-resultados-btn" class="menu-btn">Cantar Sorteo</button>
   </div>
-  <div id="publicar-resultados-screen" class="view" style="display:none;">
-    <button id="resultados-admin-back" class="menu-btn back-btn">&#9664; Volver</button>
-    <h3>Resultados del Sorteo</h3>
-    <select id="sorteo-activo-select" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;">
-      <option value="" disabled selected>Seleccione Sorteo</option>
-      <option value="demo">Sorteo de Prueba</option>
-    </select>
-    <input type="text" id="numeros-sorteados" placeholder="Números (1-75 separados por coma)" style="font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:10px auto;" />
-    <button id="publicar-resultados-btn2" class="menu-btn" style="width:180px;">Cantar Sorteo</button>
-  </div>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -159,16 +149,8 @@
       btn.addEventListener('click',()=>{window.location.href='super.html';});
     }
   });
-  function hideViews(){document.querySelectorAll('.view').forEach(v=>v.style.display='none');}
-  async function cargarSorteosActivos(){
-    const select=document.getElementById('sorteo-activo-select');
-    select.innerHTML='<option value="" selected disabled>Seleccione Sorteo</option>';
-    const snap=await db.collection('sorteos').where('estado','==','Activo').get();
-    snap.forEach(doc=>{const opt=document.createElement('option');opt.value=doc.id;opt.textContent=doc.data().nombre;select.appendChild(opt);});}
   document.getElementById('gestionar-sorteos-btn').addEventListener('click',()=>{window.location.href='gestionsorteos.html';});
-  document.getElementById('publicar-resultados-btn').addEventListener('click',()=>{hideViews();document.getElementById('publicar-resultados-screen').style.display='block';cargarSorteosActivos();});
-  document.getElementById('resultados-admin-back').addEventListener('click',()=>{hideViews();document.getElementById('main-menu').style.display='block';});
-  document.getElementById('publicar-resultados-btn2').addEventListener('click',async()=>{const id=document.getElementById('sorteo-activo-select').value;const nums=document.getElementById('numeros-sorteados').value.split(',').map(n=>parseInt(n.trim())).filter(n=>n>=1&&n<=75);if(!id||nums.length===0){alert('Datos inválidos');return;}await db.collection('sorteos').doc(id).update({resultados:nums,estado:'Finalizado'});alert('Resultados publicados');});
+  document.getElementById('publicar-resultados-btn').addEventListener('click',()=>{window.location.href='cantarsorteos.html';});
   document.getElementById('config-btn').addEventListener('click',()=>{window.location.href='configuraciones.html';});
   </script>
 </body>

--- a/cantarsorteos.html
+++ b/cantarsorteos.html
@@ -1,0 +1,609 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cantar Sorteo</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Poppins', sans-serif;
+      background: linear-gradient(rgba(255,255,255,0.7), rgba(255,255,255,0.7)),
+                  url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
+      background-repeat: repeat;
+      background-size: auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      min-height: 100vh;
+      text-align: center;
+      padding: 10px 5px 40px;
+      box-sizing: border-box;
+    }
+    h1 {
+      font-family: 'Bangers', cursive;
+      color: white;
+      text-shadow: 0 0 12px #1e3aa8;
+      margin: 5px 0 10px 0;
+      font-size: 2rem;
+    }
+    .menu-btn {
+      width: 250px;
+      height: 60px;
+      font-family: 'Bangers', cursive;
+      font-size: 1.4rem;
+      background: rgba(0, 170, 255, 0.8);
+      color: white;
+      border: 4px solid #FFD700;
+      border-radius: 10px;
+      text-shadow: 2px 2px 4px #000;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: transform 0.3s, box-shadow 0.3s, background 0.3s;
+    }
+    .menu-btn:hover { transform: scale(1.05); box-shadow: 0 0 15px rgba(255,215,0,0.8); }
+    .menu-btn:active { transform: scale(0.95); box-shadow: 0 0 5px rgba(255,215,0,0.8); }
+    #salir-btn {
+      position: fixed;
+      top: 5px;
+      left: 5px;
+      width: 120px;
+      height: 40px;
+      background: orange;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 5px;
+      font-size: 1.2rem;
+    }
+    #salir-btn .label { font-size: 1.1rem; }
+    @media (orientation: portrait) {
+      #salir-btn { width: 40px; }
+      #salir-btn .label { display: none; }
+    }
+    #sorteo-btn {
+      width: 240px;
+      font-size: 1.1rem;
+      padding: 6px 10px;
+      text-align: center;
+      border: 3px solid #FFD700;
+      border-radius: 10px;
+      background: linear-gradient(#dddddd, #ffffff);
+      cursor: pointer;
+      white-space: nowrap;
+      overflow: hidden;
+      text-transform: uppercase;
+      color: #000;
+      font-family: 'Bangers', cursive;
+      text-shadow: 1px 1px 2px #fff;
+    }
+    #sorteo-btn.diario { background: linear-gradient(#008000,#ffffff); }
+    #sorteo-btn.especial { background: linear-gradient(#ff8800,#ffffff); }
+    #sorteo-btn.finalizado { background: linear-gradient(#444,#bbbbbb); color: #fff; }
+    #sorteo-btn.jugando { background: linear-gradient(#6a0dad,#ffffff); color: #fff; }
+    .sorteo-info {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 10px;
+    }
+    #fecha-hora-sorteo {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      font-family: 'Bangers', cursive;
+      font-size: 1rem;
+    }
+    #fecha-sorteo, #hora-sorteo { display: flex; gap: 6px; align-items: center; justify-content: center; color: #0f2a0f; }
+    .datos-sorteo {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      justify-content: center;
+      margin-top: 5px;
+      font-family: 'Bangers', cursive;
+    }
+    #premio-repartir {
+      color: white;
+      font-family: 'Bangers', cursive;
+      font-size: 1.6rem;
+      text-shadow: 0 0 10px #004488;
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+    #premio-valor { text-shadow: 0 0 10px #004488; }
+    #stats-row {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 20px;
+      flex-wrap: wrap;
+    }
+    #valor-carton, #cartones-jugando {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      color: #fff;
+      text-shadow: 0 0 6px #003300;
+      font-size: 1.3rem;
+    }
+    #valor-carton span.valor, #cartones-jugando span.valor { font-size: 1.6rem; }
+    #cartones-jugando span.extra { color: #00008b; text-shadow: 0 0 6px #fff; }
+    #detalle-container {
+      position: relative;
+      border: 2px solid #013220;
+      border-radius: 12px;
+      background: linear-gradient(135deg, rgba(0,60,0,0.85), rgba(255,255,255,0.95));
+      padding: 15px 10px 60px;
+      margin-top: 10px;
+      width: min(480px, 95vw);
+      box-shadow: 0 0 10px rgba(0,0,0,0.4);
+    }
+    #sorteo-nombre {
+      font-size: 1rem;
+      font-weight: 700;
+      color: #fff;
+      text-shadow: 0 0 6px #000;
+      margin-bottom: 6px;
+    }
+    #estado-actual {
+      font-family: 'Bangers', cursive;
+      font-size: 1.2rem;
+      color: #111;
+      text-shadow: 0 0 4px rgba(255,255,255,0.8);
+    }
+    #resumen-sorteo {
+      margin-top: 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-family: 'Poppins', sans-serif;
+      color: #0b1d0b;
+      font-weight: 600;
+    }
+    #resumen-sorteo div { display: flex; justify-content: center; gap: 6px; align-items: center; }
+    .estado-btn {
+      width: 48px;
+      height: 48px;
+      border-radius: 10px;
+      border: 3px solid #FFD700;
+      background: linear-gradient(#0a8800,#ffffff);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      position: absolute;
+      bottom: 10px;
+      box-shadow: 0 0 8px rgba(0,0,0,0.4);
+      transition: transform 0.2s;
+    }
+    .estado-btn:hover { transform: scale(1.05); }
+    #sellar-btn { left: 10px; }
+    #pdf-btn { left: 70px; background: linear-gradient(#003c71,#ffffff); }
+    #jugar-btn { right: 70px; background: linear-gradient(#4b0082,#ffffff); }
+    #finalizar-btn { right: 10px; background: linear-gradient(#8b0000,#ffffff); }
+    .estado-btn img { width: 28px; height: 28px; }
+    .modal {
+      display: none;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.75);
+      justify-content: center;
+      align-items: center;
+      z-index: 1000;
+    }
+    .modal-content {
+      background: #fff;
+      padding: 12px;
+      border-radius: 10px;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 6px;
+      width: min(420px, 90vw);
+      max-height: 80vh;
+      overflow-y: auto;
+      font-family: 'Poppins', sans-serif;
+    }
+    .sorteo-item {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      padding: 6px 8px;
+      border-radius: 8px;
+      cursor: pointer;
+      border: 2px solid transparent;
+    }
+    .sorteo-item:hover { border-color: #1e90ff; }
+    .sorteo-item.diario { background: linear-gradient(#b8ffb8, #ffffff); }
+    .sorteo-item.especial { background: linear-gradient(#ffd1a1,#ffffff); }
+    .sorteo-item.sellado { background: linear-gradient(#cccccc,#ffffff); color: #333; }
+    .sorteo-item.jugando { background: linear-gradient(#d8b0ff,#ffffff); color: #331155; }
+    .sorteo-item.finalizado { background: linear-gradient(#aaaaaa,#eeeeee); color: #222; }
+    .sorteo-header { display: flex; justify-content: space-between; font-weight: 700; font-size: 1rem; }
+    .sorteo-detalle { display: flex; gap: 6px; align-items: center; font-size: 0.85rem; }
+    .sorteo-extra { display: flex; flex-direction: column; gap: 3px; font-size: 0.8rem; color: #0f2a0f; }
+    .attention { animation: zoomInOut 1s infinite; }
+    @keyframes zoomInOut { 0%,100% { transform: scale(1); } 50% { transform: scale(1.15); } }
+    #mensaje-area {
+      margin-top: 10px;
+      font-family: 'Poppins', sans-serif;
+      color: #111;
+      font-size: 0.9rem;
+      background: rgba(255,255,255,0.6);
+      padding: 6px 10px;
+      border-radius: 8px;
+      max-width: 480px;
+    }
+    #footer {
+      margin-top: auto;
+      font-size: 0.7rem;
+      color: #000;
+      text-align: center;
+    }
+    #footer #derechos { font-size: 0.6rem; }
+  </style>
+</head>
+<body>
+  <button id="salir-btn" class="menu-btn"><span class="tri">&#9664;</span><span class="label">Salir</span></button>
+  <h1>CANTAR SORTEO</h1>
+  <section id="sorteo-section">
+    <div class="sorteo-info">
+      <button id="sorteo-btn">Selecciona Sorteo</button>
+      <div id="fecha-hora-sorteo">
+        <div id="fecha-sorteo"></div>
+        <div id="hora-sorteo"></div>
+      </div>
+    </div>
+    <div class="datos-sorteo">
+      <div id="premio-repartir"><span>PREMIO A REPARTIR:</span> <span id="premio-valor">0</span></div>
+      <div id="stats-row">
+        <div id="valor-carton"><span>💵</span> Cartón: <span class="valor" id="valor-carton-valor">0</span></div>
+        <div id="cartones-jugando">
+          <img src="https://cdn-icons-png.flaticon.com/32/5065/5065890.png" class="carton-icon" alt="Cartón" style="width:28px;height:28px;">
+          Jugando: <span class="valor" id="cartones-jugando-valor">0</span>
+          <span class="extra">+</span>
+          <span class="valor extra" id="cartones-gratis-jugando">0</span>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section id="detalle-container">
+    <div id="sorteo-nombre">Selecciona un sorteo para ver los detalles</div>
+    <div id="estado-actual">Estado actual: -</div>
+    <div id="resumen-sorteo">
+      <div id="tipo-sorteo"></div>
+      <div id="cierre-sorteo"></div>
+    </div>
+    <button id="sellar-btn" class="estado-btn" title="Sellar sorteo">
+      <img src="https://api.iconify.design/mdi/seal-variant.svg?color=white" alt="Sellar">
+    </button>
+    <button id="pdf-btn" class="estado-btn" title="Generar PDF">
+      <img src="https://api.iconify.design/mdi/book-open-page-variant.svg?color=white" alt="PDF">
+    </button>
+    <button id="jugar-btn" class="estado-btn" title="Cambiar a Jugando">
+      <img src="https://api.iconify.design/mdi/slot-machine.svg?color=white" alt="Jugar">
+    </button>
+    <button id="finalizar-btn" class="estado-btn" title="Finalizar sorteo">
+      <img src="https://api.iconify.design/mdi/flag-checkered.svg?color=white" alt="Finalizar">
+    </button>
+  </section>
+  <div id="mensaje-area">Selecciona un sorteo para administrar su estado.</div>
+  <div id="footer">
+    <div id="fecha-hora"></div>
+    <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
+  </div>
+  <div id="sorteos-modal" class="modal" onclick="this.style.display='none'">
+    <div class="modal-content" onclick="event.stopPropagation();">
+      <h3 style="text-align:center;font-family:'Bangers',cursive;color:#1e3aa8;margin:0 0 6px 0;">Sorteos Disponibles</h3>
+      <div id="sorteos-list" style="display:flex;flex-direction:column;gap:6px;"></div>
+    </div>
+  </div>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
+  <script src="auth.js"></script>
+  <script src="scripts/timezone.js"></script>
+  <script>
+  ensureAuth('Administrador');
+  initServerTime().then(()=>initFechaHora());
+
+  let sorteos = [];
+  let currentSorteoId = null;
+  let currentSorteoData = null;
+  let sorteoUnsub = null;
+
+  const btnSorteo = document.getElementById('sorteo-btn');
+  const fechaEl = document.getElementById('fecha-sorteo');
+  const horaEl = document.getElementById('hora-sorteo');
+  const premioEl = document.getElementById('premio-valor');
+  const valorCartonEl = document.getElementById('valor-carton-valor');
+  const cartonesPagosEl = document.getElementById('cartones-jugando-valor');
+  const cartonesGratisEl = document.getElementById('cartones-gratis-jugando');
+  const sorteoNombreEl = document.getElementById('sorteo-nombre');
+  const estadoActualEl = document.getElementById('estado-actual');
+  const tipoEl = document.getElementById('tipo-sorteo');
+  const cierreEl = document.getElementById('cierre-sorteo');
+  const mensajeEl = document.getElementById('mensaje-area');
+  const sellarBtn = document.getElementById('sellar-btn');
+  const pdfBtn = document.getElementById('pdf-btn');
+  const jugarBtn = document.getElementById('jugar-btn');
+  const finalizarBtn = document.getElementById('finalizar-btn');
+
+  document.getElementById('salir-btn').addEventListener('click',()=>{ window.location.href='admin.html'; });
+  btnSorteo.addEventListener('click', abrirModalSorteos);
+  sellarBtn.addEventListener('click', sellarSorteo);
+  pdfBtn.addEventListener('click', abrirPDF);
+  jugarBtn.addEventListener('click', cambiarAJugando);
+  finalizarBtn.addEventListener('click', finalizarSorteo);
+
+  function getServerNow(){
+    return new Date(Date.now() + (window.serverTime?.diferencia || 0));
+  }
+
+  function formatearFecha(fecha){
+    if(!fecha) return '';
+    const partes = fecha.split('/');
+    if(partes.length === 3){
+      return `${partes[0]}/${partes[1]}/${partes[2]}`;
+    }
+    return fecha;
+  }
+
+  function formatearHora(hora){
+    if(!hora) return '';
+    const [hh, mm] = hora.split(':');
+    if(hh===undefined) return hora;
+    let h = parseInt(hh, 10);
+    const sufijo = h >= 12 ? 'pm' : 'am';
+    h = h % 12 || 12;
+    return `${h.toString().padStart(2,'0')}:${mm} ${sufijo}`;
+  }
+
+  function obtenerFechaSorteo(data){
+    if(!data || !data.fecha || !data.hora) return null;
+    const [dia, mes, anio] = data.fecha.split('/').map(n=>parseInt(n,10));
+    const [hor, min] = data.hora.split(':').map(n=>parseInt(n,10));
+    if([dia, mes, anio, hor, min].some(n=>isNaN(n))) return null;
+    return new Date(anio, mes-1, dia, hor, min);
+  }
+
+  function actualizarAnimaciones(){
+    [sellarBtn, pdfBtn, jugarBtn].forEach(btn=>btn.classList.remove('attention'));
+    if(!currentSorteoData) return;
+    const ahora = getServerNow();
+    const sorteoDate = obtenerFechaSorteo(currentSorteoData);
+    const cierre = parseInt(currentSorteoData.cierreMinutos || currentSorteoData.cierre || 0, 10);
+    const inicioSellado = sorteoDate ? new Date(sorteoDate.getTime() - cierre * 60000) : null;
+
+    if(currentSorteoData.estado !== 'Sellado' && inicioSellado && ahora >= inicioSellado){
+      sellarBtn.classList.add('attention');
+    }
+    if(currentSorteoData.estado === 'Sellado' && (currentSorteoData.pdf || '').toLowerCase() !== 'si'){
+      pdfBtn.classList.add('attention');
+    }
+    if(currentSorteoData.estado !== 'Jugando' && sorteoDate && ahora >= sorteoDate){
+      jugarBtn.classList.add('attention');
+    }
+  }
+
+  function mostrarDatos(){
+    if(!currentSorteoData){
+      btnSorteo.textContent = 'Selecciona Sorteo';
+      fechaEl.textContent = '';
+      horaEl.textContent = '';
+      premioEl.textContent = '0';
+      valorCartonEl.textContent = '0';
+      cartonesPagosEl.textContent = '0';
+      cartonesGratisEl.textContent = '0';
+      sorteoNombreEl.textContent = 'Selecciona un sorteo para ver los detalles';
+      estadoActualEl.textContent = 'Estado actual: -';
+      tipoEl.textContent = '';
+      cierreEl.textContent = '';
+      mensajeEl.textContent = 'Selecciona un sorteo para administrar su estado.';
+      [sellarBtn, pdfBtn, jugarBtn, finalizarBtn].forEach(btn=>btn.disabled=true);
+      actualizarAnimaciones();
+      return;
+    }
+    const data = currentSorteoData;
+    btnSorteo.textContent = data.nombre || 'Sorteo';
+    btnSorteo.classList.remove('diario','especial','jugando','finalizado');
+    if(data.estado === 'Jugando') btnSorteo.classList.add('jugando');
+    else if(data.estado === 'Finalizado') btnSorteo.classList.add('finalizado');
+    else if(data.tipo === 'Sorteo Diario') btnSorteo.classList.add('diario');
+    else if(data.tipo === 'Sorteo Especial') btnSorteo.classList.add('especial');
+    fechaEl.innerHTML = data.fecha ? `📅 ${formatearFecha(data.fecha)}` : '';
+    horaEl.innerHTML = data.hora ? `⏰ ${formatearHora(data.hora)}` : '';
+    premioEl.textContent = Math.round(data.totalPremios || 0);
+    valorCartonEl.textContent = data.valorCarton || 0;
+    cartonesPagosEl.textContent = data.cartonesjugando || 0;
+    cartonesGratisEl.textContent = data.cartonesgratisjugando || 0;
+    sorteoNombreEl.textContent = data.nombre || '';
+    estadoActualEl.textContent = `Estado actual: ${data.estado || '-'}`;
+    tipoEl.textContent = data.tipo ? `Tipo: ${data.tipo}` : '';
+    const cierre = parseInt(data.cierreMinutos || data.cierre || 0, 10);
+    cierreEl.textContent = isNaN(cierre) ? '' : `Minutos previos de sellado: ${cierre}`;
+    mensajeEl.textContent = 'Gestiona el estado del sorteo usando los botones inferiores.';
+    [sellarBtn, pdfBtn, jugarBtn, finalizarBtn].forEach(btn=>btn.disabled=false);
+    if((data.estado || '') === 'Finalizado'){
+      jugarBtn.disabled = true;
+      sellarBtn.disabled = true;
+      pdfBtn.disabled = false;
+    }
+    actualizarAnimaciones();
+  }
+
+  async function cargarSorteos(){
+    sorteos = [];
+    try {
+      const snap = await db.collection('sorteos').get();
+      snap.forEach(doc=>{
+        const d = doc.data();
+        sorteos.push({
+          id: doc.id,
+          nombre: d.nombre || 'Sorteo',
+          fecha: d.fecha || '',
+          hora: d.hora || '',
+          tipo: d.tipo || '',
+          estado: d.estado || 'Activo',
+          valorCarton: d.valorCarton || 0,
+          cartonesjugando: d.cartonesjugando || 0,
+          cartonesgratisjugando: d.cartonesgratisjugando || 0,
+          totalPremios: d.totalPremios || 0,
+          cierreMinutos: d.cierreMinutos || d.cierre || 0,
+          pdf: d.pdf || 'no'
+        });
+      });
+    } catch (err) {
+      console.error('Error cargando sorteos', err);
+    }
+  }
+
+  async function abrirModalSorteos(){
+    await cargarSorteos();
+    if(!sorteos.length){
+      mensajeEl.textContent = 'No hay sorteos disponibles en este momento.';
+      return;
+    }
+    const cont = document.getElementById('sorteos-list');
+    cont.innerHTML = '';
+    const ordenados = [...sorteos].sort((a,b)=>{
+      const fechaA = obtenerFechaSorteo(a) || new Date(0);
+      const fechaB = obtenerFechaSorteo(b) || new Date(0);
+      return fechaB - fechaA;
+    });
+    ordenados.forEach((s, idx)=>{
+      const div = document.createElement('div');
+      div.className = `sorteo-item ${s.estado ? s.estado.toLowerCase() : ''} ${s.tipo === 'Sorteo Diario' ? 'diario' : s.tipo === 'Sorteo Especial' ? 'especial' : ''}`.trim();
+      const header = document.createElement('div');
+      header.className = 'sorteo-header';
+      header.innerHTML = `<span>${idx+1}. ${s.nombre}</span><span>${s.estado || ''}</span>`;
+      div.appendChild(header);
+      const detalle = document.createElement('div');
+      detalle.className = 'sorteo-detalle';
+      detalle.innerHTML = `${s.fecha ? `📅 ${formatearFecha(s.fecha)}` : ''} ${s.hora ? `⏰ ${formatearHora(s.hora)}` : ''}`;
+      div.appendChild(detalle);
+      const extra = document.createElement('div');
+      extra.className = 'sorteo-extra';
+      extra.innerHTML = `<span>Premio: ${Math.round(s.totalPremios || 0)}</span><span>Cartones: ${s.cartonesjugando || 0} + ${s.cartonesgratisjugando || 0}</span>`;
+      div.appendChild(extra);
+      div.addEventListener('click',()=>{
+        seleccionarSorteo(s.id);
+        document.getElementById('sorteos-modal').style.display = 'none';
+      });
+      cont.appendChild(div);
+    });
+    document.getElementById('sorteos-modal').style.display = 'flex';
+  }
+
+  function escucharSorteo(id){
+    if(sorteoUnsub){ sorteoUnsub(); sorteoUnsub = null; }
+    const ref = db.collection('sorteos').doc(id);
+    sorteoUnsub = ref.onSnapshot(doc=>{
+      if(!doc.exists){
+        currentSorteoData = null;
+        mostrarDatos();
+        return;
+      }
+      currentSorteoData = { id: doc.id, ...doc.data() };
+      const idx = sorteos.findIndex(s=>s.id===doc.id);
+      if(idx>=0){
+        sorteos[idx] = { ...sorteos[idx], ...doc.data() };
+      }
+      mostrarDatos();
+    }, err=>console.error('Error escuchando sorteo', err));
+  }
+
+  function seleccionarSorteo(id){
+    currentSorteoId = id;
+    const encontrado = sorteos.find(s=>s.id===id);
+    currentSorteoData = encontrado ? { ...encontrado } : null;
+    escucharSorteo(id);
+    mostrarDatos();
+  }
+
+  async function sellarSorteo(){
+    if(!currentSorteoId || !currentSorteoData){ alert('Selecciona un sorteo primero.'); return; }
+    if(currentSorteoData.estado === 'Sellado'){ alert('El sorteo ya está sellado.'); return; }
+    if(currentSorteoData.estado === 'Jugando' || currentSorteoData.estado === 'Finalizado'){
+      alert('El sorteo ya se encuentra en una fase posterior.');
+      return;
+    }
+    const sorteoDate = obtenerFechaSorteo(currentSorteoData);
+    if(!sorteoDate){ alert('Datos de fecha y hora inválidos.'); return; }
+    const cierre = parseInt(currentSorteoData.cierreMinutos || currentSorteoData.cierre || 0, 10);
+    const inicioSellado = new Date(sorteoDate.getTime() - cierre * 60000);
+    const ahora = getServerNow();
+    if(ahora < inicioSellado){
+      alert('Aún el sorteo no se puede sellar, no esta en los minutos previos al sorteo');
+      return;
+    }
+    try {
+      await db.collection('sorteos').doc(currentSorteoId).update({ estado: 'Sellado' });
+      mensajeEl.textContent = 'El sorteo fue sellado correctamente.';
+    } catch (err) {
+      console.error('Error sellando sorteo', err);
+      alert('No fue posible sellar el sorteo.');
+    }
+  }
+
+  function abrirPDF(){
+    if(!currentSorteoId || !currentSorteoData){ alert('Selecciona un sorteo primero.'); return; }
+    if((currentSorteoData.estado || '') !== 'Sellado'){
+      alert('Para generar el archivo PDF de sellado el sorteo debe estar Sellado primero');
+      return;
+    }
+    const url = `pdfsorteo.html?s=${currentSorteoId}`;
+    window.location.href = url;
+  }
+
+  async function cambiarAJugando(){
+    if(!currentSorteoId || !currentSorteoData){ alert('Selecciona un sorteo primero.'); return; }
+    if(currentSorteoData.estado === 'Jugando'){ alert('El sorteo ya está en estado Jugando.'); return; }
+    if(currentSorteoData.estado === 'Finalizado'){ alert('El sorteo ya finalizó.'); return; }
+    const sorteoDate = obtenerFechaSorteo(currentSorteoData);
+    if(!sorteoDate){ alert('Datos de fecha y hora inválidos.'); return; }
+    const ahora = getServerNow();
+    if(ahora < sorteoDate){
+      alert('Aún el sorteo no ha llegado a su fecha y hora de sorteo');
+      return;
+    }
+    try {
+      await db.collection('sorteos').doc(currentSorteoId).update({ estado: 'Jugando' });
+      mensajeEl.textContent = 'El sorteo cambió a estado Jugando.';
+    } catch (err) {
+      console.error('Error cambiando a Jugando', err);
+      alert('No fue posible cambiar el estado a Jugando.');
+    }
+  }
+
+  async function finalizarSorteo(){
+    if(!currentSorteoId || !currentSorteoData){ alert('Selecciona un sorteo primero.'); return; }
+    if(currentSorteoData.estado === 'Finalizado'){ alert('El sorteo ya está finalizado.'); return; }
+    const confirmar = await confirm('¿Desea cambiar el estado del sorteo a "Finalizado"?');
+    if(!confirmar) return;
+    try {
+      await db.collection('sorteos').doc(currentSorteoId).update({ estado: 'Finalizado' });
+      mensajeEl.textContent = 'El sorteo fue finalizado correctamente.';
+    } catch (err) {
+      console.error('Error finalizando sorteo', err);
+      alert('No fue posible finalizar el sorteo.');
+    }
+  }
+
+  async function inicializar(){
+    await cargarSorteos();
+    mostrarDatos();
+  }
+
+  inicializar();
+  </script>
+</body>
+</html>

--- a/pdfsorteo.html
+++ b/pdfsorteo.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PDF Sorteo</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Poppins', sans-serif;
+      background: #ffffff;
+      margin: 0;
+      padding: 60px 15px 40px;
+      box-sizing: border-box;
+      color: #1a1a1a;
+    }
+    #salir-btn {
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      width: 120px;
+      height: 40px;
+      background: orange;
+      border: 4px solid #FFD700;
+      border-radius: 10px;
+      color: white;
+      text-shadow: 2px 2px 4px #000;
+      font-family: 'Bangers', cursive;
+      font-size: 1.2rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 5px;
+      cursor: pointer;
+      transition: transform 0.3s, box-shadow 0.3s;
+      z-index: 1001;
+    }
+    #salir-btn:hover { transform: scale(1.05); box-shadow: 0 0 15px rgba(255,215,0,0.8); }
+    #salir-btn:active { transform: scale(0.95); }
+    #salir-btn .label { font-size: 1.1rem; }
+    @media (orientation: portrait) {
+      #salir-btn { width: 40px; }
+      #salir-btn .label { display: none; }
+    }
+    #generar-pdf-btn {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      padding: 10px 18px;
+      font-family: 'Bangers', cursive;
+      font-size: 1.1rem;
+      border-radius: 12px;
+      border: 4px solid #FFD700;
+      background: linear-gradient(#003c8f, #ffffff);
+      color: #ffffff;
+      text-shadow: 1px 1px 2px #000;
+      cursor: pointer;
+      box-shadow: 0 0 10px rgba(0,0,0,0.3);
+      display: none;
+      z-index: 1001;
+    }
+    #generar-pdf-btn:hover { transform: scale(1.05); }
+    #pdf-wrapper {
+      max-width: 900px;
+      margin: 0 auto;
+      text-align: center;
+    }
+    #logo {
+      width: 140px;
+      margin: 0 auto 15px;
+      display: block;
+    }
+    #nombre-sorteo {
+      font-family: 'Bangers', cursive;
+      font-size: 2.2rem;
+      color: #0b5394;
+      margin: 5px 0;
+      text-transform: uppercase;
+    }
+    #tipo-sorteo {
+      font-family: 'Bangers', cursive;
+      font-size: 1.4rem;
+      color: #0b6623;
+      margin-bottom: 8px;
+    }
+    #fecha-hora-line {
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      font-family: 'Poppins', sans-serif;
+      font-weight: 600;
+      color: #1a1a1a;
+      margin-bottom: 18px;
+    }
+    #premios-section {
+      border: 2px solid #0b6623;
+      border-radius: 16px;
+      padding: 15px;
+      background: linear-gradient(180deg, rgba(10,120,10,0.15), rgba(255,255,255,0.95));
+      margin-bottom: 20px;
+    }
+    #premios-section h2 {
+      font-family: 'Bangers', cursive;
+      font-size: 1.6rem;
+      color: #0b6623;
+      margin: 0;
+    }
+    #total-premios {
+      font-size: 2.4rem;
+      font-weight: 700;
+      color: #0b6623;
+      text-shadow: 0 0 6px rgba(255,255,255,0.9);
+      margin: 10px 0 20px;
+    }
+    #formas-container {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+      text-align: left;
+    }
+    .forma-card {
+      border: 2px solid #003c8f;
+      border-radius: 12px;
+      padding: 10px;
+      background: rgba(255,255,255,0.9);
+      box-shadow: 0 0 8px rgba(0,0,0,0.1);
+    }
+    .forma-card h3 {
+      margin: 0 0 6px;
+      font-family: 'Bangers', cursive;
+      font-size: 1.2rem;
+      color: #0b5394;
+    }
+    .forma-info { font-weight: 600; font-size: 0.95rem; color: #0b1d0b; }
+    #cartones-section h2 {
+      font-family: 'Bangers', cursive;
+      font-size: 1.6rem;
+      color: #0b5394;
+      margin-bottom: 10px;
+    }
+    #cartones-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 12px;
+    }
+    .mini-carton-box {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 6px;
+      border-radius: 12px;
+      background: linear-gradient(#0a8800,#dff5d8);
+      box-shadow: 0 0 6px rgba(0,0,0,0.15);
+    }
+    .mini-carton-box.gratis { background: linear-gradient(#0044cc,#cce0ff); }
+    .mini-info {
+      font-weight: 700;
+      font-size: 0.85rem;
+      margin: 4px 0;
+      text-align: center;
+      color: #1a1a1a;
+    }
+    .mini-carton-wrapper {
+      background: linear-gradient(#ffffff,#cccccc);
+      border-radius: 10px;
+      padding: 4px;
+    }
+    .mini-carton {
+      border-collapse: separate;
+      border-spacing: 0;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .mini-carton th, .mini-carton td {
+      border: 1px solid #666;
+      width: 24px;
+      height: 24px;
+      text-align: center;
+      font-weight: 700;
+      font-size: 0.75rem;
+    }
+    .mini-carton th {
+      background: radial-gradient(circle,#ffffff,#ffffff 60%,#00aa00);
+      color: #ff6600;
+      font-size: 1rem;
+      text-shadow: 1px 1px 0 #000;
+    }
+    .mini-carton-box.gratis .mini-carton th {
+      background: radial-gradient(circle,#ffffff,#ffffff 60%,#0044cc);
+    }
+    .mini-carton td.free { background: radial-gradient(circle,#ffffff,#ffff00); color: #e67e22; }
+    #loading-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.6);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      font-family: 'Bangers', cursive;
+      font-size: 1.4rem;
+      gap: 12px;
+      z-index: 1200;
+    }
+    .spinner {
+      width: 50px;
+      height: 50px;
+      border: 6px solid rgba(255,255,255,0.3);
+      border-top-color: #ffffff;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+  </style>
+</head>
+<body>
+  <div id="loading-overlay">
+    <div class="spinner"></div>
+    <div id="loading-text">Generando cartones del sorteo por favor espera</div>
+  </div>
+  <button id="salir-btn"><span class="tri">&#9664;</span><span class="label">Salir</span></button>
+  <button id="generar-pdf-btn">Generar PDF</button>
+  <div id="pdf-wrapper">
+    <img id="logo" src="https://i.imgur.com/twjhNtZ.png" alt="Bingo Online">
+    <div id="info-basica">
+      <div id="nombre-sorteo">Sorteo</div>
+      <div id="tipo-sorteo"></div>
+      <div id="fecha-hora-line">
+        <span id="fecha-sorteo"></span>
+        <span id="hora-sorteo"></span>
+      </div>
+    </div>
+    <section id="premios-section">
+      <h2>CRÉDITOS TOTALES A REPARTIR</h2>
+      <div id="total-premios">0</div>
+      <div id="formas-container"></div>
+    </section>
+    <section id="cartones-section">
+      <h2>Cartones del sorteo</h2>
+      <div id="cartones-grid"></div>
+    </section>
+  </div>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-storage-compat.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNa5H1L1MSQe6hw2yYB9H9n1tFoZT3zh0+BTtPlqvGjufH6G+jD/adJzi10BGSAdoo6gWQBaIj++ImQF0kGZ7Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-HqKj1iJt+uCQXDpUe1koRaSPoaqe7i0rGUNShUMHbOWcZH/5LiCFYl8aAkaI0s5momkGLumZ5qX6bi12PtD3ug==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="auth.js"></script>
+  <script>
+  ensureAuth('Administrador');
+
+  const params = new URLSearchParams(window.location.search);
+  const sorteoId = params.get('s');
+  if(!sorteoId){
+    alert('No se indicó un sorteo.');
+    window.location.href = 'cantarsorteos.html';
+  }
+
+  const salirBtn = document.getElementById('salir-btn');
+  const pdfBtn = document.getElementById('generar-pdf-btn');
+  const loadingOverlay = document.getElementById('loading-overlay');
+  const loadingText = document.getElementById('loading-text');
+  const nombreEl = document.getElementById('nombre-sorteo');
+  const tipoEl = document.getElementById('tipo-sorteo');
+  const fechaEl = document.getElementById('fecha-sorteo');
+  const horaEl = document.getElementById('hora-sorteo');
+  const totalPremiosEl = document.getElementById('total-premios');
+  const formasCont = document.getElementById('formas-container');
+  const cartonesGrid = document.getElementById('cartones-grid');
+
+  let sorteoData = null;
+  let formasData = [];
+  let cartonesData = [];
+
+  salirBtn.addEventListener('click', ()=>{ window.location.href = 'cantarsorteos.html'; });
+  pdfBtn.addEventListener('click', generarPDF);
+
+  function formatearFecha(fecha){
+    if(!fecha) return '';
+    return `📅 ${fecha}`;
+  }
+
+  function formatearHora(hora){
+    if(!hora) return '';
+    const [hh, mm] = hora.split(':');
+    let h = parseInt(hh, 10);
+    const sufijo = h >= 12 ? 'pm' : 'am';
+    h = h % 12 || 12;
+    return `⏰ ${h.toString().padStart(2,'0')}:${mm} ${sufijo}`;
+  }
+
+  function crearMiniCarton(posiciones){
+    const table = document.createElement('table');
+    table.className = 'mini-carton';
+    const thead = document.createElement('thead');
+    const trh = document.createElement('tr');
+    ['B','I','N','G','O'].forEach(l=>{
+      const th = document.createElement('th');
+      th.textContent = l;
+      trh.appendChild(th);
+    });
+    thead.appendChild(trh);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    for(let r=0; r<5; r++){
+      const tr = document.createElement('tr');
+      for(let c=0; c<5; c++){
+        const td = document.createElement('td');
+        if(r===2 && c===2){
+          td.classList.add('free');
+          td.textContent = '★';
+        }else{
+          const found = posiciones.find(p=>p.r===r && p.c===c);
+          if(found){ td.textContent = found.valor; }
+        }
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    return table;
+  }
+
+  function renderFormas(){
+    formasCont.innerHTML = '';
+    const total = Number(sorteoData.totalPremios || 0);
+    formasData.sort((a,b)=>(a.idx||0)-(b.idx||0));
+    formasData.forEach(forma=>{
+      const card = document.createElement('div');
+      card.className = 'forma-card';
+      const titulo = document.createElement('h3');
+      titulo.textContent = `Forma ${forma.idx || ''} - ${forma.nombre || ''}`;
+      card.appendChild(titulo);
+      const premioForma = Math.round(total * (parseFloat(forma.porcentaje || 0)/100));
+      const premioInfo = document.createElement('div');
+      premioInfo.className = 'forma-info';
+      premioInfo.textContent = `Premio: ${premioForma}`;
+      card.appendChild(premioInfo);
+      const cartonesInfo = document.createElement('div');
+      cartonesInfo.className = 'forma-info';
+      cartonesInfo.textContent = `Cartones gratis: ${forma.cartonesGratis || 0}`;
+      card.appendChild(cartonesInfo);
+      formasCont.appendChild(card);
+    });
+  }
+
+  function renderCartones(){
+    cartonesGrid.innerHTML = '';
+    cartonesData.sort((a,b)=> (b.cartonNum || 0) - (a.cartonNum || 0));
+    cartonesData.forEach(data=>{
+      const box = document.createElement('div');
+      box.className = 'mini-carton-box';
+      if((data.tipocarton || '').toLowerCase() === 'gratis'){ box.classList.add('gratis'); }
+      const numero = document.createElement('div');
+      numero.className = 'mini-info';
+      numero.textContent = `Cartón ${String(data.cartonNum || 0).padStart(4,'0')}`;
+      box.appendChild(numero);
+      const wrapper = document.createElement('div');
+      wrapper.className = 'mini-carton-wrapper';
+      wrapper.appendChild(crearMiniCarton(data.posiciones || []));
+      box.appendChild(wrapper);
+      const alias = document.createElement('div');
+      alias.className = 'mini-info';
+      alias.textContent = data.alias || '';
+      box.appendChild(alias);
+      cartonesGrid.appendChild(box);
+    });
+  }
+
+  async function cargarDatos(){
+    try {
+      const sorteoDoc = await db.collection('sorteos').doc(sorteoId).get();
+      if(!sorteoDoc.exists){
+        alert('No se encontró el sorteo.');
+        window.location.href = 'cantarsorteos.html';
+        return;
+      }
+      sorteoData = sorteoDoc.data();
+      nombreEl.textContent = sorteoData.nombre || 'Sorteo';
+      tipoEl.textContent = sorteoData.tipo ? `Tipo de sorteo: ${sorteoData.tipo}` : '';
+      fechaEl.textContent = formatearFecha(sorteoData.fecha || '');
+      horaEl.textContent = formatearHora(sorteoData.hora || '');
+      totalPremiosEl.textContent = Math.round(sorteoData.totalPremios || 0);
+
+      const formasSnap = await db.collection('formas').where('sorteoId','==',sorteoId).get();
+      formasData = [];
+      formasSnap.forEach(doc=>formasData.push(doc.data()));
+      renderFormas();
+
+      const cartonesSnap = await db.collection('CartonJugado').where('sorteoId','==',sorteoId).get();
+      cartonesData = [];
+      cartonesSnap.forEach(doc=>cartonesData.push(doc.data()));
+      renderCartones();
+
+      pdfBtn.style.display = 'block';
+    } catch (err) {
+      console.error('Error cargando datos', err);
+      alert('Ocurrió un error cargando la información del sorteo.');
+      window.location.href = 'cantarsorteos.html';
+    } finally {
+      loadingOverlay.style.display = 'none';
+    }
+  }
+
+  function normalizarTexto(texto){
+    return (texto || '').toString().normalize('NFD').replace(/[^\w\s-]/g,'').trim().replace(/\s+/g,'_');
+  }
+
+  async function generarPDF(){
+    if(!sorteoData){ return; }
+    loadingText.textContent = 'Generando PDF, por favor espera';
+    loadingOverlay.style.display = 'flex';
+    try {
+      await db.collection('sorteos').doc(sorteoId).set({ pdf: 'si' }, { merge: true });
+      const { jsPDF } = window.jspdf;
+      const element = document.getElementById('pdf-wrapper');
+      const canvas = await html2canvas(element, { scale: 2, useCORS: true });
+      const imgData = canvas.toDataURL('image/png');
+      const pdf = new jsPDF('p','pt','a4');
+      const pageWidth = pdf.internal.pageSize.getWidth();
+      const pageHeight = pdf.internal.pageSize.getHeight();
+      const imgWidth = pageWidth;
+      const imgHeight = canvas.height * imgWidth / canvas.width;
+      let heightLeft = imgHeight;
+      let position = 0;
+      pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+      heightLeft -= pageHeight;
+      while(heightLeft > 0){
+        position = heightLeft - imgHeight;
+        pdf.addPage();
+        pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+        heightLeft -= pageHeight;
+      }
+      const blob = pdf.output('blob');
+      const nombre = normalizarTexto(sorteoData.nombre || 'sorteo');
+      const fecha = normalizarTexto((sorteoData.fecha || '').replace(/\//g,'-'));
+      const hora = normalizarTexto((sorteoData.hora || '').replace(/:/g,'-'));
+      const archivo = `${nombre}_${fecha}_${hora}.pdf`;
+      const storageRef = firebase.storage().ref().child(`PDF sorteos/${archivo}`);
+      await storageRef.put(blob);
+      alert('PDF generado y guardado correctamente.');
+    } catch (err) {
+      console.error('Error generando PDF', err);
+      alert('No fue posible generar el PDF.');
+    } finally {
+      loadingOverlay.style.display = 'none';
+      loadingText.textContent = 'Generando cartones del sorteo por favor espera';
+    }
+  }
+
+  cargarDatos();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Resumen
- redirigir el botón de canto de sorteos del panel de administrador a la nueva experiencia dedicada
- crear la pantalla cantarsorteos.html con la interfaz solicitada para sellar, jugar y finalizar sorteos
- añadir pdfsorteo.html para generar la ficha en PDF y almacenarla en Firebase Storage

## Pruebas
- no se ejecutaron pruebas automatizadas (no aplicable)


------
https://chatgpt.com/codex/tasks/task_e_68d2e5736c7883269d584cbdceb83a53