### PR TITLE
Ajustar primera página del PDF de resultados

### DIFF
--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1017,7 +1017,8 @@
       --pdf-bloque-padding: clamp(6px, 0.9vw, 10px);
       --pdf-columnas: 6;
       --pdf-page-width: 1120px;
-      --pdf-page-height: calc(var(--pdf-page-width) / 1.414);
+      --pdf-page-height: calc(var(--pdf-page-width) * 0.693);
+      --pdf-firstpage-columns: minmax(0, 0.64fr) minmax(0, 1fr);
       --formas-min-width: 240px;
       --formas-scale: 0.96;
       --formas-mini-max: 192px;
@@ -1042,16 +1043,21 @@
       border: 1px solid rgba(11,83,148,0.22);
       border-radius: 18px;
       background: #ffffff;
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-columns: var(--pdf-firstpage-columns);
+      grid-auto-rows: minmax(0, 1fr);
       align-items: stretch;
       gap: var(--pdf-gap);
     }
+    body.pdf-captura #first-page-layout > * {
+      min-width: 0;
+    }
     body.pdf-captura #formas-section {
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-rows: auto 1fr;
       gap: var(--pdf-gap);
       min-height: 0;
+      height: 100%;
     }
     body.pdf-captura .formas-intro {
       padding: var(--pdf-bloque-padding);
@@ -1065,7 +1071,8 @@
       gap: var(--pdf-gap);
       width: 100%;
       max-width: none;
-      min-height: clamp(380px, 36vw, 520px);
+      min-height: 0;
+      height: 100%;
       margin: 0 auto;
     }
     body.pdf-captura #resumen-layout > .resumen-bloque {
@@ -1077,6 +1084,8 @@
     body.pdf-captura .datos-generales-grid {
       gap: var(--pdf-gap);
       grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      flex: 1 1 auto;
+      min-height: 0;
     }
     body.pdf-captura #nombre-sorteo {
       font-size: clamp(2.2rem, 4.6vw, 2.9rem);
@@ -1127,10 +1136,24 @@
       grid-auto-rows: minmax(0, 1fr);
       gap: var(--pdf-gap);
       align-content: stretch;
+      min-height: 0;
+      height: 100%;
+    }
+    @media (max-width: 1020px) {
+      body.pdf-captura #first-page-layout {
+        grid-template-columns: 1fr;
+        grid-auto-rows: auto;
+      }
+      body.pdf-captura #resumen-layout,
+      body.pdf-captura #formas-section {
+        height: auto;
+      }
     }
     body.pdf-captura #formas-resumen .forma-slot {
       display: flex;
       flex: 1 1 auto;
+      min-height: 0;
+      align-items: stretch;
     }
     body.pdf-captura #formas-resumen .forma-item {
       width: 100%;


### PR DESCRIPTION
## Resumen
- ajustar las dimensiones internas usadas en modo de captura para que la primera página ocupe el ancho útil del PDF
- reorganizar el contenedor principal de la primera página en un diseño de cuadrícula que reparte el ancho entre el resumen y las formas premiadas
- asegurar que los paneles internos puedan estirarse y mantener alturas flexibles durante la captura

## Pruebas
- no se ejecutaron pruebas (no aplica)


------
https://chatgpt.com/codex/tasks/task_e_68fd31668e9883268029a20789fa8cc7