### PR TITLE
Alinear mini cartones en la primera página del PDF de resultados

### DIFF
--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -491,6 +491,33 @@
       max-width: none;
       pointer-events: none;
     }
+    #first-page-layout #formas-resumen .forma-item {
+      display: flex;
+      flex-direction: column;
+      gap: clamp(10px, 1.6vw, 16px);
+    }
+    #first-page-layout #formas-resumen .forma-resumen {
+      border-right: none;
+      border-bottom: 1px solid rgba(0,0,0,0.08);
+    }
+    #first-page-layout #formas-resumen .forma-mini-carton-wrapper {
+      border-left: none;
+      border-top: 1px solid rgba(0,0,0,0.06);
+      max-width: 100%;
+      width: 100%;
+      min-height: clamp(160px, calc(32vw * var(--formas-scale, 1)), 260px);
+      padding: clamp(10px, calc(1.8vw * var(--formas-scale, 1)), 20px);
+    }
+    #first-page-layout #formas-resumen .forma-mini-carton {
+      position: relative;
+      top: auto;
+      left: auto;
+      transform: none;
+      margin: 0 auto;
+      width: min(100%, var(--formas-mini-max, clamp(160px, 40vw, 260px)));
+      box-shadow: 0 8px 18px rgba(0,0,0,0.16);
+      pointer-events: none;
+    }
     .forma-mini-carton thead,
     .forma-mini-carton tbody,
     .forma-mini-carton tr {


### PR DESCRIPTION
## Summary
- reorganizar las formas de la primera página para que los mini cartones se ubiquen debajo de los datos
- ajustar bordes, espaciados y escalado para conservar la proporción de los mini cartones al apilarse

## Testing
- not run (cambios solo de estilos)


------
https://chatgpt.com/codex/tasks/task_e_68fd3fba90208326ae5ac33e127f071d