### PR TITLE
Ajustes visuales y flujo de sorteos en vistas de jugador y cantor

### DIFF
--- a/cantarsorteos.html
+++ b/cantarsorteos.html
@@ -172,12 +172,19 @@
       margin: 16px 8px 0;
       width: min(360px, calc(100% - 16px));
       box-shadow: 0 0 10px rgba(0,0,0,0.4);
+      transition: background 0.3s ease;
     }
-    #detalle-container.diario {
-      background: linear-gradient(135deg, rgba(0,128,0,0.85), rgba(255,255,255,0.95));
+    #detalle-container.estado-sellado {
+      background: linear-gradient(135deg, #c0c0c0, #ffffff);
     }
-    #detalle-container.especial {
-      background: linear-gradient(135deg, rgba(255,140,0,0.8), rgba(255,255,255,0.95));
+    #detalle-container.estado-pdf {
+      background: linear-gradient(135deg, #3ba74d, #ffffff);
+    }
+    #detalle-container.estado-jugando {
+      background: linear-gradient(135deg, #7f3fbf, #ffffff);
+    }
+    #detalle-container.estado-finalizado {
+      background: linear-gradient(135deg, #8b4513, #ffffff);
     }
     #sorteo-nombre {
       font-size: 1rem;
@@ -278,6 +285,10 @@
       filter: grayscale(0.9);
       opacity: 0.75;
     }
+    #tabla-cantos-container.bloqueado {
+      filter: none;
+      opacity: 1;
+    }
     #tabla-cantos {
       width: 100%;
       border-collapse: separate;
@@ -309,7 +320,8 @@
       box-shadow: 0 0 8px rgba(255,255,0,0.8);
       transform: scale(1.03);
     }
-    #tabla-cantos-container.disabled .canto-cell {
+    #tabla-cantos-container.disabled .canto-cell,
+    #tabla-cantos-container.bloqueado .canto-cell {
       pointer-events: none;
       cursor: default;
     }
@@ -489,6 +501,53 @@
   const cantoCeldas = new Map();
   let cantosSeleccionados = new Set();
   let cantosUnsub = null;
+  let sorteoCookieKey = '';
+  let restauracionPendiente = false;
+
+  function setCookie(name, value){
+    document.cookie = `${name}=${encodeURIComponent(value)};path=/;max-age=31536000`;
+  }
+
+  function getCookie(name){
+    const match = document.cookie.match(new RegExp('(?:^|; )' + name.replace(/[.$?*|{}()\[\]\\\/\+^]/g, '\\$&') + '=([^;]*)'));
+    return match ? decodeURIComponent(match[1]) : null;
+  }
+
+  function deleteCookie(name){
+    document.cookie = `${name}=;path=/;max-age=0`;
+  }
+
+  function guardarSorteoSeleccionado(id){
+    if(!sorteoCookieKey || !id) return;
+    setCookie(sorteoCookieKey, id);
+  }
+
+  function intentarRestaurarSorteo(){
+    if(!sorteoCookieKey) return false;
+    const guardado = getCookie(sorteoCookieKey);
+    if(!guardado) return false;
+    if(guardado === currentSorteoId) return true;
+    const existe = sorteos.find(s=>s.id===guardado);
+    if(!existe){
+      deleteCookie(sorteoCookieKey);
+      return false;
+    }
+    seleccionarSorteo(guardado);
+    return true;
+  }
+
+  auth.onAuthStateChanged(user=>{
+    if(!user){
+      sorteoCookieKey = '';
+      restauracionPendiente = false;
+      return;
+    }
+    sorteoCookieKey = `cantarsorteos_${user.email.replace(/[^\w]/g,'_')}`;
+    restauracionPendiente = true;
+    if(intentarRestaurarSorteo()){
+      restauracionPendiente = false;
+    }
+  });
 
   document.getElementById('salir-btn').addEventListener('click',()=>{ window.location.href='admin.html'; });
   btnSorteo.addEventListener('click', abrirModalSorteos);
@@ -627,6 +686,7 @@
   async function manejarCantoClick(clave){
     if(!currentSorteoId || !currentSorteoData) return;
     if(tablaCantosContainer.classList.contains('disabled')) return;
+    if(tablaCantosContainer.classList.contains('bloqueado')) return;
     if(cantosSeleccionados.has(clave)) return;
     const confirmar = confirm(`Confirmas la jugada de ${clave}?`);
     if(!confirmar) return;
@@ -690,10 +750,12 @@
   function actualizarTablaEstado(){
     if(!tablaCantosContainer) return;
     const estado = (currentSorteoData?.estado || '').toString().toLowerCase();
+    const esFinalizado = estado === 'finalizado';
     const habilitado = estado === 'jugando';
-    tablaCantosContainer.classList.toggle('disabled', !habilitado);
+    tablaCantosContainer.classList.toggle('disabled', !habilitado && !esFinalizado);
+    tablaCantosContainer.classList.toggle('bloqueado', esFinalizado);
     if(tablaCantosTitulo){
-      tablaCantosTitulo.textContent = 'NÚMEROS CANTADOS';
+      tablaCantosTitulo.textContent = esFinalizado ? 'NÚMEROS CANTADOS (FINALIZADO)' : 'NÚMEROS CANTADOS';
     }
   }
 
@@ -836,7 +898,7 @@
       sorteoNombreEl.textContent = 'Selecciona un sorteo para ver los detalles';
       actualizarEstadoVisual(null);
       tipoEl.innerHTML = '';
-      if(detalleContainer) detalleContainer.classList.remove('diario','especial');
+      if(detalleContainer) detalleContainer.classList.remove('estado-sellado','estado-pdf','estado-jugando','estado-finalizado');
       mensajeEl.textContent = 'Selecciona un sorteo para administrar su estado.';
       [sellarBtn, pdfBtn, jugarBtn, finalizarBtn].forEach(btn=>btn.disabled=true);
       actualizarAnimaciones();
@@ -856,9 +918,13 @@
     else if(esDiario) btnSorteo.classList.add('diario');
     else if(esEspecial) btnSorteo.classList.add('especial');
     if(detalleContainer){
-      detalleContainer.classList.remove('diario','especial');
-      if(esDiario) detalleContainer.classList.add('diario');
-      else if(esEspecial) detalleContainer.classList.add('especial');
+      detalleContainer.classList.remove('estado-sellado','estado-pdf','estado-jugando','estado-finalizado');
+      const estadoLower = estadoActual.toLowerCase();
+      const pdfEstado = (data.pdf || '').toString().toLowerCase();
+      if(estadoLower === 'finalizado') detalleContainer.classList.add('estado-finalizado');
+      else if(estadoLower === 'jugando') detalleContainer.classList.add('estado-jugando');
+      else if(pdfEstado === 'si') detalleContainer.classList.add('estado-pdf');
+      else if(estadoLower === 'sellado') detalleContainer.classList.add('estado-sellado');
     }
     if(fechaProgramadaEl) fechaProgramadaEl.textContent = data.fecha ? formatearFecha(data.fecha) : '';
     if(horaProgramadaEl) horaProgramadaEl.textContent = data.hora ? formatearHora(data.hora) : '';
@@ -920,6 +986,10 @@
       }
       if(cantosPromises.length){
         await Promise.all(cantosPromises);
+      }
+      if(restauracionPendiente){
+        const restaurado = intentarRestaurarSorteo();
+        restauracionPendiente = !restaurado;
       }
     } catch (err) {
       console.error('Error cargando sorteos', err);
@@ -1000,7 +1070,10 @@
   }
 
   function seleccionarSorteo(id){
+    if(!id) return;
     currentSorteoId = id;
+    restauracionPendiente = false;
+    guardarSorteoSeleccionado(id);
     const encontrado = sorteos.find(s=>s.id===id);
     currentSorteoData = encontrado ? { ...encontrado } : null;
     if(currentSorteoData){
@@ -1031,10 +1104,27 @@
     }
   }
 
-  function abrirPDF(){
+  async function abrirPDF(){
     if(!currentSorteoId || !currentSorteoData){ alert('Selecciona un sorteo primero.'); return; }
     if((currentSorteoData.estado || '') !== 'Sellado'){
       alert('Para generar el archivo PDF de sellado el sorteo debe estar Sellado primero');
+      return;
+    }
+    const confirmar = await confirm('¿Ya se guardó el documento PDF de este sorteo?');
+    if(confirmar){
+      try {
+        await db.collection('sorteos').doc(currentSorteoId).update({ pdf: 'si' });
+        currentSorteoData.pdf = 'si';
+        const idx = sorteos.findIndex(s=>s.id===currentSorteoId);
+        if(idx>=0) sorteos[idx].pdf = 'si';
+        mensajeEl.textContent = 'Se marcó el documento PDF como guardado.';
+        actualizarBotones();
+        actualizarAnimaciones();
+        mostrarDatos();
+      } catch (err) {
+        console.error('Error actualizando estado del PDF', err);
+        alert('No fue posible actualizar el estado del PDF.');
+      }
       return;
     }
     const url = `pdfsorteo.html?s=${currentSorteoId}`;
@@ -1085,7 +1175,9 @@
 
   async function inicializar(){
     await cargarSorteos();
-    mostrarDatos();
+    if(!intentarRestaurarSorteo()){
+      mostrarDatos();
+    }
   }
 
   setInterval(actualizarAnimaciones, 15000);

--- a/jugarcartones.html
+++ b/jugarcartones.html
@@ -84,7 +84,7 @@
     #fecha-hora-sorteo{display:flex;flex-wrap:wrap;align-items:flex-start;justify-content:center;gap:12px;font-family:'Poppins',sans-serif;text-transform:none;}
     #fecha-hora-sorteo .fecha-col{display:flex;flex-direction:column;align-items:flex-start;gap:2px;min-width:120px;}
     #fecha-hora-sorteo .sorteo-line{display:flex;align-items:center;gap:4px;font-weight:600;font-size:1rem;}
-    #fecha-hora-sorteo .actual-line{font-size:0.85rem;color:#0b5394;font-weight:600;}
+    #fecha-hora-sorteo .actual-line{font-size:0.7rem;color:#0b5394;font-weight:600;display:block;margin-top:-2px;}
     #fecha-hora-sorteo .cal-icon,#fecha-hora-sorteo .clock-icon{font-size:1.1rem;}
     .datos-sorteo{display:flex;flex-direction:column;align-items:center;gap:4px;justify-content:center;margin-top:2px;flex-wrap:wrap;font-family:'Bangers',cursive;}
     #sorteo-section{margin-bottom:5px;}
@@ -998,21 +998,19 @@ function toggleForma(idx){
     const back=document.querySelector('.carton-back');
     const player=document.getElementById('player-container');
     let color='#808080';
-    let gradient='linear-gradient(135deg,#d3d3d3,#ffffff)';
+    const baseGradient='linear-gradient(135deg,#d3d3d3,#ffffff)';
     let borde='#0b8a2a';
     if(currentSorteoTipo==='Sorteo Diario'){
       color='#0a8800';
-      gradient='linear-gradient(135deg,#0b8a2a,#a3f7a7)';
     }else if(currentSorteoTipo==='Sorteo Especial'){
       color='#ff8800';
-      gradient='linear-gradient(135deg,#ffb347,#ff7e00)';
       borde='#ff8800';
     }else{
       borde='#0b8a2a';
     }
     if(back) back.style.background=`linear-gradient(white,${color})`;
     if(player){
-      player.style.background=gradient;
+      player.style.background=baseGradient;
       player.style.borderColor=borde;
     }
   }

--- a/scripts/timezone.js
+++ b/scripts/timezone.js
@@ -102,12 +102,12 @@ async function initFechaHora(idElemento = "fecha-hora") {
       }
       const fechaSpan = document.createElement('span');
       fechaSpan.className = 'fecha-actual-icono';
-      fechaSpan.textContent = `📅 ${fechaStr}`;
+      fechaSpan.textContent = fechaStr;
       el.appendChild(fechaSpan);
       el.appendChild(document.createTextNode(' '));
       const horaSpan = document.createElement('span');
       horaSpan.className = 'hora-actual-icono';
-      horaSpan.textContent = `⏰ ${horaStr}`;
+      horaSpan.textContent = horaStr;
       el.appendChild(horaSpan);
     } catch (err) {
       console.error('Error formateando fecha/hora', err);


### PR DESCRIPTION
## Resumen
- Ajusté el bloque de fecha y hora en *jugarcartones.html* para que los valores en tiempo real sean más pequeños y mantengan el fondo gris del panel de acciones del jugador.
- Eliminé los iconos del calendario y reloj en el pie de página usando el inicializador de fecha/hora compartido.
- Incorporé persistencia del sorteo seleccionado mediante cookies en *cantarsorteos.html*, añadí cambios de degradado según estado/PDF y modifiqué el flujo del botón de PDF con la confirmación solicitada.
- Actualicé la lógica de la tabla de jugadas para bloquear la edición en estado finalizado manteniendo los colores visibles.

## Pruebas
- No se ejecutaron pruebas automatizadas (cambios de UI y lógica ligera).


------
https://chatgpt.com/codex/tasks/task_e_68d33103107083269e3a12fc4119f09a