### PR TITLE
Ajustes de cierre y validación en cantarsorteos

### DIFF
--- a/cantarsorteos.html
+++ b/cantarsorteos.html
@@ -119,15 +119,62 @@
       align-items: flex-start;
       gap: 2px;
     }
+    .valor-programado,
+    .valor-actual,
+    .valor-cierre,
+    .etiqueta-hoy,
+    .etiqueta-cierre {
+      font-size: 1.05rem;
+    }
     .valor-programado {
-      font-size: 1rem;
+      font-family: 'Bangers', cursive;
+      color: #0f2a0f;
+      text-shadow: 0 0 3px rgba(255,255,255,0.85);
+      letter-spacing: 1px;
     }
     .valor-actual {
       font-family: 'Bangers', cursive;
-      font-size: 1rem;
       color: #0b4dda;
       font-weight: 600;
       letter-spacing: 1px;
+      text-shadow: 0 0 4px rgba(255,255,255,0.9);
+    }
+    .valor-cierre {
+      font-family: 'Bangers', cursive;
+      color: #666666;
+      font-weight: 600;
+      text-shadow: 0 0 4px rgba(0,0,0,0.7);
+      letter-spacing: 1px;
+    }
+    .etiqueta-cierre {
+      font-family: 'Bangers', cursive;
+      color: #333333;
+      text-shadow: 0 0 3px rgba(255,255,255,0.9);
+      letter-spacing: 1px;
+    }
+    .etiqueta-hoy {
+      font-family: 'Bangers', cursive;
+      color: #0a2774;
+      text-shadow: 0 0 3px rgba(255,255,255,0.95);
+      letter-spacing: 1px;
+    }
+    .linea-cierre,
+    .linea-actual {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      white-space: nowrap;
+    }
+    .linea-cierre {
+      color: #3c3c3c;
+    }
+    .linea-cierre.oculto,
+    .linea-actual.oculto {
+      display: none;
+    }
+    .resaltado-actual {
+      color: #0b4dda !important;
+      text-shadow: 0 0 4px rgba(255,255,255,0.95) !important;
     }
     .datos-sorteo {
       display: flex;
@@ -209,12 +256,22 @@
     #estado-actual .estado-etiqueta {
       letter-spacing: 1px;
     }
+    .estado-etiqueta { text-transform: uppercase; }
     .estado-badge {
       padding: 2px 10px;
       border-radius: 999px;
       font-size: 1rem;
       letter-spacing: 1px;
     }
+    .tipo-estado {
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      font-size: 1.05rem;
+      text-shadow: 0 0 4px rgba(255,255,255,0.85);
+    }
+    .tipo-estado.diario { color: #0f8b0f; }
+    .tipo-estado.especial { color: #ff8c00; }
+    .tipo-estado.default { color: #1e3aa8; }
     .estado-badge.activo { background: rgba(0,128,0,0.15); color: #0f8b0f; border: 1px solid rgba(15,139,15,0.5); }
     .estado-badge.sellado { background: rgba(110,110,110,0.2); color: #444; border: 1px solid rgba(110,110,110,0.5); }
     .estado-badge.jugando { background: rgba(106,13,173,0.15); color: #6a0dad; border: 1px solid rgba(106,13,173,0.4); animation: zoomInOut 1.2s ease-in-out infinite; }
@@ -661,15 +718,25 @@
         <div id="fecha-sorteo" class="dato-programado">
           <span class="icono">📅</span>
           <div class="contenedor-valores">
+            <span id="fecha-cierre-linea" class="linea-cierre oculto">
+              <span class="etiqueta-cierre">CIERRE:</span>
+              <span id="fecha-cierre" class="valor-cierre"></span>
+            </span>
             <span id="fecha-programada" class="valor-programado"></span>
-            <span id="fecha-actual" class="valor-actual"></span>
+            <span class="linea-actual">
+              <span class="etiqueta-hoy">HOY:</span>
+              <span id="fecha-actual" class="valor-actual resaltado-actual"></span>
+            </span>
           </div>
         </div>
         <div id="hora-sorteo" class="dato-programado">
           <span class="icono">⏰</span>
           <div class="contenedor-valores">
+            <span id="hora-cierre-linea" class="linea-cierre oculto">
+              <span id="hora-cierre" class="valor-cierre"></span>
+            </span>
             <span id="hora-programada" class="valor-programado"></span>
-            <span id="hora-actual" class="valor-actual"></span>
+            <span id="hora-actual" class="valor-actual resaltado-actual"></span>
           </div>
         </div>
       </div>
@@ -690,14 +757,15 @@
   <section id="detalle-container">
     <div id="sorteo-nombre">Selecciona un sorteo para ver los detalles</div>
     <div id="estado-actual">
-      <span class="estado-etiqueta">Estado:</span>
+      <span id="tipo-estado" class="tipo-estado"></span>
+      <span class="estado-etiqueta">ESTADO:</span>
       <span id="estado-valor" class="estado-badge">-</span>
       <div id="modo-toggle-container">
-        <label class="modo-switch" title="Cambiar modo Manual/Automático">
+        <label class="modo-switch" title="Cambiar modo Manual/Validado">
           <input type="checkbox" id="modo-manual-switch" aria-label="Interruptor de modo manual">
           <span class="modo-slider"></span>
         </label>
-        <span id="modo-manual-estado">Automático</span>
+        <span id="modo-manual-estado">Validado</span>
       </div>
     </div>
     <div id="resumen-sorteo">
@@ -765,6 +833,10 @@
   const horaProgramadaEl = document.getElementById('hora-programada');
   const fechaActualValorEl = document.getElementById('fecha-actual');
   const horaActualValorEl = document.getElementById('hora-actual');
+  const fechaCierreLineaEl = document.getElementById('fecha-cierre-linea');
+  const fechaCierreEl = document.getElementById('fecha-cierre');
+  const horaCierreLineaEl = document.getElementById('hora-cierre-linea');
+  const horaCierreEl = document.getElementById('hora-cierre');
   const premioEl = document.getElementById('premio-valor');
   const valorCartonEl = document.getElementById('valor-carton-valor');
   const cartonesPagosEl = document.getElementById('cartones-jugando-valor');
@@ -773,6 +845,7 @@
   const sorteoNombreEl = document.getElementById('sorteo-nombre');
   const estadoActualEl = document.getElementById('estado-actual');
   const estadoValorEl = document.getElementById('estado-valor');
+  const tipoEstadoEl = document.getElementById('tipo-estado');
   const tipoEl = document.getElementById('tipo-sorteo');
   const mensajeEl = document.getElementById('mensaje-area');
   const sellarBtn = document.getElementById('sellar-btn');
@@ -792,6 +865,12 @@
   let pdfDestinoUrl = '';
   let pdfAccionEnCurso = false;
   let modoManual = false;
+  let infoTiempoSorteo = {
+    fecha: null,
+    fechaCierre: null,
+    hora: null,
+    horaCierre: null
+  };
   const pdfConfirmModal = document.getElementById('pdf-confirm-modal');
   const pdfConfirmSiBtn = document.getElementById('pdf-confirm-si');
   const pdfConfirmNoBtn = document.getElementById('pdf-confirm-no');
@@ -990,7 +1069,7 @@
 
   function actualizarEstadoModo(){
     if(modoManualEstadoEl){
-      modoManualEstadoEl.textContent = modoManual ? 'Manual' : 'Automático';
+      modoManualEstadoEl.textContent = modoManual ? 'Manual' : 'Validado';
     }
   }
 
@@ -1013,6 +1092,7 @@
       const horaStr = horaFormatter.format(ahora).toUpperCase();
       fechaActualValorEl.textContent = fechaStr;
       horaActualValorEl.textContent = horaStr;
+      actualizarColoresFechas(ahora);
     } catch (err) {
       console.error('Error actualizando fecha y hora actuales', err);
     }
@@ -1288,9 +1368,14 @@
     return null;
   }
 
+  function obtenerFechaCierre(data){
+    if(!data) return null;
+    return obtenerFechaDesdeValor(data.fechacierre ?? data.fecha);
+  }
+
   function obtenerFechaHoraCierre(data){
     if(!data) return null;
-    const fechaBase=obtenerFechaDesdeValor(data.fecha);
+    const fechaBase = obtenerFechaCierre(data);
     if(!fechaBase || isNaN(fechaBase.getTime())) return null;
     const valorHora=obtenerValorHoraCierre(data);
     if(valorHora){
@@ -1362,6 +1447,62 @@
     return tiempoA < tiempoB ? -1 : 1;
   }
 
+  function compararHoraActualConInfo(actual, horaInfo){
+    if(!(actual instanceof Date) || isNaN(actual.getTime()) || !horaInfo) return null;
+    const horaNumero = Number(horaInfo.hora);
+    const minutoNumero = Number(horaInfo.minuto);
+    if(isNaN(horaNumero) || isNaN(minutoNumero)) return null;
+    const minutosActual = actual.getHours() * 60 + actual.getMinutes();
+    const minutosReferencia = (horaNumero * 60) + minutoNumero;
+    if(minutosActual === minutosReferencia) return 0;
+    return minutosActual < minutosReferencia ? -1 : 1;
+  }
+
+  function aplicarResaltadoTiempo(elemento, resaltar){
+    if(!elemento) return;
+    if(resaltar) elemento.classList.add('resaltado-actual');
+    else elemento.classList.remove('resaltado-actual');
+  }
+
+  function actualizarLineaVisible(elemento, tieneValor){
+    if(!elemento) return;
+    if(tieneValor) elemento.classList.remove('oculto');
+    else elemento.classList.add('oculto');
+  }
+
+  function actualizarColoresFechas(ahoraParam){
+    const ahora = (ahoraParam instanceof Date && !isNaN(ahoraParam.getTime())) ? ahoraParam : (getServerNow() || new Date());
+    if(!(ahora instanceof Date) || isNaN(ahora.getTime())){
+      aplicarResaltadoTiempo(fechaProgramadaEl, false);
+      aplicarResaltadoTiempo(horaProgramadaEl, false);
+      aplicarResaltadoTiempo(fechaCierreEl, false);
+      aplicarResaltadoTiempo(horaCierreEl, false);
+      return;
+    }
+
+    const comparacionFechaSorteo = infoTiempoSorteo.fecha ? compararFechasCalendario(infoTiempoSorteo.fecha, ahora) : null;
+    const comparacionFechaCierre = infoTiempoSorteo.fechaCierre ? compararFechasCalendario(infoTiempoSorteo.fechaCierre, ahora) : null;
+
+    const resaltarFechaSorteo = comparacionFechaSorteo === -1;
+    let resaltarHoraSorteo = false;
+    if(infoTiempoSorteo.hora){
+      if(resaltarFechaSorteo) resaltarHoraSorteo = true;
+      else if(comparacionFechaSorteo === 0) resaltarHoraSorteo = compararHoraActualConInfo(ahora, infoTiempoSorteo.hora) === 1;
+    }
+
+    const resaltarFechaCierre = comparacionFechaCierre === -1;
+    let resaltarHoraCierre = false;
+    if(infoTiempoSorteo.horaCierre){
+      if(resaltarFechaCierre) resaltarHoraCierre = true;
+      else if(comparacionFechaCierre === 0) resaltarHoraCierre = compararHoraActualConInfo(ahora, infoTiempoSorteo.horaCierre) === 1;
+    }
+
+    aplicarResaltadoTiempo(fechaProgramadaEl, resaltarFechaSorteo);
+    aplicarResaltadoTiempo(horaProgramadaEl, resaltarHoraSorteo);
+    aplicarResaltadoTiempo(fechaCierreEl, resaltarFechaCierre);
+    aplicarResaltadoTiempo(horaCierreEl, resaltarHoraCierre);
+  }
+
   function obtenerNombreSorteoActual(){
     return (currentSorteoData && currentSorteoData.nombre) ? currentSorteoData.nombre : 'este sorteo';
   }
@@ -1415,12 +1556,20 @@
       btnSorteo.textContent = 'Selecciona Sorteo';
       if(fechaProgramadaEl) fechaProgramadaEl.textContent = '';
       if(horaProgramadaEl) horaProgramadaEl.textContent = '';
+      if(fechaCierreEl) fechaCierreEl.textContent = '';
+      if(horaCierreEl) horaCierreEl.textContent = '';
+      actualizarLineaVisible(fechaCierreLineaEl, false);
+      actualizarLineaVisible(horaCierreLineaEl, false);
       premioEl.textContent = '0';
       valorCartonEl.textContent = '0';
       cartonesPagosEl.textContent = '0';
       cartonesGratisEl.textContent = '0';
       sorteoNombreEl.textContent = 'Selecciona un sorteo para ver los detalles';
       actualizarEstadoVisual(null);
+      if(tipoEstadoEl){
+        tipoEstadoEl.textContent = '';
+        tipoEstadoEl.className = 'tipo-estado';
+      }
       tipoEl.innerHTML = '';
       if(detalleContainer) detalleContainer.classList.remove('estado-sellado','estado-pdf','estado-jugando','estado-finalizado');
       mensajeEl.textContent = 'Selecciona un sorteo para administrar su estado.';
@@ -1428,6 +1577,8 @@
       actualizarAnimaciones();
       actualizarCantosSeleccionados([]);
       actualizarTablaEstado();
+      infoTiempoSorteo = { fecha: null, fechaCierre: null, hora: null, horaCierre: null };
+      actualizarColoresFechas();
       return;
     }
     const data = currentSorteoData;
@@ -1450,17 +1601,66 @@
       else if(pdfEstado === 'si') detalleContainer.classList.add('estado-pdf');
       else if(estadoLower === 'sellado') detalleContainer.classList.add('estado-sellado');
     }
-    if(fechaProgramadaEl) fechaProgramadaEl.textContent = data.fecha ? formatearFecha(data.fecha) : '';
+    const fechaSorteoBase = obtenerFechaDesdeValor(data.fecha);
+    const fechaProgramadaCompleta = obtenerFechaSorteo(data);
+    const fechaCierreBase = obtenerFechaDesdeValor(data.fechacierre ?? data.fecha);
+    const horaSorteoInfo = obtenerHoraDesdeValor(data.hora);
+    const valorHoraCierre = obtenerValorHoraCierre(data);
+    let fechaHoraCierreCompleta = obtenerFechaHoraCierre(data);
+    if(
+      fechaHoraCierreCompleta instanceof Date &&
+      !isNaN(fechaHoraCierreCompleta.getTime()) &&
+      fechaProgramadaCompleta instanceof Date &&
+      !isNaN(fechaProgramadaCompleta.getTime()) &&
+      fechaHoraCierreCompleta.getTime() > fechaProgramadaCompleta.getTime()
+    ){
+      fechaHoraCierreCompleta = new Date(fechaProgramadaCompleta.getTime());
+    }
+    let horaCierreInfo = obtenerHoraDesdeValor(valorHoraCierre);
+    if(!horaCierreInfo && fechaHoraCierreCompleta instanceof Date && !isNaN(fechaHoraCierreCompleta.getTime())){
+      horaCierreInfo = obtenerHoraDesdeValor(fechaHoraCierreCompleta);
+    }
+    if(fechaProgramadaEl) fechaProgramadaEl.textContent = fechaSorteoBase ? formatearFecha(fechaSorteoBase) : '';
     if(horaProgramadaEl) horaProgramadaEl.textContent = data.hora ? formatearHora(data.hora) : '';
+    if(fechaCierreEl){
+      const textoFechaCierre = fechaCierreBase ? formatearFecha(fechaCierreBase) : '';
+      fechaCierreEl.textContent = textoFechaCierre;
+      actualizarLineaVisible(fechaCierreLineaEl, Boolean(textoFechaCierre));
+    }
+    if(horaCierreEl){
+      let textoHoraCierre = '';
+      if(valorHoraCierre){
+        textoHoraCierre = formatearHora(valorHoraCierre);
+      } else if(fechaHoraCierreCompleta instanceof Date && !isNaN(fechaHoraCierreCompleta.getTime())){
+        textoHoraCierre = formatearHora(fechaHoraCierreCompleta);
+      }
+      horaCierreEl.textContent = textoHoraCierre;
+      actualizarLineaVisible(horaCierreLineaEl, Boolean(textoHoraCierre));
+    }
     premioEl.textContent = Math.round(data.totalPremios || 0);
     valorCartonEl.textContent = data.valorCarton || 0;
     cartonesPagosEl.textContent = data.cartonesjugando || 0;
     cartonesGratisEl.textContent = data.cartonesgratisjugando || 0;
     sorteoNombreEl.textContent = data.nombre || '';
     actualizarEstadoVisual(data.estado);
-    const tipoNombre = ((data.tipo || '').replace(/^Sorteo\s+/i,'') || 'N/D').toUpperCase();
-    const cierreTexto = obtenerTextoHoraCierre(data) || 'N/D';
-    tipoEl.innerHTML = `<span>Tipo: ${tipoNombre}</span><span>CIERRE: ${cierreTexto}</span>`;
+    if(tipoEstadoEl){
+      const tipoTextoOriginal = (data.tipo || '').toString().trim();
+      const tipoMostrar = tipoTextoOriginal ? tipoTextoOriginal.toUpperCase() : '';
+      const clases = ['tipo-estado'];
+      if(esEspecial) clases.push('especial');
+      else if(esDiario) clases.push('diario');
+      else if(tipoMostrar) clases.push('default');
+      tipoEstadoEl.className = clases.join(' ');
+      tipoEstadoEl.textContent = tipoMostrar;
+    }
+    tipoEl.innerHTML = '';
+    infoTiempoSorteo = {
+      fecha: fechaSorteoBase instanceof Date && !isNaN(fechaSorteoBase.getTime()) ? fechaSorteoBase : null,
+      fechaCierre: fechaCierreBase instanceof Date && !isNaN(fechaCierreBase.getTime()) ? fechaCierreBase : null,
+      hora: horaSorteoInfo || null,
+      horaCierre: horaCierreInfo || null
+    };
+    actualizarColoresFechas();
     mensajeEl.textContent = '';
     actualizarBotones();
     actualizarAnimaciones();
@@ -1484,6 +1684,7 @@
         registro.nombre = registro.nombre || 'Sorteo';
         registro.estado = registro.estado || 'Activo';
         registro.fecha = registro.fecha || '';
+        registro.fechacierre = registro.fechacierre || registro.fecha || '';
         registro.hora = registro.hora || '';
         registro.tipo = registro.tipo || '';
         registro.valorCarton = registro.valorCarton || 0;
@@ -1714,26 +1915,53 @@
     }
 
     const fechaProgramada = obtenerFechaSorteo(currentSorteoData);
-    if(!fechaProgramada || isNaN(fechaProgramada.getTime())){
+    const fechaCierreBase = obtenerFechaCierre(currentSorteoData);
+    const fechaHoraCierreOriginal = obtenerFechaHoraCierre(currentSorteoData);
+    const ahora = getServerNow() || new Date();
+    const fechaProgramadaValida = fechaProgramada instanceof Date && !isNaN(fechaProgramada.getTime());
+    const fechaCierreValida = fechaCierreBase instanceof Date && !isNaN(fechaCierreBase.getTime());
+    let fechaHoraCierreNormalizada = fechaHoraCierreOriginal;
+    if(fechaHoraCierreNormalizada instanceof Date && fechaProgramadaValida && fechaHoraCierreNormalizada.getTime() > fechaProgramada.getTime()){
+      fechaHoraCierreNormalizada = new Date(fechaProgramada.getTime());
+    }
+    const fechaHoraCierreValida = fechaHoraCierreNormalizada instanceof Date && !isNaN(fechaHoraCierreNormalizada.getTime());
+
+    if(fechaCierreValida){
+      const comparacionCierre = compararFechasCalendario(ahora, fechaCierreBase);
+      if(comparacionCierre === null){
+        alert('No se pudo determinar la fecha actual para validar el cierre.');
+        return;
+      }
+      if(comparacionCierre < 0){
+        alert('Aún no es la fecha de cierre del sorteo, no puede ser Sellado');
+        return;
+      }
+      if(fechaHoraCierreValida && ahora < fechaHoraCierreNormalizada){
+        alert('Hoy es el día del sorteo pero aún no ha llegado la hora de cierre');
+        return;
+      }
+      if(!fechaHoraCierreValida && comparacionCierre === 0 && fechaProgramadaValida && ahora < fechaProgramada){
+        alert('Hoy es el día del sorteo pero aún no ha llegado la hora de cierre');
+        return;
+      }
+    } else if(fechaProgramadaValida){
+      const comparacionFecha = compararFechasCalendario(ahora, fechaProgramada);
+      if(comparacionFecha === null){
+        alert('No se pudo determinar la fecha actual para validar el cierre.');
+        return;
+      }
+      if(comparacionFecha < 0){
+        alert('Aún no es la fecha del sorteo, no puede ser Sellado');
+        return;
+      }
+      if(ahora < fechaProgramada){
+        alert('Hoy es el día del sorteo pero aún no ha llegado la hora de cierre');
+        return;
+      }
+    } else {
       const confirmarSinFecha = confirm('No se pudo determinar la fecha programada del sorteo. ¿Deseas sellarlo de todos modos?');
       if(!confirmarSinFecha) return;
       await ejecutarSellado();
-      return;
-    }
-
-    const ahora = getServerNow() || new Date();
-    const comparacionFecha = compararFechasCalendario(ahora, fechaProgramada);
-    if(comparacionFecha !== null && comparacionFecha < 0){
-      alert('Aún no es la fecha del sorteo, no puede ser Sellado');
-      return;
-    }
-
-    let fechaHoraCierre = obtenerFechaHoraCierre(currentSorteoData);
-    if(fechaHoraCierre && fechaProgramada && fechaHoraCierre.getTime() > fechaProgramada.getTime()){
-      fechaHoraCierre = new Date(fechaProgramada.getTime());
-    }
-    if(fechaHoraCierre && comparacionFecha === 0 && ahora < fechaHoraCierre){
-      alert('Hoy es el día del sorteo pero aún no ha llegado la hora de cierre');
       return;
     }
 
@@ -1865,7 +2093,7 @@
       alert('Aún no es la fecha del sorteo, no puedes iniciar el juego.');
       return;
     }
-    if(comparacionFecha === 0 && ahora <= fechaProgramada){
+    if(comparacionFecha === 0 && ahora < fechaProgramada){
       alert('Aún no ha llegado la hora programada para iniciar el juego.');
       return;
     }


### PR DESCRIPTION
## Summary
- Mostrar los datos de cierre y la etiqueta HOY en la cabecera de fechas/horas, con estilos actualizados y el tipo de sorteo destacado junto al estado.
- Añadir seguimiento de datos temporales y una rutina periódica que resalta fechas y horas pasadas según la hora del servidor.
- Revisar la lógica de sellado y arranque del juego para respetar la nueva `fechacierre`, validar correctamente los tiempos y evitar cambios de estado cuando se cancela la confirmación.

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b2a5d05483268ac8de241d814173