### PR TITLE
Filtrar premios de gestión de retiros y arreglar botón Volver

### DIFF
--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -171,15 +171,17 @@
     let unsubscribeTransacciones = null;
 
     function volverConFallback(){
+      const role=(window.currentRole||'').trim();
+      if(role && typeof redirectByRole==='function'){
+        redirectByRole(role);
+        return;
+      }
       if(window.history.length>1){
         window.history.back();
         return;
       }
-      const role=(window.currentRole)||'';
-      if(role==='Administrador'){
-        window.location.href='admin.html';
-      }else if(role==='Superadmin'){
-        window.location.href='super.html';
+      if(typeof redirectByRole==='function'){
+        redirectByRole('Colaborador');
       }else{
         window.location.href='collab.html';
       }
@@ -302,8 +304,9 @@
       snap.forEach(d=>{
         const dt={id:d.id,...d.data()};
         dt.Condicion = dt.Condicion || (dt.estado==='ARCHIVADO'?'ARCHIVADA':'VISIBLE');
-        if(dt.tipotrans==='deposito') datosRec.push(dt);
-        else datosRet.push(dt);
+        const tipo=(dt.tipotrans||'').toLowerCase();
+        if(tipo==='deposito') datosRec.push(dt);
+        else if(tipo==='retiro') datosRet.push(dt);
       });
       datosRec.sort(sortTrans);
       datosRet.sort(sortTrans);


### PR DESCRIPTION
## Summary
- redirigir el botón Volver de la vista de transacciones al menú correspondiente según el rol del usuario
- excluir las transacciones ajenas a depósitos y retiros de la tabla de gestión para evitar mostrar premios generados automáticamente

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbb96af0fc832699a4c2c6c76726c2