### PR TITLE
Ajustes de interfaz para PDF de resultados y pagos de colaboradores

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -484,6 +484,11 @@
       display: flex;
       animation: pdfFloat 3.4s ease-in-out infinite, pdfGlowRojo 2.8s ease-in-out infinite;
     }
+    #resultado-btn .pdf-btn-icon {
+      width: 30px;
+      height: 30px;
+      filter: drop-shadow(0 2px 2px rgba(0,0,0,0.35));
+    }
     #resultado-btn .pdf-floating-icon {
       background: radial-gradient(circle at 35% 30%, #ffffff 0%, #e8f5e9 58%, #a5d6a7 100%);
       border: 2px solid rgba(56, 142, 60, 0.35);
@@ -5585,9 +5590,10 @@
     }
     const estadoPdfResultado = (currentSorteoData.pdfresul || '').toString().trim().toLowerCase();
     if(estadoPdfResultado !== 'si'){
-      mostrarAvisoSimple('Se abrirá el PDF de resultados para confirmar su descarga.', 'PDF pendiente');
+      mostrarAvisoSimple('El PDF de resultados se habilitará cuando se confirme su disponibilidad. Utiliza el icono flotante para abrirlo cuando esté listo.', 'PDF pendiente');
+      return;
     }
-    abrirPdfResultados();
+    mostrarAvisoSimple('Para abrir el PDF de resultados utiliza el icono flotante en la esquina del botón.', 'PDF disponible');
   }
 
   function manejarClickPdfResultadosAlmacenado(evento){
@@ -5597,12 +5603,17 @@
       alert('Selecciona un sorteo primero.');
       return;
     }
-    const estadoPdfResultado = (currentSorteoData.pdfresul || '').toString().trim().toLowerCase();
-    if(estadoPdfResultado !== 'si'){
-      alert('No se ha confirmado la descarga del archivo PDF de resultados de este sorteo.');
+    const estadoActual = obtenerEstadoActualNormalizado();
+    if(estadoActual !== 'finalizado'){
+      alert('El sorteo debe estar finalizado para ver los resultados.');
       return;
     }
-    alert('Ya se ha confirmado la descarga del archivo PDF de resultados de este sorteo');
+    const estadoPdfResultado = (currentSorteoData.pdfresul || '').toString().trim().toLowerCase();
+    if(estadoPdfResultado !== 'si'){
+      mostrarAvisoSimple('Se abrirá el PDF de resultados para confirmar su descarga.', 'PDF pendiente');
+    } else {
+      alert('Ya se ha confirmado la descarga del archivo PDF de resultados de este sorteo');
+    }
     abrirPdfResultados();
   }
 

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -322,38 +322,29 @@
       display: inline;
     }
     .rol-badge {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 3px 8px;
-      border-radius: 999px;
+      display: inline;
       font-weight: 700;
-      font-size: 0.72rem;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
+      font-size: clamp(0.78rem, 0.7rem + 0.35vw, 1rem);
+      text-transform: none;
+      letter-spacing: normal;
       font-family: Calibri, Arial, sans-serif;
-      border: 1px solid transparent;
-      background: rgba(255,255,255,0.85);
+      border: none;
+      background: transparent;
+      padding: 0;
+      line-height: 1.2;
+      white-space: normal;
     }
     .rol-badge--colaborador {
       color: #1b5e20;
-      border-color: rgba(27,94,32,0.35);
-      background: rgba(27,94,32,0.12);
     }
     .rol-badge--administrador {
       color: #0d47a1;
-      border-color: rgba(13,71,161,0.35);
-      background: rgba(13,71,161,0.12);
     }
     .rol-badge--superadmin {
       color: #6a1b9a;
-      border-color: rgba(106,27,154,0.35);
-      background: rgba(106,27,154,0.12);
     }
     .rol-badge--jugador {
       color: #f57c00;
-      border-color: rgba(245,124,0,0.35);
-      background: rgba(245,124,0,0.12);
     }
     .modal-capa {
       position: fixed;
@@ -552,10 +543,9 @@
           <col style="width:6%">
           <col style="width:22%">
           <col style="width:22%">
-          <col style="width:14%">
-          <col style="width:14%">
+          <col style="width:16%">
+          <col style="width:18%">
           <col style="width:12%">
-          <col style="width:10%">
           <col style="width:4%">
         </colgroup>
         <thead>
@@ -565,7 +555,6 @@
             <th><input type="text" id="filtro-colab-nombre" placeholder="Nombre"></th>
             <th><input type="text" id="filtro-colab-creditos" placeholder="C. Actuales"></th>
             <th class="th-asignados">C. Asignados</th>
-            <th>Fecha</th>
             <th>Rol</th>
             <th><span id="colaboradores-marcar" class="check-header">✔</span></th>
           </tr>
@@ -1801,7 +1790,7 @@
       if(!tbody) return;
       const { mostrarArchivo = false, tipo } = opciones;
       if(!lista.length){
-        const columnasTabla = tipo==='premios' ? 8 : (tipo==='colaboradores' ? 8 : 7);
+        const columnasTabla = tipo==='premios' ? 8 : (tipo==='colaboradores' ? 7 : 7);
         tbody.innerHTML = `<tr><td colspan="${columnasTabla}"><div class="mensaje-tabla">No hay registros para mostrar.</div></td></tr>`;
         return;
       }
@@ -1830,7 +1819,8 @@
             ? pagosColaboradoresEdicion.get(item.id)
             : '';
           const numeroValor = Number(valorReferencia);
-          const valorInput = Number.isFinite(numeroValor) ? numeroValor.toFixed(2) : '';
+          const tieneDato = valorReferencia !== '' && valorReferencia !== null && valorReferencia !== undefined;
+          const valorInput = (tieneDato && Number.isFinite(numeroValor)) ? Math.trunc(numeroValor).toString() : '';
           const archivoAttr = mostrarArchivo ? ' data-archivo="1"' : '';
           const creditosActuales = Number(item.creditosActuales ?? item.creditos ?? 0);
           return `<tr data-id="${item.id}">
@@ -1838,8 +1828,7 @@
             <td class="gmail">${construirGmailHtml(item.gmail)}</td>
             <td class="alias">${escapeHtml(item.nombre)}</td>
             <td class="creditos-actuales">${formatNumber.format(creditosActuales)}</td>
-            <td class="colab-asignar"><input type="number" class="colab-input" step="0.01" min="0" data-id="${item.id}" value="${valorInput}" placeholder="0.00" disabled${archivoAttr}></td>
-            <td>${escapeHtml(item.fechaMostrar || '-')}</td>
+            <td class="colab-asignar"><input type="number" class="colab-input" step="1" min="0" data-id="${item.id}" value="${valorInput}" placeholder="0" disabled${archivoAttr}></td>
             <td class="estado">${estadoHtml}</td>
             <td><input type="checkbox" data-id="${item.id}" ${disabled}></td>
           </tr>`;


### PR DESCRIPTION
## Summary
- Ajustar el tamaño del icono PDF en el botón de resultados y limitar la apertura del PDF al icono flotante.
- Simplificar la tabla de pagos de colaboradores retirando la columna de fecha, suavizando los estilos de rol y mostrando asignaciones sin decimales.

## Testing
- No se ejecutaron pruebas (no requeridas).


------
https://chatgpt.com/codex/tasks/task_e_68fd6f0185a88326b3e1355820b7525a