### PR TITLE
Esperar autenticación antes de cargar parámetros globales

### DIFF
--- a/public/parametros.html
+++ b/public/parametros.html
@@ -501,7 +501,29 @@
       document.getElementById('session-info').style.display = 'flex';
     }
 
-    iniciarParametros();
+    let parametrosYaInicializados=false;
+    function iniciarCuandoAuthEsteLista(){
+      initFirebase()
+        .then(()=>{
+          auth.onAuthStateChanged(async usuario=>{
+            if(!usuario || parametrosYaInicializados) return;
+            try{
+              await iniciarParametros();
+              parametrosYaInicializados=true;
+            }catch(err){
+              parametrosYaInicializados=false;
+              console.error('Fallo al cargar parámetros tras autenticar',err);
+            }
+          });
+        })
+        .catch(error=>{
+          console.error('No se pudo esperar a la autenticación para cargar parámetros',error);
+          alert('No fue posible preparar la autenticación. Intenta nuevamente desde el menú Superadmin.');
+          window.location.href='super.html';
+        });
+    }
+
+    iniciarCuandoAuthEsteLista();
   </script>
   <script src="js/backNavigation.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- espera a que Firebase confirme la sesión antes de iniciar la carga de parámetros
- registra un mensaje y alerta si falla la preparación de autenticación para evitar que la pantalla quede en blanco

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fbd28a5c80832699c24875afae3998