### PR TITLE
Mejorar modal de premios y resaltar estrella central en cartones

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -207,14 +207,14 @@
     .carton th{font-size:2.5rem;color:#ff6600;background:radial-gradient(circle,#ffffff,#ffffff 60%,#00aa00);text-shadow:2px 2px 0 #000;}
     .forma-header{display:flex;flex-direction:column;align-items:center;justify-content:center;width:100%;height:100%;font-family:'Bangers',cursive;font-size:0.8rem;line-height:1;text-shadow:1px 1px 0 #000;}
     .carton td{cursor:pointer;font-size:1.8rem;text-shadow:0 0 3px green;}
-    .carton td.free{background:radial-gradient(circle,#ffffff,#ffff00);display:flex;align-items:center;justify-content:center;font-size:1.2rem;color:#4B0082;}
+    .carton td.free{background:#ffeb3b;display:flex;align-items:center;justify-content:center;font-size:1.2rem;color:#4B0082;box-shadow:inset 0 0 6px rgba(0,0,0,0.18);}
     .carton-center-info{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px;line-height:1;font-weight:bold;text-transform:none;}
     #carton-num-max{font-size:1.4rem;color:#006400;text-shadow:0 0 4px #fff,0 0 6px rgba(0,0,0,0.2);font-family:'Poppins',sans-serif;display:block;animation:wiggle 1s infinite;}
     .carton td.error{border:2px solid red;}
     .carton-back{position:absolute;top:0;left:0;right:0;bottom:0;border-radius:10px;backface-visibility:hidden;transform:rotateY(180deg);background:linear-gradient(white,gray);display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:5px;overflow:hidden;}
     .carton-back img{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:80%;height:auto;opacity:0.15;object-fit:contain;pointer-events:none;z-index:0;}
-    .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;z-index:1000;}
-    .modal-content{background:#fff;padding:10px;border-radius:10px;display:flex;flex-direction:column;align-items:flex-start;gap:5px;width:max-content;}
+    .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;z-index:1000;padding:12px;box-sizing:border-box;}
+    .modal-content{background:#fff;padding:10px;border-radius:10px;display:flex;flex-direction:column;align-items:flex-start;gap:5px;width:max-content;box-sizing:border-box;}
     #sorteos-list div{display:block;font-weight:bold;font-size:1rem;cursor:pointer;font-family:'Poppins',sans-serif;margin-bottom:2px;}
     #sorteos-list .sorteo-index{display:inline-block;width:30px;margin-right:2px;}
     #sorteos-list div .sorteo-detalle{display:flex;align-items:center;gap:4px;font-size:0.6rem;font-weight:normal;pointer-events:none;color:inherit;font-family:'Poppins',sans-serif;margin-top:-2px;padding-left:30px;}
@@ -260,31 +260,37 @@
     .info-line{font-family:'Bangers',cursive;font-size:1.5rem;text-align:center;}
     .text-forma-gratis{font-family:'Bangers',cursive;font-weight:bold;color:purple;font-size:1.1rem;text-align:center;}
     #premios-titulo,#info-cartones-titulo,#back-premios-titulo{font-size:1.1rem;text-align:center;font-family:'Bangers',cursive;}
-    #premios-modal .modal-content,#info-cartones-modal .modal-content{align-items:center;}
+    #premios-modal .modal-content{align-items:stretch;width:min(900px,92vw);max-height:90vh;overflow-y:auto;padding:clamp(16px,2.5vw,28px);gap:clamp(14px,2vw,22px);}
+    #premios-modal .modal-content>h2,#premios-modal .modal-content>.text-premio-total{align-self:center;}
+    #premios-modal #premios-aceptar{align-self:center;}
+    #info-cartones-modal .modal-content{align-items:center;}
     #info-cartones-aceptar,#premios-aceptar{font-size:1.2rem;padding:8px 20px;}
-    .text-premio-total{font-family:'Bangers',cursive;color:white;font-size:1.5rem;text-align:center;}
+    .text-premio-total{font-family:'Bangers',cursive;color:white;font-size:clamp(1.2rem,2.8vw,1.6rem);text-align:center;}
     .text-premio-total div{ text-shadow:0 0 4px darkgreen; }
-    .valor-total{font-size:3rem;text-shadow:0 0 4px darkgreen;animation:pulse 1s infinite;}
-    #premios-formas{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:8px;width:100%;box-sizing:border-box;justify-items:stretch;align-items:start;align-content:start;}
+    .valor-total{font-size:clamp(2.3rem,5.5vw,3.4rem);text-shadow:0 0 4px darkgreen;animation:pulse 1s infinite;}
+    #premios-formas{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:clamp(12px,2vw,22px);width:100%;box-sizing:border-box;justify-items:stretch;align-items:start;align-content:start;margin:0 auto;}
     #back-premios-formas{display:flex;flex-direction:column;gap:4px;width:100%;box-sizing:border-box;align-items:flex-start;}
-    .premio-row{display:flex;flex-direction:column;align-items:center;gap:6px;justify-content:flex-start;font-family:'Bangers',cursive;font-weight:bold;margin:0;padding:8px 10px;border-radius:16px;background:rgba(255,255,255,0.9);box-shadow:0 4px 12px rgba(0,0,0,0.18);width:100%;box-sizing:border-box;}
-    .premio-mini-box{display:flex;flex-direction:column;align-items:center;gap:6px;width:100%;max-width:100%;}
-    .premio-mini-box .forma-mini-etiqueta{font-size:0.8rem;background:linear-gradient(90deg,#4B0082,#00008b);color:#fff;padding:3px 10px;border-radius:999px;text-shadow:0 0 5px #000;font-family:'Bangers',cursive;}
-    .premio-mini-box .mini-carton-wrapper{--forma-color:#0a8800;--forma-color-suave:#6fdc8a;padding:6px;border-radius:14px;box-shadow:0 8px 18px rgba(0,0,0,0.25);background:linear-gradient(160deg,var(--forma-color),var(--forma-color-suave));display:flex;justify-content:center;align-items:center;}
+    .premio-row{display:flex;flex-direction:column;align-items:center;gap:clamp(10px,1.8vw,18px);justify-content:flex-start;font-family:'Bangers',cursive;font-weight:bold;margin:0;padding:clamp(10px,2vw,18px);border-radius:16px;background:rgba(255,255,255,0.9);box-shadow:0 4px 12px rgba(0,0,0,0.18);width:100%;box-sizing:border-box;}
+    .premio-mini-box{display:flex;flex-direction:column;align-items:center;gap:clamp(5px,1.4vw,10px);width:100%;max-width:100%;}
+    .premio-mini-box .forma-mini-etiqueta{font-size:clamp(0.8rem,1.9vw,0.95rem);background:linear-gradient(90deg,#4B0082,#00008b);color:#fff;padding:clamp(3px,0.8vw,5px) clamp(10px,2vw,14px);border-radius:999px;text-shadow:0 0 5px #000;font-family:'Bangers',cursive;}
+    .premio-mini-box .mini-carton-wrapper{--forma-color:#0a8800;--forma-color-suave:#6fdc8a;padding:clamp(6px,1.8vw,9px);border-radius:14px;box-shadow:0 8px 18px rgba(0,0,0,0.25);background:linear-gradient(160deg,var(--forma-color),var(--forma-color-suave));display:flex;justify-content:center;align-items:center;}
     .forma-carton-wrapper{display:flex;justify-content:center;width:100%;}
     .premio-mini-box .mini-carton{border-radius:10px;}
     .premio-mini-box .mini-carton-forma{border-collapse:separate;border-spacing:1.5px;background:rgba(255,255,255,0.92);padding:3px;border-radius:10px;box-shadow:inset 0 0 6px rgba(0,0,0,0.12);}
     .premio-mini-box .mini-carton-forma th,.premio-mini-box .mini-carton-forma td{width:11px;height:11px;font-size:0.45rem;}
     .premio-mini-box .mini-carton-forma th{font-size:0.68rem;padding:1.5px 0;}
-    .premio-info{display:flex;flex-direction:column;gap:6px;align-items:center;font-family:'Poppins',sans-serif;font-weight:600;color:#333;text-align:center;width:100%;}
-    .premio-info .premio-valor{font-size:1.1rem;font-family:'Bangers',cursive;text-shadow:0 0 6px #fff,0 0 10px #fff;}
-    .premio-info .cartones-valor{font-size:1rem;font-family:'Bangers',cursive;text-shadow:0 0 6px #fff,0 0 10px #fff;}
-    .premio-info .forma-nombre{font-family:'Bangers',cursive;font-weight:700;font-size:1.25rem;text-shadow:0 0 10px rgba(255,255,255,0.9);margin:0;}
+    .premio-info{display:flex;flex-direction:column;gap:clamp(6px,1.4vw,12px);align-items:center;font-family:'Poppins',sans-serif;font-weight:600;color:#333;text-align:center;width:100%;}
+    .premio-info .premio-valor{font-size:clamp(1rem,2.4vw,1.25rem);font-family:'Bangers',cursive;text-shadow:0 0 6px #fff,0 0 10px #fff;}
+    .premio-info .cartones-valor{font-size:clamp(0.95rem,2.2vw,1.15rem);font-family:'Bangers',cursive;text-shadow:0 0 6px #fff,0 0 10px #fff;}
+    .premio-info .forma-nombre{font-family:'Bangers',cursive;font-weight:700;font-size:clamp(1.05rem,2.5vw,1.35rem);text-shadow:0 0 10px rgba(255,255,255,0.9);margin:0;}
     .mini-carton-forma td{border:1px solid rgba(0,0,0,0.15);border-radius:4px;background:rgba(255,255,255,0.95);}
     .mini-carton-forma td.star{background:var(--forma-celda-color,rgba(255,255,255,0.9));box-shadow:0 0 8px rgba(0,0,0,0.25);}
     .mini-carton-forma td.free{background:var(--forma-celda-color,rgba(255,255,255,0.9));}
+    .mini-carton-forma td.central-star{background:#ffeb3b!important;border-color:#d6c200!important;box-shadow:0 0 8px rgba(0,0,0,0.2);display:flex;align-items:center;justify-content:center;}
     .mini-carton-forma td.star .forma-estrella{display:inline-block;font-size:0.58rem;color:#fff;text-shadow:0 0 6px rgba(0,0,0,0.85);}
-    @media (min-width:520px){.premio-row{flex-direction:row;align-items:flex-start;gap:10px;}.premio-info{text-align:left;align-items:flex-start;}}
+    .mini-carton-forma td.central-star .forma-estrella{color:#6b6b6b;text-shadow:0 0 4px rgba(0,0,0,0.35);}
+    .mini-free-cell{background:#ffeb3b!important;border-color:#d6c200!important;display:flex;align-items:center;justify-content:center;}
+    .mini-free-star{display:inline-block;color:#6b6b6b;font-size:0.8rem;text-shadow:0 0 4px rgba(0,0,0,0.3);}
     .premio-row.solo-texto{flex-direction:column;align-items:flex-start;gap:4px;}
     .premio-row.solo-texto .premio-info{gap:2px;min-width:auto;}
     .premio-row.solo-texto .premio-info .forma-titulo{font-family:'Bangers',cursive;font-size:1rem;text-shadow:0 0 6px #fff,0 0 10px #fff;}
@@ -1870,13 +1876,18 @@ function toggleForma(idx){
         const clave=`${r}-${c}`;
         const esObjetivo=objetivos.has(clave);
         if(r===2&&c===2){
-          td.classList.add('free','star');
+          td.classList.add('free','star','central-star');
         }else if(esObjetivo){
           td.classList.add('star');
         }
         if(td.classList.contains('star')){
-          td.style.backgroundColor=colorCelda||'';
-          td.style.borderColor=aclararColorHex(color,0.5)||td.style.borderColor;
+          if(td.classList.contains('central-star')){
+            td.style.backgroundColor='#ffeb3b';
+            td.style.borderColor='#d6c200';
+          }else{
+            td.style.backgroundColor=colorCelda||'';
+            td.style.borderColor=aclararColorHex(color,0.5)||td.style.borderColor;
+          }
           const estrella=document.createElement('span');
           estrella.className='forma-estrella';
           estrella.textContent='★';
@@ -1903,7 +1914,13 @@ function toggleForma(idx){
       const tr=document.createElement('tr');
       for(let c=0;c<5;c++){
         const td=document.createElement('td');
-        if(r===2&&c===2){td.innerHTML='<span style="color:orange;">★</span>';}else{
+        if(r===2&&c===2){
+          td.classList.add('mini-free-cell');
+          const estrella=document.createElement('span');
+          estrella.className='mini-free-star';
+          estrella.textContent='★';
+          td.appendChild(estrella);
+        }else{
           const found=lista.find(p=>p.r===r&&p.c===c);
           if(found) td.textContent=found.valor;
         }


### PR DESCRIPTION
## Summary
- ampliar y hacer desplazable el modal de premios con un diseño responsivo de dos columnas
- ajustar fuentes, espaciados y alineaciones para presentar datos compactos debajo de cada mini cartón
- actualizar los estilos y el renderizado de la estrella central de los cartones para fondo amarillo y estrella gris

## Testing
- No se ejecutaron pruebas automatizadas (no aplicaba)


------
https://chatgpt.com/codex/tasks/task_e_68f7e0616a1c832696f5d0baab282512