### PR TITLE
Garantizar inicialización de Firebase antes de suscripciones de Centro de Pagos

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -2142,9 +2142,20 @@
       });
     });
 
-    configurarFiltros();
-    configurarBotones();
-    suscribirColecciones();
+    async function iniciarCentroPagos(){
+      configurarFiltros();
+      configurarBotones();
+      try {
+        await ensureFirebaseListo();
+      } catch (err) {
+        console.error('No se pudo inicializar Firebase para Centro de Pagos', err);
+        alert('No fue posible inicializar la conexión con la base de datos. Intenta recargar la página.');
+        return;
+      }
+      suscribirColecciones();
+    }
+
+    iniciarCentroPagos();
   </script>
   <script src="js/backNavigation.js"></script>
 </body>


### PR DESCRIPTION
## Resumen
- espera a que la inicialización de Firebase concluya antes de suscribirse a las colecciones de pagos y premios
- añade manejo de errores para informar cuando no sea posible conectar con la base de datos

## Pruebas
- no se ejecutaron pruebas (no aplicable)


------
https://chatgpt.com/codex/tasks/task_e_68fa7efdc6708326b5c94c0ad4a858e1