### PR TITLE
feat: mejorar avisos visuales de premios y ganadores

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -741,6 +741,16 @@
     .modal.modal-ganadores.activa {
       display: flex;
     }
+    .modal.modal-nuevos-ganadores {
+      inset: 0;
+      padding: 16px;
+      box-sizing: border-box;
+      background: rgba(8,16,32,0.82);
+      z-index: 1700;
+    }
+    .modal.modal-nuevos-ganadores.activa {
+      display: flex;
+    }
     .modal-ganadores .modal-contenido {
       background: #fff;
       border-radius: 18px;
@@ -754,6 +764,72 @@
       flex-direction: column;
       gap: 12px;
       box-sizing: border-box;
+    }
+    .modal-nuevos-ganadores .modal-contenido {
+      background: linear-gradient(160deg, rgba(24,24,24,0.94), rgba(96,24,24,0.94));
+      border-radius: 20px;
+      padding: 22px 26px;
+      max-width: min(480px, 92vw);
+      width: min(480px, 92vw);
+      box-shadow: 0 20px 45px rgba(0,0,0,0.45);
+      border: 3px solid rgba(255,160,0,0.55);
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      align-items: center;
+      text-align: center;
+    }
+    #nuevos-ganadores-titulo {
+      font-family: 'Bangers', cursive;
+      font-size: 1.9rem;
+      letter-spacing: 1px;
+      margin: 0;
+      color: #fff;
+      text-shadow: 0 0 14px rgba(255,120,0,0.95), 0 0 28px rgba(255,69,0,0.75);
+    }
+    #nuevos-ganadores-lista {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      width: 100%;
+    }
+    .nuevos-ganadores-linea {
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #fefefe;
+      text-shadow: 0 0 10px rgba(0,0,0,0.7);
+    }
+    .nuevos-ganadores-linea .nuevos-ganadores-forma {
+      color: var(--forma-color, #ffd54f);
+      text-shadow: 0 0 8px rgba(255,255,255,0.95);
+      font-weight: 700;
+    }
+    .nuevos-ganadores-linea .nuevos-ganadores-cantidad {
+      font-family: 'Bangers', cursive;
+      font-size: 1.5rem;
+      color: #fff;
+      text-shadow: 0 0 14px rgba(255,140,0,0.9);
+      margin-left: 6px;
+    }
+    #nuevos-ganadores-aceptar {
+      font-family: 'Bangers', cursive;
+      font-size: 1.25rem;
+      padding: 10px 34px;
+      border-radius: 999px;
+      border: 3px solid rgba(255,171,64,0.85);
+      background: linear-gradient(160deg, rgba(255,152,0,0.92), rgba(255,234,167,0.95));
+      color: #3b1b00;
+      cursor: pointer;
+      box-shadow: 0 14px 32px rgba(0,0,0,0.4);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    #nuevos-ganadores-aceptar:hover {
+      transform: translateY(-1px) scale(1.03);
+      box-shadow: 0 18px 36px rgba(0,0,0,0.45);
+    }
+    #nuevos-ganadores-aceptar:active {
+      transform: translateY(1px) scale(0.97);
+      box-shadow: 0 10px 24px rgba(0,0,0,0.35);
     }
     .info-overlay {
       position: fixed;
@@ -1528,6 +1604,13 @@
       <div id="modal-ganadores-sin" class="modal-mensaje"></div>
     </div>
   </div>
+  <div id="nuevos-ganadores-modal" class="modal modal-nuevos-ganadores" role="dialog" aria-modal="true" aria-labelledby="nuevos-ganadores-titulo" aria-hidden="true">
+    <div class="modal-contenido" role="document">
+      <h2 id="nuevos-ganadores-titulo">HAY GANADOR O GANADORES NUEVOS</h2>
+      <div id="nuevos-ganadores-lista"></div>
+      <button id="nuevos-ganadores-aceptar" type="button">Aceptar</button>
+    </div>
+  </div>
   <div id="mensaje-area">Selecciona un sorteo para administrar su estado.</div>
   <div id="footer">
     <div id="fecha-hora"></div>
@@ -1641,6 +1724,9 @@
   const modalGanadoresSubtituloEl = document.getElementById('modal-ganadores-subtitulo');
   const modalGanadoresListaEl = document.getElementById('modal-ganadores-lista');
   const modalGanadoresSinEl = document.getElementById('modal-ganadores-sin');
+  const nuevosGanadoresModalEl = document.getElementById('nuevos-ganadores-modal');
+  const nuevosGanadoresListaEl = document.getElementById('nuevos-ganadores-lista');
+  const nuevosGanadoresAceptarBtn = document.getElementById('nuevos-ganadores-aceptar');
   const modalComplementariosEl = document.getElementById('complementarios-modal');
   const modalComplementariosMensajeEl = document.getElementById('complementarios-modal-mensaje');
   const modalComplementariosAceptarBtn = document.getElementById('complementarios-modal-aceptar');
@@ -1716,6 +1802,10 @@
   let sincronizacionMetadatosEnCurso = false;
   let sincronizacionResultadosNecesaria = false;
   let sincronizacionResultadosTimeout = null;
+  let cantosInicializados = false;
+  let nuevosGanadoresModalActivo = false;
+  let mostrarComplementariosPendiente = false;
+  let evaluandoCantoActual = false;
 
   function manejarAceptarConfirmacionCanto(){
     cerrarConfirmacionCanto(true);
@@ -2156,6 +2246,16 @@
   if(modalGanadoresEl){
     modalGanadoresEl.addEventListener('click', manejarClickModalGanadores);
   }
+  if(nuevosGanadoresAceptarBtn){
+    nuevosGanadoresAceptarBtn.addEventListener('click', cerrarModalNuevosGanadores);
+  }
+  if(nuevosGanadoresModalEl){
+    nuevosGanadoresModalEl.addEventListener('click', evento=>{
+      if(evento.target === nuevosGanadoresModalEl){
+        cerrarModalNuevosGanadores();
+      }
+    });
+  }
   document.addEventListener('keydown', manejarTeclaModalGanadores);
   if(modalComplementariosAceptarBtn){
     modalComplementariosAceptarBtn.addEventListener('click', cerrarModalComplementarios);
@@ -2179,6 +2279,9 @@
   }
   document.addEventListener('keydown', evento=>{
     if(evento.key === 'Escape'){
+      if(nuevosGanadoresModalActivo){
+        cerrarModalNuevosGanadores();
+      }
       if(modalComplementariosEl?.classList?.contains('activa')){
         cerrarModalComplementarios();
       }
@@ -2767,6 +2870,9 @@
   }
 
   function procesarCantos(datos){
+    const mapaGanadoresPrevio = capturarResumenGanadores(cartonesGanadoresPorForma);
+    const longitudAnterior = cantosOrdenados.length;
+    const esPrimerProcesamiento = !cantosInicializados;
     const payload = Array.isArray(datos)
       ? { numeros: datos }
       : (datos && typeof datos === 'object' ? datos : { numeros: [] });
@@ -2806,6 +2912,7 @@
         resultadoMapa.set(numero, estado);
       }
     });
+    evaluandoCantoActual = true;
     cantosOrdenados = normalizados;
     cantosIndiceMap = new Map();
     normalizados.forEach((numero, idx)=>{
@@ -2816,6 +2923,15 @@
     cantosResultadoMap = resultadoMapa;
     actualizarNumerosNoJugados();
     calcularGanadores();
+    revisarGanadoresNuevos({
+      mapaPrevio: mapaGanadoresPrevio,
+      longitudAnterior,
+      longitudActual: normalizados.length,
+      esPrimerProcesamiento
+    });
+    cantosInicializados = true;
+    evaluandoCantoActual = false;
+    gestionarComplementariosPendientes();
   }
 
   function obtenerIndiceLimiteGanador(totalCantos){
@@ -3040,14 +3156,14 @@
     if(!todasFormasConGanadores){
       cerrarModalComplementarios();
       notificacionComplementariosMostrada = false;
+      mostrarComplementariosPendiente = false;
     } else {
       const transicion = !estadoAnterior
         && Number.isInteger(indiceUltimoGanador)
         && cantosOrdenados.length > 0
         && indiceUltimoGanador === cantosOrdenados.length - 1;
       if(transicion && !notificacionComplementariosMostrada){
-        abrirModalComplementarios();
-        notificacionComplementariosMostrada = true;
+        mostrarComplementariosPendiente = true;
       }
     }
     actualizarEstilosCantos();
@@ -3145,6 +3261,7 @@
     });
     evaluarEstadoFormasGanadoras();
     actualizarBotonesFormas();
+    gestionarComplementariosPendientes();
   }
 
   function actualizarNumerosNoJugados(){
@@ -3594,8 +3711,106 @@
   }
 
   function manejarTeclaModalGanadores(event){
-    if(event.key === 'Escape' && modalGanadoresEl?.classList?.contains('activa')){
+    if(event.key !== 'Escape') return;
+    if(modalGanadoresEl?.classList?.contains('activa')){
       cerrarModalGanadores();
+      return;
+    }
+    if(nuevosGanadoresModalActivo){
+      cerrarModalNuevosGanadores();
+    }
+  }
+
+  function crearLineaNuevosGanadores(nombre, color, total){
+    const linea = document.createElement('div');
+    linea.className = 'nuevos-ganadores-linea';
+    if(color){
+      linea.style.setProperty('--forma-color', color);
+    }
+    const textoInicio = document.createTextNode('Ganadores con ');
+    const nombreSpan = document.createElement('span');
+    nombreSpan.className = 'nuevos-ganadores-forma';
+    nombreSpan.textContent = nombre;
+    const textoMedio = document.createTextNode(': ');
+    const cantidadSpan = document.createElement('span');
+    cantidadSpan.className = 'nuevos-ganadores-cantidad';
+    cantidadSpan.textContent = String(total);
+    linea.append(textoInicio, nombreSpan, textoMedio, cantidadSpan);
+    return linea;
+  }
+
+  function mostrarModalNuevosGanadores(detalles){
+    if(!nuevosGanadoresModalEl || !nuevosGanadoresListaEl) return;
+    nuevosGanadoresListaEl.innerHTML = '';
+    detalles.forEach(detalle=>{
+      const linea = crearLineaNuevosGanadores(detalle.nombre, detalle.color, detalle.total);
+      nuevosGanadoresListaEl.appendChild(linea);
+    });
+    nuevosGanadoresModalEl.classList.add('activa');
+    nuevosGanadoresModalEl.setAttribute('aria-hidden', 'false');
+    nuevosGanadoresModalActivo = true;
+    if(nuevosGanadoresAceptarBtn){
+      nuevosGanadoresAceptarBtn.focus({ preventScroll: true });
+    }
+  }
+
+  function cerrarModalNuevosGanadores(){
+    if(!nuevosGanadoresModalEl) return;
+    nuevosGanadoresModalEl.classList.remove('activa');
+    nuevosGanadoresModalEl.setAttribute('aria-hidden', 'true');
+    if(nuevosGanadoresListaEl){
+      nuevosGanadoresListaEl.innerHTML = '';
+    }
+    nuevosGanadoresModalActivo = false;
+    gestionarComplementariosPendientes();
+  }
+
+  function capturarResumenGanadores(map){
+    const resumen = new Map();
+    if(!(map instanceof Map)) return resumen;
+    map.forEach((info, indice)=>{
+      const idxNumero = Number(indice);
+      if(!Number.isFinite(idxNumero)) return;
+      const total = Array.isArray(info?.cartones) ? info.cartones.length : 0;
+      resumen.set(idxNumero, { total });
+    });
+    return resumen;
+  }
+
+  function revisarGanadoresNuevos({ mapaPrevio, longitudAnterior, longitudActual, esPrimerProcesamiento }){
+    const anterior = Number(longitudAnterior) || 0;
+    const actual = Number(longitudActual) || 0;
+    if(actual <= anterior) return;
+    if(esPrimerProcesamiento) return;
+    const nuevos = [];
+    cartonesGanadoresPorForma.forEach((registro, indice)=>{
+      const idxNumero = Number(indice);
+      if(!Number.isFinite(idxNumero)) return;
+      const totalActual = Array.isArray(registro?.cartones) ? registro.cartones.length : 0;
+      if(totalActual <= 0) return;
+      const previo = mapaPrevio instanceof Map ? Number(mapaPrevio.get(idxNumero)?.total || 0) : 0;
+      if(totalActual > previo){
+        const forma = registro?.forma || obtenerResumenForma(idxNumero) || { idx: idxNumero };
+        const nombreForma = (forma?.nombre && forma.nombre.trim()) ? forma.nombre.trim() : `Forma ${String(idxNumero).padStart(2,'0')}`;
+        const colorForma = obtenerColorParaForma(forma?.idx || idxNumero || 1);
+        nuevos.push({ nombre: nombreForma, color: colorForma, total: totalActual });
+      }
+    });
+    if(!nuevos.length) return;
+    mostrarModalNuevosGanadores(nuevos);
+  }
+
+  function gestionarComplementariosPendientes(){
+    if(!mostrarComplementariosPendiente) return;
+    if(nuevosGanadoresModalActivo || evaluandoCantoActual) return;
+    if(!todasFormasConGanadores){
+      mostrarComplementariosPendiente = false;
+      return;
+    }
+    mostrarComplementariosPendiente = false;
+    if(!notificacionComplementariosMostrada){
+      notificacionComplementariosMostrada = true;
+      abrirModalComplementarios();
     }
   }
 
@@ -3612,6 +3827,17 @@
     todasFormasConGanadores = false;
     indiceUltimoGanador = null;
     notificacionComplementariosMostrada = false;
+    cantosInicializados = false;
+    mostrarComplementariosPendiente = false;
+    evaluandoCantoActual = false;
+    nuevosGanadoresModalActivo = false;
+    if(nuevosGanadoresModalEl){
+      nuevosGanadoresModalEl.classList.remove('activa');
+      nuevosGanadoresModalEl.setAttribute('aria-hidden', 'true');
+    }
+    if(nuevosGanadoresListaEl){
+      nuevosGanadoresListaEl.innerHTML = '';
+    }
     cartonesResultadoRegistrado = new Map();
     sincronizacionMetadatosNecesaria = false;
     if(sincronizacionMetadatosTimeout){

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -265,19 +265,26 @@
     .text-premio-total{font-family:'Bangers',cursive;color:white;font-size:1.5rem;text-align:center;}
     .text-premio-total div{ text-shadow:0 0 4px darkgreen; }
     .valor-total{font-size:3rem;text-shadow:0 0 4px darkgreen;animation:pulse 1s infinite;}
-    #premios-formas,#back-premios-formas{display:flex;flex-direction:column;gap:8px;width:100%;box-sizing:border-box;}
-    #back-premios-formas{gap:4px;align-items:flex-start;}
-    .premio-row{display:flex;align-items:center;gap:12px;justify-content:flex-start;font-family:'Bangers',cursive;font-weight:bold;margin-bottom:0;padding:8px 10px;border-radius:12px;background:rgba(255,255,255,0.85);box-shadow:0 2px 6px rgba(0,0,0,0.15);flex-wrap:wrap;}
-    .premio-mini-box{display:flex;flex-direction:column;align-items:center;gap:4px;flex-shrink:0;}
-    .premio-mini-box .forma-mini-etiqueta{font-size:0.75rem;background:linear-gradient(90deg,#4B0082,#00008b);color:#fff;padding:2px 6px;border-radius:6px;text-shadow:0 0 4px #000;font-family:'Bangers',cursive;}
-    .premio-mini-box .mini-carton-wrapper{padding:2px;border-radius:10px;box-shadow:0 0 4px rgba(0,0,0,0.25);background:linear-gradient(#0a8800,#f5f5a5);}
-    .forma-carton-wrapper{display:inline-flex;}
-    .premio-mini-box .mini-carton{border-radius:8px;}
-    .premio-mini-box .mini-carton th,.premio-mini-box .mini-carton td{border-width:1px;}
-    .premio-info{display:flex;flex-direction:column;gap:4px;align-items:flex-start;font-family:'Poppins',sans-serif;font-weight:600;color:#333;min-width:140px;}
+    #premios-formas{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:8px;width:100%;box-sizing:border-box;justify-items:stretch;align-items:start;align-content:start;}
+    #back-premios-formas{display:flex;flex-direction:column;gap:4px;width:100%;box-sizing:border-box;align-items:flex-start;}
+    .premio-row{display:flex;flex-direction:column;align-items:center;gap:6px;justify-content:flex-start;font-family:'Bangers',cursive;font-weight:bold;margin:0;padding:8px 10px;border-radius:16px;background:rgba(255,255,255,0.9);box-shadow:0 4px 12px rgba(0,0,0,0.18);width:100%;box-sizing:border-box;}
+    .premio-mini-box{display:flex;flex-direction:column;align-items:center;gap:6px;width:100%;max-width:100%;}
+    .premio-mini-box .forma-mini-etiqueta{font-size:0.8rem;background:linear-gradient(90deg,#4B0082,#00008b);color:#fff;padding:3px 10px;border-radius:999px;text-shadow:0 0 5px #000;font-family:'Bangers',cursive;}
+    .premio-mini-box .mini-carton-wrapper{--forma-color:#0a8800;--forma-color-suave:#6fdc8a;padding:6px;border-radius:14px;box-shadow:0 8px 18px rgba(0,0,0,0.25);background:linear-gradient(160deg,var(--forma-color),var(--forma-color-suave));display:flex;justify-content:center;align-items:center;}
+    .forma-carton-wrapper{display:flex;justify-content:center;width:100%;}
+    .premio-mini-box .mini-carton{border-radius:10px;}
+    .premio-mini-box .mini-carton-forma{border-collapse:separate;border-spacing:1.5px;background:rgba(255,255,255,0.92);padding:3px;border-radius:10px;box-shadow:inset 0 0 6px rgba(0,0,0,0.12);}
+    .premio-mini-box .mini-carton-forma th,.premio-mini-box .mini-carton-forma td{width:11px;height:11px;font-size:0.45rem;}
+    .premio-mini-box .mini-carton-forma th{font-size:0.68rem;padding:1.5px 0;}
+    .premio-info{display:flex;flex-direction:column;gap:6px;align-items:center;font-family:'Poppins',sans-serif;font-weight:600;color:#333;text-align:center;width:100%;}
     .premio-info .premio-valor{font-size:1.1rem;font-family:'Bangers',cursive;text-shadow:0 0 6px #fff,0 0 10px #fff;}
     .premio-info .cartones-valor{font-size:1rem;font-family:'Bangers',cursive;text-shadow:0 0 6px #fff,0 0 10px #fff;}
-    .premio-info .forma-nombre{font-family:'Poppins',sans-serif;font-weight:600;font-size:0.75rem;color:#4B0082;text-shadow:none;margin-top:2px;}
+    .premio-info .forma-nombre{font-family:'Bangers',cursive;font-weight:700;font-size:1.25rem;text-shadow:0 0 10px rgba(255,255,255,0.9);margin:0;}
+    .mini-carton-forma td{border:1px solid rgba(0,0,0,0.15);border-radius:4px;background:rgba(255,255,255,0.95);}
+    .mini-carton-forma td.star{background:var(--forma-celda-color,rgba(255,255,255,0.9));box-shadow:0 0 8px rgba(0,0,0,0.25);}
+    .mini-carton-forma td.free{background:var(--forma-celda-color,rgba(255,255,255,0.9));}
+    .mini-carton-forma td.star .forma-estrella{display:inline-block;font-size:0.58rem;color:#fff;text-shadow:0 0 6px rgba(0,0,0,0.85);}
+    @media (min-width:520px){.premio-row{flex-direction:row;align-items:flex-start;gap:10px;}.premio-info{text-align:left;align-items:flex-start;}}
     .premio-row.solo-texto{flex-direction:column;align-items:flex-start;gap:4px;}
     .premio-row.solo-texto .premio-info{gap:2px;min-width:auto;}
     .premio-row.solo-texto .premio-info .forma-titulo{font-family:'Bangers',cursive;font-size:1rem;text-shadow:0 0 6px #fff,0 0 10px #fff;}
@@ -459,6 +466,33 @@ const CONSECUTIVOS_COLLECTION='ConsecutivosCarton';
 let unsubscribeConsecutivoCarton=null;
 let ultimoNumeroCartonAsignado=0;
 let siguienteNumeroCarton=1;
+
+function normalizarHex(hex){
+  if(typeof hex!=='string') return hex;
+  let limpio=hex.replace('#','');
+  if(limpio.length===3){
+    limpio=limpio.split('').map(ch=>ch+ch).join('');
+  }
+  if(limpio.length!==6) return null;
+  return limpio;
+}
+
+function aclararColorHex(hex,factor=0.55){
+  const limpio=normalizarHex(hex);
+  if(!limpio) return hex;
+  const r=parseInt(limpio.slice(0,2),16);
+  const g=parseInt(limpio.slice(2,4),16);
+  const b=parseInt(limpio.slice(4,6),16);
+  const mezclar=canal=>{
+    if(Number.isNaN(canal)) return canal;
+    return Math.round(canal+(255-canal)*factor);
+  };
+  const canalHex=val=>{
+    if(!Number.isFinite(val)) return 'ff';
+    return Math.min(255,Math.max(0,val)).toString(16).padStart(2,'0');
+  };
+  return `#${canalHex(mezclar(r))}${canalHex(mezclar(g))}${canalHex(mezclar(b))}`;
+}
 
 function formatearNumeroCarton(valor){
   const numero=Number(valor);
@@ -1040,8 +1074,7 @@ function toggleForma(idx){
     const jugarBtn=document.getElementById('jugar-carton-btn');
     if(s.estado==='Sellado' || s.estado==='Jugando') jugarBtn.disabled=true; else jugarBtn.disabled=false;
     if(s.estado==='Sellado'){
-      const mensaje=mostrarMensajeSellado(s.nombre||'este sorteo');
-      alert(mensaje);
+      mostrarMensajeSellado(s.nombre||'este sorteo');
     }
     actualizarFondoCarton();
     guardarSorteoSeleccionado(s);
@@ -1121,8 +1154,7 @@ function toggleForma(idx){
     const sorteoData=sorteoDoc.data();
     currentSorteoEstado=sorteoData?.estado||currentSorteoEstado;
     if(currentSorteoEstado==='Sellado'){
-      const mensaje=mostrarMensajeSellado(currentSorteoNombre||sorteoData?.nombre||'este sorteo');
-      alert(mensaje);
+      mostrarMensajeSellado(currentSorteoNombre||sorteoData?.nombre||'este sorteo');
       return;
     }
 
@@ -1299,6 +1331,7 @@ function toggleForma(idx){
       limpiarcarton();
     }catch(error){
       let mensaje='No se pudo registrar tu cartón. Inténtalo nuevamente.';
+      let mostrarAlerta=true;
       if(error?.message==='SIN_CREDITOS'){
         mensaje='No tienes créditos suficientes.';
       }else if(error?.message==='SIN_GRATIS'){
@@ -1306,7 +1339,8 @@ function toggleForma(idx){
       }else if(error?.message==='LIMITE_GRATIS'){
         mensaje='Se alcanzó el límite de cartones gratis para este sorteo.';
       }else if(error?.message==='SORTEO_SELLADO'){
-        mensaje=mostrarMensajeSellado(currentSorteoNombre||sorteoData?.nombre||'este sorteo');
+        mostrarAlerta=false;
+        mostrarMensajeSellado(currentSorteoNombre||sorteoData?.nombre||'este sorteo');
       }else if(error?.message==='SORTEO_NO_ENCONTRADO'){
         mensaje='No se encontró la información actual del sorteo seleccionado.';
       }else if(error?.message==='BILLETERA_NO_ENCONTRADA'){
@@ -1318,7 +1352,9 @@ function toggleForma(idx){
       }else{
         console.error('Error registrando cartón',error);
       }
-      alert(mensaje);
+      if(mostrarAlerta){
+        alert(mensaje);
+      }
       return;
     }
   }
@@ -1345,8 +1381,7 @@ function toggleForma(idx){
     const sorteoData=sorteoDoc.data();
     currentSorteoEstado=sorteoData?.estado||currentSorteoEstado;
     if(currentSorteoEstado==='Sellado'){
-      const mensaje=mostrarMensajeSellado(currentSorteoNombre||sorteoData?.nombre||'este sorteo');
-      alert(mensaje);
+      mostrarMensajeSellado(currentSorteoNombre||sorteoData?.nombre||'este sorteo');
       return;
     }
     const valor=toNumberSafe(sorteoData.valorCarton,0);
@@ -1567,14 +1602,25 @@ function toggleForma(idx){
           const miniWrapper=document.createElement('div');
           miniWrapper.className='mini-carton-wrapper';
           miniWrapper.classList.add('forma-carton-wrapper');
-          miniWrapper.style.background=`linear-gradient(${color},#ffffff)`;
+          miniWrapper.style.setProperty('--forma-color',color);
+          const colorSuave=aclararColorHex(color,0.68);
+          if(colorSuave) miniWrapper.style.setProperty('--forma-color-suave',colorSuave);
           const posiciones=Array.isArray(f.posiciones)?f.posiciones:[];
-          miniWrapper.appendChild(crearMiniCarton(posiciones));
+          miniWrapper.appendChild(crearMiniCartonForma(posiciones,color));
           miniBox.appendChild(miniWrapper);
           fila.appendChild(miniBox);
 
           const info=document.createElement('div');
           info.className='premio-info';
+          const nombreForma=(f.nombre&&f.nombre.trim())?f.nombre.trim():`Forma ${String(f.idx).padStart(2,'0')}`;
+          if(nombreForma){
+            const nombreDiv=document.createElement('div');
+            nombreDiv.className='forma-nombre';
+            nombreDiv.textContent=nombreForma;
+            nombreDiv.style.color=color;
+            nombreDiv.style.textShadow='0 0 8px rgba(255,255,255,0.85)';
+            info.appendChild(nombreDiv);
+          }
           const premioLinea=document.createElement('div');
           premioLinea.style.color=color;
           premioLinea.innerHTML=`Premio: <span class=\"premio-valor\">${premioForma}</span>`;
@@ -1583,12 +1629,6 @@ function toggleForma(idx){
           cartLinea.style.color=color;
           cartLinea.innerHTML=`Cartones: <span class=\"cartones-valor\">${cartonesAsignados}</span>`;
           info.appendChild(cartLinea);
-          if(f.nombre){
-            const nombreDiv=document.createElement('div');
-            nombreDiv.className='forma-nombre';
-            nombreDiv.textContent=f.nombre;
-            info.appendChild(nombreDiv);
-          }
           fila.appendChild(info);
           cont.appendChild(fila);
         });
@@ -1804,6 +1844,50 @@ function toggleForma(idx){
     }
     desactivarModoEdicion();
     limpiarcarton();
+  }
+
+  function crearMiniCartonForma(posiciones,color){
+    const lista=Array.isArray(posiciones)?posiciones:[];
+    const objetivos=new Set();
+    lista.forEach(pos=>{
+      const fila=Number(pos?.r);
+      const col=Number(pos?.c);
+      if(Number.isInteger(fila)&&Number.isInteger(col)) objetivos.add(`${fila}-${col}`);
+    });
+    const tabla=document.createElement('table');
+    tabla.className='mini-carton mini-carton-forma';
+    const colorCelda=aclararColorHex(color,0.7);
+    if(colorCelda) tabla.style.setProperty('--forma-celda-color',colorCelda);
+    const head=document.createElement('thead');
+    const trh=document.createElement('tr');
+    ['B','I','N','G','O'].forEach(l=>{const th=document.createElement('th');th.textContent=l;trh.appendChild(th);});
+    head.appendChild(trh);tabla.appendChild(head);
+    const tbody=document.createElement('tbody');
+    for(let r=0;r<5;r++){
+      const tr=document.createElement('tr');
+      for(let c=0;c<5;c++){
+        const td=document.createElement('td');
+        const clave=`${r}-${c}`;
+        const esObjetivo=objetivos.has(clave);
+        if(r===2&&c===2){
+          td.classList.add('free','star');
+        }else if(esObjetivo){
+          td.classList.add('star');
+        }
+        if(td.classList.contains('star')){
+          td.style.backgroundColor=colorCelda||'';
+          td.style.borderColor=aclararColorHex(color,0.5)||td.style.borderColor;
+          const estrella=document.createElement('span');
+          estrella.className='forma-estrella';
+          estrella.textContent='★';
+          td.appendChild(estrella);
+        }
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    }
+    tabla.appendChild(tbody);
+    return tabla;
   }
 
   function crearMiniCarton(posiciones){


### PR DESCRIPTION
## Summary
- Ajustar las miniaturas y etiquetas del modal de premios en jugarcartones, mostrando las estrellas con fondos por forma y reduciendo el espacio ocupado.
- Incorporar un modal de nuevos ganadores en cantarsorteos con estilos destacados, detección tras cada canto y coordinación con el aviso de cantos complementarios.

## Testing
- No se ejecutaron pruebas automatizadas (no aplicable).


------
https://chatgpt.com/codex/tasks/task_e_68f7cf6cc8e08326af0136dc6c0dc431