### PR TITLE
Actualizar selección de sorteos y flujo de PDF

### DIFF
--- a/cantarsorteos.html
+++ b/cantarsorteos.html
@@ -240,10 +240,17 @@
       transition: transform 0.2s;
     }
     .estado-btn:hover { transform: scale(1.05); }
-    #pdf-btn { background: linear-gradient(#003c71,#ffffff); }
+    #sellar-btn { background: linear-gradient(#707070,#d9d9d9); }
+    #pdf-btn { background: linear-gradient(#008c3a,#66d17a); }
     #jugar-btn { background: linear-gradient(#4b0082,#ffffff); }
     #finalizar-btn { background: linear-gradient(#8b0000,#ffffff); }
     .estado-btn img { width: 24px; height: 24px; }
+    #sellar-btn .stop-icon {
+      font-family: 'Bangers', cursive;
+      font-size: 0.95rem;
+      letter-spacing: 1px;
+      color: #ffffff;
+    }
     #tabla-cantos-wrapper {
       margin: 16px 8px 0;
       width: min(360px, calc(100% - 16px));
@@ -414,7 +421,7 @@
     </div>
     <div id="acciones-sorteo">
       <button id="sellar-btn" class="estado-btn" title="Sellar sorteo">
-        <img src="https://api.iconify.design/mdi/seal-variant.svg?color=white" alt="Sellar">
+        <span class="stop-icon">STOP</span>
       </button>
       <button id="pdf-btn" class="estado-btn" title="Generar PDF">
         <img src="https://api.iconify.design/mdi/file-pdf-box.svg?color=white" alt="PDF">
@@ -664,11 +671,19 @@
     cantosUnsub = ref.onSnapshot(doc=>{
       if(!doc.exists){
         actualizarCantosSeleccionados([]);
+        if(currentSorteoData) currentSorteoData.cantos = [];
         return;
       }
       const data = doc.data() || {};
       const numeros = Array.isArray(data.numeros) ? data.numeros : [];
       actualizarCantosSeleccionados(numeros);
+      if(currentSorteoData){
+        currentSorteoData.cantos = numeros;
+      }
+      const idx = sorteos.findIndex(s=>s.id===id);
+      if(idx>=0){
+        sorteos[idx].cantos = numeros;
+      }
     }, err=>console.error('Error escuchando cantos', err));
   }
 
@@ -869,30 +884,42 @@
     try {
       const snap = await db.collection('sorteos').get();
       const pendientesPdf = [];
+      const cantosPromises = [];
       snap.forEach(doc=>{
         const d = doc.data();
-        sorteos.push({
-          id: doc.id,
-          nombre: d.nombre || 'Sorteo',
-          fecha: d.fecha || '',
-          hora: d.hora || '',
-          tipo: d.tipo || '',
-          estado: d.estado || 'Activo',
-          valorCarton: d.valorCarton || 0,
-          cartonesjugando: d.cartonesjugando || 0,
-          cartonesgratisjugando: d.cartonesgratisjugando || 0,
-          totalPremios: d.totalPremios || 0,
-          cierreMinutos: d.cierreMinutos || d.cierre || 0,
-          pdf: d.pdf || 'no'
-        });
+        const registro = { id: doc.id, ...d, pdf: d.pdf || 'no', cantos: [] };
+        registro.nombre = registro.nombre || 'Sorteo';
+        registro.estado = registro.estado || 'Activo';
+        registro.fecha = registro.fecha || '';
+        registro.hora = registro.hora || '';
+        registro.tipo = registro.tipo || '';
+        registro.valorCarton = registro.valorCarton || 0;
+        registro.cartonesjugando = registro.cartonesjugando || 0;
+        registro.cartonesgratisjugando = registro.cartonesgratisjugando || 0;
+        registro.totalPremios = registro.totalPremios || 0;
+        if(typeof registro.cierreMinutos === 'undefined'){ registro.cierreMinutos = registro.cierre || 0; }
+        sorteos.push(registro);
         if(typeof d.pdf === 'undefined' || d.pdf === null || d.pdf === ''){
           pendientesPdf.push(doc.id);
         }
+        cantosPromises.push(
+          db.collection('cantos').doc(doc.id).get().then(cantoDoc=>{
+            if(!cantoDoc.exists){
+              registro.cantos = [];
+              return;
+            }
+            const dataCantos = cantoDoc.data() || {};
+            registro.cantos = Array.isArray(dataCantos.numeros) ? dataCantos.numeros : [];
+          }).catch(err=>console.error('Error cargando cantos de sorteo', err))
+        );
       });
       if(pendientesPdf.length){
         await Promise.all(pendientesPdf.map(id=>
           db.collection('sorteos').doc(id).set({ pdf: 'no' }, { merge: true })
         )).catch(err=>console.error('Error asegurando pdf en sorteos', err));
+      }
+      if(cantosPromises.length){
+        await Promise.all(cantosPromises);
       }
     } catch (err) {
       console.error('Error cargando sorteos', err);
@@ -905,20 +932,27 @@
       mensajeEl.textContent = 'No hay sorteos disponibles en este momento.';
       return;
     }
+    mensajeEl.textContent = '';
     const cont = document.getElementById('sorteos-list');
     cont.innerHTML = '';
+    const estadoOrden = { jugando: 0, sellado: 1, activo: 2, finalizado: 3 };
+    const ahora = getServerNow() || new Date();
+    const referencia = ahora instanceof Date && !isNaN(ahora.getTime()) ? ahora : new Date();
     const ordenados = [...sorteos].sort((a,b)=>{
-      const fechaA = obtenerFechaSorteo(a) || new Date(0);
-      const fechaB = obtenerFechaSorteo(b) || new Date(0);
-      return fechaB - fechaA;
+      const estadoA = (a.estado || '').toString().toLowerCase();
+      const estadoB = (b.estado || '').toString().toLowerCase();
+      const prioridadA = estadoOrden.hasOwnProperty(estadoA) ? estadoOrden[estadoA] : 4;
+      const prioridadB = estadoOrden.hasOwnProperty(estadoB) ? estadoOrden[estadoB] : 4;
+      if(prioridadA !== prioridadB) return prioridadA - prioridadB;
+      const fechaA = obtenerFechaSorteo(a);
+      const fechaB = obtenerFechaSorteo(b);
+      const diffA = fechaA ? Math.abs(fechaA - referencia) : Number.MAX_SAFE_INTEGER;
+      const diffB = fechaB ? Math.abs(fechaB - referencia) : Number.MAX_SAFE_INTEGER;
+      if(diffA !== diffB) return diffA - diffB;
+      if(fechaA && fechaB && fechaA.getTime() !== fechaB.getTime()) return fechaA - fechaB;
+      return (a.nombre || '').localeCompare(b.nombre || '');
     });
-    const activos = ordenados.filter(s=> (s.estado || '').toLowerCase() === 'activo');
-    if(!activos.length){
-      mensajeEl.textContent = 'No hay sorteos activos disponibles en este momento.';
-      document.getElementById('sorteos-modal').style.display = 'none';
-      return;
-    }
-    activos.forEach((s, idx)=>{
+    ordenados.forEach((s, idx)=>{
       const div = document.createElement('div');
       div.className = `sorteo-item ${s.estado ? s.estado.toLowerCase() : ''} ${s.tipo === 'Sorteo Diario' ? 'diario' : s.tipo === 'Sorteo Especial' ? 'especial' : ''}`.trim();
       const header = document.createElement('div');
@@ -931,7 +965,8 @@
       div.appendChild(detalle);
       const extra = document.createElement('div');
       extra.className = 'sorteo-extra';
-      extra.innerHTML = `<span>Premio: ${Math.round(s.totalPremios || 0)}</span><span>Cartones: ${s.cartonesjugando || 0} + ${s.cartonesgratisjugando || 0}</span>`;
+      const cantosRegistrados = Array.isArray(s.cantos) ? s.cantos.length : 0;
+      extra.innerHTML = `<span>Premio: ${Math.round(s.totalPremios || 0)}</span><span>Cartones: ${s.cartonesjugando || 0} + ${s.cartonesgratisjugando || 0}</span><span>Cantos: ${cantosRegistrados}</span>`;
       div.appendChild(extra);
       div.addEventListener('click',()=>{
         seleccionarSorteo(s.id);
@@ -952,11 +987,13 @@
         detenerCantos();
         return;
       }
-      currentSorteoData = { id: doc.id, ...doc.data() };
+      const cantosPrevios = currentSorteoData?.cantos || sorteos.find(s=>s.id===doc.id)?.cantos || [];
+      currentSorteoData = { id: doc.id, ...doc.data(), cantos: cantosPrevios };
       asegurarCampoPdf(doc.id, currentSorteoData);
       const idx = sorteos.findIndex(s=>s.id===doc.id);
       if(idx>=0){
-        sorteos[idx] = { ...sorteos[idx], ...doc.data() };
+        const cantosExistentes = sorteos[idx].cantos || [];
+        sorteos[idx] = { ...sorteos[idx], ...doc.data(), cantos: cantosExistentes };
       }
       mostrarDatos();
     }, err=>console.error('Error escuchando sorteo', err));
@@ -968,6 +1005,7 @@
     currentSorteoData = encontrado ? { ...encontrado } : null;
     if(currentSorteoData){
       asegurarCampoPdf(currentSorteoId, currentSorteoData);
+      actualizarCantosSeleccionados(currentSorteoData.cantos || []);
     }
     escucharSorteo(id);
     escucharCantos(id);

--- a/pdfsorteo.html
+++ b/pdfsorteo.html
@@ -51,7 +51,7 @@
       font-size: 1.1rem;
       border-radius: 12px;
       border: 4px solid #FFD700;
-      background: linear-gradient(#003c8f, #ffffff);
+      background: linear-gradient(#008c3a, #66d17a);
       color: #ffffff;
       text-shadow: 1px 1px 2px #000;
       cursor: pointer;
@@ -236,6 +236,75 @@
       from { transform: rotate(0deg); }
       to { transform: rotate(360deg); }
     }
+    #confirmacion-guardado {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.65);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+      box-sizing: border-box;
+      z-index: 1300;
+    }
+    #confirmacion-guardado.oculto { display: none; }
+    .confirmacion-contenido {
+      background: #ffffff;
+      border-radius: 14px;
+      padding: 24px 20px;
+      max-width: 360px;
+      width: 100%;
+      text-align: center;
+      box-shadow: 0 10px 25px rgba(0,0,0,0.35);
+      font-family: 'Poppins', sans-serif;
+    }
+    .confirmacion-contenido h3 {
+      margin: 0 0 12px 0;
+      font-family: 'Bangers', cursive;
+      font-size: 1.4rem;
+      color: #0b5394;
+    }
+    .confirmacion-contenido p {
+      margin: 0;
+      font-size: 0.95rem;
+      color: #1a1a1a;
+    }
+    .confirmacion-acciones {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      justify-content: center;
+      margin-top: 18px;
+    }
+    .confirmacion-acciones button {
+      padding: 8px 16px;
+      border-radius: 10px;
+      border: 3px solid #FFD700;
+      font-family: 'Bangers', cursive;
+      font-size: 1rem;
+      cursor: pointer;
+      background: linear-gradient(#008c3a, #66d17a);
+      color: #ffffff;
+      text-shadow: 1px 1px 1px rgba(0,0,0,0.4);
+      box-shadow: 0 0 8px rgba(0,0,0,0.3);
+    }
+    .confirmacion-acciones button.secundario {
+      background: linear-gradient(#9c9c9c, #e0e0e0);
+      color: #222;
+    }
+    #mensaje-resultado {
+      margin: 20px auto 0;
+      max-width: 600px;
+      text-align: center;
+      font-family: 'Poppins', sans-serif;
+      font-weight: 600;
+      color: #0b6623;
+    }
+    #mensaje-resultado.error { color: #8b0000; }
+    #mensaje-resultado.info { color: #0b5394; }
   </style>
 </head>
 <body>
@@ -265,6 +334,17 @@
       <div id="cartones-grid"></div>
     </section>
   </div>
+  <div id="mensaje-resultado" aria-live="polite"></div>
+  <div id="confirmacion-guardado" class="oculto" role="dialog" aria-modal="true">
+    <div class="confirmacion-contenido">
+      <h3>Guardar PDF</h3>
+      <p>¿Se guardó correctamente el PDF en el dispositivo?</p>
+      <div class="confirmacion-acciones">
+        <button id="confirmar-guardado-btn">Sí, se guardó</button>
+        <button id="reintentar-guardado-btn" class="secundario">Volver a intentar</button>
+      </div>
+    </div>
+  </div>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -289,17 +369,22 @@
   const totalPremiosEl = document.getElementById('total-premios');
   const formasCont = document.getElementById('formas-container');
   const cartonesGrid = document.getElementById('cartones-grid');
+  const confirmacionOverlay = document.getElementById('confirmacion-guardado');
+  const confirmarGuardadoBtn = document.getElementById('confirmar-guardado-btn');
+  const reintentarGuardadoBtn = document.getElementById('reintentar-guardado-btn');
+  const mensajeResultado = document.getElementById('mensaje-resultado');
 
   let sorteoData = null;
   let formasData = [];
   let cartonesData = [];
-  let esperandoConfirmacionPDF = false;
   let pdfFileName = '';
 
   const coloresFormas = ['#006400', '#b8860b', '#00008b', '#4b0082', '#8b4513', '#d2691e'];
 
   salirBtn.addEventListener('click', ()=>{ window.location.href = 'cantarsorteos.html'; });
   pdfBtn.addEventListener('click', generarPDF);
+  if(confirmarGuardadoBtn){ confirmarGuardadoBtn.addEventListener('click', confirmarGuardado); }
+  if(reintentarGuardadoBtn){ reintentarGuardadoBtn.addEventListener('click', reintentarGuardado); }
 
   function formatearFecha(fecha){
     if(!fecha) return '';
@@ -358,6 +443,48 @@
     const fecha = formatearFechaArchivo(sorteoData.fecha || '');
     const hora = formatearHoraArchivo(sorteoData.hora || '');
     return `${nombre}_${fecha}_${hora}`;
+  }
+
+  function limpiarMensaje(){
+    if(!mensajeResultado) return;
+    mensajeResultado.textContent = '';
+    mensajeResultado.classList.remove('error','info');
+  }
+
+  function mostrarMensaje(texto, tipo='exito'){
+    if(!mensajeResultado) return;
+    limpiarMensaje();
+    if(!texto) return;
+    if(tipo === 'error') mensajeResultado.classList.add('error');
+    else if(tipo === 'info') mensajeResultado.classList.add('info');
+    mensajeResultado.textContent = texto;
+  }
+
+  function mostrarConfirmacionGuardado(){
+    if(!confirmacionOverlay) return;
+    confirmacionOverlay.classList.remove('oculto');
+    if(confirmarGuardadoBtn){ confirmarGuardadoBtn.focus(); }
+  }
+
+  function ocultarConfirmacionGuardado(){
+    if(!confirmacionOverlay) return;
+    confirmacionOverlay.classList.add('oculto');
+  }
+
+  async function confirmarGuardado(){
+    ocultarConfirmacionGuardado();
+    try {
+      await db.collection('sorteos').doc(sorteoId).set({ pdf: 'si' }, { merge: true });
+      mostrarMensaje('Se confirmó el guardado del PDF.');
+    } catch (err) {
+      console.error('Error actualizando estado del PDF', err);
+      mostrarMensaje('No fue posible actualizar la información del PDF. Intenta nuevamente.', 'error');
+    }
+  }
+
+  function reintentarGuardado(){
+    ocultarConfirmacionGuardado();
+    mostrarMensaje('Cuando tengas el PDF guardado, vuelve a presionar "Generar PDF" para intentarlo nuevamente.', 'info');
   }
 
   function crearMiniCarton(posiciones){
@@ -480,36 +607,20 @@
     }
   }
 
-  async function manejarConfirmacionGuardado(){
-    const confirmado = confirm('¿Se guardó correctamente el PDF en el dispositivo?');
-    if(!confirmado){
-      alert('Debes guardar el PDF para continuar con el sorteo.');
-      return;
-    }
-    try {
-      await db.collection('sorteos').doc(sorteoId).set({ pdf: 'si' }, { merge: true });
-      alert('Se confirmó el guardado del PDF.');
-    } catch (err) {
-      console.error('Error actualizando estado del PDF', err);
-      alert('No fue posible actualizar la información del PDF. Intenta nuevamente.');
-    }
-  }
-
   function generarPDF(){
     if(!sorteoData){ return; }
+    limpiarMensaje();
+    ocultarConfirmacionGuardado();
     const tituloOriginal = document.title;
     const nombreArchivo = pdfFileName || construirNombreArchivo();
     document.title = nombreArchivo;
-    esperandoConfirmacionPDF = true;
     const handler = ()=>{
-      document.title = tituloOriginal;
       window.removeEventListener('afterprint', handler);
-      if(!esperandoConfirmacionPDF) return;
-      esperandoConfirmacionPDF = false;
-      setTimeout(manejarConfirmacionGuardado, 150);
+      document.title = tituloOriginal;
+      setTimeout(mostrarConfirmacionGuardado, 200);
     };
     window.addEventListener('afterprint', handler);
-    setTimeout(()=>{ window.print(); }, 200);
+    window.requestAnimationFrame(()=>window.print());
   }
 
   cargarDatos();


### PR DESCRIPTION
## Resumen
- Mostrar todos los sorteos en el modal de selección con orden dinámico por estado y cercanía temporal, cargando números cantados asociados.
- Ajustar los estilos de los botones de acciones (STOP gris para sellar y degradado verde para PDF).
- Simplificar la generación de PDF reemplazando diálogos bloqueantes por una confirmación interna posterior al guardado.

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d326507a008326a0e887ff915d4f74