### PR TITLE
Corrige navegación de salida para superadmin

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -140,15 +140,7 @@
   <script src="js/auth.js"></script>
   <script>
   ensureAuth('Administrador');
-  auth.onAuthStateChanged(async user=>{
-    if(!user) return;
-    const role = await getUserRole(user);
-    if(role==='Superadmin'){
-      const btn=document.getElementById('salir-super-btn');
-      btn.style.display='flex';
-      btn.addEventListener('click',()=>{window.location.href='super.html';});
-    }
-  });
+  setupSuperadminExit('#salir-super-btn');
   document.getElementById('gestionar-sorteos-btn').addEventListener('click',()=>{window.location.href='gestionsorteos.html';});
   document.getElementById('publicar-resultados-btn').addEventListener('click',()=>{window.location.href='cantarsorteos.html';});
   document.getElementById('config-btn').addEventListener('click',()=>{window.location.href='configuraciones.html';});

--- a/public/collab.html
+++ b/public/collab.html
@@ -128,15 +128,7 @@
   const verificarScreen=document.getElementById('verificar-recargas-screen');
   const detalleRecarga=document.getElementById('detalle-recarga');
   let recargaActual=null;
-  auth.onAuthStateChanged(async user=>{
-    if(!user) return;
-    const role = await getUserRole(user);
-    if(role==='Superadmin'){
-      const btn=document.getElementById('salir-super-btn');
-      btn.style.display='flex';
-      btn.addEventListener('click',()=>{window.location.href='super.html';});
-    }
-  });
+  setupSuperadminExit('#salir-super-btn');
   function hideViews(){
     document.querySelectorAll('.view').forEach(v=>v.style.display='none');
   }

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -286,6 +286,44 @@ function redirectByRole(role){
   }
 }
 
+function setupSuperadminExit(buttonSelector = '#salir-super-btn', redirect = 'super.html'){
+  if(!hasWindow()) return;
+  initFirebase()
+    .then(()=>{
+      const button = typeof buttonSelector === 'string' ? document.querySelector(buttonSelector) : buttonSelector;
+      if(!button) return;
+      if(button.dataset.superExitReady === 'true') return;
+      button.dataset.superExitReady = 'true';
+      const bindRedirect = ()=>{
+        if(button.dataset.superExitBound === 'true') return;
+        button.addEventListener('click', ()=>{ window.location.href = redirect; });
+        button.dataset.superExitBound = 'true';
+      };
+      auth.onAuthStateChanged(async user=>{
+        if(!user){
+          button.style.display = 'none';
+          return;
+        }
+        try{
+          const role = await getUserRole(user);
+          if(role === 'Superadmin'){
+            bindRedirect();
+            button.style.display = 'flex';
+            button.style.backgroundColor = '#d32f2f';
+            button.style.borderColor = '#8b0000';
+          }else{
+            button.style.display = 'none';
+          }
+        }catch(err){
+          console.error('No se pudo determinar si el usuario es Superadmin', err);
+        }
+      });
+    })
+    .catch(err=>{
+      console.error('No se pudo configurar el botón de retorno a Superadmin', err);
+    });
+}
+
 function ensureAuth(roleExpected){
   initFirebase()
     .then(() => {
@@ -341,4 +379,4 @@ function startUserStatusWatcher(){
   },60000);
 }
 
-if (typeof module !== "undefined") { module.exports = { redirectByRole, ensureAuth }; }
+if (typeof module !== "undefined") { module.exports = { redirectByRole, ensureAuth, setupSuperadminExit }; }

--- a/public/player.html
+++ b/public/player.html
@@ -350,16 +350,7 @@
   <script src="js/timezone.js"></script>
 <script>
 ensureAuth();
-auth.onAuthStateChanged(async user=>{
-  if(user){
-    const role = await getUserRole(user);
-    if(role==="Superadmin"){
-      const btn=document.getElementById("salir-super-btn");
-      btn.style.display="flex";
-      btn.addEventListener("click",()=>{window.location.href="super.html";});
-    }
-  }
-});
+setupSuperadminExit('#salir-super-btn');
 initFechaHora('fecha-hora');
 
 document.getElementById("carton-btn").addEventListener("click",()=>{window.location.href="jugarcartones.html";});


### PR DESCRIPTION
## Summary
- añade la utilidad `setupSuperadminExit` en `auth.js` para reactivar el botón rojo de salida cuando un superadmin accede a otros menús
- actualiza los menús de administrador, colaborador y jugador para apoyarse en la nueva utilidad y volver correctamente al panel de superadmin

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1881394088326a44046d183889bd3