### PR TITLE
Align resultados PDF and collaborator payout flows

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -366,6 +366,7 @@
                 <option value="deposito">DEPOSITO</option>
                 <option value="retiro">RETIRO</option>
                 <option value="premio">PREMIO</option>
+                <option value="pago" id="filtro-tipo-pago">PAGO</option>
               </select>
             </th>
             <th><input id="filtro-monto" type="number" placeholder="MONTO"></th>
@@ -443,6 +444,16 @@
     initFirebase().then(() => {
       auth.onAuthStateChanged(async user => {
         if(!user) return;
+        const filtroTipoSelect = document.getElementById('filtro-tipo');
+        const opcionPago = document.getElementById('filtro-tipo-pago');
+        if(opcionPago && filtroTipoSelect){
+          const rolActual = (window.currentRole || '').toLowerCase();
+          const visible = rolActual === 'colaborador';
+          opcionPago.hidden = !visible;
+          if(!visible && filtroTipoSelect.value === 'pago'){
+            filtroTipoSelect.value = '';
+          }
+        }
         cargarBancosBilletera();
         cargarBancosBingo();
         const paramDoc = await db.collection('Variablesglobales').doc('Parametros').get();
@@ -586,9 +597,11 @@
         const esDeposito=tipoTrans==='deposito';
         const esRetiro=tipoTrans==='retiro';
         const esPremio=tipoTrans==='premio';
+        const esPago=tipoTrans==='pago';
+        const esResaltado=esPremio||esPago;
         const colorTipo=esDeposito?'green':esRetiro?'red':'#1b5e20';
-        const montoStyle=esPremio?`background:#1b5e20;color:#fff;`:`color:${colorTipo};`;
-        const fechaStyle=esPremio?`color:#1b5e20;`:'';
+        const montoStyle=esResaltado?`background:#1b5e20;color:#fff;`:`color:${colorTipo};`;
+        const fechaStyle=esResaltado?`color:#1b5e20;`:'';
         tr.innerHTML=`<td>${n}</td><td style="color:${colorTipo}">${tipoTrans.toUpperCase()}</td><td class="celda-monto" style="${montoStyle}">${montoFmt}</td><td class="celda-fecha" style="${fechaStyle}">${f}</td><td style="color:${estadoColor}">${t.estado}</td>`;
         const fechaTd=tr.querySelector('.celda-fecha');
         fechaTd.style.cursor='pointer';
@@ -611,8 +624,9 @@
         const fg=formatearFecha(t.fechagestion||'');
         const hg=formatearHora(t.horagestion||'');
         const cont=document.querySelector('#modal-detalle .contenido');
-        if(t.tipotrans==='premio'){
-          cont.innerHTML=`<div style="color:#1b5e20;font-weight:bold;">Referencia: PREMIO</div>`+
+        if(t.tipotrans==='premio' || t.tipotrans==='pago'){
+          const etiqueta=t.tipotrans==='pago'?'PAGO':'PREMIO';
+          cont.innerHTML=`<div style="color:#1b5e20;font-weight:bold;">Referencia: ${etiqueta}</div>`+
           `<div style="color:green;">Fecha de gestión: ${fg}</div>`+
           `<div style="color:green;">Hora de gestión: ${hg}</div>`+
           `<button id="modal-ok">Aceptar</button>`;
@@ -635,7 +649,7 @@
         const comG=t.tipotrans==='retiro'?solicitado*porcentajeAdministra/100:0;
         const total=parseFloat(t.Monto);
         const cont=document.querySelector('#modal-detalle .contenido');
-        if(t.tipotrans==='premio'){
+        if(t.tipotrans==='premio' || t.tipotrans==='pago'){
           cont.innerHTML=
             `<div style="font-weight:bold;color:#1b5e20;">Total recibido: ${total.toFixed(2)}</div>`+
             `<button id='modal-ok'>Aceptar</button>`;

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -133,6 +133,15 @@
     #tabla-colaboradores .colab-input:disabled {
       color: inherit;
     }
+    #tabla-colaboradores td.creditos-actuales {
+      font-family: Calibri, Arial, sans-serif;
+      font-weight: 700;
+      color: #0d47a1;
+      text-align: right;
+    }
+    #tabla-colaboradores td.colab-asignar {
+      background: rgba(255,255,255,0.7);
+    }
     .switch { position: relative; display: inline-block; width: 42px; height: 24px; }
     .switch input { display: none; }
     .slider {
@@ -281,6 +290,13 @@
       cursor: pointer;
       font-size: 1rem;
     }
+    .th-asignados {
+      font-family: Calibri, Arial, sans-serif;
+      font-size: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+    }
     .estado-pendiente { color: orange; }
     .estado-aprobado { color: green; }
     .estado-archivado { color: brown; }
@@ -305,12 +321,39 @@
     .gmail-cell .gmail-full {
       display: inline;
     }
-    .estado-rol {
-      display: inline-block;
-      padding: 2px 4px;
-      background: rgba(0,0,0,0.1);
-      border-radius: 4px;
-      font-weight: 600;
+    .rol-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 3px 8px;
+      border-radius: 999px;
+      font-weight: 700;
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      font-family: Calibri, Arial, sans-serif;
+      border: 1px solid transparent;
+      background: rgba(255,255,255,0.85);
+    }
+    .rol-badge--colaborador {
+      color: #1b5e20;
+      border-color: rgba(27,94,32,0.35);
+      background: rgba(27,94,32,0.12);
+    }
+    .rol-badge--administrador {
+      color: #0d47a1;
+      border-color: rgba(13,71,161,0.35);
+      background: rgba(13,71,161,0.12);
+    }
+    .rol-badge--superadmin {
+      color: #6a1b9a;
+      border-color: rgba(106,27,154,0.35);
+      background: rgba(106,27,154,0.12);
+    }
+    .rol-badge--jugador {
+      color: #f57c00;
+      border-color: rgba(245,124,0,0.35);
+      background: rgba(245,124,0,0.12);
     }
     .modal-capa {
       position: fixed;
@@ -509,9 +552,10 @@
           <col style="width:6%">
           <col style="width:22%">
           <col style="width:22%">
-          <col style="width:18%">
-          <col style="width:16%">
+          <col style="width:14%">
+          <col style="width:14%">
           <col style="width:12%">
+          <col style="width:10%">
           <col style="width:4%">
         </colgroup>
         <thead>
@@ -519,9 +563,10 @@
             <th>N°</th>
             <th><input type="text" id="filtro-colab-gmail" placeholder="Gmail"></th>
             <th><input type="text" id="filtro-colab-nombre" placeholder="Nombre"></th>
-            <th><input type="text" id="filtro-colab-creditos" placeholder="Créditos"></th>
-            <th>-</th>
-            <th>Tipo</th>
+            <th><input type="text" id="filtro-colab-creditos" placeholder="C. Actuales"></th>
+            <th class="th-asignados">C. Asignados</th>
+            <th>Fecha</th>
+            <th>Rol</th>
             <th><span id="colaboradores-marcar" class="check-header">✔</span></th>
           </tr>
         </thead>
@@ -1641,6 +1686,16 @@
       return texto.charAt(0).toUpperCase() + texto.slice(1);
     }
 
+    function construirRolBadgeHtml(tipo){
+      const texto = (tipo || '').toString().trim();
+      if(!texto) return '';
+      const base = texto.toLowerCase();
+      const clasePermitida = ['colaborador','administrador','superadmin','jugador'].includes(base)
+        ? base
+        : 'colaborador';
+      return `<span class="rol-badge rol-badge--${clasePermitida}">${escapeHtml(texto)}</span>`;
+    }
+
     function guardarInfoUsuarioCache(info = {}){
       const base = { ...info };
       if(base.email){
@@ -1746,14 +1801,16 @@
       if(!tbody) return;
       const { mostrarArchivo = false, tipo } = opciones;
       if(!lista.length){
-        tbody.innerHTML = `<tr><td colspan="${tipo==='premios'?8:7}"><div class="mensaje-tabla">No hay registros para mostrar.</div></td></tr>`;
+        const columnasTabla = tipo==='premios' ? 8 : (tipo==='colaboradores' ? 8 : 7);
+        tbody.innerHTML = `<tr><td colspan="${columnasTabla}"><div class="mensaje-tabla">No hay registros para mostrar.</div></td></tr>`;
         return;
       }
       const filas = lista.map((item, indice)=>{
       const numero = indice + 1;
       const estadoClase = item.estado === 'APROBADO' ? 'estado-aprobado' : (item.estado === 'PENDIENTE' ? 'estado-pendiente' : 'estado-archivado');
+      const rolNormalizado = normalizarTipoUsuario(item.tipo || item.estado || '');
       const estadoHtml = tipo === 'colaboradores'
-        ? `<span class="estado-rol">${escapeHtml(item.tipo || item.estado || '')}</span>`
+        ? construirRolBadgeHtml(rolNormalizado)
         : `<span class="${estadoClase}">${escapeHtml(item.estado)}</span>`;
         const disabled = mostrarArchivo ? 'disabled' : '';
         if(tipo === 'premios'){
@@ -1771,18 +1828,17 @@
         if(tipo === 'colaboradores'){
           const valorReferencia = pagosColaboradoresEdicion.has(item.id)
             ? pagosColaboradoresEdicion.get(item.id)
-            : item.creditos;
+            : '';
           const numeroValor = Number(valorReferencia);
           const valorInput = Number.isFinite(numeroValor) ? numeroValor.toFixed(2) : '';
           const archivoAttr = mostrarArchivo ? ' data-archivo="1"' : '';
-          const placeholder = Number.isFinite(Number(item.creditosActuales))
-            ? formatNumberEntero.format(Math.round(Number(item.creditosActuales)))
-            : '0';
+          const creditosActuales = Number(item.creditosActuales ?? item.creditos ?? 0);
           return `<tr data-id="${item.id}">
             <td>${numero}</td>
             <td class="gmail">${construirGmailHtml(item.gmail)}</td>
             <td class="alias">${escapeHtml(item.nombre)}</td>
-            <td><input type="number" class="colab-input" step="0.01" min="0" data-id="${item.id}" value="${valorInput}" placeholder="${escapeHtml(placeholder)}" disabled${archivoAttr}></td>
+            <td class="creditos-actuales">${formatNumber.format(creditosActuales)}</td>
+            <td class="colab-asignar"><input type="number" class="colab-input" step="0.01" min="0" data-id="${item.id}" value="${valorInput}" placeholder="0.00" disabled${archivoAttr}></td>
             <td>${escapeHtml(item.fechaMostrar || '-')}</td>
             <td class="estado">${estadoHtml}</td>
             <td><input type="checkbox" data-id="${item.id}" ${disabled}></td>
@@ -1828,7 +1884,8 @@
       return origen.filter(item=>{
         if(filtrosColaboradores.gmail && !item.gmail.toLowerCase().includes(filtrosColaboradores.gmail)) return false;
         if(filtrosColaboradores.nombre && !item.nombre.toLowerCase().includes(filtrosColaboradores.nombre)) return false;
-        if(filtrosColaboradores.creditos && !String(item.creditos ?? '').includes(filtrosColaboradores.creditos)) return false;
+        const creditosTexto = String(item.creditosActuales ?? item.creditos ?? '');
+        if(filtrosColaboradores.creditos && !creditosTexto.includes(filtrosColaboradores.creditos)) return false;
         if(filtrosColaboradores.tipo){
           const tipoActual = (item.tipo || item.estado || '').toString().toLowerCase();
           if(tipoActual !== filtrosColaboradores.tipo) return false;
@@ -1911,8 +1968,15 @@
         if(typeof fechaServidor !== 'function' || typeof horaServidor !== 'function'){
           await initServerTime();
         }
+        const tipoTransaccion = (enRegistro.tipotrans || 'premio').toString().toLowerCase();
+        const referencia = enRegistro.referencia
+          || (tipoTransaccion === 'pago' ? 'PAGO' : 'PREMIO');
+        const sorteoNombre = enRegistro.sorteoNombre
+          || (tipoTransaccion === 'pago'
+            ? 'Pago a colaborador'
+            : (enRegistro.referencia === 'ASIGNACION_MANUAL' ? 'Asignación manual' : ''));
         await dbRef().collection('transacciones').add({
-          tipotrans: 'premio',
+          tipotrans: tipoTransaccion,
           Monto: monto,
           estado: 'APROBADO',
           IDbilletera: enRegistro.billetera,
@@ -1922,9 +1986,9 @@
           horagestion: typeof horaServidor === 'function' ? horaServidor() : '',
           usuariogestor: authInstance().currentUser?.email || '',
           rolusuario: window.currentRole || '',
-          referencia: enRegistro.referencia || 'PREMIO',
+          referencia,
           sorteoId: enRegistro.sorteoId || '',
-          sorteoNombre: enRegistro.sorteoNombre || (enRegistro.referencia === 'ASIGNACION_MANUAL' ? 'Asignación manual' : '')
+          sorteoNombre
         });
       } catch (err) {
         console.error('No se pudo registrar la transacción de premio', err);
@@ -2053,10 +2117,12 @@
             billetera,
             creditos: monto,
             sorteoId: '',
-            sorteoNombre: 'Asignación manual',
-            referencia: 'ASIGNACION_MANUAL'
+            sorteoNombre: 'Pago a colaborador',
+            referencia: 'PAGO',
+            tipotrans: 'pago'
           });
           registro.creditosActuales = (Number(registro.creditosActuales) || 0) + monto;
+          registro.creditos = registro.creditosActuales;
           guardarInfoUsuarioCache({
             email: billetera,
             alias: registro.alias,

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -16,9 +16,12 @@
       font-family: 'Poppins', sans-serif;
       background: #ffffff;
       margin: 0;
-      padding: clamp(12px, 1.6vw, 18px) clamp(8px, 1.4vw, 16px);
+      padding: clamp(16px, 2.4vw, 26px) clamp(12px, 2vw, 20px);
       box-sizing: border-box;
       color: #1a1a1a;
+      --formas-scale: 1;
+      --formas-min-width: clamp(240px, 26vw, 300px);
+      --formas-mini-max: clamp(150px, 30vw, 220px);
     }
     body.modal-activa {
       overflow: hidden;
@@ -190,77 +193,51 @@
       margin: 0 auto;
       text-align: center;
       width: min(1440px, 100%);
-      padding: 0 clamp(6px, 1vw, 14px);
+      padding: 0 clamp(8px, 1.6vw, 18px);
       display: grid;
-      gap: clamp(12px, 1.6vw, 18px);
+      gap: clamp(18px, 2.4vw, 26px);
     }
     #first-page-layout {
-      width: 100%;
-    }
-    #first-page-grid {
       display: grid;
-      gap: clamp(14px, 2vw, 24px);
-      align-items: stretch;
-    }
-    @media (min-width: 900px) {
-      #first-page-grid {
-        grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
-      }
-    }
-    body.pdf-captura #first-page-grid {
-      grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
-      gap: var(--pdf-gap);
-    }
-    .first-page-section {
-      display: flex;
-      flex-direction: column;
-      gap: clamp(12px, 1.6vw, 18px);
-      background: rgba(255,255,255,0.96);
-      border-radius: 16px;
-      padding: clamp(14px, 1.6vw, 20px);
-      box-shadow: 0 6px 18px rgba(15,35,95,0.08);
-      min-width: 0;
-      min-height: 0;
-    }
-    body.pdf-captura .first-page-section {
-      padding: var(--pdf-section-padding);
-      gap: var(--pdf-gap);
-      box-shadow: none;
-      border: 1px solid rgba(11,83,148,0.12);
-      background: rgba(255,255,255,0.98);
-    }
-    .formas-header {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
+      gap: clamp(18px, 2.6vw, 28px);
+      margin: 0 auto;
+      width: 100%;
       text-align: left;
     }
-    .formas-header h2 {
+    #formas-section {
+      display: grid;
+      gap: clamp(12px, 2vw, 18px);
+    }
+    .formas-intro {
+      background: #ffffff;
+      border: 1px solid rgba(11,83,148,0.16);
+      border-radius: 14px;
+      padding: clamp(14px, 1.8vw, 22px);
+      box-shadow: 0 6px 18px rgba(15,35,95,0.08);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .formas-intro h2 {
       font-family: 'Bangers', cursive;
       font-size: clamp(1.4rem, 4vw, 1.9rem);
       color: #0b5394;
       margin: 0;
       letter-spacing: 0.6px;
     }
-    .formas-header p {
+    .formas-intro p {
       margin: 0;
       font-weight: 600;
       color: #415a77;
       font-size: clamp(0.92rem, 2.2vw, 1.02rem);
     }
     #formas-resumen {
-      --formas-col-min: clamp(240px, 26vw, 300px);
-      flex: 1 1 auto;
+      --formas-col-min: var(--formas-min-width);
       display: grid;
-      gap: clamp(12px, 1.6vw, 18px);
-      grid-template-columns: repeat(auto-fit, minmax(var(--formas-min-width, var(--formas-col-min)), 1fr));
+      gap: clamp(10px, calc(1.8vw * var(--formas-scale, 1)), 20px);
+      grid-template-columns: repeat(auto-fit, minmax(var(--formas-col-min), 1fr));
       width: 100%;
       align-content: start;
-    }
-    body.pdf-captura #formas-resumen {
-      --formas-col-min: 260px;
-      grid-template-columns: repeat(auto-fit, minmax(var(--formas-min-width, var(--formas-col-min)), 1fr));
-      gap: clamp(16px, 2vw, 20px);
     }
     .forma-slot {
       display: flex;
@@ -400,7 +377,7 @@
     }
     .forma-item {
       display: grid;
-      grid-template-columns: minmax(0, 1fr) clamp(130px, 28vw, 220px);
+      grid-template-columns: minmax(0, 1fr) minmax(0, var(--formas-mini-max));
       align-items: stretch;
       min-width: 0;
       width: 100%;
@@ -413,8 +390,8 @@
     }
     .forma-resumen {
       display: grid;
-      gap: 6px;
-      padding: 12px 14px;
+      gap: calc(6px * var(--formas-scale, 1));
+      padding: calc(12px * var(--formas-scale, 1)) calc(14px * var(--formas-scale, 1));
       position: relative;
       min-width: 0;
       text-align: left;
@@ -424,28 +401,28 @@
     }
     .forma-info {
       display: grid;
-      gap: 6px;
+      gap: calc(6px * var(--formas-scale, 1));
       text-align: left;
       align-content: start;
       min-width: 0;
     }
     .forma-titulo {
       font-family: 'Bangers', cursive;
-      font-size: 1.12rem;
+      font-size: clamp(1rem, calc(1.12rem * var(--formas-scale, 1)), 1.42rem);
       color: var(--forma-color, #0b5394);
       text-transform: uppercase;
       letter-spacing: 0.5px;
       grid-column: 1 / -1;
     }
     .forma-detalle {
-      font-size: 0.92rem;
+      font-size: clamp(0.86rem, calc(0.92rem * var(--formas-scale, 1)), 1.08rem);
       color: #0b1d0b;
       display: grid;
       grid-template-columns: auto 1fr;
-      gap: 4px 8px;
+      gap: clamp(3px, calc(0.6vw * var(--formas-scale, 1)), 8px) clamp(6px, calc(1vw * var(--formas-scale, 1)), 12px);
       align-items: center;
       background: rgba(11,83,148,0.04);
-      padding: 6px 10px;
+      padding: clamp(4px, calc(0.7vw * var(--formas-scale, 1)), 10px) clamp(6px, calc(1vw * var(--formas-scale, 1)), 14px);
       border-radius: 10px;
     }
     .forma-detalle.sin-valor {
@@ -800,20 +777,20 @@
     }
     .forma-extra-info {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-      gap: 4px 8px;
-      margin-top: 6px;
-      font-size: 0.78rem;
+      grid-template-columns: repeat(auto-fit, minmax(clamp(130px, calc(150px * var(--formas-scale, 1)), 220px), 1fr));
+      gap: clamp(4px, calc(0.9vw * var(--formas-scale, 1)), 10px) clamp(6px, calc(1.2vw * var(--formas-scale, 1)), 14px);
+      margin-top: clamp(4px, calc(0.8vw * var(--formas-scale, 1)), 10px);
+      font-size: clamp(0.72rem, calc(0.8rem * var(--formas-scale, 1)), 0.96rem);
       color: #163768;
     }
     .forma-extra-item {
       display: flex;
       flex-direction: column;
-      gap: 2px;
+      gap: clamp(2px, calc(0.5vw * var(--formas-scale, 1)), 6px);
       background: rgba(255,255,255,0.82);
       border: 1px solid rgba(11,83,148,0.18);
       border-radius: 8px;
-      padding: 6px 8px;
+      padding: clamp(6px, calc(0.9vw * var(--formas-scale, 1)), 12px) clamp(8px, calc(1.1vw * var(--formas-scale, 1)), 14px);
       box-shadow: inset 0 0 0 1px rgba(255,255,255,0.45);
     }
     .forma-extra-item.forma-extra-cartones {
@@ -822,12 +799,12 @@
     .extra-label {
       font-weight: 700;
       color: #0b5394;
-      font-size: 0.72rem;
+      font-size: clamp(0.68rem, calc(0.72rem * var(--formas-scale, 1)), 0.86rem);
       text-transform: uppercase;
       letter-spacing: 0.5px;
     }
     .extra-value {
-      font-size: 0.78rem;
+      font-size: clamp(0.72rem, calc(0.82rem * var(--formas-scale, 1)), 0.98rem);
       color: #0d2345;
       word-break: break-word;
     }
@@ -1064,17 +1041,21 @@
       border-radius: 18px;
       background: #ffffff;
       display: grid;
-    }
-    body.pdf-captura #first-page-grid {
-      display: grid;
       grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
       align-items: stretch;
       gap: var(--pdf-gap);
-      min-height: calc(var(--pdf-page-height) - var(--pdf-gap) * 2);
     }
-    body.pdf-captura .first-page-section {
+    body.pdf-captura #formas-section {
+      display: grid;
+      grid-template-rows: auto 1fr;
+      gap: var(--pdf-gap);
       min-height: 0;
-      height: 100%;
+    }
+    body.pdf-captura .formas-intro {
+      padding: var(--pdf-bloque-padding);
+      box-shadow: none;
+      border-width: 0.7px;
+      border-color: rgba(11,83,148,0.28);
     }
     body.pdf-captura #resumen-layout {
       display: grid;
@@ -1274,9 +1255,7 @@
   </div>
   <div id="pdf-wrapper">
     <div id="first-page-layout">
-      <div id="first-page-grid">
-        <section id="resumen-section" class="first-page-section">
-          <div id="resumen-layout">
+      <div id="resumen-layout">
         <div id="resumen-header" class="resumen-bloque">
           <div class="header-logo">
             <img id="logo" src="https://i.imgur.com/twjhNtZ.png" alt="Bingo Online">
@@ -1314,16 +1293,14 @@
           <h2>CRÉDITOS TOTALES A REPARTIR</h2>
           <div id="total-premios">0</div>
         </div>
-          </div>
-        </section>
-        <section id="formas-section" class="first-page-section">
-          <div class="formas-header">
-            <h2>Formas premiadas</h2>
-            <p>Cartones ganadores y distribución de premios del sorteo.</p>
-          </div>
-          <div id="formas-resumen" class="formas-grid"></div>
-        </section>
       </div>
+      <section id="formas-section">
+        <div class="formas-intro resumen-bloque">
+          <h2>Formas premiadas</h2>
+          <p>Cartones ganadores y distribución de premios del sorteo.</p>
+        </div>
+        <div id="formas-resumen" class="formas-grid" aria-label="Formas premiadas"></div>
+      </section>
     </div>
     <section id="cartones-section">
       <h2>Cartones del sorteo</h2>
@@ -2627,14 +2604,14 @@
       const totalCartonesGratis = obtenerCartonesGratisForma(forma);
       const cartonesGratisPorGanador = cantidadGanadores > 0
         ? Math.floor(totalCartonesGratis / cantidadGanadores)
-        : totalCartonesGratis;
+        : 0;
 
-      const detallePremio = crearDetalleForma('Premio total', premioTotal > 0
+      const detallePremio = crearDetalleForma('Créditos ganados', premioTotal > 0
         ? `${formatearNumero(premioTotal)}`
         : '-');
       info.appendChild(detallePremio);
 
-      const detalleGratis = crearDetalleForma('Cartones gratis totales', formatearNumero(totalCartonesGratis), { usarIconoCarton: true });
+      const detalleGratis = crearDetalleForma('Cartones gratis ganados', formatearNumero(totalCartonesGratis), { usarIconoCarton: true });
       info.appendChild(detalleGratis);
 
       const extraInfo = document.createElement('div');
@@ -2642,27 +2619,27 @@
 
       const itemGanadores = document.createElement('div');
       itemGanadores.className = 'forma-extra-item';
-      itemGanadores.innerHTML = `<span class="extra-label">Ganadores:</span><span class="extra-value">${cantidadGanadores}</span>`;
+      itemGanadores.innerHTML = `<span class="extra-label">Cantidad de ganadores</span><span class="extra-value">${cantidadGanadores}</span>`;
       extraInfo.appendChild(itemGanadores);
 
       const itemCartones = document.createElement('div');
       itemCartones.className = 'forma-extra-item forma-extra-cartones';
       if(cantidadGanadores){
         const listado = ganadores.map(carton=>formatearNumeroCarton(carton)).join(', ');
-        itemCartones.innerHTML = `<span class="extra-label">Cartones:</span><span class="extra-value">${listado}</span>`;
+        itemCartones.innerHTML = `<span class="extra-label">Cartones ganadores</span><span class="extra-value">${listado}</span>`;
       }else{
-        itemCartones.innerHTML = `<span class="extra-label">Cartones:</span><span class="extra-value sin-datos">Sin ganadores</span>`;
+        itemCartones.innerHTML = `<span class="extra-label">Cartones ganadores</span><span class="extra-value sin-datos">Sin ganadores</span>`;
       }
       extraInfo.appendChild(itemCartones);
 
       const itemPremio = document.createElement('div');
       itemPremio.className = 'forma-extra-item';
-      itemPremio.innerHTML = `<span class="extra-label">Premio por cartón:</span><span class="extra-value">${formatearNumero(premioIndividual)}</span>`;
+      itemPremio.innerHTML = `<span class="extra-label">Créditos por ganador</span><span class="extra-value">${formatearNumero(premioIndividual)}</span>`;
       extraInfo.appendChild(itemPremio);
 
       const itemGratis = document.createElement('div');
       itemGratis.className = 'forma-extra-item';
-      itemGratis.innerHTML = `<span class="extra-label">Cartones gratis por ganador:</span><span class="extra-value">${formatearNumero(cartonesGratisPorGanador)}</span>`;
+      itemGratis.innerHTML = `<span class="extra-label">Cartones gratis por ganador</span><span class="extra-value">${formatearNumero(cartonesGratisPorGanador)}</span>`;
       extraInfo.appendChild(itemGratis);
 
       info.appendChild(extraInfo);
@@ -2686,9 +2663,7 @@
     const spanEtiqueta = document.createElement('span');
     spanEtiqueta.className = 'etiqueta';
     const usarIconoCarton = Boolean(opciones && opciones.usarIconoCarton);
-    const textoEtiqueta = usarIconoCarton
-      ? 'Gratis:'
-      : `${etiqueta}:`;
+    const textoEtiqueta = `${etiqueta}:`;
     if(usarIconoCarton){
       const icono = document.createElement('img');
       icono.src = 'https://cdn-icons-png.flaticon.com/32/5065/5065890.png';


### PR DESCRIPTION
## Summary
- align the resultados PDF first page with the sorteo layout while adding responsive metrics for winners and free cards
- update the collaborator payments table to separate current and assigned credits, color roles, and register payouts as PAGO transactions
- expose a collaborator-only PAGO filter in the wallet and style those transactions like prize deposits

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fc1f9c8f388326910f41379baf1d81