### PR TITLE
Aplicar estilo marrón a tiempos de sorteos finalizados

### DIFF
--- a/cantarsorteos.html
+++ b/cantarsorteos.html
@@ -197,6 +197,10 @@
       text-shadow: none;
       filter: brightness(0.9);
     }
+    .estado-tiempo-finalizado {
+      color: #8b4513;
+      text-shadow: 0 0 6px rgba(0,0,0,0.45);
+    }
     .datos-sorteo {
       display: flex;
       flex-direction: column;
@@ -1710,6 +1714,12 @@
 
   function actualizarColoresFechas(ahoraParam){
     const ahora = (ahoraParam instanceof Date && !isNaN(ahoraParam.getTime())) ? ahoraParam : (getServerNow() || new Date());
+    const esFinalizado = currentSorteoData && (currentSorteoData.estado || '').toString().toLowerCase() === 'finalizado';
+    [fechaProgramadaEl, horaProgramadaEl, fechaCierreEl, horaCierreEl].forEach(elemento=>{
+      if(elemento){
+        elemento.classList.toggle('estado-tiempo-finalizado', Boolean(esFinalizado));
+      }
+    });
     if(!(ahora instanceof Date) || isNaN(ahora.getTime())){
       aplicarResaltadoTiempo(fechaProgramadaEl, false);
       aplicarResaltadoTiempo(horaProgramadaEl, false);


### PR DESCRIPTION
## Summary
- agrega una clase CSS con el color marrón requerido para tiempos de sorteos finalizados
- actualiza la lógica de colores para aplicar la nueva clase en las fechas y horas programadas y de cierre

## Testing
- no se realizaron pruebas


------
https://chatgpt.com/codex/tasks/task_e_68d6f9f343c08326b53fbc6af4a4b2d8