### PR TITLE
Mejorar la captura horizontal del PDF de resultados

### DIFF
--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1070,34 +1070,38 @@
       padding-right: 0;
       display: flex;
       flex-direction: column;
+      align-items: center;
       gap: var(--pdf-gap);
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout {
-      width: 100%;
+      width: var(--pdf-page-width);
       max-width: none;
-      min-height: 0;
+      min-width: var(--pdf-page-width);
+      min-height: var(--pdf-page-height);
       margin: 0;
-      padding: 0;
+      padding: var(--pdf-gap);
       border: none;
       border-radius: 0;
       background: transparent;
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-columns: var(--pdf-firstpage-columns);
+      grid-auto-rows: minmax(0, 1fr);
       align-items: stretch;
       gap: var(--pdf-gap);
+      box-sizing: border-box;
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout > * {
       min-width: 0;
       width: 100%;
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout #resumen-layout {
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: var(--pdf-gap);
     }
     body.pdf-captura.pdf-firstpage-horizontal #first-page-layout #formas-section {
-      display: flex;
-      flex-direction: column;
+      display: grid;
+      grid-template-rows: auto 1fr;
       gap: var(--pdf-gap);
       min-height: 0;
     }
@@ -3061,6 +3065,9 @@
     const nombreArchivo = `${construirNombreArchivo()}.pdf`;
     const primeraPagina = document.getElementById('first-page-layout');
     let removerClaseHorizontal = false;
+    const valorPrevioAnchoPagina = document.body.style.getPropertyValue('--pdf-page-width');
+    const valorPrevioAltoPagina = document.body.style.getPropertyValue('--pdf-page-height');
+    let restaurarDimensionesPagina = false;
     if(!primeraPagina){
       alert('No se encontró el contenido del sorteo para generar el PDF.');
       return;
@@ -3118,6 +3125,10 @@
       }
       const pageWidth = pdf.internal.pageSize.getWidth();
       const pageHeight = pdf.internal.pageSize.getHeight();
+      const factorPuntosAPixeles = 96 / 72;
+      document.body.style.setProperty('--pdf-page-width', `${Math.round(pageWidth * factorPuntosAPixeles)}px`);
+      document.body.style.setProperty('--pdf-page-height', `${Math.round(pageHeight * factorPuntosAPixeles)}px`);
+      restaurarDimensionesPagina = true;
       const marginX = 18;
       const marginY = 18;
 
@@ -3256,6 +3267,18 @@
       restaurarCartones();
       restaurarFormas();
       document.body.classList.remove('pdf-captura');
+      if(restaurarDimensionesPagina){
+        if(valorPrevioAnchoPagina){
+          document.body.style.setProperty('--pdf-page-width', valorPrevioAnchoPagina);
+        } else {
+          document.body.style.removeProperty('--pdf-page-width');
+        }
+        if(valorPrevioAltoPagina){
+          document.body.style.setProperty('--pdf-page-height', valorPrevioAltoPagina);
+        } else {
+          document.body.style.removeProperty('--pdf-page-height');
+        }
+      }
       if(removerClaseHorizontal){
         document.body.classList.remove('pdf-firstpage-horizontal');
       }


### PR DESCRIPTION
## Summary
- Ajusta los estilos de la primera página al momento de la captura para que conserve la cuadrícula horizontal y use un ancho fijo equivalente al del PDF, incluso en móviles.
- Sincroniza las variables CSS de tamaño de página con las dimensiones reales del PDF y restaura los valores previos al finalizar.

## Testing
- No se ejecutaron pruebas (cambios de frontend).


------
https://chatgpt.com/codex/tasks/task_e_68fd6562d6108326a778752c210202d3