### PR TITLE
Mostrar cartones gratis por ganador y resaltar estado de límites

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -3250,6 +3250,13 @@
     return 0;
   }
 
+  function obtenerCartonesGratisPorGanador(forma,totalGanadores){
+    const totalCartones = obtenerCartonesGratisForma(forma);
+    if(totalCartones <= 0) return 0;
+    const ganadores = Math.max(1, Number(totalGanadores) || 0);
+    return Math.max(0, Math.floor(totalCartones / ganadores));
+  }
+
   function calcularGanadores(){
     cartonesGanadoresPorForma = new Map();
     formasPorCarton = new Map();
@@ -3673,7 +3680,8 @@
     const premio = obtenerCreditosForma(forma);
     const totalGanadores = Math.max(1, (cartonesGanadoresPorForma.get(Number(forma?.idx))?.cartones?.length) || 1);
     const montoIndividual = premio > 0 ? Math.floor(premio / totalGanadores) : 0;
-    const cartonesGratisForma = obtenerCartonesGratisForma(forma);
+    const cartonesGratisTotales = obtenerCartonesGratisForma(forma);
+    const cartonesGratisPorGanador = obtenerCartonesGratisPorGanador(forma, totalGanadores);
     const premiosCol = document.createElement('div');
     premiosCol.className = 'ganador-premios';
 
@@ -3693,11 +3701,14 @@
     cartonesItem.className = 'ganador-premio-item';
     const cartonesLabel = document.createElement('div');
     cartonesLabel.className = 'ganador-premio-label';
-    cartonesLabel.textContent = 'CARTONES GRATIS:';
+    cartonesLabel.textContent = 'CARTONES GRATIS POR GANADOR:';
     const cartonesValor = document.createElement('div');
     cartonesValor.className = 'ganador-premio-monto ganador-premio-monto--cartones';
-    cartonesValor.textContent = formatearNumero(cartonesGratisForma);
-    if(cartonesGratisForma <= 0){
+    cartonesValor.textContent = formatearNumero(cartonesGratisPorGanador);
+    if(cartonesGratisTotales > 0){
+      cartonesItem.title = `Total forma: ${formatearNumero(cartonesGratisTotales)} cartones gratis`;
+    }
+    if(cartonesGratisPorGanador <= 0){
       cartonesItem.classList.add('ganador-premio-item--sin-premio');
       cartonesValor.classList.add('sin-premio');
     }

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4355,6 +4355,13 @@
     return 0;
   }
 
+  function obtenerCartonesGratisPorGanador(forma,totalGanadores){
+    const totalCartones=obtenerCartonesGratisForma(forma);
+    if(totalCartones<=0) return 0;
+    const ganadores=Math.max(1, Number(totalGanadores)||0);
+    return Math.max(0, Math.floor(totalCartones/ganadores));
+  }
+
   function actualizarHeader(){
     const mostrarManual = !haySorteoJugando && !!(activeSorteo && sorteoManualSeleccionadoId);
     if(!haySorteoJugando && !mostrarManual){
@@ -4709,7 +4716,8 @@
         registro.add(idx);
         const forma=item?.forma || formasActivas.find(f=>Number(f.idx)===idx) || {idx};
         const creditos=obtenerCreditosForma(forma);
-        const cartonesGratis=obtenerCartonesGratisForma(forma);
+        const totalGanadores=Math.max(1,(cartonesGanadoresPorForma.get(idx)?.cartones?.length)||0);
+        const cartonesGratis=obtenerCartonesGratisPorGanador(forma,totalGanadores);
         const nombre=(forma?.nombre||'').toString().trim();
         const color=obtenerColorParaForma(idx);
         const cartonLabel=formatearInfoCarton(carton);
@@ -5000,7 +5008,8 @@
       const premioFormaTotal=obtenerCreditosForma(forma);
       const totalGanadores=ordenados.length;
       const premioIndividual=totalGanadores>0?Math.floor(premioFormaTotal/totalGanadores):0;
-      const cartonesGratisForma=obtenerCartonesGratisForma(forma);
+      const cartonesGratisTotales=obtenerCartonesGratisForma(forma);
+      const cartonesGratisPorGanador=obtenerCartonesGratisPorGanador(forma,totalGanadores);
       ordenados.forEach(carton=>{
         const card=document.createElement('div');
         card.className='ganador-card';
@@ -5045,11 +5054,14 @@
         cartonesItem.className='ganador-premio-item';
         const cartonesLabel=document.createElement('div');
         cartonesLabel.className='ganador-premio-label';
-        cartonesLabel.textContent='CARTONES GRATIS:';
+        cartonesLabel.textContent='CARTONES GRATIS POR GANADOR:';
         const cartonesValor=document.createElement('div');
         cartonesValor.className='ganador-premio-monto ganador-premio-monto--cartones';
-        cartonesValor.textContent=formatearCreditos(cartonesGratisForma);
-        if(cartonesGratisForma<=0){
+        cartonesValor.textContent=formatearCreditos(cartonesGratisPorGanador);
+        if(cartonesGratisTotales>0){
+          cartonesItem.title=`Total forma: ${formatearCreditos(cartonesGratisTotales)} cartones gratis`;
+        }
+        if(cartonesGratisPorGanador<=0){
           cartonesItem.classList.add('ganador-premio-item--sin-premio');
           cartonesValor.classList.add('sin-premio');
         }

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -169,7 +169,7 @@
       font-weight:600;
     }
     #cartones-jugando-valor,#gratis-plus,#cartones-gratis-jugando{animation:wiggle 1s infinite;display:inline-block;}
-    #cartones-gratis-jugando{color:#00008b;}
+    #cartones-gratis-jugando{color:#0b3d91;}
     #valor-carton{color:green;display:flex;align-items:center;gap:5px;}
     #cartones-jugando{color:purple;display:flex;align-items:center;gap:5px;}
     #gratis-plus{font-weight:bold;color:black;font-family:'Bangers',cursive;}
@@ -184,7 +184,7 @@
       font-size:1.5rem;
       display:inline-block;
       animation:pulse 1s infinite;
-      color:#4b0082;
+      color:#0b3d91;
       text-shadow:0 0 5px #fff;
     }
     #creditos-label{
@@ -207,7 +207,7 @@
     #jugados-btn-container{position:absolute;bottom:5px;right:50px;}
     #ver-jugados-btn{width:40px;height:40px;display:flex;align-items:center;justify-content:center;background:linear-gradient(purple,#ffffff);border:3px solid #FFD700;border-radius:8px;cursor:pointer;position:relative;}
     #jugados-count{position:absolute;top:-8px;left:-8px;background:purple;color:white;border-radius:50%;width:20px;height:20px;display:flex;align-items:center;justify-content:center;font-size:0.8rem;font-family:'Bangers',cursive;z-index:10;}
-    #jugados-gratis-count{position:absolute;top:-8px;right:-8px;background:#00008b;color:white;border-radius:50%;width:20px;height:20px;display:flex;align-items:center;justify-content:center;font-size:0.8rem;font-family:'Bangers',cursive;z-index:10;}
+    #jugados-gratis-count{position:absolute;top:-8px;right:-8px;background:#0b3d91;color:white;border-radius:50%;width:20px;height:20px;display:flex;align-items:center;justify-content:center;font-size:0.8rem;font-family:'Bangers',cursive;z-index:10;}
     #limpiar-btn{width:40px;height:40px;display:flex;align-items:center;justify-content:center;position:absolute;bottom:5px;right:95px;background:linear-gradient(gray,#ffffff);border:3px solid #FFD700;border-radius:8px;cursor:pointer;}
     #azar-btn{width:40px;height:40px;display:flex;align-items:center;justify-content:center;position:absolute;bottom:5px;right:140px;background:linear-gradient(#ffffff,#dddddd);border:3px solid #FFD700;border-radius:8px;cursor:pointer;}
     #ir-billetera-btn{width:40px;height:40px;font-size:1.2rem;display:flex;align-items:center;justify-content:center;position:absolute;bottom:5px;right:5px;margin-left:0;}
@@ -474,6 +474,8 @@ let cartonesJugando=0;
 let cartonesGratisJugando=0;
 const formColors=['#90ee90','#fffacd','#add8e6','#d8b0ff','#ffcc99'];
 const formGlows=['#006400','#b8860b','#00008b','#4b0082','#8b4513'];
+const COLOR_CARTONES_GRATIS_DISPONIBLE='#0b3d91';
+const COLOR_CARTONES_GRATIS_LIMITE='#c62828';
 let editandoTipo=null;
 let editandoId=null;
 const selladoOverlay=document.getElementById('sellado-overlay');
@@ -483,16 +485,27 @@ let unsubscribeConsecutivoCarton=null;
 let ultimoNumeroCartonAsignado=0;
 let siguienteNumeroCarton=1;
 
+function obtenerColorCartonesGratisActual(){
+  const limiteAlcanzado=maxCartonesGratis>0 && cartonesGratisJugando>=maxCartonesGratis;
+  return limiteAlcanzado?COLOR_CARTONES_GRATIS_LIMITE:COLOR_CARTONES_GRATIS_DISPONIBLE;
+}
+
 function actualizarEstadoCartonesGratis(){
   const gratisLabel=document.getElementById('gratis-label');
   if(!gratisLabel) return;
   const limiteAlcanzado=maxCartonesGratis>0 && cartonesGratisJugando>=maxCartonesGratis;
+  const colorActual=obtenerColorCartonesGratisActual();
+  gratisLabel.style.color=colorActual;
+  const gratisJugandoEl=document.getElementById('cartones-gratis-jugando');
+  if(gratisJugandoEl){
+    gratisJugandoEl.style.color=colorActual;
+  }
   if(limiteAlcanzado){
-    gratisLabel.style.color='red';
     gratisLabel.style.animation='none';
+    gratisLabel.style.textShadow='0 0 6px rgba(198,40,40,0.35)';
   }else{
-    gratisLabel.style.color='';
     gratisLabel.style.animation='';
+    gratisLabel.style.textShadow='0 0 5px #fff';
   }
 }
 
@@ -1654,7 +1667,8 @@ function toggleForma(idx){
     const cj=document.getElementById('info-cartones-jugando');
     cj.innerHTML=`Cartones jugando: <strong style="color:purple;">${cartonesJugando}</strong>`;
     const cg=document.getElementById('info-cartones-gratis');
-    cg.innerHTML=`Cartones Gratis jugando: <strong style="color:#00008b;">${cartonesGratisJugando}</strong>`;
+    const colorGratis=obtenerColorCartonesGratisActual();
+    cg.innerHTML=`Cartones Gratis jugando: <strong style="color:${colorGratis};">${cartonesGratisJugando}</strong>`;
     document.getElementById('info-cartones-modal').style.display='flex';
   }
 


### PR DESCRIPTION
## Summary
- Mostrar en los modales de ganadores los cartones gratis asignados por ganador e indicar el total de la forma
- Incluir la cantidad de cartones gratis en la modal de celebración de ganadores
- Resaltar el estado de cartones gratis del jugador y del sorteo con colores dinámicos en jugarcartones

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68febb1f8ed4832682bc518f4a688513