### PR TITLE
Configurar previews de Firebase por rama base

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,14 +2,25 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging
 permissions:
   checks: write
   contents: read
   pull-requests: write
 jobs:
   build_and_preview:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.base_ref == matrix.branch }}
+    strategy:
+      matrix:
+        include:
+          - branch: dev
+            channel: dev-preview
+          - branch: staging
+            channel: staging-preview
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,3 +30,4 @@ jobs:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD }}
           projectId: bingo-online-231fd
+          channelId: ${{ matrix.channel }}


### PR DESCRIPTION
## Summary
- limitar el flujo de Firebase Hosting a pull requests contra las ramas dev y staging
- definir un channelId específico por rama base y pasarlo a la acción de despliegue para aislar los previews

## Testing
- no se realizaron pruebas (cambios en workflow)


------
https://chatgpt.com/codex/tasks/task_e_68d82319bd6c832687fe9c920aad318e