### PR TITLE
Ensure server time initialization waits for Firestore

### DIFF
--- a/public/js/timezone.js
+++ b/public/js/timezone.js
@@ -37,10 +37,29 @@ async function sincronizarHora() {
   }
 }
 
+async function asegurarDb() {
+  if (typeof db !== 'undefined' && db) {
+    return db;
+  }
+  if (typeof initFirebase === 'function') {
+    try {
+      await initFirebase();
+    } catch (err) {
+      console.error('No se pudo inicializar Firebase antes de obtener la hora del servidor', err);
+      throw err;
+    }
+  }
+  if (typeof db === 'undefined' || !db) {
+    throw new Error('Firestore no está disponible para obtener la hora del servidor');
+  }
+  return db;
+}
+
 async function initServerTime() {
   if (serverTime.zonaIana) return; // ya inicializado
   try {
-    const doc = await db.collection('Variablesglobales').doc('Parametros').get();
+    const database = await asegurarDb();
+    const doc = await database.collection('Variablesglobales').doc('Parametros').get();
     if (!doc.exists) throw new Error('Documento Parametros no existe');
     const { Pais = '', ZonaHoraria = '' } = doc.data();
     serverTime.Pais = Pais;


### PR DESCRIPTION
## Summary
- evita que initServerTime consulte Firestore antes de que la instancia `db` esté lista invocando initFirebase cuando sea necesario

## Testing
- not run (motivo: se requiere autenticación de Firebase para las pruebas de integración)

------
https://chatgpt.com/codex/tasks/task_e_68e54aee31788326b312b31e83bc1698