### PR TITLE
Corrige error sintáctico que impedía abrir el modal de sorteos

### DIFF
--- a/cantarsorteos.html
+++ b/cantarsorteos.html
@@ -1221,7 +1221,7 @@
                 idx: dataForma.idx || dataForma.indice || arr.length + 1,
                 nombre: dataForma.nombre || '',
                 porcentaje: dataForma.porcentaje ?? dataForma.porcentajePremio ?? 0,
-                cartonesGratis: dataForma.cartonesGratis ?? dataForma.cartones || 0
+                cartonesGratis: dataForma.cartonesGratis ?? (dataForma.cartones || 0)
               });
             });
             arr.sort((a,b)=>(parseInt(a.idx,10)||0)-(parseInt(b.idx,10)||0));


### PR DESCRIPTION
## Resumen
- Ajusta la obtención de cartones gratis en cantarsorteos para evitar la mezcla inválida de los operadores `??` y `||`.
- Restaura la ejecución del script principal, reactivando la apertura del modal, la tabla de cantos y el botón Salir.

## Pruebas
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d43b45c8cc8326a761aef05a4bb749