### PR TITLE
Fix PDF reopening and access flows

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -1753,6 +1753,12 @@
     hora: null,
     horaCierre: null
   };
+
+  function obtenerEstadoActualNormalizado(){
+    return (currentSorteoData && currentSorteoData.estado)
+      ? currentSorteoData.estado.toString().trim().toLowerCase()
+      : '';
+  }
   const clasesEstadoTiempo = [
     'estado-tiempo-futuro',
     'estado-tiempo-proximo',
@@ -4307,7 +4313,7 @@
 
   function actualizarAnimacionFilaProgramada(){
     if(!filaProgramada) return;
-    const estadoActual = (currentSorteoData && currentSorteoData.estado) ? currentSorteoData.estado.toString().toLowerCase() : '';
+    const estadoActual = obtenerEstadoActualNormalizado();
     const estaJugando = estadoActual === 'jugando';
     const fechaEnAzul = fechaProgramadaEl && fechaProgramadaEl.classList.contains('estado-tiempo-actual');
     const horaEnAzul = horaProgramadaEl && horaProgramadaEl.classList.contains('estado-tiempo-actual');
@@ -4324,7 +4330,7 @@
 
   function actualizarColoresFechas(ahoraParam){
     const ahora = (ahoraParam instanceof Date && !isNaN(ahoraParam.getTime())) ? ahoraParam : (getServerNow() || new Date());
-    const esFinalizado = currentSorteoData && (currentSorteoData.estado || '').toString().toLowerCase() === 'finalizado';
+    const esFinalizado = obtenerEstadoActualNormalizado() === 'finalizado';
     [fechaProgramadaEl, horaProgramadaEl, fechaCierreEl, horaCierreEl].forEach(elemento=>{
       if(elemento){
         elemento.classList.toggle('estado-tiempo-finalizado', Boolean(esFinalizado));
@@ -4412,7 +4418,7 @@
     [sellarBtn, pdfBtn, jugarBtn, finalizarBtn].forEach(btn=>btn.classList.remove('attention'));
     actualizarBotones();
     if(!currentSorteoData) return;
-    const estadoLower = (currentSorteoData.estado || '').toString().toLowerCase();
+    const estadoLower = obtenerEstadoActualNormalizado();
     const pdfEstado = (currentSorteoData.pdf || '').toString().toLowerCase();
     if(estadoLower === 'activo'){
       sellarBtn.classList.add('attention');
@@ -4447,7 +4453,7 @@
       finalizarBtn.classList.remove('pdf-disponible');
       return;
     }
-    const estado = (currentSorteoData.estado || '').toLowerCase();
+    const estado = obtenerEstadoActualNormalizado();
     const pdfEstado = (currentSorteoData.pdf || '').toString().toLowerCase();
     const pdfResultadoEstado = (currentSorteoData.pdfresul || '').toString().toLowerCase();
 
@@ -5003,7 +5009,7 @@
       return;
     }
 
-    const estadoActual = (currentSorteoData.estado || '').toString().toLowerCase();
+    const estadoActual = obtenerEstadoActualNormalizado();
     if(estadoActual === 'sellado'){ alert('El sorteo ya está sellado.'); return; }
     if(estadoActual === 'jugando' || estadoActual === 'finalizado'){
       alert('El sorteo ya se encuentra en una fase posterior.');
@@ -5177,7 +5183,7 @@
   async function abrirPDF(){
     if(!currentSorteoId || !currentSorteoData){ alert('Selecciona un sorteo primero.'); return; }
 
-    const estadoActual = (currentSorteoData.estado || '').toString().toLowerCase();
+    const estadoActual = obtenerEstadoActualNormalizado();
     if(estadoActual === 'finalizado'){
       let estadoPdfResultado = (currentSorteoData.pdfresul || '').toString().trim().toLowerCase();
       if(estadoPdfResultado !== 'si'){
@@ -5325,7 +5331,7 @@
       return;
     }
 
-    const estadoActual = (currentSorteoData.estado || '').toString().toLowerCase();
+    const estadoActual = obtenerEstadoActualNormalizado();
     if(estadoActual === 'jugando'){ alert('El sorteo ya está en estado Jugando.'); return; }
     if(estadoActual === 'finalizado'){ alert('El sorteo ya finalizó.'); return; }
     if(estadoActual !== 'sellado'){
@@ -5414,7 +5420,7 @@
       return;
     }
 
-    const estadoActual = (currentSorteoData.estado || '').toString().toLowerCase();
+    const estadoActual = obtenerEstadoActualNormalizado();
     if(estadoActual === 'finalizado'){
       let estadoPdfResultado = (currentSorteoData.pdfresul || '').toString().trim().toLowerCase();
       if(estadoPdfResultado !== 'si'){

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -785,14 +785,30 @@
       togglePagos.addEventListener('change', ()=>{ contenidoPagos.style.display = togglePagos.checked ? 'block' : 'none'; });
       contenidoPagos.style.display = 'none';
 
-      document.getElementById('volver-btn').addEventListener('click', volverConFallback);
+      document.getElementById('volver-btn').addEventListener('click', e=>volverConFallback(e));
     }
 
-    function volverConFallback(){
+    let intentoRetornoActivo = false;
+
+    function volverConFallback(event){
+      if(event){ event.preventDefault(); }
+      if(intentoRetornoActivo){
+        intentoRetornoActivo = false;
+        window.location.href = 'cantarsorteos.html';
+        return;
+      }
       if(window.history.length > 1){
+        intentoRetornoActivo = true;
+        setTimeout(()=>{
+          if(intentoRetornoActivo){
+            intentoRetornoActivo = false;
+            window.location.href = 'cantarsorteos.html';
+          }
+        }, 600);
         window.history.back();
         return;
       }
+      intentoRetornoActivo = false;
       const role = (window.currentRole)||'';
       if(role === 'Administrador'){ window.location.href = 'admin.html'; }
       else if(role === 'Superadmin'){ window.location.href = 'super.html'; }

--- a/public/parametros.html
+++ b/public/parametros.html
@@ -129,6 +129,67 @@
       margin-left: 4px;
       font-weight: bold;
     }
+    #password-modal {
+      position: fixed;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.55);
+      z-index: 1000;
+      padding: 20px;
+    }
+    #password-modal.visible {
+      display: flex;
+    }
+    #password-modal .modal-box {
+      background: #fff;
+      padding: 20px;
+      border-radius: 12px;
+      max-width: 320px;
+      width: 100%;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+      font-family: Calibri, Arial, sans-serif;
+      text-align: left;
+    }
+    #password-modal h3 {
+      margin-top: 0;
+      text-align: center;
+      font-family: 'Bangers', cursive;
+      letter-spacing: 1px;
+    }
+    #password-modal input[type="password"] {
+      width: 100%;
+      padding: 8px;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      box-sizing: border-box;
+      margin-top: 10px;
+    }
+    #password-modal .modal-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 10px;
+      margin-top: 15px;
+    }
+    #password-modal button {
+      font-family: Calibri, Arial, sans-serif;
+      padding: 6px 14px;
+      border-radius: 6px;
+      border: none;
+      cursor: pointer;
+      background: rgba(0, 170, 255, 0.8);
+      color: #fff;
+    }
+    #password-modal button#password-cancel {
+      background: #888;
+    }
+    #password-error {
+      display: none;
+      color: #c62828;
+      margin-top: 10px;
+      font-size: 0.85rem;
+    }
   </style>
 </head>
 <body>
@@ -136,6 +197,18 @@
   <div id="session-info" style="display:none;">
     <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
+  </div>
+  <div id="password-modal" aria-hidden="true">
+    <div class="modal-box" role="dialog" aria-modal="true" aria-labelledby="password-modal-title">
+      <h3 id="password-modal-title">Confirmar acceso</h3>
+      <p>Ingresa la contraseña de Superadmin para continuar.</p>
+      <input type="password" id="password-input" autocomplete="current-password" placeholder="Contraseña" />
+      <div id="password-error" role="alert"></div>
+      <div class="modal-actions">
+        <button type="button" id="password-cancel">Cancelar</button>
+        <button type="button" id="password-submit">Ingresar</button>
+      </div>
+    </div>
   </div>
   <h2 style="margin-top:20px;">Parámetros Globales</h2>
   <div id="parametros-form">
@@ -226,24 +299,90 @@
       }
     }
 
-    async function solicitarPassword(){
-      const pwd = await prompt('Ingresa tu contraseña');
-      if(!pwd){ window.location.href='super.html'; return; }
-      try{
-        const doc = await db.collection('Variablesglobales').doc('Parametros').get();
-        if(doc.exists && doc.data().contrasenasu === pwd){
-          cargarFormulario(doc.data());
-          document.getElementById('parametros-form').style.display = 'flex';
-          document.getElementById('session-info').style.display = 'flex';
-        }else{
-          alert('Contraseña incorrecta');
-          window.location.href='super.html';
-        }
-      }catch(e){
-        console.error(e);
-        alert('Error al verificar contraseña');
-        window.location.href='super.html';
+    function solicitarPassword(expectedPassword){
+      const modal = document.getElementById('password-modal');
+      const input = document.getElementById('password-input');
+      const cancelarBtn = document.getElementById('password-cancel');
+      const ingresarBtn = document.getElementById('password-submit');
+      const errorEl = document.getElementById('password-error');
+      const esperado = (expectedPassword || '').toString();
+      if(!modal || !input || !cancelarBtn || !ingresarBtn){
+        return Promise.resolve(false);
       }
+
+      return new Promise(resolve=>{
+        const mostrarError = mensaje => {
+          if(errorEl){
+            errorEl.textContent = mensaje;
+            errorEl.style.display = 'block';
+          }else{
+            alert(mensaje);
+          }
+        };
+
+        const limpiar = ()=>{
+          modal.classList.remove('visible');
+          modal.setAttribute('aria-hidden', 'true');
+          input.value = '';
+          if(errorEl){
+            errorEl.textContent = '';
+            errorEl.style.display = 'none';
+          }
+          ingresarBtn.removeEventListener('click', manejarSubmit);
+          cancelarBtn.removeEventListener('click', manejarCancelar);
+          input.removeEventListener('keydown', manejarKeydown);
+          modal.removeEventListener('click', manejarBackdrop);
+        };
+
+        const manejarSubmit = evento => {
+          evento.preventDefault();
+          const valor = input.value.trim();
+          if(!valor){
+            mostrarError('Ingresa la contraseña.');
+            input.focus();
+            return;
+          }
+          if(valor !== esperado){
+            mostrarError('Contraseña incorrecta.');
+            input.select();
+            return;
+          }
+          limpiar();
+          resolve(true);
+        };
+
+        const manejarCancelar = evento => {
+          evento.preventDefault();
+          limpiar();
+          resolve(false);
+        };
+
+        const manejarKeydown = evento => {
+          if(evento.key === 'Enter'){
+            manejarSubmit(evento);
+          }else if(evento.key === 'Escape'){
+            manejarCancelar(evento);
+          }
+        };
+
+        const manejarBackdrop = evento => {
+          if(evento.target === modal){
+            manejarCancelar(evento);
+          }
+        };
+
+        modal.classList.add('visible');
+        modal.setAttribute('aria-hidden', 'false');
+        if(errorEl){
+          errorEl.textContent = '';
+          errorEl.style.display = 'none';
+        }
+        ingresarBtn.addEventListener('click', manejarSubmit);
+        cancelarBtn.addEventListener('click', manejarCancelar);
+        input.addEventListener('keydown', manejarKeydown);
+        modal.addEventListener('click', manejarBackdrop);
+        setTimeout(()=>input.focus({ preventScroll: true }), 50);
+      });
     }
     function cargarFormulario(data){
       document.getElementById('aplicacion').value = data.Aplicacion || '';
@@ -296,7 +435,39 @@
         if(logout){logout.addEventListener('click',e=>{e.preventDefault();logout();});}
       }
     });
-    (async()=>{ await cargarPaises(); await solicitarPassword(); })();
+    async function iniciarParametros(){
+      await cargarPaises();
+      let datosParametros = null;
+      try{
+        const doc = await db.collection('Variablesglobales').doc('Parametros').get();
+        if(!doc.exists){
+          alert('No se encontraron parámetros configurados.');
+          window.location.href='super.html';
+          return;
+        }
+        datosParametros = doc.data() || {};
+      }catch(error){
+        console.error('Error al obtener parámetros', error);
+        alert('No fue posible obtener los parámetros.');
+        window.location.href='super.html';
+        return;
+      }
+
+      const contrasenaEsperada = (datosParametros.contrasenasu || '').toString().trim();
+      if(contrasenaEsperada){
+        const accesoPermitido = await solicitarPassword(contrasenaEsperada);
+        if(!accesoPermitido){
+          window.location.href='super.html';
+          return;
+        }
+      }
+
+      cargarFormulario(datosParametros);
+      document.getElementById('parametros-form').style.display = 'flex';
+      document.getElementById('session-info').style.display = 'flex';
+    }
+
+    iniciarParametros();
   </script>
   <script src="js/backNavigation.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- normaliza las comprobaciones de estado en cantarsorteos para reabrir el PDF de resultados cuando la descarga sigue pendiente
- corrige el botón Volver del Centro de Pagos para que retorne confiablemente a la pantalla principal
- agrega un modal de contraseña para validar el acceso a Parámetros antes de mostrar el formulario

## Testing
- not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f98ad134a8832684f90133638ac7a1