### PR TITLE
Crear modal de confirmación de canto dinámicamente

### DIFF
--- a/cantarsorteos.html
+++ b/cantarsorteos.html
@@ -1019,24 +1019,6 @@
   }
 
   function asegurarModalConfirmacionCanto(){
-    if(!cantoConfirmModal){
-      const modal = document.createElement('div');
-      modal.id = 'canto-confirm-modal';
-      modal.className = 'confirm-modal';
-      modal.setAttribute('role', 'dialog');
-      modal.setAttribute('aria-modal', 'true');
-      modal.setAttribute('aria-labelledby', 'canto-confirm-mensaje');
-      modal.innerHTML = `
-        <div class="pdf-confirm-box canto-confirm-box">
-          <p id="canto-confirm-mensaje" class="canto-confirm-mensaje">¿Este es el Canto a guardar?</p>
-          <div id="canto-confirm-valor"></div>
-          <div class="pdf-confirm-actions canto-confirm-actions">
-            <button id="canto-confirm-aceptar">Aceptar</button>
-            <button id="canto-confirm-cancelar" class="secundario">Cancelar</button>
-          </div>
-        </div>`;
-      document.body.appendChild(modal);
-    }
     cantoConfirmModal = document.getElementById('canto-confirm-modal');
     cantoConfirmMensajeEl = document.getElementById('canto-confirm-mensaje');
     cantoConfirmValorEl = document.getElementById('canto-confirm-valor');
@@ -1109,6 +1091,26 @@
   }
 
   function mostrarConfirmacionCanto(clave){
+    let modalExistente = document.getElementById('canto-confirm-modal');
+    if(!modalExistente){
+      modalExistente = document.createElement('div');
+      modalExistente.id = 'canto-confirm-modal';
+      modalExistente.className = 'confirm-modal';
+      modalExistente.setAttribute('role', 'dialog');
+      modalExistente.setAttribute('aria-modal', 'true');
+      modalExistente.setAttribute('aria-labelledby', 'canto-confirm-mensaje');
+      modalExistente.innerHTML = `
+        <div class="pdf-confirm-box canto-confirm-box">
+          <p id="canto-confirm-mensaje" class="canto-confirm-mensaje">¿Este es el Canto a guardar?</p>
+          <div id="canto-confirm-valor"></div>
+          <div class="pdf-confirm-actions canto-confirm-actions">
+            <button id="canto-confirm-aceptar">Aceptar</button>
+            <button id="canto-confirm-cancelar" class="secundario">Cancelar</button>
+          </div>
+        </div>`;
+      document.body.appendChild(modalExistente);
+    }
+    cantoConfirmModal = modalExistente;
     asegurarModalConfirmacionCanto();
     if(!cantoConfirmModal || !cantoConfirmMensajeEl || !cantoConfirmValorEl){
       return Promise.resolve(false);


### PR DESCRIPTION
## Summary
- crear dinámicamente el modal de confirmación de canto cuando no existe en el DOM
- reutilizar las referencias del modal y sus controles tras la inserción para mostrar el mensaje y el valor del canto

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad1143e1483269aeed98ad1b99fe4