### PR TITLE
Fix handling of free card limits when creating or editing draws

### DIFF
--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -262,7 +262,8 @@
       document.getElementById('fecha-sorteo').value=data.fecha||'';
       document.getElementById('hora-sorteo').value=data.hora||'';
       document.getElementById('hora-cierre').value=data.cierre||'';
-      document.getElementById('max-carton-gratis').value=data.maxcg||'';
+      const maxcgValue=(data.maxcg===undefined||data.maxcg===null||data.maxcg==='')?'':data.maxcg;
+      document.getElementById('max-carton-gratis').value=maxcgValue;
       document.getElementById('valor-carton').value=data.valor||'';
       if(data.tipo){
         document.querySelectorAll('#tipo-sorteo-group button').forEach(b=>b.classList.remove('active'));
@@ -337,7 +338,7 @@
     const d=doc.data();
     let est=d.estado||'';
     if(d.condicion==='ARCHIVADO') est='Archivado';
-    const data={nombre:d.nombre||'',tipo:d.tipo||'',fecha:d.fecha||'',hora:d.hora||'',cierre:d.horacierre||d.cierre||'',maxcg:d.maxcartongratis||'',valor:d.valorCarton||'',estado:est,formas:[]};
+    const data={nombre:d.nombre||'',tipo:d.tipo||'',fecha:d.fecha||'',hora:d.hora||'',cierre:d.horacierre||d.cierre||'',maxcg:(d.maxcartongratis??''),valor:d.valorCarton||'',estado:est,formas:[]};
     const snap=await db.collection('formas').where('sorteoId','==',sorteoId).get();
     const arr=[];snap.forEach(s=>arr.push(s.data()));
     arr.sort((a,b)=>(a.idx||0)-(b.idx||0));
@@ -622,7 +623,7 @@ firebase.auth().onAuthStateChanged(u=>{
     const fecha=fechaInput.value;
     const hora=horaInput.value;
     const cierreVal=cierreInput.value;
-    const maxcgVal=maxcgInput.value;
+    const maxcgVal=maxcgInput.value.trim();
     const valorVal=valorInput.value;
     if(!nombre){alert('Asigna un nombre al Sorteo');nombreInput.focus();return;}
     if(!tipo){alert('Elije un tipo de sorteo');return;}
@@ -636,7 +637,15 @@ firebase.auth().onAuthStateChanged(u=>{
       return;
     }
     const cierre=cierreVal;
-    const maxcartongratis=parseInt(maxcgVal)||0;
+    let maxcartongratis=null;
+    if(maxcgVal!==''){
+      if(!/^\d+$/.test(maxcgVal)){
+        alert('El máximo de cartones gratis debe ser un número entero igual o mayor a 0.');
+        maxcgInput.focus();
+        return;
+      }
+      maxcartongratis=parseInt(maxcgVal,10);
+    }
     const valor=parseFloat(valorVal);
     const condicion = estado==='Archivado'?'ARCHIVADO':'VISIBLE';
     if(estado==='Archivado') estado='Inactivo';
@@ -678,7 +687,13 @@ firebase.auth().onAuthStateChanged(u=>{
     }
     if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
-      await db.collection('sorteos').doc(sorteoId).update({nombre,tipo,fecha,hora,horacierre:cierre,maxcartongratis:maxcartongratis,valorCarton:valor,estado,condicion});
+      const updateData={nombre,tipo,fecha,hora,horacierre:cierre,valorCarton:valor,estado,condicion};
+      if(maxcartongratis!==null){
+        updateData.maxcartongratis=maxcartongratis;
+      }else{
+        updateData.maxcartongratis=firebase.firestore.FieldValue.delete();
+      }
+      await db.collection('sorteos').doc(sorteoId).update(updateData);
       const snap=await db.collection('formas').where('sorteoId','==',sorteoId).get();
       const batch=db.batch();
       snap.forEach(d=>batch.delete(db.collection('formas').doc(d.id)));

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -603,7 +603,7 @@
     const fecha=fechaInput.value;
     const hora=horaInput.value;
     const cierreVal=cierreInput.value;
-    const maxcgVal=maxcgInput.value;
+    const maxcgVal=maxcgInput.value.trim();
     const valorVal=valorInput.value;
     if(!nombre){alert('Asigna un nombre al Sorteo');nombreInput.focus();return;}
     if(!tipo){alert('Elije un tipo de sorteo');return;}
@@ -617,7 +617,15 @@
       return;
     }
     const cierre=cierreVal;
-    const maxcartongratis=parseInt(maxcgVal)||0;
+    let maxcartongratis=null;
+    if(maxcgVal!==''){
+      if(!/^\d+$/.test(maxcgVal)){
+        alert('El máximo de cartones gratis debe ser un número entero igual o mayor a 0.');
+        maxcgInput.focus();
+        return;
+      }
+      maxcartongratis=parseInt(maxcgVal,10);
+    }
     const valor=parseFloat(valorVal);
     const condicion = estado==='Archivado'?'ARCHIVADO':'VISIBLE';
     if(estado==='Archivado') estado='Inactivo';
@@ -659,7 +667,11 @@
     }
     if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
-      const sorteoRef=await db.collection('sorteos').add({nombre,tipo,fecha,hora,horacierre:cierre,maxcartongratis:maxcartongratis,cartonesgratisjugando:0,valorCarton:valor,estado,condicion});
+      const sorteoData={nombre,tipo,fecha,hora,horacierre:cierre,cartonesgratisjugando:0,valorCarton:valor,estado,condicion};
+      if(maxcartongratis!==null){
+        sorteoData.maxcartongratis=maxcartongratis;
+      }
+      const sorteoRef=await db.collection('sorteos').add(sorteoData);
       const batch=db.batch();
       formas.forEach(f=>{const ref=db.collection('formas').doc();batch.set(ref,{sorteoId:sorteoRef.id,...f});});
       await batch.commit();


### PR DESCRIPTION
## Summary
- treat an empty "max free cards" field as unlimited when creating a draw and validate non-negative integer inputs
- apply the same validation when editing draws and remove the stored limit when the field is cleared so players can use all free cards

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f92aa152388326816e25096e83c0b2