### PR TITLE
Fix navigation flows and back button behavior

### DIFF
--- a/public/collab.html
+++ b/public/collab.html
@@ -124,6 +124,10 @@
   <script src="js/auth.js"></script>
   <script>
   ensureAuth('Colaborador');
+  const mainMenu=document.getElementById('main-menu');
+  const verificarScreen=document.getElementById('verificar-recargas-screen');
+  const detalleRecarga=document.getElementById('detalle-recarga');
+  let recargaActual=null;
   auth.onAuthStateChanged(async user=>{
     if(!user) return;
     const role = await getUserRole(user);
@@ -136,7 +140,18 @@
   function hideViews(){
     document.querySelectorAll('.view').forEach(v=>v.style.display='none');
   }
-  let recargaActual=null;
+  function mostrarMenuPrincipal(){
+    hideViews();
+    mainMenu.style.display='block';
+    recargaActual=null;
+    detalleRecarga.innerHTML='';
+  }
+  function mostrarGestionRecargas(){
+    hideViews();
+    mainMenu.style.display='none';
+    verificarScreen.style.display='block';
+    cargarRecargas();
+  }
   async function cargarRecargas(){
     const tabla=document.getElementById('tabla-recargas');
     tabla.innerHTML="<tr><th>N° Recarga</th><th>Nombre</th><th>Monto</th><th>Banco Origen</th><th>Referencia</th><th>Fecha</th><th>Estatus</th></tr>";
@@ -156,16 +171,16 @@
     const doc=snap.docs[0];
     recargaActual=doc.id;
     const d=doc.data();
-    document.getElementById('detalle-recarga').innerHTML=`Banco origen: ${d.banco_origen||''}<br>Banco destino: ${d.banco_destino||''}<br>Monto: ${d.monto}<br>Referencia de pago: ${d.referencia}<br>Comentario: ${d.comentario||''}`; }
+    detalleRecarga.innerHTML=`Banco origen: ${d.banco_origen||''}<br>Banco destino: ${d.banco_destino||''}<br>Monto: ${d.monto}<br>Referencia de pago: ${d.referencia}<br>Comentario: ${d.comentario||''}`; }
   async function verificarRecarga(){
     if(!recargaActual) return;
     await db.collection('recargas').doc(recargaActual).update({estatus:'VERIFICADA',colaborador:auth.currentUser.email,gestion:firebase.firestore.FieldValue.serverTimestamp()});
     alert('Verificacion completada exitosamente');
     recargaActual=null;
     await cargarRecargas();
-    document.getElementById('detalle-recarga').innerHTML=''; }
-  document.getElementById('ver-recargas-btn').addEventListener('click',()=>{window.location.href='transacciones.html';});
-  document.getElementById('ver-recargas-back').addEventListener('click',()=>{hideViews();document.getElementById('main-menu').style.display='block';});
+    detalleRecarga.innerHTML=''; }
+  document.getElementById('ver-recargas-btn').addEventListener('click',mostrarGestionRecargas);
+  document.getElementById('ver-recargas-back').addEventListener('click',mostrarMenuPrincipal);
   document.getElementById('cargar-recarga-btn').addEventListener('click',cargarRecargaSeleccion);
   document.getElementById('verificar-recarga-btn').addEventListener('click',verificarRecarga);
   </script>

--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -201,6 +201,13 @@
   <script type="module">
   import { UPLOAD_ENDPOINT } from './js/config.js';
   ensureAuth('Administrador');
+  function volverConFallback(){
+    if(window.history.length>1){
+      window.history.back();
+      return;
+    }
+    window.location.href='gestionsorteos.html';
+  }
   const LOGO_URL='https://i.imgur.com/twjhNtZ.png';
   const preloadLogo=new Image();
   preloadLogo.src=LOGO_URL;
@@ -582,7 +589,7 @@ firebase.auth().onAuthStateChanged(u=>{
     document.getElementById('image-modal').style.display='none';
   });
 
-  document.getElementById('volver-btn').addEventListener('click',()=>{window.history.back();});
+  document.getElementById('volver-btn').addEventListener('click',volverConFallback);
 
     document.querySelectorAll('#tipo-sorteo-group button').forEach(btn=>{
       btn.addEventListener('click',()=>{

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -201,6 +201,13 @@
   <script type="module">
   import { UPLOAD_ENDPOINT } from './js/config.js';
   ensureAuth('Administrador');
+  function volverConFallback(){
+    if(window.history.length>1){
+      window.history.back();
+      return;
+    }
+    window.location.href='gestionsorteos.html';
+  }
   const LOGO_URL='https://i.imgur.com/twjhNtZ.png';
   const preloadLogo=new Image();
   preloadLogo.src=LOGO_URL;
@@ -563,7 +570,7 @@
     document.getElementById('image-modal').style.display='none';
   });
 
-  document.getElementById('volver-btn').addEventListener('click',()=>{window.history.back();});
+  document.getElementById('volver-btn').addEventListener('click',volverConFallback);
 
     document.querySelectorAll('#tipo-sorteo-group button').forEach(btn=>{
       btn.addEventListener('click',()=>{

--- a/public/super.html
+++ b/public/super.html
@@ -123,11 +123,23 @@
   <script src="js/auth.js"></script>
   <script>
   ensureAuth('Superadmin');
-  function hideViews(){document.querySelectorAll('.view').forEach(v=>v.style.display='none');}
+  const mainMenu=document.getElementById('main-menu');
+  const reportesScreen=document.getElementById('reportes-screen');
+  function hideViews(){
+    document.querySelectorAll('.view').forEach(v=>v.style.display='none');
+  }
+  function mostrarMenuPrincipal(){
+    hideViews();
+    mainMenu.style.display='block';
+  }
   document.getElementById("acceder-usuario-btn").addEventListener("click",()=>{window.location.href="accederusuario.html";});
   document.getElementById("gestionar-usuarios-btn").addEventListener("click",()=>{window.location.href="gestionarusuarios.html";});
-  document.getElementById('reportes-btn').addEventListener('click',()=>{hideViews();document.getElementById('reportes-screen').style.display='block';});
-  document.getElementById('reportes-back').addEventListener('click',()=>{hideViews();document.getElementById('main-menu').style.display='block';});
+  document.getElementById('reportes-btn').addEventListener('click',()=>{
+    hideViews();
+    mainMenu.style.display='none';
+    reportesScreen.style.display='block';
+  });
+  document.getElementById('reportes-back').addEventListener('click',mostrarMenuPrincipal);
   document.getElementById('user-name').addEventListener('click',()=>{window.location.href='parametros.html';});
   document.getElementById('user-email').addEventListener('click',()=>{window.location.href='parametros.html';});
   </script>

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -167,6 +167,20 @@
   <script>
     ensureAuth('Colaborador');
     initServerTime();
+    function volverConFallback(){
+      if(window.history.length>1){
+        window.history.back();
+        return;
+      }
+      const role=(window.currentRole)||'';
+      if(role==='Administrador'){
+        window.location.href='admin.html';
+      }else if(role==='Superadmin'){
+        window.location.href='super.html';
+      }else{
+        window.location.href='collab.html';
+      }
+    }
     const transRef=db.collection('transacciones');
     const datosRec=[];const datosRet=[];
     function loadRefCookies(){
@@ -610,7 +624,7 @@
     document.getElementById('filtro-ret-estado').addEventListener('change',e=>{filtrosRet.estado=e.target.value;renderRet();});
     actualizarPendientes();
     setInterval(actualizarPendientes,10000);
-    document.getElementById('volver-btn').addEventListener('click',()=>{history.back();});
+    document.getElementById('volver-btn').addEventListener('click',volverConFallback);
     actualizarArchivarRecBtn();
     actualizarArchivarRetBtn();
     cargarBancos();


### PR DESCRIPTION
## Summary
- restore the collaborator menu so it toggles the transfer verification view without leaving the dashboard and clears the current request when returning
- adjust the Superadmin report navigation to hide the main menu and bring it back through the Volver control
- add defensive Volver fallbacks on draw management and transaction pages so users reach the right parent view even without browser history

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e184840fd88326af1e3b5de54d6359