### PR TITLE
Configure Firebase deployment matrix for dev, staging, and main

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -4,6 +4,8 @@ name: Deploy to Firebase Hosting on merge
 on:
   push:
     branches:
+      - dev
+      - staging
       - main
 
 permissions:
@@ -13,6 +15,19 @@ permissions:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env:
+          - branch: dev
+            channelId: dev
+            target: ""
+          - branch: staging
+            channelId: staging
+            target: ""
+          - branch: main
+            channelId: ""
+            target: live
+    if: ${{ matrix.env.branch == github.ref_name }}
     steps:
       - uses: actions/checkout@v4
 
@@ -21,6 +36,7 @@ jobs:
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD }}
-          channelId: live
+          channelId: ${{ matrix.env.channelId }}
+          target: ${{ matrix.env.target }}
           projectId: bingo-online-231fd
 


### PR DESCRIPTION
## Summary
- deploy dev, staging, and main branches via the Firebase Hosting workflow
- add a matrix to map branches to their respective deployment targets or channels
- ensure only the main branch deploys to the live target

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d821e333708326a2d76f78f97accfa