### PR TITLE
Optimiza portada del PDF de resultados y anima acceso a pagos

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -441,6 +441,9 @@
       border-color: #ffcc80;
       box-shadow: 0 6px 14px rgba(255, 152, 0, 0.32);
     }
+    #centro-pagos-btn.animacion-pagos {
+      animation: zoomPulse 1.9s ease-in-out infinite;
+    }
     .estado-btn img,
     .estado-btn svg { width: 24px; height: 24px; }
     .estado-btn .pdf-floating-icon {
@@ -4477,6 +4480,9 @@
       if(resultadoBtn){
         resultadoBtn.classList.remove('pdf-disponible');
       }
+      if(centroPagosBtn){
+        centroPagosBtn.classList.remove('animacion-pagos');
+      }
       forzarVisibilidadResultado(false);
       return;
     }
@@ -4497,6 +4503,10 @@
     pdfBtn.classList.toggle('pdf-disponible', pdfEstado === 'si');
     if(resultadoBtn){
       resultadoBtn.classList.toggle('pdf-disponible', pdfResultadoEstado === 'si');
+    }
+    if(centroPagosBtn){
+      const animarPagos = pdfResultadoEstado === 'si';
+      centroPagosBtn.classList.toggle('animacion-pagos', animarPagos);
     }
     forzarVisibilidadResultado(esFinalizado);
   }
@@ -4540,6 +4550,9 @@
       if(resultadoBtn){
         resultadoBtn.classList.remove('pdf-disponible');
       }
+      if(centroPagosBtn){
+        centroPagosBtn.classList.remove('animacion-pagos');
+      }
       forzarVisibilidadResultado(false);
       actualizarAnimaciones();
       aplicarDatosCantos([]);
@@ -4552,6 +4565,10 @@
     const data = currentSorteoData;
     sincronizarFormasBase(data.formas || []);
     btnSorteo.textContent = data.nombre || 'Sorteo';
+    if(centroPagosBtn){
+      const animarPagos = (data.pdfresul || '').toString().trim().toLowerCase() === 'si';
+      centroPagosBtn.classList.toggle('animacion-pagos', animarPagos);
+    }
     btnSorteo.classList.remove('diario','especial','jugando','finalizado');
     const estadoActual = data.estado || '';
     const tipoActual = (data.tipo || '').toLowerCase();

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -209,6 +209,7 @@
     }
     body.pdf-captura #first-page-grid {
       grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+      gap: var(--pdf-gap);
     }
     .first-page-section {
       display: flex;
@@ -222,7 +223,8 @@
       min-height: 0;
     }
     body.pdf-captura .first-page-section {
-      padding: clamp(18px, 2.2vw, 26px);
+      padding: var(--pdf-section-padding);
+      gap: var(--pdf-gap);
       box-shadow: none;
       border: 1px solid rgba(11,83,148,0.12);
       background: rgba(255,255,255,0.98);
@@ -1029,12 +1031,15 @@
       justify-content: flex-start;
       width: 100%;
       margin: 0;
-      padding: clamp(12px, 2vw, 20px);
+      padding: clamp(6px, 1.4vw, 12px);
       background: #ffffff;
+      --pdf-gap: clamp(6px, 0.9vw, 12px);
+      --pdf-section-padding: clamp(8px, 1.1vw, 14px);
+      --pdf-bloque-padding: clamp(6px, 0.9vw, 10px);
       --pdf-columnas: 6;
-      --formas-min-width: 280px;
-      --formas-scale: 1;
-      --formas-mini-max: clamp(150px, 30vw, 220px);
+      --formas-min-width: 240px;
+      --formas-scale: 0.96;
+      --formas-mini-max: clamp(140px, 26vw, 200px);
     }
     body.pdf-captura #salir-btn,
     body.pdf-captura #acciones-fixed {
@@ -1043,26 +1048,27 @@
     body.pdf-captura #pdf-wrapper {
       max-width: 1440px;
       width: min(1440px, 100%);
-      padding: clamp(14px, 2.2vw, 24px) clamp(16px, 2.6vw, 28px);
+      padding: clamp(8px, 1.4vw, 14px);
       box-sizing: border-box;
+      gap: var(--pdf-gap);
     }
     body.pdf-captura #first-page-layout {
       width: 100%;
     }
     body.pdf-captura #resumen-layout {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      column-gap: clamp(16px, 2.4vw, 24px);
-      row-gap: clamp(12px, 2vw, 22px);
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      column-gap: var(--pdf-gap);
+      row-gap: var(--pdf-gap);
       width: 100%;
       max-width: none;
-      min-height: clamp(520px, 48vw, 640px);
+      min-height: clamp(380px, 36vw, 520px);
       margin: 0 auto;
       align-content: stretch;
       grid-auto-flow: dense;
     }
     body.pdf-captura #resumen-layout > .resumen-bloque {
-      padding: clamp(20px, 2.8vw, 28px);
+      padding: var(--pdf-bloque-padding);
       box-shadow: none;
       border-width: 0.7px;
       border-color: rgba(11,83,148,0.28);
@@ -1077,7 +1083,10 @@
       grid-column: 1 / -1;
       align-items: center;
       flex-wrap: nowrap;
-      gap: clamp(12px, 2.2vw, 22px);
+      gap: var(--pdf-gap);
+    }
+    body.pdf-captura #logo {
+      width: clamp(86px, 12vw, 108px);
     }
     body.pdf-captura #resumen-header .header-info {
       align-items: flex-start;
@@ -1089,48 +1098,60 @@
       justify-content: flex-start;
       text-align: left;
       align-items: center;
-      gap: clamp(10px, 2vw, 18px);
+      gap: var(--pdf-gap);
+      padding: var(--pdf-bloque-padding);
     }
     body.pdf-captura .totales-header h2 {
       margin-bottom: 0;
-      font-size: clamp(2.2rem, 4.6vw, 3rem);
+      font-size: clamp(1.9rem, 4vw, 2.6rem);
     }
     body.pdf-captura #total-premios {
-      font-size: clamp(2.4rem, 5.2vw, 3.2rem);
+      font-size: clamp(2.1rem, 4.6vw, 3rem);
     }
     body.pdf-captura .dato-inline {
-      font-size: clamp(1.05rem, 1.6vw, 1.25rem);
-      padding: clamp(7px, 1.2vw, 14px);
+      font-size: clamp(1.02rem, 1.5vw, 1.2rem);
+      padding: var(--pdf-bloque-padding);
       box-shadow: none;
       border: 0.6px solid rgba(11,83,148,0.32);
+      gap: clamp(4px, 0.9vw, 10px);
     }
     body.pdf-captura .dato-inline .dato-label,
     body.pdf-captura .dato-inline .dato-valor {
-      font-size: clamp(1.05rem, 1.6vw, 1.25rem);
+      font-size: clamp(1.02rem, 1.5vw, 1.2rem);
+    }
+    body.pdf-captura #formas-resumen {
+      --formas-col-min: var(--formas-min-width);
+      grid-auto-rows: minmax(0, 1fr);
+      gap: var(--pdf-gap);
+      align-content: stretch;
     }
     body.pdf-captura #formas-resumen .forma-item {
       width: 100%;
       min-height: 100%;
       border-width: 0.7px;
       border-color: rgba(11,83,148,0.28);
+      grid-template-columns: minmax(0, 1fr) minmax(0, var(--formas-mini-max));
     }
     body.pdf-captura .forma-resumen {
-      padding: clamp(14px, 1.8vw, 20px);
+      padding: clamp(8px, 1vw, 12px);
       border-right-width: 0.6px;
+      gap: clamp(4px, 0.8vw, 9px);
     }
     body.pdf-captura .forma-titulo {
-      font-size: clamp(1.18rem, 2vw, 1.35rem);
+      font-size: clamp(1.08rem, 1.9vw, 1.28rem);
     }
     body.pdf-captura .forma-detalle {
-      font-size: clamp(1rem, 1.7vw, 1.18rem);
+      font-size: clamp(0.95rem, 1.6vw, 1.12rem);
+      padding: clamp(4px, 0.6vw, 8px) clamp(6px, 0.8vw, 10px);
+      gap: clamp(3px, 0.7vw, 8px) clamp(4px, 0.8vw, 10px);
     }
     body.pdf-captura .forma-detalle .valor {
-      font-size: clamp(1.02rem, 1.8vw, 1.22rem);
+      font-size: clamp(0.98rem, 1.6vw, 1.16rem);
     }
     body.pdf-captura .forma-mini-carton-wrapper {
-      padding: clamp(8px, 1.4vw, 14px);
+      padding: clamp(4px, 0.8vw, 10px);
       border-left-width: 0.6px;
-      min-height: clamp(160px, 34vw, 230px);
+      min-height: clamp(130px, 24vw, 190px);
       max-width: var(--formas-mini-max);
     }
     body.pdf-captura #cartones-section {
@@ -1174,7 +1195,8 @@
       font-size: 1.06em;
     }
     body.pdf-captura .forma-mini-carton {
-      font-size: calc(0.92rem * var(--formas-scale));
+      font-size: calc(0.88rem * var(--formas-scale));
+      width: min(100%, var(--formas-mini-max));
     }
     body.pdf-captura .forma-mini-carton th,
     body.pdf-captura .forma-mini-carton td {
@@ -2677,23 +2699,28 @@
     const prevScale = document.body.style.getPropertyValue('--formas-scale');
     const prevMiniMax = document.body.style.getPropertyValue('--formas-mini-max');
 
-    let minWidth = 280;
-    let escala = 1;
-    let miniMax = 220;
+    let minWidth = 240;
+    let escala = 0.96;
+    let miniMax = 200;
     if(total >= 5){
-      minWidth = 250;
-      escala = 0.94;
-      miniMax = 205;
+      minWidth = 220;
+      escala = 0.9;
+      miniMax = 185;
     }
     if(total >= 8){
-      minWidth = 220;
-      escala = 0.88;
-      miniMax = 190;
+      minWidth = 200;
+      escala = 0.86;
+      miniMax = 170;
     }
     if(total >= 12){
-      minWidth = 200;
-      escala = 0.84;
-      miniMax = 175;
+      minWidth = 185;
+      escala = 0.82;
+      miniMax = 160;
+    }
+    if(total >= 16){
+      minWidth = 170;
+      escala = 0.78;
+      miniMax = 150;
     }
     document.body.style.setProperty('--formas-min-width', `${minWidth}px`);
     document.body.style.setProperty('--formas-scale', escala.toFixed(3));


### PR DESCRIPTION
## Resumen
- compactar márgenes y distribuir de forma dinámica los bloques de la primera página del PDF de resultados
- ajustar la escala automática de las formas premiadas para conservar las miniaturas en la captura PDF
- activar una animación de zoom en el botón del centro de pagos cuando el PDF de resultados fue confirmado

## Pruebas
- No se realizaron pruebas automatizadas; se requiere verificación manual

------
https://chatgpt.com/codex/tasks/task_e_68fb8a4392d4832684f55a5ff0de0d52