### PR TITLE
Actualizar lógica de cierre de sorteos por hora

### DIFF
--- a/cantarsorteos.html
+++ b/cantarsorteos.html
@@ -523,7 +523,7 @@
       flex-wrap: wrap;
     }
     .sorteo-detalle span { display: inline-flex; align-items: center; gap: 4px; }
-    .cierre-minutos {
+    .cierre-hora {
       font-weight: 700;
       color: #0b4dda;
       text-shadow: 0 0 4px rgba(255,255,255,0.6);
@@ -1269,11 +1269,58 @@
     return formatoNumeroES.format(Math.round(numero));
   }
 
-  function obtenerCierreMinutosRegistro(sorteo){
+  function obtenerValorHoraCierre(sorteo){
     if(!sorteo) return null;
-    const posible = sorteo.cierreMinutos ?? sorteo.cierre ?? sorteo.cierreminutos;
-    const valor = parseInt(posible, 10);
-    return isNaN(valor) ? null : valor;
+    const claves=['horacierre','horaCierre','hora_cierre','cierre','cierreHora','cierrehora'];
+    for(const clave of claves){
+      const valor=sorteo?.[clave];
+      if(valor===undefined || valor===null || valor==='') continue;
+      if(typeof valor==='string'){
+        const texto=valor.trim();
+        if(!texto) continue;
+        if(!/[0-9]:/.test(texto) && !/[ap]\.?m\.?/i.test(texto) && /^\d+$/.test(texto)){
+          continue;
+        }
+        return texto;
+      }
+      return valor;
+    }
+    return null;
+  }
+
+  function obtenerFechaHoraCierre(data){
+    if(!data) return null;
+    const fechaBase=obtenerFechaDesdeValor(data.fecha);
+    if(!fechaBase || isNaN(fechaBase.getTime())) return null;
+    const valorHora=obtenerValorHoraCierre(data);
+    if(valorHora){
+      const info=obtenerHoraDesdeValor(valorHora);
+      if(info){
+        return new Date(fechaBase.getFullYear(),fechaBase.getMonth(),fechaBase.getDate(),info.hora,info.minuto);
+      }
+      if(valorHora instanceof Date && !isNaN(valorHora.getTime())){
+        return new Date(fechaBase.getFullYear(),fechaBase.getMonth(),fechaBase.getDate(),valorHora.getHours(),valorHora.getMinutes());
+      }
+    }
+    const minutosFallback=parseInt(data.cierreMinutos ?? data.cierre ?? data.cierreminutos,10);
+    if(!isNaN(minutosFallback)){
+      const fechaSorteo=obtenerFechaSorteo(data);
+      if(fechaSorteo && !isNaN(fechaSorteo.getTime())){
+        return new Date(fechaSorteo.getTime()-minutosFallback*60000);
+      }
+    }
+    return null;
+  }
+
+  function obtenerTextoHoraCierre(data){
+    const valor=obtenerValorHoraCierre(data);
+    if(valor){
+      const texto=formatearHora(valor);
+      if(texto) return texto;
+    }
+    const minutos=parseInt(data?.cierreMinutos ?? data?.cierre ?? data?.cierreminutos,10);
+    if(!isNaN(minutos)) return `${minutos} min.`;
+    return '';
   }
 
   function generarSubtotalesFormas(formas, totalPremios){
@@ -1313,12 +1360,6 @@
     const tiempoB = fechaB.getTime();
     if(tiempoA === tiempoB) return 0;
     return tiempoA < tiempoB ? -1 : 1;
-  }
-
-  function restarMinutos(fecha, minutos){
-    if(!(fecha instanceof Date) || isNaN(fecha.getTime())) return null;
-    const valorMinutos = Number(minutos) || 0;
-    return new Date(fecha.getTime() - valorMinutos * 60000);
   }
 
   function obtenerNombreSorteoActual(){
@@ -1417,11 +1458,9 @@
     cartonesGratisEl.textContent = data.cartonesgratisjugando || 0;
     sorteoNombreEl.textContent = data.nombre || '';
     actualizarEstadoVisual(data.estado);
-    const cierreVal = parseInt(data.cierreMinutos || data.cierre || 0, 10);
-    const cierreMin = isNaN(cierreVal) ? null : cierreVal;
     const tipoNombre = ((data.tipo || '').replace(/^Sorteo\s+/i,'') || 'N/D').toUpperCase();
-    const cierreTexto = cierreMin !== null ? `${cierreMin} min.` : 'N/D';
-    tipoEl.innerHTML = `<span>Tipo: ${tipoNombre}</span><span>Cierre: ${cierreTexto}</span>`;
+    const cierreTexto = obtenerTextoHoraCierre(data) || 'N/D';
+    tipoEl.innerHTML = `<span>Tipo: ${tipoNombre}</span><span>CIERRE: ${cierreTexto}</span>`;
     mensajeEl.textContent = '';
     actualizarBotones();
     actualizarAnimaciones();
@@ -1451,7 +1490,9 @@
         registro.cartonesjugando = registro.cartonesjugando || 0;
         registro.cartonesgratisjugando = registro.cartonesgratisjugando || 0;
         registro.totalPremios = registro.totalPremios || 0;
-        if(typeof registro.cierreMinutos === 'undefined'){ registro.cierreMinutos = registro.cierre || 0; }
+        if((registro.horacierre === undefined || registro.horacierre === null || registro.horacierre==='') && registro.cierre){
+          registro.horacierre = registro.cierre;
+        }
         registrosMap.set(doc.id, registro);
         if(typeof d.pdf === 'undefined' || d.pdf === null || d.pdf === ''){
           pendientesPdf.push(doc.id);
@@ -1552,8 +1593,8 @@
       const detalle = document.createElement('div');
       detalle.className = 'sorteo-detalle';
       const fechaTexto = s.fecha ? `<span class="detalle-fecha">📅 ${formatearFecha(s.fecha)}</span>` : '';
-      const cierreValor = obtenerCierreMinutosRegistro(s);
-      const cierreHtml = cierreValor !== null ? `<span class="cierre-minutos">${cierreValor} min</span>` : '';
+      const cierreTexto = obtenerTextoHoraCierre(s);
+      const cierreHtml = cierreTexto ? `<span class="cierre-hora">CIERRE: ${cierreTexto}</span>` : '';
       const horaBase = s.hora ? `⏰ ${formatearHora(s.hora)}` : '';
       let horaTexto = '';
       if(horaBase){
@@ -1687,9 +1728,11 @@
       return;
     }
 
-    const cierreMinutos = obtenerCierreMinutosRegistro(currentSorteoData) ?? 0;
-    const horaCierre = restarMinutos(fechaProgramada, cierreMinutos);
-    if(horaCierre && (comparacionFecha === 0 || comparacionFecha > 0) && ahora < horaCierre){
+    let fechaHoraCierre = obtenerFechaHoraCierre(currentSorteoData);
+    if(fechaHoraCierre && fechaProgramada && fechaHoraCierre.getTime() > fechaProgramada.getTime()){
+      fechaHoraCierre = new Date(fechaProgramada.getTime());
+    }
+    if(fechaHoraCierre && comparacionFecha === 0 && ahora < fechaHoraCierre){
       alert('Hoy es el día del sorteo pero aún no ha llegado la hora de cierre');
       return;
     }
@@ -1813,7 +1856,16 @@
     }
 
     const ahora = getServerNow() || new Date();
-    if(ahora < fechaProgramada){
+    const comparacionFecha = compararFechasCalendario(ahora, fechaProgramada);
+    if(comparacionFecha === null){
+      alert('No se pudo determinar la fecha actual para validar el inicio.');
+      return;
+    }
+    if(comparacionFecha < 0){
+      alert('Aún no es la fecha del sorteo, no puedes iniciar el juego.');
+      return;
+    }
+    if(comparacionFecha === 0 && ahora <= fechaProgramada){
       alert('Aún no ha llegado la hora programada para iniciar el juego.');
       return;
     }

--- a/cronActualizarEstadosSorteos.js
+++ b/cronActualizarEstadosSorteos.js
@@ -60,6 +60,62 @@ async function initServerTime() {
   }
 }
 
+function obtenerHoraDesdeTexto(valor) {
+  if (!valor) return null;
+  if (typeof valor === 'number' && !isNaN(valor)) return null;
+  if (typeof valor === 'object') {
+    if (valor instanceof Date) {
+      return { hora: valor.getHours(), minuto: valor.getMinutes() };
+    }
+    if (typeof valor.seconds === 'number') {
+      const fecha = new Date(valor.seconds * 1000);
+      return { hora: fecha.getHours(), minuto: fecha.getMinutes() };
+    }
+    if (typeof valor.toDate === 'function') {
+      const fecha = valor.toDate();
+      return { hora: fecha.getHours(), minuto: fecha.getMinutes() };
+    }
+  }
+  const original = valor.toString().trim();
+  if (!original) return null;
+  if (!/[0-9]:/.test(original) && !/[ap]\.?m\.?/i.test(original) && /^\d+$/.test(original)) {
+    return null;
+  }
+  const texto = original.toLowerCase();
+  let sufijo = null;
+  if (/p\s*\.?m\.?/.test(texto)) sufijo = 'pm';
+  if (/a\s*\.?m\.?/.test(texto)) sufijo = 'am';
+  const limpio = texto.replace(/[^0-9:]/g, '');
+  if (!limpio) return null;
+  const partes = limpio.split(':');
+  let horas = parseInt(partes[0] || '0', 10);
+  const minutos = parseInt((partes[1] || '0').slice(0, 2), 10);
+  if (isNaN(horas) || isNaN(minutos)) return null;
+  if (sufijo === 'pm' && horas < 12) horas += 12;
+  if (sufijo === 'am' && horas === 12) horas = 0;
+  return { hora: horas, minuto: minutos };
+}
+
+function obtenerFechaHoraCierre(d, sorteoDate) {
+  if (!(sorteoDate instanceof Date) || isNaN(sorteoDate.getTime())) return null;
+  const posibles = ['horacierre', 'horaCierre', 'hora_cierre', 'cierre', 'cierreHora', 'cierrehora'];
+  for (const clave of posibles) {
+    const valor = d?.[clave];
+    if (valor !== undefined && valor !== null && valor !== '') {
+      const info = obtenerHoraDesdeTexto(valor);
+      if (info) {
+        const fecha = new Date(sorteoDate.getFullYear(), sorteoDate.getMonth(), sorteoDate.getDate(), info.hora, info.minuto, 0, 0);
+        if (!isNaN(fecha.getTime())) return fecha;
+      }
+    }
+  }
+  const cierreMin = parseInt(d?.cierreMinutos || 0, 10);
+  if (!isNaN(cierreMin) && cierreMin > 0) {
+    return new Date(sorteoDate.getTime() - cierreMin * 60000);
+  }
+  return null;
+}
+
 // ----- Lógica de actualización de estados -----
 async function actualizarEstadosSorteos() {
   if (!serverTime.zonaIana) await initServerTime();
@@ -73,12 +129,12 @@ async function actualizarEstadosSorteos() {
       const [dia, mes, anio] = d.fecha.split('/').map(n => parseInt(n, 10));
       const [hor, min] = d.hora.split(':').map(n => parseInt(n, 10));
       const sorteoDate = new Date(anio, mes - 1, dia, hor, min);
-      const cierre = parseInt(d.cierreMinutos || 0, 10);
-      const selladoDate = new Date(sorteoDate.getTime() - cierre * 60000);
+      if (isNaN(sorteoDate.getTime())) return;
+      const cierreDate = obtenerFechaHoraCierre(d, sorteoDate);
       if (d.estado === 'Activo') {
         if (ahora >= sorteoDate) {
           updates.push(doc.ref.update({ estado: 'Jugando' }));
-        } else if (ahora >= selladoDate) {
+        } else if (cierreDate && ahora >= cierreDate) {
           updates.push(doc.ref.update({ estado: 'Sellado' }));
         }
       } else if (d.estado === 'Sellado' && ahora >= sorteoDate) {

--- a/editarsorte.html
+++ b/editarsorte.html
@@ -132,8 +132,8 @@
     #fecha-sorteo{color:#4b0082;font-weight:bold;}
     #hora-label{font-size:1rem;color:purple;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #hora-sorteo{color:purple;font-weight:bold;}
-    #minutos-label{font-size:1rem;color:#ff8c00;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
-    #cierre-minutos{color:#ff8c00;font-weight:bold;}
+    #cierre-label{font-size:1rem;color:#ff8c00;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
+    #hora-cierre{color:#ff8c00;font-weight:bold;}
     #max-carton-gratis{width:40px;text-align:center;font-weight:bold;}
     #max-carton-gratis::placeholder{font-size:0.6rem;}
     #valor-label{font-size:1rem;color:#006400;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
@@ -182,7 +182,7 @@
     <div class="input-wrapper"><input id="hora-sorteo" type="time"><span class="label-right" id="hora-label">Hora</span></div>
   </div>
   <div class="row">
-    <div class="input-wrapper"><span class="label-left" id="minutos-label">MINUTOS</span><input id="cierre-minutos" type="number" placeholder="Minutos antes de cerrar jugadas"></div>
+    <div class="input-wrapper"><span class="label-left" id="cierre-label">CIERRE</span><input id="hora-cierre" type="time" placeholder="Hora de cierre de jugadas"></div>
     <div class="input-wrapper"><input id="max-carton-gratis" type="number" min="0" max="99" placeholder="Max CG" style="width:40px;text-align:center;"></div>
     <div class="input-wrapper"><input id="valor-carton" type="number" placeholder="Valor del Cartón"><span class="label-right" id="valor-label">VALOR CARTÓN</span></div>
   </div>
@@ -217,7 +217,7 @@
     const nombre=document.getElementById('nombre-sorteo').value.trim();
     const fecha=document.getElementById('fecha-sorteo').value;
     const hora=document.getElementById('hora-sorteo').value;
-    const cierre=document.getElementById('cierre-minutos').value;
+    const cierre=document.getElementById('hora-cierre').value;
     const maxcg=document.getElementById('max-carton-gratis').value;
     const valor=document.getElementById('valor-carton').value;
     const tipoBtn=document.querySelector('#tipo-sorteo-group button.active');
@@ -253,7 +253,7 @@
       document.getElementById('nombre-sorteo').value=data.nombre||'';
       document.getElementById('fecha-sorteo').value=data.fecha||'';
       document.getElementById('hora-sorteo').value=data.hora||'';
-      document.getElementById('cierre-minutos').value=data.cierre||'';
+      document.getElementById('hora-cierre').value=data.cierre||'';
       document.getElementById('max-carton-gratis').value=data.maxcg||'';
       document.getElementById('valor-carton').value=data.valor||'';
       if(data.tipo){
@@ -307,7 +307,7 @@
     document.getElementById('nombre-sorteo').addEventListener('input',saveState);
     document.getElementById('fecha-sorteo').addEventListener('input',saveState);
     document.getElementById('hora-sorteo').addEventListener('input',saveState);
-    document.getElementById('cierre-minutos').addEventListener('input',saveState);
+    document.getElementById('hora-cierre').addEventListener('input',saveState);
     document.getElementById('max-carton-gratis').addEventListener('input',saveState);
     document.getElementById('valor-carton').addEventListener('input',saveState);
     document.querySelectorAll('.tab-content .nombre-forma,.tab-content .porcentaje-forma,.tab-content .cartones-forma,.tab-content .imagen-url').forEach(i=>i.addEventListener('input',e=>{
@@ -329,7 +329,7 @@
     const d=doc.data();
     let est=d.estado||'';
     if(d.condicion==='ARCHIVADO') est='Archivado';
-    const data={nombre:d.nombre||'',tipo:d.tipo||'',fecha:d.fecha||'',hora:d.hora||'',cierre:d.cierreMinutos||'',maxcg:d.maxcartongratis||'',valor:d.valorCarton||'',estado:est,formas:[]};
+    const data={nombre:d.nombre||'',tipo:d.tipo||'',fecha:d.fecha||'',hora:d.hora||'',cierre:d.horacierre||d.cierre||'',maxcg:d.maxcartongratis||'',valor:d.valorCarton||'',estado:est,formas:[]};
     const snap=await db.collection('formas').where('sorteoId','==',sorteoId).get();
     const arr=[];snap.forEach(s=>arr.push(s.data()));
     arr.sort((a,b)=>(a.idx||0)-(b.idx||0));
@@ -603,7 +603,7 @@ firebase.auth().onAuthStateChanged(u=>{
     const nombreInput=document.getElementById('nombre-sorteo');
     const fechaInput=document.getElementById('fecha-sorteo');
     const horaInput=document.getElementById('hora-sorteo');
-    const cierreInput=document.getElementById('cierre-minutos');
+    const cierreInput=document.getElementById('hora-cierre');
     const maxcgInput=document.getElementById('max-carton-gratis');
     const valorInput=document.getElementById('valor-carton');
     const nombre=nombreInput.value.trim();
@@ -620,9 +620,9 @@ firebase.auth().onAuthStateChanged(u=>{
     if(!tipo){alert('Elije un tipo de sorteo');return;}
     if(!fecha){alert('Elige una fecha para el Sorteo');fechaInput.focus();return;}
     if(!hora){alert('Debes elegir una hora para el Sorteo');horaInput.focus();return;}
-    if(!cierreVal){alert('Elije una cantidad de minutos para cierre previo de Jugadas');cierreInput.focus();return;}
+    if(!cierreVal){alert('Elije una hora de cierre previo de Jugadas');cierreInput.focus();return;}
     if(!valorVal){alert('Coloca un valor para el cartón');valorInput.focus();return;}
-    const cierre=parseInt(cierreVal);
+    const cierre=cierreVal;
     const maxcartongratis=parseInt(maxcgVal)||0;
     const valor=parseFloat(valorVal);
     const condicion = estado==='Archivado'?'ARCHIVADO':'VISIBLE';
@@ -665,7 +665,7 @@ firebase.auth().onAuthStateChanged(u=>{
     }
     if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
-      await db.collection('sorteos').doc(sorteoId).update({nombre,tipo,fecha,hora,cierreMinutos:cierre,maxcartongratis:maxcartongratis,valorCarton:valor,estado,condicion});
+      await db.collection('sorteos').doc(sorteoId).update({nombre,tipo,fecha,hora,horacierre:cierre,maxcartongratis:maxcartongratis,valorCarton:valor,estado,condicion});
       const snap=await db.collection('formas').where('sorteoId','==',sorteoId).get();
       const batch=db.batch();
       snap.forEach(d=>batch.delete(db.collection('formas').doc(d.id)));

--- a/gestionsorteos.html
+++ b/gestionsorteos.html
@@ -399,6 +399,19 @@
     return `${hnum}:${mm} ${ampm}`;
   }
 
+  function formatoValorCierre(valor){
+    if(valor===null || typeof valor==='undefined') return '';
+    if(typeof valor==='number' && !isNaN(valor)){
+      return `${valor} min`;
+    }
+    const texto=valor.toString().trim();
+    if(!texto) return '';
+    if(/^\d+$/.test(texto)){
+      return `${texto} min`;
+    }
+    return formatoHora12(texto);
+  }
+
   function mostrarPremios(formas){
     const modal=document.getElementById('modal-premios');
     const cont=document.getElementById('modal-premios-content');
@@ -433,7 +446,7 @@
     cont.innerHTML=`<div style="font-weight:bold;color:darkgreen;">Tipo de Sorteo: ${d.tipo||''}</div>`+
                    `<div style="font-weight:bold;color:darkblue;">Valor Cartón: ${d.valorCarton||''}</div>`+
                    `<div style="font-weight:bold;color:darkorange;">Hora Sorteo: ${formatoHora12(d.hora)}</div>`+
-                   `<div style="font-weight:bold;color:darkorange;">Minutos cierre: ${d.cierreMinutos||''}</div>`;
+                   `<div style="font-weight:bold;color:darkorange;">Hora cierre: ${formatoValorCierre(d.horacierre||d.cierre||d.cierreMinutos||'')}</div>`;
     modal.style.display='flex';
   }
 

--- a/nuevosorteo.html
+++ b/nuevosorteo.html
@@ -132,8 +132,8 @@
     #fecha-sorteo{color:#4b0082;font-weight:bold;}
     #hora-label{font-size:1rem;color:purple;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
     #hora-sorteo{color:purple;font-weight:bold;}
-    #minutos-label{font-size:1rem;color:#ff8c00;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
-    #cierre-minutos{color:#ff8c00;font-weight:bold;}
+    #cierre-label{font-size:1rem;color:#ff8c00;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
+    #hora-cierre{color:#ff8c00;font-weight:bold;}
     #max-carton-gratis{width:40px;text-align:center;font-weight:bold;}
     #max-carton-gratis::placeholder{font-size:0.6rem;}
     #valor-label{font-size:1rem;color:#006400;text-shadow:0 0 1px #fff,1px 1px 1px #000;}
@@ -182,7 +182,7 @@
     <div class="input-wrapper"><input id="hora-sorteo" type="time"><span class="label-right" id="hora-label">Hora</span></div>
   </div>
   <div class="row">
-    <div class="input-wrapper"><span class="label-left" id="minutos-label">MINUTOS</span><input id="cierre-minutos" type="number" placeholder="Minutos antes de cerrar jugadas"></div>
+    <div class="input-wrapper"><span class="label-left" id="cierre-label">CIERRE</span><input id="hora-cierre" type="time" placeholder="Hora de cierre de jugadas"></div>
     <div class="input-wrapper"><input id="max-carton-gratis" type="number" min="0" max="99" placeholder="Max CG" style="width:40px;text-align:center;"></div>
     <div class="input-wrapper"><input id="valor-carton" type="number" placeholder="Valor del Cartón"><span class="label-right" id="valor-label">VALOR CARTÓN</span></div>
   </div>
@@ -214,7 +214,7 @@
     const nombre=document.getElementById('nombre-sorteo').value.trim();
     const fecha=document.getElementById('fecha-sorteo').value;
     const hora=document.getElementById('hora-sorteo').value;
-    const cierre=document.getElementById('cierre-minutos').value;
+    const cierre=document.getElementById('hora-cierre').value;
     const maxcg=document.getElementById('max-carton-gratis').value;
     const valor=document.getElementById('valor-carton').value;
     const tipoBtn=document.querySelector('#tipo-sorteo-group button.active');
@@ -250,7 +250,7 @@
       document.getElementById('nombre-sorteo').value=data.nombre||'';
       document.getElementById('fecha-sorteo').value=data.fecha||'';
       document.getElementById('hora-sorteo').value=data.hora||'';
-      document.getElementById('cierre-minutos').value=data.cierre||'';
+      document.getElementById('hora-cierre').value=data.cierre||'';
       document.getElementById('max-carton-gratis').value=data.maxcg||'';
       document.getElementById('valor-carton').value=data.valor||'';
       if(data.tipo){
@@ -304,7 +304,7 @@
     document.getElementById('nombre-sorteo').addEventListener('input',saveState);
     document.getElementById('fecha-sorteo').addEventListener('input',saveState);
     document.getElementById('hora-sorteo').addEventListener('input',saveState);
-    document.getElementById('cierre-minutos').addEventListener('input',saveState);
+    document.getElementById('hora-cierre').addEventListener('input',saveState);
     document.getElementById('max-carton-gratis').addEventListener('input',saveState);
     document.getElementById('valor-carton').addEventListener('input',saveState);
     document.querySelectorAll('.tab-content .nombre-forma,.tab-content .porcentaje-forma,.tab-content .cartones-forma,.tab-content .imagen-url').forEach(i=>i.addEventListener('input',e=>{
@@ -584,7 +584,7 @@
     const nombreInput=document.getElementById('nombre-sorteo');
     const fechaInput=document.getElementById('fecha-sorteo');
     const horaInput=document.getElementById('hora-sorteo');
-    const cierreInput=document.getElementById('cierre-minutos');
+    const cierreInput=document.getElementById('hora-cierre');
     const maxcgInput=document.getElementById('max-carton-gratis');
     const valorInput=document.getElementById('valor-carton');
     const nombre=nombreInput.value.trim();
@@ -601,9 +601,9 @@
     if(!tipo){alert('Elije un tipo de sorteo');return;}
     if(!fecha){alert('Elige una fecha para el Sorteo');fechaInput.focus();return;}
     if(!hora){alert('Debes elegir una hora para el Sorteo');horaInput.focus();return;}
-    if(!cierreVal){alert('Elije una cantidad de minutos para cierre previo de Jugadas');cierreInput.focus();return;}
+    if(!cierreVal){alert('Elije una hora de cierre previo de Jugadas');cierreInput.focus();return;}
     if(!valorVal){alert('Coloca un valor para el cartón');valorInput.focus();return;}
-    const cierre=parseInt(cierreVal);
+    const cierre=cierreVal;
     const maxcartongratis=parseInt(maxcgVal)||0;
     const valor=parseFloat(valorVal);
     const condicion = estado==='Archivado'?'ARCHIVADO':'VISIBLE';
@@ -646,7 +646,7 @@
     }
     if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
-      const sorteoRef=await db.collection('sorteos').add({nombre,tipo,fecha,hora,cierreMinutos:cierre,maxcartongratis:maxcartongratis,cartonesgratisjugando:0,valorCarton:valor,estado,condicion});
+      const sorteoRef=await db.collection('sorteos').add({nombre,tipo,fecha,hora,horacierre:cierre,maxcartongratis:maxcartongratis,cartonesgratisjugando:0,valorCarton:valor,estado,condicion});
       const batch=db.batch();
       formas.forEach(f=>{const ref=db.collection('formas').doc();batch.set(ref,{sorteoId:sorteoRef.id,...f});});
         await batch.commit();

--- a/scripts/estadoSorteos.js
+++ b/scripts/estadoSorteos.js
@@ -1,3 +1,59 @@
+function obtenerHoraDesdeTexto(valor){
+  if(!valor) return null;
+  if(typeof valor==='number' && !isNaN(valor)) return null;
+  if(typeof valor==='object'){
+    if(valor instanceof Date){
+      return {hora:valor.getHours(),minuto:valor.getMinutes()};
+    }
+    if(typeof valor.seconds==='number'){
+      const fecha=new Date(valor.seconds*1000);
+      return {hora:fecha.getHours(),minuto:fecha.getMinutes()};
+    }
+    if(typeof valor.toDate==='function'){
+      const fecha=valor.toDate();
+      return {hora:fecha.getHours(),minuto:fecha.getMinutes()};
+    }
+  }
+  const original=valor.toString().trim();
+  if(!original) return null;
+  if(!/[0-9]:/.test(original) && !/[ap]\.?m\.?/i.test(original) && /^\d+$/.test(original)){
+    return null;
+  }
+  const texto=original.toLowerCase();
+  let sufijo=null;
+  if(/p\s*\.?m\.?/.test(texto)) sufijo='pm';
+  if(/a\s*\.?m\.?/.test(texto)) sufijo='am';
+  const limpio=texto.replace(/[^0-9:]/g,'');
+  if(!limpio) return null;
+  const partes=limpio.split(':');
+  let horas=parseInt(partes[0]||'0',10);
+  const minutos=parseInt((partes[1]||'0').slice(0,2),10);
+  if(isNaN(horas)||isNaN(minutos)) return null;
+  if(sufijo==='pm' && horas<12) horas+=12;
+  if(sufijo==='am' && horas===12) horas=0;
+  return {hora:horas,minuto:minutos};
+}
+
+function obtenerFechaHoraCierre(d,sorteoDate){
+  if(!(sorteoDate instanceof Date) || isNaN(sorteoDate.getTime())) return null;
+  const posibles=['horacierre','horaCierre','hora_cierre','cierre','cierreHora','cierrehora'];
+  for(const clave of posibles){
+    const valor=d?.[clave];
+    if(valor!==undefined && valor!==null && valor!==''){
+      const info=obtenerHoraDesdeTexto(valor);
+      if(info){
+        const fecha=new Date(sorteoDate.getFullYear(),sorteoDate.getMonth(),sorteoDate.getDate(),info.hora,info.minuto,0,0);
+        if(!isNaN(fecha.getTime())) return fecha;
+      }
+    }
+  }
+  const cierreMin=parseInt(d?.cierreMinutos||0,10);
+  if(!isNaN(cierreMin) && cierreMin>0){
+    return new Date(sorteoDate.getTime()-cierreMin*60000);
+  }
+  return null;
+}
+
 async function actualizarEstadosSorteos(){
   await initServerTime();
   const ahora = new Date(Date.now() + serverTime.diferencia);
@@ -10,12 +66,12 @@ async function actualizarEstadosSorteos(){
       const [dia,mes,anio]=d.fecha.split('/').map(n=>parseInt(n,10));
       const [hor,min]=d.hora.split(':').map(n=>parseInt(n,10));
       const sorteoDate=new Date(anio,mes-1,dia,hor,min);
-      const cierre=parseInt(d.cierreMinutos||0,10);
-      const selladoDate=new Date(sorteoDate.getTime()-cierre*60000);
+      if(isNaN(sorteoDate.getTime())) return;
+      const cierreDate=obtenerFechaHoraCierre(d,sorteoDate);
       if(d.estado==='Activo'){
         if(ahora>=sorteoDate){
           updates.push(doc.ref.update({estado:'Jugando'}));
-        }else if(ahora>=selladoDate){
+        }else if(cierreDate && ahora>=cierreDate){
           updates.push(doc.ref.update({estado:'Sellado'}));
         }
       }else if(d.estado==='Sellado' && ahora>=sorteoDate){


### PR DESCRIPTION
## Resumen
- Reemplazar el campo de cierre por hora en los formularios de creación y edición de sorteos.
- Mostrar la hora de cierre en la gestión y control de sorteos, preservando compatibilidad con datos antiguos.
- Ajustar la lógica automática de cambio de estados para considerar la hora de cierre y las validaciones solicitadas.

## Pruebas
- No se realizaron pruebas automatizadas.

------
https://chatgpt.com/codex/tasks/task_e_68d6014f7b9c832696aa02d4ed5aa5ea