### PR TITLE
Update production hosting target to new site

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -5,7 +5,7 @@
       "hosting": {
         "dev":  ["bingo-online-231fd-dev"],
         "stg":  ["bingo-online-231fd-stg"],
-        "prod": ["bingo-online-231fd"]
+        "prod": ["test-bingo-02"]
       }
     }
   }


### PR DESCRIPTION
## Summary
- retarget the Firebase Hosting `prod` alias to the new site `test-bingo-02`
- ensure GitHub Actions deployments to production publish to the unblocked domain

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e10e59ea3883268ff488b445ffd3a4