### PR TITLE
Adjust first page PDF layout to use full width

### DIFF
--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1068,6 +1068,9 @@
       width: 100%;
       padding-left: 0;
       padding-right: 0;
+      display: flex;
+      flex-direction: column;
+      gap: var(--pdf-gap);
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout {
       width: 100%;
@@ -1078,30 +1081,25 @@
       border: none;
       border-radius: 0;
       background: transparent;
-      grid-template-columns: repeat(12, minmax(0, 1fr));
-      grid-auto-rows: minmax(0, auto);
-      align-items: start;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
       gap: var(--pdf-gap);
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout > * {
       min-width: 0;
+      width: 100%;
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout #resumen-layout {
-      display: contents;
-    }
-    body.pdf-captura.pdf-firstpage-horizontal #first-page-layout #resumen-header,
-    body.pdf-captura.pdf-firstpage-horizontal #first-page-layout .datos-generales-grid,
-    body.pdf-captura.pdf-firstpage-horizontal #first-page-layout .totales-header {
-      grid-column: 1 / span 5;
+      display: flex;
+      flex-direction: column;
+      gap: var(--pdf-gap);
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout #formas-section {
-      grid-column: 6 / -1;
-      grid-row: 1 / -1;
-      display: grid;
-      grid-template-rows: auto 1fr;
+      display: flex;
+      flex-direction: column;
       gap: var(--pdf-gap);
-      min-height: 100%;
-      align-content: start;
+      min-height: 0;
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout #formas-resumen {
       align-content: stretch;


### PR DESCRIPTION
## Summary
- ensure the PDF capture mode uses a flex layout for the first page container
- remove the grid-based wrapper overrides so the first page content can span the available width
- keep the formas section flexible to match the on-screen distribution during PDF generation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd3a8e3ba883269cf2a1e45bdc573b