### PR TITLE
Mejora validaciones de sorteos y actualiza iconografía de PDF

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -907,7 +907,7 @@
         <span class="stop-icon">STOP</span>
       </button>
       <button id="pdf-btn" class="estado-btn" title="Generar PDF">
-        <img src="https://api.iconify.design/mdi/file-pdf-box.svg?color=white" alt="PDF">
+        <img src="https://api.iconify.design/material-symbols/picture-as-pdf-rounded.svg?color=%23ff1744" alt="Documento PDF">
       </button>
       <button id="jugar-btn" class="estado-btn" title="Cambiar a Jugando">
         <img src="https://api.iconify.design/mdi/slot-machine.svg?color=white" alt="Jugar">

--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -629,6 +629,11 @@ firebase.auth().onAuthStateChanged(u=>{
     if(!hora){alert('Debes elegir una hora para el Sorteo');horaInput.focus();return;}
     if(!cierreVal){alert('Elije una hora de cierre previo de Jugadas');cierreInput.focus();return;}
     if(!valorVal){alert('Coloca un valor para el cartón');valorInput.focus();return;}
+    if(cierreVal && hora && cierreVal>hora){
+      alert('La hora de cierre no puede ser mayor a la hora del sorteo');
+      cierreInput.focus();
+      return;
+    }
     const cierre=cierreVal;
     const maxcartongratis=parseInt(maxcgVal)||0;
     const valor=parseFloat(valorVal);
@@ -681,7 +686,7 @@ firebase.auth().onAuthStateChanged(u=>{
       alert('Sorteo editado correctamente');
       if(cookieKey) setCookie(cookieKey,'',0);
       localStorage.removeItem('editSorteoId');
-      setTimeout(()=>{window.location.href='gestionsorteos.html';},100);
+      window.location.href='gestionsorteos.html';
     }catch(e){console.error(e);alert('Error al actualizar');}
     });
   </script>

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -610,6 +610,11 @@
     if(!hora){alert('Debes elegir una hora para el Sorteo');horaInput.focus();return;}
     if(!cierreVal){alert('Elije una hora de cierre previo de Jugadas');cierreInput.focus();return;}
     if(!valorVal){alert('Coloca un valor para el cartón');valorInput.focus();return;}
+    if(cierreVal && hora && cierreVal>hora){
+      alert('La hora de cierre no puede ser mayor a la hora del sorteo');
+      cierreInput.focus();
+      return;
+    }
     const cierre=cierreVal;
     const maxcartongratis=parseInt(maxcgVal)||0;
     const valor=parseFloat(valorVal);
@@ -659,7 +664,7 @@
       await batch.commit();
       alert('Sorteo creado exitosamente');
       if(cookieKey) setCookie(cookieKey,'',0);
-      setTimeout(()=>{window.location.href='gestionsorteos.html';},100);
+      window.location.href='gestionsorteos.html';
     }catch(e){console.error(e);alert('Error al guardar');}
     });
   </script>


### PR DESCRIPTION
## Resumen
- agrega validación para evitar que la hora de cierre supere la hora del sorteo en la creación y edición
- redirige a la gestión de sorteos solo después de que la persona usuaria confirme el mensaje de éxito
- actualiza el ícono del botón de PDF por un documento en color rojo

## Pruebas
- no se ejecutaron pruebas (cambios en frontend estático)


------
https://chatgpt.com/codex/tasks/task_e_68e3bfa870b08326aa9eec42dce3160c