### PR TITLE
Mejora del icono PDF y flujo hacia generación de cartones

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -422,20 +422,17 @@
     .estado-btn img,
     .estado-btn svg { width: 24px; height: 24px; }
     #pdf-btn .pdf-btn-icon {
-      width: 28px;
-      height: 28px;
+      width: 30px;
+      height: 30px;
+      filter: drop-shadow(0 2px 2px rgba(0,0,0,0.35));
     }
     #pdf-btn.pdf-disponible::after {
       content: '';
       position: absolute;
-      top: -8px;
-      left: -8px;
-      width: 28px;
-      height: 32px;
-      border-radius: 8px;
-      background: #ffffff url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 40"%3E%3Crect x="2" y="4" width="28" height="32" rx="4" fill="%23d32f2f"/%3E%3Cpath fill="%23ffffff" d="M8 14h4c1.7 0 3 1.3 3 3s-1.3 3-3 3H10v4H8zm2 2h2c.6 0 1-.4 1-1s-.4-1-1-1h-2zm8-4h4v2h-2v2h2v2h-4zm6 0h4c1.1 0 2 .9 2 2v6c0 1.1-.9 2-2 2h-4zm2 2v6h2v-6z"/%3E%3C/svg%3E') center/18px 24px no-repeat;
-      border: 2px solid #ffffff;
-      box-shadow: 0 0 8px rgba(0,0,0,0.35);
+      inset: -6px;
+      border-radius: 16px;
+      box-shadow: 0 0 12px rgba(255,255,255,0.9), 0 0 22px rgba(255,255,255,0.65);
+      pointer-events: none;
     }
     #sellar-btn .stop-icon {
       font-family: 'Bangers', cursive;
@@ -908,9 +905,17 @@
         <span class="stop-icon">STOP</span>
       </button>
       <button id="pdf-btn" class="estado-btn" title="Generar PDF">
-        <svg class="pdf-btn-icon" viewBox="0 0 64 48" role="img" aria-label="Documento PDF">
-          <rect x="2" y="2" width="60" height="44" rx="8" ry="8" fill="#ffffff" stroke="#d32f2f" stroke-width="4"></rect>
-          <text x="32" y="32" text-anchor="middle" font-family="'Poppins', sans-serif" font-weight="700" font-size="24" fill="#d32f2f">PDF</text>
+        <svg class="pdf-btn-icon" viewBox="0 0 48 48" role="img" aria-label="Documento PDF">
+          <defs>
+            <linearGradient id="pdfIconGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stop-color="#ffffff" />
+              <stop offset="100%" stop-color="#ffebee" />
+            </linearGradient>
+          </defs>
+          <path d="M14 4h18l8 8v28a4 4 0 0 1-4 4H14a4 4 0 0 1-4-4V8a4 4 0 0 1 4-4z" fill="url(#pdfIconGradient)" stroke="#d32f2f" stroke-width="2" stroke-linejoin="round"></path>
+          <path d="M32 4v8h8" fill="#ffffff" stroke="#d32f2f" stroke-width="2" stroke-linejoin="round"></path>
+          <rect x="14" y="22" width="20" height="16" rx="3" fill="#d32f2f"></rect>
+          <text x="24" y="33" text-anchor="middle" font-family="'Poppins', sans-serif" font-weight="700" font-size="11" fill="#ffffff" letter-spacing="1">PDF</text>
         </svg>
       </button>
       <button id="jugar-btn" class="estado-btn" title="Cambiar a Jugando">
@@ -2772,9 +2777,9 @@
     pdfDestinoUrl = '';
     cerrarPdfConfirmacion();
     if(destino){
-      const nuevaVentana = window.open(destino, '_blank');
+      const nuevaVentana = window.open(destino, '_blank', 'noopener');
       if(!nuevaVentana){
-        window.location.assign(destino);
+        window.location.href = destino;
       }
     }
   }
@@ -2790,7 +2795,9 @@
       }
       return;
     }
-    pdfDestinoUrl = `pdfsorteo.html?s=${currentSorteoId}`;
+    const destinoUrl = new URL('pdfsorteo.html', window.location.href);
+    destinoUrl.searchParams.set('s', currentSorteoId);
+    pdfDestinoUrl = destinoUrl.toString();
     mostrarPdfConfirmacion();
   }
 


### PR DESCRIPTION
## Summary
- Actualicé el icono del botón PDF para mostrar un documento más legible acompañado de un resplandor blanco en estado disponible.
- Ajusté la lógica de redirección para que, al indicar que el PDF no está generado, se abra correctamente la vista `pdfsorteo.html`.

## Testing
- No se ejecutaron pruebas (cambios de interfaz).

------
https://chatgpt.com/codex/tasks/task_e_68e3cb6d6c9883268bc2e972b726a1dd