### PR TITLE
Configure firestore db secrets per environment

### DIFF
--- a/.github/workflows/deploy-by-branch.yml
+++ b/.github/workflows/deploy-by-branch.yml
@@ -26,6 +26,7 @@ jobs:
           sed -i "s|__FIREBASE_STORAGE_BUCKET__|${FIREBASE_STORAGE_BUCKET}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_MESSAGING_SENDER_ID__|${FIREBASE_MESSAGING_SENDER_ID}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_APP_ID__|${FIREBASE_APP_ID}|g" public/firebase-config.js
+          sed -i "s|__FIREBASE_FIRESTORE_DB__|${FIREBASE_FIRESTORE_DB}|g" public/firebase-config.js
         env:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
@@ -34,6 +35,7 @@ jobs:
           FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_FIRESTORE_DB: ${{ secrets.FIREBASE_FIRESTORE_DB_DEV }}
 
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
@@ -61,6 +63,7 @@ jobs:
           sed -i "s|__FIREBASE_STORAGE_BUCKET__|${FIREBASE_STORAGE_BUCKET}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_MESSAGING_SENDER_ID__|${FIREBASE_MESSAGING_SENDER_ID}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_APP_ID__|${FIREBASE_APP_ID}|g" public/firebase-config.js
+          sed -i "s|__FIREBASE_FIRESTORE_DB__|${FIREBASE_FIRESTORE_DB}|g" public/firebase-config.js
         env:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
@@ -69,6 +72,7 @@ jobs:
           FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_FIRESTORE_DB: ${{ secrets.FIREBASE_FIRESTORE_DB_STG }}
 
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
@@ -96,6 +100,7 @@ jobs:
           sed -i "s|__FIREBASE_STORAGE_BUCKET__|${FIREBASE_STORAGE_BUCKET}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_MESSAGING_SENDER_ID__|${FIREBASE_MESSAGING_SENDER_ID}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_APP_ID__|${FIREBASE_APP_ID}|g" public/firebase-config.js
+          sed -i "s|__FIREBASE_FIRESTORE_DB__|${FIREBASE_FIRESTORE_DB}|g" public/firebase-config.js
         env:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
@@ -104,6 +109,7 @@ jobs:
           FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_FIRESTORE_DB: ${{ secrets.FIREBASE_FIRESTORE_DB_PROD }}
 
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -32,6 +32,7 @@ jobs:
           sed -i "s|__FIREBASE_STORAGE_BUCKET__|${FIREBASE_STORAGE_BUCKET}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_MESSAGING_SENDER_ID__|${FIREBASE_MESSAGING_SENDER_ID}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_APP_ID__|${FIREBASE_APP_ID}|g" public/firebase-config.js
+          sed -i "s|__FIREBASE_FIRESTORE_DB__|${FIREBASE_FIRESTORE_DB}|g" public/firebase-config.js
         env:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
@@ -40,6 +41,7 @@ jobs:
           FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_FIRESTORE_DB: ${{ github.base_ref == 'dev' && secrets.FIREBASE_FIRESTORE_DB_DEV || secrets.FIREBASE_FIRESTORE_DB_STG }}
 
       - name: Deploy to Firebase Hosting (dev)
         if: ${{ github.base_ref == 'dev' }}

--- a/README.md
+++ b/README.md
@@ -98,9 +98,14 @@ Los flujos definidos en `.github/workflows/` generan `public/firebase-config.js`
 - `FIREBASE_STORAGE_BUCKET`
 - `FIREBASE_MESSAGING_SENDER_ID`
 - `FIREBASE_APP_ID`
-- `FIREBASE_FIRESTORE_DB`
 
-Cada secreto debe contener el valor correspondiente del proyecto de Firebase. Si utiliza otras herramientas de despliegue, replique el mismo proceso de copiado y reemplazo de marcadores antes de publicar los archivos.
+Además, cada entorno despliega contra una instancia distinta de Cloud Firestore mediante el campo `firestoreDatabaseId`. Defina secretos individuales por entorno con los valores adecuados del ID de base de datos:
+
+- `FIREBASE_FIRESTORE_DB_DEV`
+- `FIREBASE_FIRESTORE_DB_STG`
+- `FIREBASE_FIRESTORE_DB_PROD`
+
+En los workflows se inserta automáticamente el secreto correspondiente en `public/firebase-config.js` según la rama (`dev`, `staging` o `main`). Si utiliza otras herramientas de despliegue, replique el mismo proceso de copiado y reemplazo de marcadores antes de publicar los archivos.
 
 ### Selección de base de datos de Firestore por entorno
 


### PR DESCRIPTION
## Summary
- ensure each deployment workflow reemplaza firestoreDatabaseId según el entorno correspondiente
- documentar los secretos de Firestore por entorno en el README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31a7d524c832685880ac79d78f030