### PR TITLE
Fix App Check initialization for compat build

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,18 +1,3 @@
-import { initializeAppCheck, ReCaptchaV3Provider } from "firebase/app-check";
-
-
-if (!self.FIREBASE_APPCHECK_SITE_KEY) {
-  alert("App Check no configurado correctamente");
-  throw new Error("Falta configuración de App Check");
-}
-
-const appCheck = initializeAppCheck(firebaseApp, {
-  provider: new ReCaptchaV3Provider(self.FIREBASE_APPCHECK_SITE_KEY),
-  isTokenAutoRefreshEnabled: true
-});
-
-
-
 let app, auth, db, provider, appName = 'BingOnline';
 const DISABLED_MSG = "Tu cuenta ha sido deshabilitada, Motivado posiblemente a que has incumplido una o más clausulas en nuestros Terminos y condiciones. Contacta con un administrador del sistema si necesitas información.";
 let firebaseInitPromise = null;
@@ -180,6 +165,10 @@ async function initAppCheck(){
     const autoRefresh = config.isTokenAutoRefreshEnabled !== false;
     const provider = normalizeAppCheckProvider(config.provider);
     const siteKey = String(config.siteKey).trim();
+
+    if(hasWindow()){
+      window.FIREBASE_APPCHECK_SITE_KEY = siteKey;
+    }
 
     const appCheck = firebase.appCheck();
     if(provider === 'recaptcha-enterprise'){


### PR DESCRIPTION
## Summary
- remove the unused App Check module import and inline initialization that broke the compat bundle
- rely on the existing dynamic loader to activate App Check and expose the site key on window for reuse

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e46d6704f083269ef3bbd5aa81c613