### PR TITLE
Alinear cabecera temporal y reforzar validaciones

### DIFF
--- a/cantarsorteos.html
+++ b/cantarsorteos.html
@@ -92,43 +92,75 @@
     }
     #fecha-hora-sorteo {
       display: flex;
-      flex-wrap: wrap;
-      align-items: flex-start;
       justify-content: center;
-      gap: 12px;
       font-family: 'Bangers', cursive;
       font-size: 1rem;
     }
-    .dato-programado {
-      display: flex;
-      align-items: flex-start;
-      gap: 8px;
-      color: #0f2a0f;
+    #fecha-hora-sorteo .tabla-fechas {
+      border-collapse: collapse;
+      margin: 0 auto;
+    }
+    #fecha-hora-sorteo .tabla-fechas td {
+      border: none;
+      padding: 2px 6px;
+      vertical-align: middle;
       white-space: nowrap;
     }
-    .dato-programado .icono {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 28px;
-      font-size: 1.1rem;
+    #fecha-hora-sorteo .col-icono {
+      text-align: right;
+      padding-right: 4px;
+      width: 32px;
     }
-    .dato-programado .contenedor-valores {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 2px;
+    #fecha-hora-sorteo .col-valor {
+      text-align: left;
+      padding-left: 6px;
+    }
+    #fecha-hora-sorteo .fila-tiempo.oculta {
+      display: none;
+    }
+    .valor-programado,
+    .valor-actual,
+    .valor-cierre {
+      font-size: 1.05rem;
     }
     .valor-programado {
-      font-size: 1rem;
+      font-family: 'Bangers', cursive;
+      color: #0f2a0f;
+      text-shadow: 0 0 3px rgba(255,255,255,0.85);
+      letter-spacing: 1px;
     }
     .valor-actual {
       font-family: 'Bangers', cursive;
-      font-size: 1rem;
       color: #0b4dda;
       font-weight: 600;
       letter-spacing: 1px;
+      text-shadow: 0 0 4px rgba(255,255,255,0.9);
     }
+    .valor-cierre {
+      font-family: 'Bangers', cursive;
+      color: #ffffff;
+      font-weight: 600;
+      text-shadow: 0 0 6px rgba(0,0,0,0.9);
+      letter-spacing: 1px;
+    }
+    .resaltado-actual {
+      color: #0b4dda !important;
+      text-shadow: 0 0 4px rgba(255,255,255,0.95) !important;
+    }
+    .icono-simbolo {
+      display: inline-block;
+      width: 26px;
+      height: 26px;
+      background-size: contain;
+      background-repeat: no-repeat;
+      background-position: center;
+    }
+    .icono-stop { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA2NCA2NCc+CiAgPHBhdGggZmlsbD0nI2QzMmYyZicgZD0nTTI0IDRoMTZsMjAgMjB2MTZsLTIwIDIwSDI0TDQgNDBWMjR6Jy8+CiAgPHJlY3QgeD0nMjQnIHk9JzI0JyB3aWR0aD0nMTYnIGhlaWdodD0nMTYnIHJ4PScyJyBmaWxsPSdub25lJyBzdHJva2U9JyNmZmZmZmYnIHN0cm9rZS13aWR0aD0nNCcvPgo8L3N2Zz4='); }
+    .icono-calendario { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA2NCA2NCc+CiAgPHJlY3QgeD0nNicgeT0nMTAnIHdpZHRoPSc1MicgaGVpZ2h0PSc0OCcgcng9JzYnIGZpbGw9JyNkMzJmMmYnLz4KICA8cmVjdCB4PSc2JyB5PScyMicgd2lkdGg9JzUyJyBoZWlnaHQ9JzM2JyBmaWxsPScjZmZmZmZmJy8+CiAgPHJlY3QgeD0nMTInIHk9JzYnIHdpZHRoPSc4JyBoZWlnaHQ9JzE2JyByeD0nMicgZmlsbD0nI2QzMmYyZicvPgogIDxyZWN0IHg9JzQ0JyB5PSc2JyB3aWR0aD0nOCcgaGVpZ2h0PScxNicgcng9JzInIGZpbGw9JyNkMzJmMmYnLz4KICA8cmVjdCB4PScxOCcgeT0nMzInIHdpZHRoPScyOCcgaGVpZ2h0PScyMCcgcng9JzMnIGZpbGw9JyNkMzJmMmYnIG9wYWNpdHk9JzAuMTUnLz4KPC9zdmc+'); }
+    .icono-calendario-azul { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA2NCA2NCc+CiAgPHJlY3QgeD0nNicgeT0nMTAnIHdpZHRoPSc1MicgaGVpZ2h0PSc0OCcgcng9JzYnIGZpbGw9JyMxOTc2ZDInLz4KICA8cmVjdCB4PSc2JyB5PScyMicgd2lkdGg9JzUyJyBoZWlnaHQ9JzM2JyBmaWxsPScjZmZmZmZmJy8+CiAgPHJlY3QgeD0nMTInIHk9JzYnIHdpZHRoPSc4JyBoZWlnaHQ9JzE2JyByeD0nMicgZmlsbD0nIzE5NzZkMicvPgogIDxyZWN0IHg9JzQ0JyB5PSc2JyB3aWR0aD0nOCcgaGVpZ2h0PScxNicgcng9JzInIGZpbGw9JyMxOTc2ZDInLz4KICA8cmVjdCB4PScxOCcgeT0nMzInIHdpZHRoPScyOCcgaGVpZ2h0PScyMCcgcng9JzMnIGZpbGw9JyMxOTc2ZDInIG9wYWNpdHk9JzAuMTUnLz4KPC9zdmc+'); }
+    .icono-reloj-gris { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA2NCA2NCc+CiAgPGNpcmNsZSBjeD0nMzInIGN5PSczMicgcj0nMjgnIGZpbGw9JyNlY2VmZjEnLz4KICA8Y2lyY2xlIGN4PSczMicgY3k9JzMyJyByPScyNCcgZmlsbD0nI2NmZDhkYycvPgogIDxwYXRoIGQ9J00zMiAxOHYxNGwxMiA4JyBmaWxsPSdub25lJyBzdHJva2U9JyM0NTVhNjQnIHN0cm9rZS13aWR0aD0nNCcgc3Ryb2tlLWxpbmVjYXA9J3JvdW5kJyBzdHJva2UtbGluZWpvaW49J3JvdW5kJy8+Cjwvc3ZnPg=='); }
+    .icono-reloj-rojo { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA2NCA2NCc+CiAgPGNpcmNsZSBjeD0nMzInIGN5PSczMicgcj0nMjgnIGZpbGw9JyNmZmViZWUnLz4KICA8Y2lyY2xlIGN4PSczMicgY3k9JzMyJyByPScyNCcgZmlsbD0nI2U1MzkzNScvPgogIDxwYXRoIGQ9J00zMiAxOHYxNGwxMiA4JyBmaWxsPSdub25lJyBzdHJva2U9JyNmZmZmZmYnIHN0cm9rZS13aWR0aD0nNCcgc3Ryb2tlLWxpbmVjYXA9J3JvdW5kJyBzdHJva2UtbGluZWpvaW49J3JvdW5kJy8+Cjwvc3ZnPg=='); }
+    .icono-reloj-azul { background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCA2NCA2NCc+CiAgPGNpcmNsZSBjeD0nMzInIGN5PSczMicgcj0nMjgnIGZpbGw9JyNlM2YyZmQnLz4KICA8Y2lyY2xlIGN4PSczMicgY3k9JzMyJyByPScyNCcgZmlsbD0nIzFlODhlNScvPgogIDxwYXRoIGQ9J00zMiAxOHYxNGwxMiA4JyBmaWxsPSdub25lJyBzdHJva2U9JyNmZmZmZmYnIHN0cm9rZS13aWR0aD0nNCcgc3Ryb2tlLWxpbmVjYXA9J3JvdW5kJyBzdHJva2UtbGluZWpvaW49J3JvdW5kJy8+Cjwvc3ZnPg=='); }
     .datos-sorteo {
       display: flex;
       flex-direction: column;
@@ -209,12 +241,22 @@
     #estado-actual .estado-etiqueta {
       letter-spacing: 1px;
     }
+    .estado-etiqueta { text-transform: uppercase; }
     .estado-badge {
       padding: 2px 10px;
       border-radius: 999px;
       font-size: 1rem;
       letter-spacing: 1px;
     }
+    .tipo-estado {
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      font-size: 1.05rem;
+      text-shadow: 0 0 4px rgba(255,255,255,0.85);
+    }
+    .tipo-estado.diario { color: #0f8b0f; }
+    .tipo-estado.especial { color: #ff8c00; }
+    .tipo-estado.default { color: #1e3aa8; }
     .estado-badge.activo { background: rgba(0,128,0,0.15); color: #0f8b0f; border: 1px solid rgba(15,139,15,0.5); }
     .estado-badge.sellado { background: rgba(110,110,110,0.2); color: #444; border: 1px solid rgba(110,110,110,0.5); }
     .estado-badge.jugando { background: rgba(106,13,173,0.15); color: #6a0dad; border: 1px solid rgba(106,13,173,0.4); animation: zoomInOut 1.2s ease-in-out infinite; }
@@ -658,20 +700,28 @@
     <div class="sorteo-info">
       <button id="sorteo-btn">Selecciona Sorteo</button>
       <div id="fecha-hora-sorteo">
-        <div id="fecha-sorteo" class="dato-programado">
-          <span class="icono">📅</span>
-          <div class="contenedor-valores">
-            <span id="fecha-programada" class="valor-programado"></span>
-            <span id="fecha-actual" class="valor-actual"></span>
-          </div>
-        </div>
-        <div id="hora-sorteo" class="dato-programado">
-          <span class="icono">⏰</span>
-          <div class="contenedor-valores">
-            <span id="hora-programada" class="valor-programado"></span>
-            <span id="hora-actual" class="valor-actual"></span>
-          </div>
-        </div>
+        <table class="tabla-fechas" role="presentation">
+          <tbody>
+            <tr id="fila-fecha-cierre" class="fila-tiempo oculta">
+              <td class="col-icono"><span class="icono-simbolo icono-stop" aria-hidden="true"></span></td>
+              <td class="col-valor"><span id="fecha-cierre" class="valor-cierre"></span></td>
+              <td class="col-icono"><span class="icono-simbolo icono-reloj-gris" aria-hidden="true"></span></td>
+              <td class="col-valor"><span id="hora-cierre" class="valor-cierre"></span></td>
+            </tr>
+            <tr id="fila-fecha-programada" class="fila-tiempo">
+              <td class="col-icono"><span class="icono-simbolo icono-calendario" aria-hidden="true"></span></td>
+              <td class="col-valor"><span id="fecha-programada" class="valor-programado"></span></td>
+              <td class="col-icono"><span class="icono-simbolo icono-reloj-rojo" aria-hidden="true"></span></td>
+              <td class="col-valor"><span id="hora-programada" class="valor-programado"></span></td>
+            </tr>
+            <tr id="fila-fecha-actual" class="fila-tiempo">
+              <td class="col-icono"><span class="icono-simbolo icono-calendario-azul" aria-hidden="true"></span></td>
+              <td class="col-valor"><span id="fecha-actual" class="valor-actual resaltado-actual"></span></td>
+              <td class="col-icono"><span class="icono-simbolo icono-reloj-azul" aria-hidden="true"></span></td>
+              <td class="col-valor"><span id="hora-actual" class="valor-actual resaltado-actual"></span></td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
     <div class="datos-sorteo">
@@ -690,14 +740,15 @@
   <section id="detalle-container">
     <div id="sorteo-nombre">Selecciona un sorteo para ver los detalles</div>
     <div id="estado-actual">
-      <span class="estado-etiqueta">Estado:</span>
+      <span id="tipo-estado" class="tipo-estado"></span>
+      <span class="estado-etiqueta">ESTADO:</span>
       <span id="estado-valor" class="estado-badge">-</span>
       <div id="modo-toggle-container">
-        <label class="modo-switch" title="Cambiar modo Manual/Automático">
+        <label class="modo-switch" title="Cambiar modo Manual/Validado">
           <input type="checkbox" id="modo-manual-switch" aria-label="Interruptor de modo manual">
           <span class="modo-slider"></span>
         </label>
-        <span id="modo-manual-estado">Automático</span>
+        <span id="modo-manual-estado">Validado</span>
       </div>
     </div>
     <div id="resumen-sorteo">
@@ -765,6 +816,9 @@
   const horaProgramadaEl = document.getElementById('hora-programada');
   const fechaActualValorEl = document.getElementById('fecha-actual');
   const horaActualValorEl = document.getElementById('hora-actual');
+  const filaFechaCierreEl = document.getElementById('fila-fecha-cierre');
+  const fechaCierreEl = document.getElementById('fecha-cierre');
+  const horaCierreEl = document.getElementById('hora-cierre');
   const premioEl = document.getElementById('premio-valor');
   const valorCartonEl = document.getElementById('valor-carton-valor');
   const cartonesPagosEl = document.getElementById('cartones-jugando-valor');
@@ -773,6 +827,7 @@
   const sorteoNombreEl = document.getElementById('sorteo-nombre');
   const estadoActualEl = document.getElementById('estado-actual');
   const estadoValorEl = document.getElementById('estado-valor');
+  const tipoEstadoEl = document.getElementById('tipo-estado');
   const tipoEl = document.getElementById('tipo-sorteo');
   const mensajeEl = document.getElementById('mensaje-area');
   const sellarBtn = document.getElementById('sellar-btn');
@@ -792,6 +847,12 @@
   let pdfDestinoUrl = '';
   let pdfAccionEnCurso = false;
   let modoManual = false;
+  let infoTiempoSorteo = {
+    fecha: null,
+    fechaCierre: null,
+    hora: null,
+    horaCierre: null
+  };
   const pdfConfirmModal = document.getElementById('pdf-confirm-modal');
   const pdfConfirmSiBtn = document.getElementById('pdf-confirm-si');
   const pdfConfirmNoBtn = document.getElementById('pdf-confirm-no');
@@ -990,7 +1051,7 @@
 
   function actualizarEstadoModo(){
     if(modoManualEstadoEl){
-      modoManualEstadoEl.textContent = modoManual ? 'Manual' : 'Automático';
+      modoManualEstadoEl.textContent = modoManual ? 'Manual' : 'Validado';
     }
   }
 
@@ -1013,6 +1074,7 @@
       const horaStr = horaFormatter.format(ahora).toUpperCase();
       fechaActualValorEl.textContent = fechaStr;
       horaActualValorEl.textContent = horaStr;
+      actualizarColoresFechas(ahora);
     } catch (err) {
       console.error('Error actualizando fecha y hora actuales', err);
     }
@@ -1288,9 +1350,14 @@
     return null;
   }
 
+  function obtenerFechaCierre(data){
+    if(!data) return null;
+    return obtenerFechaDesdeValor(data.fechacierre ?? data.fecha);
+  }
+
   function obtenerFechaHoraCierre(data){
     if(!data) return null;
-    const fechaBase=obtenerFechaDesdeValor(data.fecha);
+    const fechaBase = obtenerFechaCierre(data);
     if(!fechaBase || isNaN(fechaBase.getTime())) return null;
     const valorHora=obtenerValorHoraCierre(data);
     if(valorHora){
@@ -1310,6 +1377,19 @@
       }
     }
     return null;
+  }
+
+  function obtenerHoraInfoCierre(data){
+    if(!data) return null;
+    const valorHoraCierre = obtenerValorHoraCierre(data);
+    let horaInfo = obtenerHoraDesdeValor(valorHoraCierre);
+    if(!horaInfo){
+      const fechaHoraCierre = obtenerFechaHoraCierre(data);
+      if(fechaHoraCierre instanceof Date && !isNaN(fechaHoraCierre.getTime())){
+        horaInfo = obtenerHoraDesdeValor(fechaHoraCierre);
+      }
+    }
+    return horaInfo || null;
   }
 
   function obtenerTextoHoraCierre(data){
@@ -1360,6 +1440,88 @@
     const tiempoB = fechaB.getTime();
     if(tiempoA === tiempoB) return 0;
     return tiempoA < tiempoB ? -1 : 1;
+  }
+
+  function compararHoraActualConInfo(actual, horaInfo){
+    if(!(actual instanceof Date) || isNaN(actual.getTime()) || !horaInfo) return null;
+    const horaNumero = Number(horaInfo.hora);
+    const minutoNumero = Number(horaInfo.minuto);
+    if(isNaN(horaNumero) || isNaN(minutoNumero)) return null;
+    const minutosActual = actual.getHours() * 60 + actual.getMinutes();
+    const minutosReferencia = (horaNumero * 60) + minutoNumero;
+    if(minutosActual === minutosReferencia) return 0;
+    return minutosActual < minutosReferencia ? -1 : 1;
+  }
+
+  function aplicarResaltadoTiempo(elemento, resaltar){
+    if(!elemento) return;
+    if(resaltar) elemento.classList.add('resaltado-actual');
+    else elemento.classList.remove('resaltado-actual');
+  }
+
+  function actualizarFilaVisible(elemento, tieneContenido){
+    if(!elemento) return;
+    if(tieneContenido) elemento.classList.remove('oculta');
+    else elemento.classList.add('oculta');
+  }
+
+  function calcularResaltadoTiempo(fechaObjetivo, horaInfo, referencia){
+    const resultado = { fecha: false, hora: false };
+    if(!(referencia instanceof Date) || isNaN(referencia.getTime())) return resultado;
+    if(!(fechaObjetivo instanceof Date) || isNaN(fechaObjetivo.getTime())) return resultado;
+    const comparacionFecha = compararFechasCalendario(referencia, fechaObjetivo);
+    if(comparacionFecha === null) return resultado;
+    if(comparacionFecha === 1){
+      resultado.fecha = true;
+      resultado.hora = true;
+      return resultado;
+    }
+    if(comparacionFecha === -1){
+      return resultado;
+    }
+    if(!horaInfo){
+      resultado.fecha = true;
+      return resultado;
+    }
+    const comparacionHora = compararHoraActualConInfo(referencia, horaInfo);
+    if(comparacionHora === null) return resultado;
+    if(comparacionHora >= 0){
+      resultado.fecha = true;
+      resultado.hora = true;
+    }
+    return resultado;
+  }
+
+  function esMomentoAlcanzado(fechaObjetivo, horaInfo, referencia){
+    if(!(referencia instanceof Date) || isNaN(referencia.getTime())) return null;
+    if(!(fechaObjetivo instanceof Date) || isNaN(fechaObjetivo.getTime())) return null;
+    const comparacionFecha = compararFechasCalendario(referencia, fechaObjetivo);
+    if(comparacionFecha === null) return null;
+    if(comparacionFecha === 1) return true;
+    if(comparacionFecha === -1) return false;
+    if(!horaInfo) return true;
+    const comparacionHora = compararHoraActualConInfo(referencia, horaInfo);
+    if(comparacionHora === null) return null;
+    return comparacionHora >= 0;
+  }
+
+  function actualizarColoresFechas(ahoraParam){
+    const ahora = (ahoraParam instanceof Date && !isNaN(ahoraParam.getTime())) ? ahoraParam : (getServerNow() || new Date());
+    if(!(ahora instanceof Date) || isNaN(ahora.getTime())){
+      aplicarResaltadoTiempo(fechaProgramadaEl, false);
+      aplicarResaltadoTiempo(horaProgramadaEl, false);
+      aplicarResaltadoTiempo(fechaCierreEl, false);
+      aplicarResaltadoTiempo(horaCierreEl, false);
+      return;
+    }
+
+    const resaltadoSorteo = calcularResaltadoTiempo(infoTiempoSorteo.fecha, infoTiempoSorteo.hora, ahora);
+    const resaltadoCierre = calcularResaltadoTiempo(infoTiempoSorteo.fechaCierre, infoTiempoSorteo.horaCierre, ahora);
+
+    aplicarResaltadoTiempo(fechaProgramadaEl, resaltadoSorteo.fecha);
+    aplicarResaltadoTiempo(horaProgramadaEl, resaltadoSorteo.hora);
+    aplicarResaltadoTiempo(fechaCierreEl, resaltadoCierre.fecha);
+    aplicarResaltadoTiempo(horaCierreEl, resaltadoCierre.hora);
   }
 
   function obtenerNombreSorteoActual(){
@@ -1415,12 +1577,19 @@
       btnSorteo.textContent = 'Selecciona Sorteo';
       if(fechaProgramadaEl) fechaProgramadaEl.textContent = '';
       if(horaProgramadaEl) horaProgramadaEl.textContent = '';
+      if(fechaCierreEl) fechaCierreEl.textContent = '';
+      if(horaCierreEl) horaCierreEl.textContent = '';
+      actualizarFilaVisible(filaFechaCierreEl, false);
       premioEl.textContent = '0';
       valorCartonEl.textContent = '0';
       cartonesPagosEl.textContent = '0';
       cartonesGratisEl.textContent = '0';
       sorteoNombreEl.textContent = 'Selecciona un sorteo para ver los detalles';
       actualizarEstadoVisual(null);
+      if(tipoEstadoEl){
+        tipoEstadoEl.textContent = '';
+        tipoEstadoEl.className = 'tipo-estado';
+      }
       tipoEl.innerHTML = '';
       if(detalleContainer) detalleContainer.classList.remove('estado-sellado','estado-pdf','estado-jugando','estado-finalizado');
       mensajeEl.textContent = 'Selecciona un sorteo para administrar su estado.';
@@ -1428,6 +1597,8 @@
       actualizarAnimaciones();
       actualizarCantosSeleccionados([]);
       actualizarTablaEstado();
+      infoTiempoSorteo = { fecha: null, fechaCierre: null, hora: null, horaCierre: null };
+      actualizarColoresFechas();
       return;
     }
     const data = currentSorteoData;
@@ -1450,17 +1621,66 @@
       else if(pdfEstado === 'si') detalleContainer.classList.add('estado-pdf');
       else if(estadoLower === 'sellado') detalleContainer.classList.add('estado-sellado');
     }
-    if(fechaProgramadaEl) fechaProgramadaEl.textContent = data.fecha ? formatearFecha(data.fecha) : '';
+    const fechaSorteoBase = obtenerFechaDesdeValor(data.fecha);
+    const fechaProgramadaCompleta = obtenerFechaSorteo(data);
+    const fechaCierreBase = obtenerFechaDesdeValor(data.fechacierre ?? data.fecha);
+    const horaSorteoInfo = obtenerHoraDesdeValor(data.hora);
+    const valorHoraCierre = obtenerValorHoraCierre(data);
+    let fechaHoraCierreCompleta = obtenerFechaHoraCierre(data);
+    if(
+      fechaHoraCierreCompleta instanceof Date &&
+      !isNaN(fechaHoraCierreCompleta.getTime()) &&
+      fechaProgramadaCompleta instanceof Date &&
+      !isNaN(fechaProgramadaCompleta.getTime()) &&
+      fechaHoraCierreCompleta.getTime() > fechaProgramadaCompleta.getTime()
+    ){
+      fechaHoraCierreCompleta = new Date(fechaProgramadaCompleta.getTime());
+    }
+    let horaCierreInfo = obtenerHoraDesdeValor(valorHoraCierre);
+    if(!horaCierreInfo && fechaHoraCierreCompleta instanceof Date && !isNaN(fechaHoraCierreCompleta.getTime())){
+      horaCierreInfo = obtenerHoraDesdeValor(fechaHoraCierreCompleta);
+    }
+    if(fechaProgramadaEl) fechaProgramadaEl.textContent = fechaSorteoBase ? formatearFecha(fechaSorteoBase) : '';
     if(horaProgramadaEl) horaProgramadaEl.textContent = data.hora ? formatearHora(data.hora) : '';
+    let textoFechaCierre = '';
+    if(fechaCierreEl){
+      textoFechaCierre = fechaCierreBase ? formatearFecha(fechaCierreBase) : '';
+      fechaCierreEl.textContent = textoFechaCierre;
+    }
+    let textoHoraCierre = '';
+    if(horaCierreEl){
+      if(valorHoraCierre){
+        textoHoraCierre = formatearHora(valorHoraCierre);
+      } else if(fechaHoraCierreCompleta instanceof Date && !isNaN(fechaHoraCierreCompleta.getTime())){
+        textoHoraCierre = formatearHora(fechaHoraCierreCompleta);
+      }
+      horaCierreEl.textContent = textoHoraCierre;
+    }
+    actualizarFilaVisible(filaFechaCierreEl, Boolean(textoFechaCierre || textoHoraCierre));
     premioEl.textContent = Math.round(data.totalPremios || 0);
     valorCartonEl.textContent = data.valorCarton || 0;
     cartonesPagosEl.textContent = data.cartonesjugando || 0;
     cartonesGratisEl.textContent = data.cartonesgratisjugando || 0;
     sorteoNombreEl.textContent = data.nombre || '';
     actualizarEstadoVisual(data.estado);
-    const tipoNombre = ((data.tipo || '').replace(/^Sorteo\s+/i,'') || 'N/D').toUpperCase();
-    const cierreTexto = obtenerTextoHoraCierre(data) || 'N/D';
-    tipoEl.innerHTML = `<span>Tipo: ${tipoNombre}</span><span>CIERRE: ${cierreTexto}</span>`;
+    if(tipoEstadoEl){
+      const tipoTextoOriginal = (data.tipo || '').toString().trim();
+      const tipoMostrar = tipoTextoOriginal ? tipoTextoOriginal.toUpperCase() : '';
+      const clases = ['tipo-estado'];
+      if(esEspecial) clases.push('especial');
+      else if(esDiario) clases.push('diario');
+      else if(tipoMostrar) clases.push('default');
+      tipoEstadoEl.className = clases.join(' ');
+      tipoEstadoEl.textContent = tipoMostrar;
+    }
+    tipoEl.innerHTML = '';
+    infoTiempoSorteo = {
+      fecha: fechaSorteoBase instanceof Date && !isNaN(fechaSorteoBase.getTime()) ? fechaSorteoBase : null,
+      fechaCierre: fechaCierreBase instanceof Date && !isNaN(fechaCierreBase.getTime()) ? fechaCierreBase : null,
+      hora: horaSorteoInfo || null,
+      horaCierre: horaCierreInfo || null
+    };
+    actualizarColoresFechas();
     mensajeEl.textContent = '';
     actualizarBotones();
     actualizarAnimaciones();
@@ -1484,6 +1704,7 @@
         registro.nombre = registro.nombre || 'Sorteo';
         registro.estado = registro.estado || 'Activo';
         registro.fecha = registro.fecha || '';
+        registro.fechacierre = registro.fechacierre || registro.fecha || '';
         registro.hora = registro.hora || '';
         registro.tipo = registro.tipo || '';
         registro.valorCarton = registro.valorCarton || 0;
@@ -1713,27 +1934,56 @@
       return;
     }
 
-    const fechaProgramada = obtenerFechaSorteo(currentSorteoData);
-    if(!fechaProgramada || isNaN(fechaProgramada.getTime())){
+    const fechaProgramada = infoTiempoSorteo.fecha || obtenerFechaSorteo(currentSorteoData);
+    const horaProgramadaInfo = infoTiempoSorteo.hora || obtenerHoraDesdeValor(currentSorteoData.hora);
+    const fechaCierreBase = infoTiempoSorteo.fechaCierre || obtenerFechaCierre(currentSorteoData);
+    const horaCierreInfo = infoTiempoSorteo.horaCierre || obtenerHoraInfoCierre(currentSorteoData);
+    const ahora = getServerNow() || new Date();
+    const fechaProgramadaValida = fechaProgramada instanceof Date && !isNaN(fechaProgramada.getTime());
+    const fechaCierreValida = fechaCierreBase instanceof Date && !isNaN(fechaCierreBase.getTime());
+
+    if(fechaCierreValida){
+      const comparacionCierre = compararFechasCalendario(ahora, fechaCierreBase);
+      if(comparacionCierre === null){
+        alert('No se pudo determinar la fecha actual para validar el cierre.');
+        return;
+      }
+      const cierreAlcanzado = esMomentoAlcanzado(fechaCierreBase, horaCierreInfo, ahora);
+      if(cierreAlcanzado === null){
+        alert('No se pudo determinar la hora de cierre del sorteo.');
+        return;
+      }
+      if(!cierreAlcanzado){
+        if(comparacionCierre === -1){
+          alert('Aún no es la fecha de cierre del sorteo, no puede ser Sellado');
+        } else {
+          alert('Hoy es el día del sorteo pero aún no ha llegado la hora de cierre');
+        }
+        return;
+      }
+    } else if(fechaProgramadaValida){
+      const comparacionFecha = compararFechasCalendario(ahora, fechaProgramada);
+      if(comparacionFecha === null){
+        alert('No se pudo determinar la fecha actual para validar el cierre.');
+        return;
+      }
+      const cierreProgramado = esMomentoAlcanzado(fechaProgramada, horaProgramadaInfo, ahora);
+      if(cierreProgramado === null){
+        alert('No se pudo determinar la hora programada del sorteo.');
+        return;
+      }
+      if(!cierreProgramado){
+        if(comparacionFecha === -1){
+          alert('Aún no es la fecha del sorteo, no puede ser Sellado');
+        } else {
+          alert('Hoy es el día del sorteo pero aún no ha llegado la hora de cierre');
+        }
+        return;
+      }
+    } else {
       const confirmarSinFecha = confirm('No se pudo determinar la fecha programada del sorteo. ¿Deseas sellarlo de todos modos?');
       if(!confirmarSinFecha) return;
       await ejecutarSellado();
-      return;
-    }
-
-    const ahora = getServerNow() || new Date();
-    const comparacionFecha = compararFechasCalendario(ahora, fechaProgramada);
-    if(comparacionFecha !== null && comparacionFecha < 0){
-      alert('Aún no es la fecha del sorteo, no puede ser Sellado');
-      return;
-    }
-
-    let fechaHoraCierre = obtenerFechaHoraCierre(currentSorteoData);
-    if(fechaHoraCierre && fechaProgramada && fechaHoraCierre.getTime() > fechaProgramada.getTime()){
-      fechaHoraCierre = new Date(fechaProgramada.getTime());
-    }
-    if(fechaHoraCierre && comparacionFecha === 0 && ahora < fechaHoraCierre){
-      alert('Hoy es el día del sorteo pero aún no ha llegado la hora de cierre');
       return;
     }
 
@@ -1849,24 +2099,30 @@
       return;
     }
 
-    const fechaProgramada = obtenerFechaSorteo(currentSorteoData);
-    if(!fechaProgramada || isNaN(fechaProgramada.getTime())){
+    const fechaProgramadaBase = infoTiempoSorteo.fecha || obtenerFechaDesdeValor(currentSorteoData.fecha);
+    const horaProgramadaInfo = infoTiempoSorteo.hora || obtenerHoraDesdeValor(currentSorteoData.hora);
+    if(!(fechaProgramadaBase instanceof Date) || isNaN(fechaProgramadaBase.getTime())){
       alert('No se pudo determinar la fecha y hora programada del sorteo.');
       return;
     }
 
     const ahora = getServerNow() || new Date();
-    const comparacionFecha = compararFechasCalendario(ahora, fechaProgramada);
+    const comparacionFecha = compararFechasCalendario(ahora, fechaProgramadaBase);
     if(comparacionFecha === null){
       alert('No se pudo determinar la fecha actual para validar el inicio.');
       return;
     }
-    if(comparacionFecha < 0){
-      alert('Aún no es la fecha del sorteo, no puedes iniciar el juego.');
+    const inicioPermitido = esMomentoAlcanzado(fechaProgramadaBase, horaProgramadaInfo, ahora);
+    if(inicioPermitido === null){
+      alert('No se pudo determinar la hora programada del sorteo.');
       return;
     }
-    if(comparacionFecha === 0 && ahora <= fechaProgramada){
-      alert('Aún no ha llegado la hora programada para iniciar el juego.');
+    if(!inicioPermitido){
+      if(comparacionFecha === -1){
+        alert('Aún no es la fecha del sorteo, no puedes iniciar el juego.');
+      } else {
+        alert('Aún no ha llegado la hora programada para iniciar el juego.');
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Reordenar la cabecera de fechas y horas en una tabla centrada con nuevos íconos y estilos, eliminando las etiquetas HOY y CIERRE.
- Ajustar la coloración dinámica de fechas/horas mediante nuevos auxiliares que evalúan si los momentos fueron alcanzados.
- Actualizar las validaciones de sellado e inicio del juego para comparar contra la fecha/hora de cierre usando la nueva lógica compartida.

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b2a5d05483268ac8de241d814173