### PR TITLE
Ajusta el resaltado de fechas en Cantar sorteo

### DIFF
--- a/cantarsorteos.html
+++ b/cantarsorteos.html
@@ -1616,7 +1616,7 @@
     if(opciones.validacionesActivas){
       if(comparacion < 0) return 'estado-tiempo-futuro';
       if(opciones.actualSoloCuandoMayor){
-        return comparacion > 0 ? 'estado-tiempo-actual' : 'estado-tiempo-futuro';
+        return comparacion >= 0 ? 'estado-tiempo-actual' : 'estado-tiempo-futuro';
       }
       return 'estado-tiempo-actual';
     }
@@ -1688,7 +1688,7 @@
     const validacionesActivas = !esModoManual();
     const opcionesFechaProgramada = validacionesActivas ? { validacionesActivas: true, actualSoloCuandoMayor: true } : undefined;
     const opcionesHoraProgramada = validacionesActivas ? { validacionesActivas: true } : undefined;
-    const opcionesFechaCierre = validacionesActivas ? { validacionesActivas: true } : undefined;
+    const opcionesFechaCierre = validacionesActivas ? { validacionesActivas: true, actualSoloCuandoMayor: true } : undefined;
     const opcionesHoraCierre = validacionesActivas ? { validacionesActivas: true, actualCuandoCoincide: true } : undefined;
 
     const estadoFechaProgramada = estadoFechaRespectoAhora(infoTiempoSorteo.fecha, ahora, opcionesFechaProgramada);


### PR DESCRIPTION
## Summary
- permite que `estadoFechaRespectoAhora` marque como actual las fechas que coinciden con la jornada del sorteo incluso cuando se usa `actualSoloCuandoMayor`
- alinea las opciones de validación automática para que la fecha de cierre comparta el nuevo criterio de resaltado

## Testing
- No se ejecutaron pruebas automatizadas (motivo: verificación manual del comportamiento lógico)


------
https://chatgpt.com/codex/tasks/task_e_68d6f52e87c8832681d121a952d05f4f