### PR TITLE
Agregar modal de celebración para ganadores en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1719,6 +1719,167 @@
       .modal-formas-sin-aceptar:active {
           transform: translateY(1px) scale(0.98);
       }
+      .modal-celebracion {
+          padding: 16px;
+          background: rgba(8,16,32,0.82);
+          z-index: 2400;
+      }
+      .modal-celebracion .modal-contenido {
+          background: linear-gradient(160deg, rgba(24,24,24,0.94), rgba(96,24,24,0.94));
+          border-radius: 20px;
+          padding: 22px 26px;
+          max-width: min(480px, 92vw);
+          width: min(480px, 92vw);
+          box-shadow: 0 20px 45px rgba(0,0,0,0.45);
+          border: 3px solid rgba(255,160,0,0.55);
+          align-items: center;
+          text-align: center;
+          gap: 14px;
+      }
+      #modal-celebracion-titulo {
+          font-family: 'Bangers', cursive;
+          font-size: clamp(1.8rem, 5vw, 2.1rem);
+          letter-spacing: 1px;
+          margin: 0;
+          color: #fff;
+          text-shadow: 0 0 14px rgba(255,120,0,0.95), 0 0 28px rgba(255,69,0,0.75);
+      }
+      #modal-celebracion-mensaje {
+          margin: 0;
+          font-size: 0.95rem;
+          color: rgba(255,255,255,0.88);
+          text-shadow: 0 0 10px rgba(0,0,0,0.6);
+      }
+      #modal-celebracion-lista {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          width: 100%;
+      }
+      .celebracion-linea {
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+          align-items: center;
+          justify-content: center;
+          font-size: 1.05rem;
+          font-weight: 600;
+          color: #fefefe;
+          text-shadow: 0 0 10px rgba(0,0,0,0.7);
+          padding: 10px 12px;
+          border-radius: 14px;
+          background: linear-gradient(135deg, rgba(255,255,255,0.08), rgba(255,255,255,0.04));
+          border: 1px solid rgba(255,255,255,0.18);
+      }
+      .celebracion-linea::before {
+          content: '';
+          display: block;
+          width: 70px;
+          height: 4px;
+          border-radius: 999px;
+          background: var(--celebracion-color, rgba(255,215,64,0.8));
+          box-shadow: 0 0 14px rgba(255,215,64,0.7);
+      }
+      .celebracion-forma {
+          font-family: 'Bangers', cursive;
+          font-size: clamp(1.15rem, 3.6vw, 1.45rem);
+          letter-spacing: 0.5px;
+          color: #fff;
+          text-shadow: 0 0 16px rgba(255,160,0,0.85);
+      }
+      .celebracion-premios {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 6px 10px;
+          justify-content: center;
+          font-size: 0.95rem;
+      }
+      .celebracion-premio {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 6px 12px;
+          border-radius: 999px;
+          background: rgba(0,0,0,0.35);
+          border: 1px solid rgba(255,255,255,0.35);
+          font-weight: 700;
+      }
+      .celebracion-premio-creditos {
+          background: rgba(67,160,71,0.35);
+          border-color: rgba(76,175,80,0.55);
+          color: #e8f5e9;
+          text-shadow: 0 0 10px rgba(0,0,0,0.7);
+      }
+      .celebracion-premio-cartones {
+          background: rgba(21,101,192,0.35);
+          border-color: rgba(30,136,229,0.55);
+          color: #e3f2fd;
+      }
+      .celebracion-carton {
+          font-size: 0.85rem;
+          font-weight: 500;
+          color: rgba(255,255,255,0.85);
+      }
+      #modal-celebracion-aceptar {
+          font-family: 'Bangers', cursive;
+          font-size: clamp(1rem, 3.2vw, 1.25rem);
+          padding: 10px 34px;
+          border-radius: 999px;
+          border: 3px solid rgba(255,171,64,0.85);
+          background: linear-gradient(160deg, rgba(255,152,0,0.92), rgba(255,234,167,0.95));
+          color: #3b1b00;
+          cursor: pointer;
+          box-shadow: 0 14px 32px rgba(0,0,0,0.4);
+          transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      #modal-celebracion-aceptar:hover {
+          transform: translateY(-1px) scale(1.03);
+          box-shadow: 0 18px 36px rgba(0,0,0,0.45);
+      }
+      #modal-celebracion-aceptar:active {
+          transform: translateY(1px) scale(0.97);
+          box-shadow: 0 10px 24px rgba(0,0,0,0.35);
+      }
+      #confeti-overlay {
+          position: fixed;
+          inset: 0;
+          pointer-events: none;
+          overflow: hidden;
+          display: none;
+          z-index: 3200;
+      }
+      #confeti-overlay.activo {
+          display: block;
+      }
+      .confeti-papelillo {
+          position: absolute;
+          top: -12vh;
+          width: var(--confeti-ancho, 12px);
+          height: var(--confeti-alto, 18px);
+          background: var(--confeti-color, #ffd54f);
+          opacity: var(--confeti-opacidad, 0.85);
+          border-radius: 2px;
+          animation: confetiCaida var(--confeti-duracion, 4s) linear infinite;
+          transform-origin: center;
+          will-change: transform;
+      }
+      .confeti-papelillo:nth-child(3n) {
+          border-radius: 50%;
+      }
+      .confeti-papelillo.estrella {
+          width: var(--confeti-tamano-estrella, 18px);
+          height: var(--confeti-tamano-estrella, 18px);
+          clip-path: polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%);
+          border-radius: 0;
+      }
+      @keyframes confetiCaida {
+          0% {
+              transform: translate3d(0, 0, 0) rotate(0deg);
+          }
+          100% {
+              transform: translate3d(var(--confeti-drift, 0px), 120vh, 0) rotate(720deg);
+          }
+      }
       .ganador-card {
           background: linear-gradient(135deg, rgba(255,255,255,0.96), rgba(240,240,240,0.96));
           border-radius: 14px;
@@ -2527,6 +2688,17 @@
     </div>
   </div>
 
+  <div id="confeti-overlay" aria-hidden="true"></div>
+
+  <div id="modal-celebracion" class="modal modal-celebracion" role="dialog" aria-modal="true" aria-labelledby="modal-celebracion-titulo" aria-hidden="true">
+    <div class="modal-contenido" role="document">
+      <h2 id="modal-celebracion-titulo">¡Felicidades!</h2>
+      <p id="modal-celebracion-mensaje">Así se ven tus premios más recientes:</p>
+      <div id="modal-celebracion-lista"></div>
+      <button type="button" id="modal-celebracion-aceptar">Aceptar</button>
+    </div>
+  </div>
+
   <div id="complementarios-aviso" class="aviso-overlay aviso-overlay--complementarios" role="dialog" aria-modal="true" aria-labelledby="complementarios-aviso-titulo" aria-hidden="true">
     <div class="aviso-overlay__box">
       <h2 id="complementarios-aviso-titulo" class="aviso-overlay__titulo">Cantos de transparencia</h2>
@@ -2585,8 +2757,14 @@
   const modalFormasSinGanadoresListaEl = document.getElementById('modal-formas-sin-ganadores-lista');
   const modalFormasSinGanadoresCerrarBtn = document.getElementById('modal-formas-sin-ganadores-cerrar');
   const modalFormasSinGanadoresAceptarBtn = document.getElementById('modal-formas-sin-ganadores-aceptar');
+  const confetiOverlayEl = document.getElementById('confeti-overlay');
+  const modalCelebracionEl = document.getElementById('modal-celebracion');
+  const modalCelebracionListaEl = document.getElementById('modal-celebracion-lista');
+  const modalCelebracionAceptarBtn = document.getElementById('modal-celebracion-aceptar');
+  const modalCelebracionMensajeEl = document.getElementById('modal-celebracion-mensaje');
 
   const FORM_COLORS = ['#90ee90', '#fffacd', '#add8e6', '#d8b0ff', '#ffcc99', '#f77fb3', '#9ad3bc', '#fecf6a'];
+  const CONFETI_COLORES = ['#ff5252', '#ffeb3b', '#69f0ae', '#40c4ff', '#ff80ab', '#7c4dff', '#fdd835', '#ff9100'];
   const BINGO_LETRAS = ['B','I','N','G','O'];
 
   const TEXTO_BOTON_CONSULTAR_SELECCIONADOS = 'CONSULTAR SORTEOS FINALIZADOS';
@@ -2612,6 +2790,7 @@
   const animacionesCartones = new Map();
   const celdasPenalizadasTimers = new Map();
   const celdasComplementariasTimers = new Map();
+  const formasCelebradasPorCarton = new Map();
   let cartonPrincipalInfo = null;
   let resaltadoTemporal = {timer:null, tablas:null, cartonId:null};
   let formaDestacadaSeleccionada = null;
@@ -2627,6 +2806,7 @@
   let ultimoCantoPopupNumeroEl = null;
   let ultimoCantoTimer = null;
   let formasSinGanadoresAlertaClave = '';
+  let celebracionModalActiva = false;
 
   let recalculoAlturaCartonProgramado = false;
   const actualizarAlturaBotonesRetrato = () => {
@@ -4395,6 +4575,153 @@
     }
   }
 
+  function crearLineaCelebracionGanador(detalle){
+    const linea=document.createElement('div');
+    linea.className='celebracion-linea';
+    if(detalle?.color){
+      linea.style.setProperty('--celebracion-color', detalle.color);
+    }
+    const formaTexto=document.createElement('div');
+    formaTexto.className='celebracion-forma';
+    const etiqueta=`Forma ${String(detalle?.idx ?? '').padStart(2,'0')}`;
+    const nombre=(detalle?.nombre||'').toString().trim();
+    formaTexto.textContent=nombre?`${etiqueta} · ${nombre}`:etiqueta;
+    linea.appendChild(formaTexto);
+
+    const premios=document.createElement('div');
+    premios.className='celebracion-premios';
+    const creditosSpan=document.createElement('span');
+    creditosSpan.className='celebracion-premio celebracion-premio-creditos';
+    const creditosNumero=Number(detalle?.creditos)||0;
+    creditosSpan.textContent=`+${formatearCreditos(creditosNumero)} créditos`;
+    premios.appendChild(creditosSpan);
+    const cartonesNumero=Number(detalle?.cartonesGratis)||0;
+    if(cartonesNumero>0){
+      const cartonesSpan=document.createElement('span');
+      cartonesSpan.className='celebracion-premio celebracion-premio-cartones';
+      const sufijo=cartonesNumero===1?'cartón gratis':'cartones gratis';
+      cartonesSpan.textContent=`+${cartonesNumero} ${sufijo}`;
+      premios.appendChild(cartonesSpan);
+    }
+    linea.appendChild(premios);
+
+    if(detalle?.cartonLabel){
+      const cartonInfo=document.createElement('div');
+      cartonInfo.className='celebracion-carton';
+      cartonInfo.textContent=detalle.cartonLabel;
+      linea.appendChild(cartonInfo);
+    }
+    return linea;
+  }
+
+  function iniciarConfetiCelebracion(){
+    if(!confetiOverlayEl) return;
+    confetiOverlayEl.innerHTML='';
+    const anchoVentana=Math.max(window.innerWidth||0,320);
+    const piezas=Math.min(140, Math.max(60, Math.round(anchoVentana/8)));
+    for(let i=0;i<piezas;i++){
+      const pieza=document.createElement('span');
+      pieza.className='confeti-papelillo';
+      const color=CONFETI_COLORES[i%CONFETI_COLORES.length];
+      pieza.style.setProperty('--confeti-color', color);
+      if(Math.random()<0.28){
+        pieza.classList.add('estrella');
+        const tam=14+Math.random()*10;
+        pieza.style.setProperty('--confeti-tamano-estrella', `${tam}px`);
+      }else{
+        const ancho=6+Math.random()*8;
+        const alto=12+Math.random()*16;
+        pieza.style.setProperty('--confeti-ancho', `${ancho}px`);
+        pieza.style.setProperty('--confeti-alto', `${alto}px`);
+      }
+      const izquierda=Math.random()*100;
+      pieza.style.left=`${izquierda}vw`;
+      const duracion=3+Math.random()*2.5;
+      pieza.style.setProperty('--confeti-duracion', `${duracion}s`);
+      pieza.style.animationDelay=`-${Math.random()*duracion}s`;
+      const deriva=(Math.random()*80-40).toFixed(2);
+      pieza.style.setProperty('--confeti-drift', `${deriva}px`);
+      const opacidad=(0.6+Math.random()*0.4).toFixed(2);
+      pieza.style.setProperty('--confeti-opacidad', opacidad);
+      confetiOverlayEl.appendChild(pieza);
+    }
+    confetiOverlayEl.classList.add('activo');
+  }
+
+  function detenerConfetiCelebracion(){
+    if(!confetiOverlayEl) return;
+    confetiOverlayEl.classList.remove('activo');
+    confetiOverlayEl.innerHTML='';
+  }
+
+  function mostrarModalCelebracionGanador(detalles){
+    if(!modalCelebracionEl || !modalCelebracionListaEl) return;
+    const lista=Array.isArray(detalles)?detalles.filter(Boolean):[];
+    if(!lista.length) return;
+    modalCelebracionListaEl.innerHTML='';
+    lista.forEach(detalle=>{
+      modalCelebracionListaEl.appendChild(crearLineaCelebracionGanador(detalle));
+    });
+    if(modalCelebracionMensajeEl){
+      const total=lista.length;
+      modalCelebracionMensajeEl.textContent=total===1?'¡Ganaste con una forma!':`¡Ganaste con ${total} formas!`;
+    }
+    modalCelebracionEl.classList.add('activa');
+    modalCelebracionEl.setAttribute('aria-hidden','false');
+    celebracionModalActiva = true;
+    iniciarConfetiCelebracion();
+    modalCelebracionAceptarBtn?.focus({preventScroll:true});
+  }
+
+  function cerrarModalCelebracionGanador(){
+    if(!modalCelebracionEl) return;
+    modalCelebracionEl.classList.remove('activa');
+    modalCelebracionEl.setAttribute('aria-hidden','true');
+    celebracionModalActiva = false;
+    if(modalCelebracionListaEl){
+      modalCelebracionListaEl.innerHTML='';
+    }
+    detenerConfetiCelebracion();
+  }
+
+  function gestionarCelebracionesNuevosGanadores(cartones){
+    if(!Array.isArray(cartones) || !cartones.length){
+      return;
+    }
+    const idsActuales=new Set(cartones.map(carton=>carton?.id).filter(Boolean));
+    Array.from(formasCelebradasPorCarton.keys()).forEach(id=>{
+      if(!idsActuales.has(id)){
+        formasCelebradasPorCarton.delete(id);
+      }
+    });
+    const detalles=[];
+    cartones.forEach(carton=>{
+      if(!carton || !carton.id) return;
+      let registro=formasCelebradasPorCarton.get(carton.id);
+      if(!registro){
+        registro=new Set();
+      }
+      const formasGanadas=Array.isArray(carton.formasGanadas)?carton.formasGanadas:[];
+      formasGanadas.forEach(item=>{
+        const idx=Number(item?.forma?.idx ?? item?.idx);
+        if(!Number.isInteger(idx)) return;
+        if(registro.has(idx)) return;
+        registro.add(idx);
+        const forma=item?.forma || formasActivas.find(f=>Number(f.idx)===idx) || {idx};
+        const creditos=obtenerCreditosForma(forma);
+        const cartonesGratis=obtenerCartonesGratisForma(forma);
+        const nombre=(forma?.nombre||'').toString().trim();
+        const color=obtenerColorParaForma(idx);
+        const cartonLabel=formatearInfoCarton(carton);
+        detalles.push({idx, nombre, creditos, cartonesGratis, color, cartonLabel});
+      });
+      formasCelebradasPorCarton.set(carton.id, registro);
+    });
+    if(detalles.length){
+      mostrarModalCelebracionGanador(detalles);
+    }
+  }
+
   function renderFormas(){
     limpiarPanelFormas();
     if(!formasActivas.length){
@@ -4419,6 +4746,12 @@
     mostrarMensajeSinCartonesJugador(false);
     jugadorSinCartonesEnSorteo = false;
     const lista=Array.from(cartonesSorteo.values()).filter(c=>c.userId===(usuarioActual?usuarioActual.uid:null));
+    const idsActuales=new Set(lista.map(carton=>carton.id).filter(Boolean));
+    Array.from(formasCelebradasPorCarton.keys()).forEach(id=>{
+      if(!idsActuales.has(id)){
+        formasCelebradasPorCarton.delete(id);
+      }
+    });
     if(!lista.length){
       const estadoSorteoActual = (activeSorteo?.estado || activeSorteo?.estadoSorteo || '').toString().toLowerCase();
       const mostrarRecomendacion = haySorteoJugando && !!activeSorteo && estadoSorteoActual === 'jugando';
@@ -4428,6 +4761,9 @@
         cartonesMensajeEl.textContent='';
       }else{
         cartonesMensajeEl.textContent='No tienes cartones participando en este sorteo.';
+      }
+      if(celebracionModalActiva){
+        cerrarModalCelebracionGanador();
       }
       cartonSeleccionadoId=null;
       cartonPrincipalInfo=null;
@@ -4460,6 +4796,7 @@
       const numB=b.cartonNum ?? b.Ncarton ?? Number.MAX_SAFE_INTEGER;
       return numA-numB;
     });
+    gestionarCelebracionesNuevosGanadores(decorados);
     if(!cartonSeleccionadoId || !decorados.some(c=>c.id===cartonSeleccionadoId)){
       cartonSeleccionadoId=decorados[0].id;
       formaDestacadaSeleccionada=null;
@@ -4775,6 +5112,16 @@
       }
     });
   }
+  if(modalCelebracionAceptarBtn){
+    modalCelebracionAceptarBtn.addEventListener('click',cerrarModalCelebracionGanador);
+  }
+  if(modalCelebracionEl){
+    modalCelebracionEl.addEventListener('click',evento=>{
+      if(evento.target===modalCelebracionEl){
+        cerrarModalCelebracionGanador();
+      }
+    });
+  }
 
   if(complementariosAvisoAceptarBtn){
     complementariosAvisoAceptarBtn.addEventListener('click',cerrarAvisoComplementarios);
@@ -4796,6 +5143,10 @@
   actualizarSinSorteoUI();
   document.addEventListener('keydown',evento=>{
     if(evento.key!=='Escape') return;
+    if(celebracionModalActiva || modalCelebracionEl?.classList?.contains('activa')){
+      cerrarModalCelebracionGanador();
+      return;
+    }
     if(complementariosAvisoEl?.classList?.contains('activa')){
       cerrarAvisoComplementarios();
     }


### PR DESCRIPTION
## Summary
- mostrar un modal de celebración en juegoactivo cuando el jugador gana alguna forma, con estilos alineados a cantarsorteos
- incluir una animación de confeti con papelillos y estrellas mientras el modal está visible
- registrar las nuevas formas ganadas por cartón para evitar repeticiones y permitir cerrar la celebración con controles de accesibilidad

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fe694d891c832684c4dafb5818d48d