### PR TITLE
Mejoras de visualización en pdfsorteo

### DIFF
--- a/public/pdfsorteo.html
+++ b/public/pdfsorteo.html
@@ -125,24 +125,25 @@
       margin: 0;
     }
     #datos-generales {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px 18px;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      gap: 14px 24px;
       justify-content: center;
-      align-items: center;
+      align-items: stretch;
       margin: 14px auto 26px;
-      padding: 12px 18px;
+      padding: 18px 22px;
       border-radius: 18px;
-      background: rgba(255,255,255,0.85);
+      background: rgba(255,255,255,0.88);
       box-shadow: inset 0 0 0 1px rgba(11,83,148,0.08);
       width: 100%;
     }
     .dato-inline {
       display: flex;
-      gap: 6px;
-      align-items: baseline;
-      font-size: 0.98rem;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 1rem;
       color: #0b5394;
+      text-align: center;
     }
     .dato-inline .dato-label {
       font-family: 'Bangers', cursive;
@@ -152,8 +153,12 @@
     .dato-inline .dato-valor {
       font-family: 'Poppins', sans-serif;
       font-weight: 600;
-      color: #1a1a1a;
     }
+    #dato-fecha { color: #005bbb; }
+    #dato-cierre { color: #c62828; }
+    #dato-hora { color: #2e7d32; }
+    #dato-valor { color: #c76a00; }
+    #dato-maxgratis { color: #6a1b9a; }
     #premios-section {
       border: 3px solid rgba(11,102,35,0.3);
       border-radius: 18px;
@@ -225,11 +230,12 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 6px;
+      padding: 5px;
       border-radius: 14px;
-      background: linear-gradient(135deg, var(--forma-color, #0b5394), #cfcfcf);
+      background: linear-gradient(135deg, var(--forma-color, #0b5394), #f0f0f0);
       box-shadow: 0 8px 18px rgba(0,0,0,0.12);
-      min-width: 110px;
+      min-width: 96px;
+      max-width: 118px;
     }
     .forma-mini-carton {
       border-collapse: separate;
@@ -238,14 +244,18 @@
       border-radius: 12px;
       overflow: hidden;
     }
+    .forma-mini-carton {
+      --mini-cell: 18px;
+    }
     .forma-mini-carton th,
     .forma-mini-carton td {
       border: 1px solid rgba(0,0,0,0.12);
-      width: 22px;
-      height: 22px;
+      width: var(--mini-cell);
+      height: var(--mini-cell);
       text-align: center;
       font-weight: 700;
       font-size: 0.68rem;
+      background: #ffffff;
     }
     .forma-mini-carton th {
       font-size: 0.9rem;
@@ -253,15 +263,21 @@
       background: radial-gradient(circle,#ffffff,#ffffff 60%,rgba(0,170,0,0.6));
       text-shadow: 1px 1px 0 #000;
     }
+    .forma-mini-carton td.star {
+      background: rgba(255,255,255,0.9);
+    }
+    .forma-mini-carton td.star .forma-estrella {
+      color: var(--forma-color, #0b5394);
+    }
     .forma-mini-carton td.free {
-      background: radial-gradient(circle,#fff3c4,#ffffff);
-      font-size: 0.9rem;
-      color: #ff8c00;
+      background: #ff962a;
+    }
+    .forma-mini-carton td.free .forma-estrella {
+      color: #ffffff;
     }
     .forma-mini-carton .forma-estrella {
       font-size: 1rem;
-      color: var(--forma-color, #0b5394);
-      text-shadow: 0 0 4px rgba(255,255,255,0.8);
+      text-shadow: 0 0 4px rgba(0,0,0,0.12);
     }
     #cartones-section {
       margin-top: 40px;
@@ -275,10 +291,10 @@
       text-align: center;
     }
     #cartones-grid {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 18px;
-      justify-content: center;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 20px;
+      justify-items: center;
     }
     .pdf-carton {
       display: flex;
@@ -292,7 +308,9 @@
       box-shadow: 0 10px 24px rgba(0,0,0,0.08);
       border: 1px solid rgba(0,0,0,0.05);
       page-break-inside: avoid;
-      width: min(320px, 100%);
+      width: 100%;
+      max-width: 320px;
+      justify-self: center;
     }
     .pdf-carton-wrapper {
       border-radius: 16px;
@@ -304,10 +322,10 @@
       background: linear-gradient(135deg, rgba(0,0,255,0.75), rgba(255,255,102,0.6));
     }
     .pdf-carton-table {
+      --cell-size: clamp(42px, 8vw, 60px);
       border-collapse: separate;
       border-spacing: 0;
-      width: 100%;
-      max-width: 280px;
+      width: calc(var(--cell-size) * 5);
       margin: 0 auto;
       background: linear-gradient(#ffffff,#e8e8e8);
       border-radius: 12px;
@@ -316,12 +334,17 @@
     .pdf-carton-table th,
     .pdf-carton-table td {
       border: 2px solid rgba(128,128,128,0.65);
-      width: 20%;
-      aspect-ratio: 1 / 1;
+      width: var(--cell-size);
+      height: var(--cell-size);
       text-align: center;
       font-weight: 700;
-      font-size: 1rem;
       color: #1a1a1a;
+    }
+    .pdf-carton-table th {
+      font-size: calc(var(--cell-size) * 0.75);
+    }
+    .pdf-carton-table td {
+      font-size: calc(var(--cell-size) * 0.5);
     }
     .pdf-carton-table th {
       font-size: 1.6rem;
@@ -330,9 +353,9 @@
       text-shadow: 2px 2px 0 #000;
     }
     .pdf-carton-table td.free {
-      background: radial-gradient(circle,#ffff9c,#ffffff);
-      font-size: 1.3rem;
-      color: #ff8c00;
+      background: radial-gradient(circle,#ffbd4f,#ffe8b3);
+      font-size: calc(var(--cell-size) * 0.65);
+      color: #ffffff;
     }
     .pdf-carton-datos {
       display: flex;
@@ -408,6 +431,16 @@
       .pdf-carton-table td { font-size: 0.9rem; }
     }
     @media (max-width: 640px) {
+      #cartones-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .pdf-carton { width: 100%; }
+    }
+    @media (orientation: landscape) and (max-width: 900px) {
+      #cartones-grid { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+    }
+    @media (max-width: 480px) {
+      #datos-generales { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 640px) {
       .forma-resumen { grid-template-columns: 1fr; }
       .forma-mini-carton-wrapper { justify-self: center; }
       .forma-info { justify-items: flex-start; }
@@ -434,8 +467,8 @@
       </div>
       <div id="datos-generales">
         <div class="dato-inline"><span class="dato-label">Fecha del sorteo:</span><span id="dato-fecha" class="dato-valor">-</span></div>
-        <div class="dato-inline"><span class="dato-label">Hora del sorteo:</span><span id="dato-hora" class="dato-valor">-</span></div>
         <div class="dato-inline"><span class="dato-label">Hora de cierre:</span><span id="dato-cierre" class="dato-valor">-</span></div>
+        <div class="dato-inline"><span class="dato-label">Hora del sorteo:</span><span id="dato-hora" class="dato-valor">-</span></div>
         <div class="dato-inline"><span class="dato-label">Valor del cartón:</span><span id="dato-valor" class="dato-valor">-</span></div>
         <div class="dato-inline"><span class="dato-label">Cartones gratis máximos:</span><span id="dato-maxgratis" class="dato-valor">-</span></div>
       </div>
@@ -504,6 +537,30 @@
   }
 
   const coloresFormas = ['#006400', '#b8860b', '#00008b', '#4b0082', '#8b4513', '#d2691e'];
+
+  function aclararColorHex(hex, factor = 0.55){
+    if(typeof hex !== 'string') return hex;
+    let limpio = hex.replace('#','');
+    if(limpio.length === 3){
+      limpio = limpio.split('').map(ch=>ch+ch).join('');
+    }
+    if(limpio.length !== 6) return hex;
+    const r = parseInt(limpio.slice(0,2), 16);
+    const g = parseInt(limpio.slice(2,4), 16);
+    const b = parseInt(limpio.slice(4,6), 16);
+    const mezcla = (canal)=>{
+      if(Number.isNaN(canal)) return canal;
+      return Math.round(canal + (255 - canal) * factor);
+    };
+    const nr = mezcla(r);
+    const ng = mezcla(g);
+    const nb = mezcla(b);
+    const hexCanal = (val)=>{
+      if(!Number.isFinite(val)) return 'ff';
+      return Math.min(255, Math.max(0, val)).toString(16).padStart(2,'0');
+    };
+    return `#${hexCanal(nr)}${hexCanal(ng)}${hexCanal(nb)}`;
+  }
 
   salirBtn.addEventListener('click', ()=>{ window.location.href = 'cantarsorteos.html'; });
   if(generarCartonesBtn){ generarCartonesBtn.disabled = true; }
@@ -614,12 +671,14 @@
       for(let c=0; c<5; c++){
         const td = document.createElement('td');
         if(r===2 && c===2){
-          td.classList.add('free');
+          td.classList.add('free','star');
           td.innerHTML = '<span class="forma-estrella">★</span>';
         }else{
           const seleccionada = posiciones.some(p=>Number(p.r)===r && Number(p.c)===c);
           if(seleccionada){
+            td.classList.add('star');
             td.innerHTML = '<span class="forma-estrella">★</span>';
+            td.style.backgroundColor = aclararColorHex(color, 0.7);
           }
         }
         tr.appendChild(td);
@@ -904,45 +963,45 @@
 
       const cartonElements = Array.from(document.querySelectorAll('.pdf-carton'));
       if(cartonElements.length){
-        let primeraPaginaCartones = true;
+        let paginaIniciada = false;
         let columna = 0;
         let cursorY = marginY;
         let alturaFila = 0;
-        const columnasMax = 2;
         const espacioHorizontal = 18;
-        const espacioVertical = 18;
+        const espacioVertical = 22;
         const anchoUtil = pageWidth - marginX * 2;
+        const anchoReferencia = 260;
+        const columnasMax = Math.max(2, Math.floor((anchoUtil + espacioHorizontal) / (anchoReferencia + espacioHorizontal)));
         const anchoColumna = (anchoUtil - espacioHorizontal * (columnasMax - 1)) / columnasMax;
         const limiteY = pageHeight - marginY;
 
         for(const elemento of cartonElements){
-          if(primeraPaginaCartones){
-            pdf.addPage();
-            primeraPaginaCartones = false;
-            columna = 0;
-            cursorY = marginY;
-            alturaFila = 0;
-          } else if(columna >= columnasMax){
-            columna = 0;
-            cursorY += alturaFila + espacioVertical;
-            alturaFila = 0;
-          }
-
           const canvas = await window.html2canvas(elemento, {
             scale: 2,
             useCORS: true,
             logging: false
           });
+
           const escala = anchoColumna / canvas.width;
-          let renderWidth = anchoColumna;
-          let renderHeight = canvas.height * escala;
+          const renderWidth = anchoColumna;
+          const renderHeight = canvas.height * escala;
+
+          if(!paginaIniciada){
+            pdf.addPage();
+            paginaIniciada = true;
+          }
+
+          if(columna >= columnasMax){
+            columna = 0;
+            cursorY += alturaFila + espacioVertical;
+            alturaFila = 0;
+          }
 
           if(cursorY + renderHeight > limiteY){
             pdf.addPage();
             columna = 0;
             cursorY = marginY;
             alturaFila = 0;
-            renderHeight = canvas.height * (anchoColumna / canvas.width);
           }
 
           const posX = marginX + columna * (anchoColumna + espacioHorizontal);


### PR DESCRIPTION
## Summary
- Ajusté la presentación del resumen del sorteo y los colores de los datos para facilitar la lectura tanto en la vista web como en el PDF.
- Actualicé las miniaturas de las formas para mostrar las estrellas con fondos acordes al color de cada forma y reordené la información mostrada.
- Reorganicé la grilla de cartones y la distribución en el PDF para evitar deformaciones y aprovechar mejor el espacio de cada página.

## Testing
- No se ejecutaron pruebas (no aplica)


------
https://chatgpt.com/codex/tasks/task_e_68e66eba86388326bc24aefb98091ac7