### PR TITLE
Asegurar autenticación antes de cargar sorteos

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -3177,10 +3177,11 @@
   async function inicializar(){
     let primerIntentoFallido = false;
     let mensajePostCarga = '';
+    const esperaAuth = authListoPromesa.catch(()=>{});
     try {
       await initFirebase();
-      const esperaAuth = authListoPromesa.catch(()=>{});
-      await Promise.all([esperaAuth, cargarSorteos()]);
+      await esperaAuth;
+      await cargarSorteos();
     } catch (err) {
       primerIntentoFallido = true;
       console.error('Error inicializando los sorteos', err);
@@ -3189,6 +3190,7 @@
     if(primerIntentoFallido){
       try {
         await initFirebase();
+        await esperaAuth;
         await cargarSorteos({ forzar: true });
         mensajePostCarga = 'Los sorteos se cargaron tras un reintento.';
       } catch (reintentoErr) {


### PR DESCRIPTION
## Resumen
- esperar a que Firebase finalice la autenticación antes de cargar los sorteos en cantarsorteos.html
- reutilizar la misma promesa de autenticación tanto en el intento inicial como en el reintento forzado

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e5631f7db48326af8cde9784f30e8e