### PR TITLE
Derivar UPLOAD_ENDPOINT según origen seguro

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,18 @@ npm start
 ```
 
 El formulario de nuevo sorteo obtiene la URL de este servicio desde la
-variable `UPLOAD_ENDPOINT` exportada en `config.js`. Por defecto apunta a
-`http://localhost:3000/upload`. Para entornos distintos a localhost puede
-definirse la variable de entorno `UPLOAD_ENDPOINT` o asignarse
-`window.UPLOAD_ENDPOINT` antes de cargar los scripts.
+variable `UPLOAD_ENDPOINT` exportada en `config.js`. En navegadores que se
+ejecutan bajo HTTPS la URL por defecto se deriva automáticamente del origen
+actual (`${window.location.origin}/upload`) para evitar contenido mixto. En
+otros escenarios el valor por defecto continúa siendo `http://localhost:3000/upload`.
+
+Para despliegues productivos exponga el servicio auxiliar bajo HTTPS y
+defina explícitamente la URL del endpoint, ya sea mediante la variable de
+entorno `UPLOAD_ENDPOINT` (por ejemplo `UPLOAD_ENDPOINT=https://api.midominio.com/upload`)
+o estableciendo `window.UPLOAD_ENDPOINT` antes de cargar los scripts del
+frontend. Esto permite separar el hosting estático del backend de subida y
+garantiza que las páginas servidas por HTTPS no disparen advertencias por
+contenido inseguro.
 
 Para utilizar el botón de habilitar/deshabilitar usuarios en `gestionarusuarios.html` este servicio debe estar activo y accesible desde la URL indicada. El cliente envía un *ID token* de Firebase y el middleware `verificarToken` comprueba la colección `users/{email}` en Firestore: solo los roles **Superadmin** y **Administrador** pueden invocar `/toggleUser`.
 

--- a/config.js
+++ b/config.js
@@ -10,8 +10,36 @@ export const firebaseConfig = {
 
 // Endpoint para la subida de imágenes. Se puede sobrescribir mediante la
 // variable de entorno UPLOAD_ENDPOINT o definiendo window.UPLOAD_ENDPOINT
-// antes de cargar los scripts.
-export const UPLOAD_ENDPOINT =
-  (typeof window !== 'undefined' && window.UPLOAD_ENDPOINT) ||
-  (typeof process !== 'undefined' && process.env && process.env.UPLOAD_ENDPOINT) ||
-  'http://localhost:3000/upload';
+// antes de cargar los scripts. Cuando se ejecuta en un navegador bajo HTTPS
+// se deriva automáticamente del origen actual para evitar contenido mixto.
+const hasWindow = typeof window !== 'undefined';
+const hasProcess = typeof process !== 'undefined';
+
+let resolvedUploadEndpoint =
+  (hasWindow && window.UPLOAD_ENDPOINT) ||
+  (hasProcess && process.env && process.env.UPLOAD_ENDPOINT) ||
+  undefined;
+
+if (!resolvedUploadEndpoint && hasWindow && window.location) {
+  if (window.location.protocol === 'https:') {
+    resolvedUploadEndpoint = `${window.location.origin}/upload`;
+  }
+}
+
+if (!resolvedUploadEndpoint) {
+  resolvedUploadEndpoint = 'http://localhost:3000/upload';
+}
+
+if (
+  hasWindow &&
+  window.location &&
+  window.location.protocol === 'https:' &&
+  /^http:\/\//i.test(resolvedUploadEndpoint)
+) {
+  console.warn(
+    '[config] Se está utilizando un UPLOAD_ENDPOINT no seguro (http) desde un contexto HTTPS. ' +
+      'Actualice la configuración para exponer el servicio por HTTPS y evitar contenido mixto.'
+  );
+}
+
+export const UPLOAD_ENDPOINT = resolvedUploadEndpoint;


### PR DESCRIPTION
## Summary
- Ajusta el cálculo por defecto de `UPLOAD_ENDPOINT` en navegadores HTTPS para reutilizar el origen actual y emitir una advertencia si se intenta usar HTTP desde contexto seguro.
- Mantiene la prioridad de `window.UPLOAD_ENDPOINT` y de la variable de entorno `UPLOAD_ENDPOINT` respecto al valor derivado o local.
- Documenta en el README cómo configurar el servicio auxiliar en despliegues productivos, remarcando la necesidad de exponerlo por HTTPS.

## Testing
- No se ejecutaron pruebas (no aplica).


------
https://chatgpt.com/codex/tasks/task_e_68dc6d098f908326bae434b132010ae6