### PR TITLE
Ensure Firebase initialization before loading parameters

### DIFF
--- a/public/parametros.html
+++ b/public/parametros.html
@@ -459,6 +459,15 @@
       }
     });
     async function iniciarParametros(){
+      try{
+        await initFirebase();
+      }catch(error){
+        console.error('No se pudo inicializar Firebase antes de cargar parámetros', error);
+        alert('No se pudo preparar la conexión con los datos de parámetros. Intenta nuevamente más tarde.');
+        window.location.href='super.html';
+        return;
+      }
+
       await cargarPaises();
       let datosParametros = null;
       try{


### PR DESCRIPTION
## Summary
- ensure the parameters page waits for Firebase initialization before loading data
- show an informative alert and redirect if Firebase cannot be initialized

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fbc8171c8883268ced43c9e195ae30