### PR TITLE
Mejoras visuales y de PDF en pdfsorteo

### DIFF
--- a/public/pdfsorteo.html
+++ b/public/pdfsorteo.html
@@ -100,33 +100,51 @@
     }
     #resumen-header {
       display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 10px;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 18px;
       margin-bottom: 18px;
+      text-align: left;
+    }
+    #resumen-header .header-logo {
+      flex: 0 0 auto;
     }
     #logo {
-      width: 150px;
-      margin: 0 auto 5px;
+      width: 110px;
       display: block;
+    }
+    #resumen-header .header-info {
+      flex: 1 1 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      align-items: flex-start;
     }
     #nombre-sorteo {
       font-family: 'Bangers', cursive;
-      font-size: 2.4rem;
+      font-size: clamp(2rem, 4vw, 2.6rem);
       color: #0b5394;
       margin: 0;
       text-transform: uppercase;
       letter-spacing: 1px;
     }
-    #tipo-sorteo-titulo {
+    #valor-sorteo-destacado {
       font-family: 'Bangers', cursive;
-      font-size: 1.5rem;
-      color: #0b6623;
-      margin: 0;
+      font-size: clamp(1.8rem, 3.6vw, 2.2rem);
+      color: #b85c00;
+      text-align: left;
+      line-height: 1.1;
+    }
+    #tipo-sorteo-titulo {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.95rem;
+      color: #0b5394;
+      margin: 4px 0 0;
+      font-weight: 600;
     }
     #datos-generales {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       gap: 14px 24px;
       justify-content: center;
       align-items: stretch;
@@ -136,14 +154,20 @@
       background: rgba(255,255,255,0.88);
       box-shadow: inset 0 0 0 1px rgba(11,83,148,0.08);
       width: 100%;
+      max-width: 100%;
+      box-sizing: border-box;
     }
     .dato-inline {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
+      display: grid;
+      grid-template-columns: auto 1fr;
+      align-items: center;
+      gap: 10px;
       font-size: 1rem;
       color: #0b5394;
-      text-align: center;
+      text-align: left;
+      padding: 8px 14px;
+      border-radius: 12px;
+      background: rgba(11,83,148,0.05);
     }
     .dato-inline .dato-label {
       font-family: 'Bangers', cursive;
@@ -153,6 +177,9 @@
     .dato-inline .dato-valor {
       font-family: 'Poppins', sans-serif;
       font-weight: 600;
+      color: #1a1a1a;
+      justify-self: end;
+      text-align: right;
     }
     #dato-fecha { color: #005bbb; }
     #dato-cierre { color: #c62828; }
@@ -187,20 +214,20 @@
     }
     .forma-resumen {
       display: grid;
-      grid-template-columns: minmax(220px, 1fr) auto;
-      gap: 12px 18px;
-      align-items: center;
+      grid-template-columns: minmax(230px, 1.5fr) minmax(130px, 1fr);
+      gap: 12px 24px;
+      align-items: stretch;
       background: rgba(255,255,255,0.92);
       border-radius: 18px;
-      padding: 12px;
+      padding: 16px;
       border: 2px solid rgba(0,0,0,0.05);
       box-shadow: 0 8px 18px rgba(0,0,0,0.06);
       position: relative;
     }
     .forma-info {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 6px 18px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
       text-align: left;
     }
     .forma-titulo {
@@ -215,8 +242,12 @@
       font-size: 0.95rem;
       color: #0b1d0b;
       display: flex;
-      gap: 4px;
+      gap: 8px;
       align-items: baseline;
+      justify-content: space-between;
+      background: rgba(11,83,148,0.04);
+      padding: 8px 12px;
+      border-radius: 12px;
     }
     .forma-detalle .etiqueta {
       font-weight: 600;
@@ -230,12 +261,12 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      padding: 5px;
+      padding: 6px;
       border-radius: 14px;
       background: linear-gradient(135deg, var(--forma-color, #0b5394), #f0f0f0);
       box-shadow: 0 8px 18px rgba(0,0,0,0.12);
-      min-width: 96px;
-      max-width: 118px;
+      min-width: 110px;
+      max-width: 140px;
     }
     .forma-mini-carton {
       border-collapse: separate;
@@ -252,10 +283,13 @@
       border: 1px solid rgba(0,0,0,0.12);
       width: var(--mini-cell);
       height: var(--mini-cell);
-      text-align: center;
+      aspect-ratio: 1 / 1;
+      display: grid;
+      place-items: center;
       font-weight: 700;
       font-size: 0.68rem;
       background: #ffffff;
+      padding: 0;
     }
     .forma-mini-carton th {
       font-size: 0.9rem;
@@ -292,8 +326,8 @@
     }
     #cartones-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 20px;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 18px;
       justify-items: center;
     }
     .pdf-carton {
@@ -309,7 +343,7 @@
       border: 1px solid rgba(0,0,0,0.05);
       page-break-inside: avoid;
       width: 100%;
-      max-width: 320px;
+      max-width: 260px;
       justify-self: center;
     }
     .pdf-carton-wrapper {
@@ -322,7 +356,7 @@
       background: linear-gradient(135deg, rgba(0,0,255,0.75), rgba(255,255,102,0.6));
     }
     .pdf-carton-table {
-      --cell-size: clamp(42px, 8vw, 60px);
+      --cell-size: clamp(34px, 6vw, 46px);
       border-collapse: separate;
       border-spacing: 0;
       width: calc(var(--cell-size) * 5);
@@ -330,21 +364,25 @@
       background: linear-gradient(#ffffff,#e8e8e8);
       border-radius: 12px;
       overflow: hidden;
+      table-layout: fixed;
     }
     .pdf-carton-table th,
     .pdf-carton-table td {
       border: 2px solid rgba(128,128,128,0.65);
       width: var(--cell-size);
       height: var(--cell-size);
-      text-align: center;
+      aspect-ratio: 1 / 1;
+      display: grid;
+      place-items: center;
       font-weight: 700;
       color: #1a1a1a;
+      padding: 0;
     }
     .pdf-carton-table th {
       font-size: calc(var(--cell-size) * 0.75);
     }
     .pdf-carton-table td {
-      font-size: calc(var(--cell-size) * 0.5);
+      font-size: calc(var(--cell-size) * 0.48);
     }
     .pdf-carton-table th {
       font-size: 1.6rem;
@@ -364,6 +402,7 @@
       text-align: center;
       font-family: 'Poppins', sans-serif;
       font-weight: 600;
+      word-break: break-word;
     }
     .pdf-carton-datos .numero {
       font-size: 1.05rem;
@@ -427,8 +466,8 @@
       #resumen-pdf { padding: 22px 14px; }
       #acciones-fixed { right: 6px; }
       #acciones-fixed button { padding: 8px 14px; font-size: 1rem; }
-      .pdf-carton-table th,
-      .pdf-carton-table td { font-size: 0.9rem; }
+      #resumen-header { flex-direction: column; align-items: flex-start; }
+      #valor-sorteo-destacado { text-align: left; }
     }
     @media (max-width: 640px) {
       #cartones-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -443,7 +482,7 @@
     @media (max-width: 640px) {
       .forma-resumen { grid-template-columns: 1fr; }
       .forma-mini-carton-wrapper { justify-self: center; }
-      .forma-info { justify-items: flex-start; }
+      .forma-info { width: 100%; }
     }
   </style>
 </head>
@@ -461,11 +500,17 @@
   <div id="pdf-wrapper">
     <section id="resumen-pdf">
       <div id="resumen-header">
-        <img id="logo" src="https://i.imgur.com/twjhNtZ.png" alt="Bingo Online">
-        <h1 id="nombre-sorteo">Sorteo</h1>
-        <h2 id="tipo-sorteo-titulo"></h2>
+        <div class="header-logo">
+          <img id="logo" src="https://i.imgur.com/twjhNtZ.png" alt="Bingo Online">
+        </div>
+        <div class="header-info">
+          <h1 id="nombre-sorteo">Sorteo</h1>
+          <div id="valor-sorteo-destacado">-</div>
+          <div id="tipo-sorteo-titulo"></div>
+        </div>
       </div>
       <div id="datos-generales">
+        <div class="dato-inline"><span class="dato-label">Tipo de sorteo:</span><span id="dato-tipo" class="dato-valor">-</span></div>
         <div class="dato-inline"><span class="dato-label">Fecha del sorteo:</span><span id="dato-fecha" class="dato-valor">-</span></div>
         <div class="dato-inline"><span class="dato-label">Hora de cierre:</span><span id="dato-cierre" class="dato-valor">-</span></div>
         <div class="dato-inline"><span class="dato-label">Hora del sorteo:</span><span id="dato-hora" class="dato-valor">-</span></div>
@@ -507,11 +552,13 @@
   const loadingText = document.getElementById('loading-text');
   const nombreEl = document.getElementById('nombre-sorteo');
   const tipoTituloEl = document.getElementById('tipo-sorteo-titulo');
+  const valorDestacadoEl = document.getElementById('valor-sorteo-destacado');
   const datoFechaEl = document.getElementById('dato-fecha');
   const datoHoraEl = document.getElementById('dato-hora');
   const datoCierreEl = document.getElementById('dato-cierre');
   const datoValorEl = document.getElementById('dato-valor');
   const datoMaxGratisEl = document.getElementById('dato-maxgratis');
+  const datoTipoEl = document.getElementById('dato-tipo');
   const totalPremiosEl = document.getElementById('total-premios');
   const formasCont = document.getElementById('formas-resumen');
   const cartonesGrid = document.getElementById('cartones-grid');
@@ -759,6 +806,7 @@
     const numero = document.createElement('div');
     const numeroValor = Number(data.cartonNum ?? data.Ncarton);
     const numeroTexto = Number.isFinite(numeroValor) ? String(numeroValor).padStart(4,'0') : (data.Ncarton || data.cartonNum || '-');
+    carton.dataset.numero = Number.isFinite(numeroValor) ? numeroValor : 0;
     numero.className = 'numero';
     numero.textContent = `Cartón ${numeroTexto}`;
     infoInferior.appendChild(numero);
@@ -833,7 +881,11 @@
       cartonesGrid.innerHTML = '<div class="cartones-placeholder">No se encontraron cartones generados para este sorteo.</div>';
       return;
     }
-    cartonesData.sort((a,b)=> (Number(a.cartonNum) || 0) - (Number(b.cartonNum) || 0));
+    cartonesData.sort((a,b)=>{
+      const numA = Number(a.cartonNum ?? a.Ncarton) || 0;
+      const numB = Number(b.cartonNum ?? b.Ncarton) || 0;
+      return numB - numA;
+    });
     const fragment = document.createDocumentFragment();
     cartonesData.forEach(data=>{
       fragment.appendChild(crearCartonVisual(data));
@@ -853,12 +905,14 @@
       }
       sorteoData = sorteoDoc.data();
       nombreEl.textContent = sorteoData.nombre || 'Sorteo';
-      tipoTituloEl.textContent = sorteoData.tipo ? `Tipo de sorteo: ${sorteoData.tipo}` : '';
+      valorDestacadoEl.textContent = `${formatearNumero(sorteoData.valorCarton || 0)} créditos`;
+      tipoTituloEl.textContent = sorteoData.tipo ? sorteoData.tipo : '';
       datoFechaEl.textContent = formatearFechaParaMostrar(sorteoData.fecha || '');
       datoHoraEl.textContent = formatearHoraParaMostrar(sorteoData.hora || '');
       datoCierreEl.textContent = formatearHoraParaMostrar(sorteoData.horacierre || '');
       datoValorEl.textContent = `${formatearNumero(sorteoData.valorCarton || 0)} créditos`;
       datoMaxGratisEl.textContent = formatearNumero(sorteoData.maxcartongratis || 0);
+      datoTipoEl.textContent = sorteoData.tipo || '-';
       totalPremiosEl.textContent = formatearNumero(sorteoData.totalPremios || 0);
       pdfFileName = construirNombreArchivo();
 
@@ -943,8 +997,8 @@
       const pdf = new jsPDFLib('p', 'pt', 'a4');
       const pageWidth = pdf.internal.pageSize.getWidth();
       const pageHeight = pdf.internal.pageSize.getHeight();
-      const marginX = 36;
-      const marginY = 36;
+      const marginX = 24;
+      const marginY = 24;
 
       const resumenCanvas = await window.html2canvas(resumen, {
         scale: 2,
@@ -961,16 +1015,23 @@
       const resumenY = (pageHeight - resumenHeight) / 2;
       pdf.addImage(resumenCanvas.toDataURL('image/png'), 'PNG', resumenX, resumenY, resumenWidth, resumenHeight);
 
-      const cartonElements = Array.from(document.querySelectorAll('.pdf-carton'));
+      const cartonElements = Array.from(document.querySelectorAll('.pdf-carton'))
+        .sort((a,b)=>{
+          const numA = Number(a.dataset.numero || 0);
+          const numB = Number(b.dataset.numero || 0);
+          return numB - numA;
+        });
       if(cartonElements.length){
         let paginaIniciada = false;
         let columna = 0;
         let cursorY = marginY;
         let alturaFila = 0;
-        const espacioHorizontal = 18;
-        const espacioVertical = 22;
+        const espacioHorizontal = 12;
+        const espacioVertical = 14;
         const anchoUtil = pageWidth - marginX * 2;
-        const anchoReferencia = 260;
+        const muestra = cartonElements[0];
+        const anchoVisual = muestra ? Math.max(muestra.getBoundingClientRect().width, 200) : 220;
+        const anchoReferencia = Math.max(200, Math.min(260, anchoVisual));
         const columnasMax = Math.max(2, Math.floor((anchoUtil + espacioHorizontal) / (anchoReferencia + espacioHorizontal)));
         const anchoColumna = (anchoUtil - espacioHorizontal * (columnasMax - 1)) / columnasMax;
         const limiteY = pageHeight - marginY;


### PR DESCRIPTION
## Resumen
- Reorganiza el encabezado de `pdfsorteo.html` para mostrar el logo reducido, el nombre del sorteo y el valor destacado sin desbordes junto a los datos generales alineados.
- Ajusta la disposición de las formas y los cartones miniatura con celdas cuadradas y contenedores responsivos para evitar desbordes en la vista.
- Ordena y compacta los cartones generados (pagados y gratis) tanto en la vista como en el PDF, reduciendo espacios para aprovechar mejor cada página.

## Pruebas
- No se ejecutaron pruebas automatizadas (la vista depende de servicios de Firebase para poblar datos).


------
https://chatgpt.com/codex/tasks/task_e_68e68848f66c8326b7a71bf6b5d7c773