### PR TITLE
Alinear en vertical las formas en la primera página del PDF de resultados

### DIFF
--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1205,13 +1205,14 @@
       min-height: 100%;
       border-width: 0.7px;
       border-color: rgba(11,83,148,0.28);
-      grid-template-columns: minmax(0, 1fr) minmax(0, var(--formas-mini-max));
-      display: grid;
+      display: flex;
+      flex-direction: column;
       align-items: stretch;
     }
     body.pdf-captura .forma-resumen {
       padding: clamp(8px, 1vw, 12px);
-      border-right-width: 0.6px;
+      border-right-width: 0;
+      border-bottom: 0.6px solid rgba(11,83,148,0.28);
       gap: clamp(4px, 0.8vw, 9px);
     }
     body.pdf-captura .forma-titulo {
@@ -1227,9 +1228,11 @@
     }
     body.pdf-captura .forma-mini-carton-wrapper {
       padding: clamp(4px, 0.8vw, 10px);
-      border-left-width: 0.6px;
+      border-left-width: 0;
+      border-top: 0.6px solid rgba(11,83,148,0.28);
       min-height: clamp(130px, 24vw, 190px);
-      max-width: var(--formas-mini-max);
+      max-width: none;
+      width: 100%;
       display: flex;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
## Summary
- reorganize the PDF-first-page form containers vertically so the miniature cards appear beneath the form details
- adjust the borders and wrapper sizing to preserve miniature card proportions when stacked vertically

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fd5f9845088326a882896fe710a945