### PR TITLE
Fix free card usage and admin back navigation

### DIFF
--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -203,11 +203,13 @@
   import { UPLOAD_ENDPOINT } from './js/config.js';
   ensureAuth('Administrador');
   function volverConFallback(){
-    if(window.history.length>1){
-      window.history.back();
+    const fallbackUrl='gestionsorteos.html';
+    const ref=document.referrer||'';
+    if(ref && ref.startsWith(window.location.origin)){
+      window.location.href=ref;
       return;
     }
-    window.location.href='gestionsorteos.html';
+    window.location.href=fallbackUrl;
   }
   const LOGO_URL='https://i.imgur.com/twjhNtZ.png';
   const preloadLogo=new Image();

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -1248,7 +1248,7 @@ function toggleForma(idx){
         if(!Number.isFinite(creditosActual) || !Number.isFinite(gratisActual)){
           throw new Error('BILLETERA_DATOS_INVALIDOS');
         }
-        let gratisUsadosTx=0;
+        let gratisUsadosTx=gratisUsadosJugador;
         let tipoCarton='pagado';
         let creditosRestantes=creditosActual;
         let gratisRestantes=gratisActual;
@@ -1257,17 +1257,6 @@ function toggleForma(idx){
             throw new Error('SIN_GRATIS');
           }
           if(maxGratisActual>0){
-            const jugadorGratisQuery=db.collection('CartonJugado')
-              .where('sorteoId','==',currentSorteo)
-              .where('userId','==',user.uid);
-            const jugadorGratisSnap=await tx.get(jugadorGratisQuery);
-            gratisUsadosTx=0;
-            jugadorGratisSnap.forEach(doc=>{
-              const dataDoc=doc.data()||{};
-              if((dataDoc.tipocarton||'').toString().toLowerCase()==='gratis'){
-                gratisUsadosTx++;
-              }
-            });
             if(gratisUsadosTx>=maxGratisActual){
               throw new Error('LIMITE_GRATIS');
             }

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -203,11 +203,13 @@
   import { UPLOAD_ENDPOINT } from './js/config.js';
   ensureAuth('Administrador');
   function volverConFallback(){
-    if(window.history.length>1){
-      window.history.back();
+    const fallbackUrl='gestionsorteos.html';
+    const ref=document.referrer||'';
+    if(ref && ref.startsWith(window.location.origin)){
+      window.location.href=ref;
       return;
     }
-    window.location.href='gestionsorteos.html';
+    window.location.href=fallbackUrl;
   }
   const LOGO_URL='https://i.imgur.com/twjhNtZ.png';
   const preloadLogo=new Image();


### PR DESCRIPTION
## Summary
- avoid transaction queries when validating free card usage to keep the limit check working
- adjust the back buttons in the sorteo creation and edit pages to fall back to the management list

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f93f2e2a888326bb7f086652b714c5