### PR TITLE
Ajustar layout horizontal del PDF de resultados

### DIFF
--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1089,33 +1089,38 @@
     body.pdf-captura.pdf-firstpage-horizontal {
       padding-left: 0;
       padding-right: 0;
+      overflow-x: auto;
     }
     body.pdf-captura.pdf-firstpage-horizontal #pdf-wrapper {
-      max-width: none;
-      width: 100%;
-      padding-left: 0;
-      padding-right: 0;
-      display: flex;
-      flex-direction: column;
+      max-width: var(--pdf-page-width);
+      width: var(--pdf-page-width);
+      min-width: var(--pdf-page-width);
+      margin: 0 auto;
+      padding-left: var(--pdf-gap);
+      padding-right: var(--pdf-gap);
+      display: grid;
       gap: var(--pdf-gap);
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout {
       width: 100%;
-      max-width: none;
-      min-height: 0;
-      margin: 0;
-      padding: 0;
-      border: none;
-      border-radius: 0;
-      background: transparent;
-      display: flex;
-      flex-direction: column;
+      max-width: var(--pdf-page-width);
+      min-width: var(--pdf-page-width);
+      min-height: var(--pdf-page-height);
+      margin: 0 auto;
+      padding: var(--pdf-gap);
+      border: 1px solid rgba(11,83,148,0.22);
+      border-radius: 18px;
+      background: #ffffff;
+      display: grid;
+      grid-template-columns: var(--pdf-firstpage-columns);
+      grid-auto-rows: minmax(0, 1fr);
       align-items: stretch;
       gap: var(--pdf-gap);
+      box-sizing: border-box;
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout > * {
       min-width: 0;
-      width: 100%;
+      width: auto;
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout #resumen-layout {
       display: flex;
@@ -1123,8 +1128,8 @@
       gap: var(--pdf-gap);
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout #formas-section {
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-rows: auto 1fr;
       gap: var(--pdf-gap);
       min-height: 0;
     }


### PR DESCRIPTION
## Resumen
- forzar que la primera página del PDF de resultados respete el ancho y la distribución usados en escritorio incluso al generar desde móviles en orientación horizontal
- ajustar el contenedor capturado para mantener la cuadrícula original, conservando bordes y espaciados del diseño

## Pruebas
- no se ejecutaron pruebas automatizadas (cambios de estilos)


------
https://chatgpt.com/codex/tasks/task_e_68fd44c33120832690a7cfc00c0c8c5f