### PR TITLE
Fix display of free card awards in winner modals

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -3253,8 +3253,38 @@
   function obtenerCartonesGratisPorGanador(forma,totalGanadores){
     const totalCartones = obtenerCartonesGratisForma(forma);
     if(totalCartones <= 0) return 0;
-    const ganadores = Math.max(1, Number(totalGanadores) || 0);
-    return Math.max(0, Math.floor(totalCartones / ganadores));
+    let ganadoresNumero = Number(totalGanadores);
+    if(!Number.isFinite(ganadoresNumero)){
+      ganadoresNumero = 1;
+    }else{
+      ganadoresNumero = Math.floor(ganadoresNumero);
+    }
+    if(ganadoresNumero <= 0){
+      return 0;
+    }
+    if(ganadoresNumero === 1){
+      return totalCartones;
+    }
+    if(totalCartones < ganadoresNumero){
+      return totalCartones;
+    }
+    const dividido = Math.floor(totalCartones / ganadoresNumero);
+    return dividido > 0 ? dividido : totalCartones;
+  }
+
+  function obtenerCartonesGratisTotalesEntregados(forma,totalGanadores){
+    const porGanador = obtenerCartonesGratisPorGanador(forma,totalGanadores);
+    if(porGanador <= 0) return 0;
+    let ganadoresNumero = Number(totalGanadores);
+    if(!Number.isFinite(ganadoresNumero)){
+      ganadoresNumero = 1;
+    }else{
+      ganadoresNumero = Math.floor(ganadoresNumero);
+    }
+    if(ganadoresNumero <= 0){
+      return 0;
+    }
+    return porGanador * ganadoresNumero;
   }
 
   function calcularGanadores(){
@@ -3680,7 +3710,7 @@
     const premio = obtenerCreditosForma(forma);
     const totalGanadores = Math.max(1, (cartonesGanadoresPorForma.get(Number(forma?.idx))?.cartones?.length) || 1);
     const montoIndividual = premio > 0 ? Math.floor(premio / totalGanadores) : 0;
-    const cartonesGratisTotales = obtenerCartonesGratisForma(forma);
+    const cartonesGratisTotales = obtenerCartonesGratisTotalesEntregados(forma, totalGanadores);
     const cartonesGratisPorGanador = obtenerCartonesGratisPorGanador(forma, totalGanadores);
     const premiosCol = document.createElement('div');
     premiosCol.className = 'ganador-premios';

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -1225,6 +1225,43 @@
       return 0;
     }
 
+    function cpObtenerCartonesGratisPorGanador(forma,totalGanadores){
+      const totalCartones = cpObtenerCartonesGratisForma(forma);
+      if(totalCartones <= 0) return 0;
+      let ganadoresNumero = Number(totalGanadores);
+      if(!Number.isFinite(ganadoresNumero)){
+        ganadoresNumero = 1;
+      }else{
+        ganadoresNumero = Math.floor(ganadoresNumero);
+      }
+      if(ganadoresNumero <= 0){
+        return 0;
+      }
+      if(ganadoresNumero === 1){
+        return totalCartones;
+      }
+      if(totalCartones < ganadoresNumero){
+        return totalCartones;
+      }
+      const dividido = Math.floor(totalCartones / ganadoresNumero);
+      return dividido > 0 ? dividido : totalCartones;
+    }
+
+    function cpObtenerCartonesGratisTotalesEntregados(forma,totalGanadores){
+      const porGanador = cpObtenerCartonesGratisPorGanador(forma,totalGanadores);
+      if(porGanador <= 0) return 0;
+      let ganadoresNumero = Number(totalGanadores);
+      if(!Number.isFinite(ganadoresNumero)){
+        ganadoresNumero = 1;
+      }else{
+        ganadoresNumero = Math.floor(ganadoresNumero);
+      }
+      if(ganadoresNumero <= 0){
+        return 0;
+      }
+      return porGanador * ganadoresNumero;
+    }
+
     function cpCalcularResultados(ctx){
       ctx.cartonesGanadoresPorForma = new Map();
       ctx.formasPorCarton = new Map();
@@ -1305,10 +1342,10 @@
         const ganadores = Array.isArray(registro?.cartones) ? registro.cartones : [];
         if(!forma || !ganadores.length) return;
         const totalCreditos = cpObtenerCreditosForma(ctx, forma);
-        const totalGratis = cpObtenerCartonesGratisForma(forma);
         const cantidad = ganadores.length || 1;
+        const totalGratis = cpObtenerCartonesGratisTotalesEntregados(forma, cantidad);
         const creditosPorGanador = cantidad > 0 ? Math.floor(totalCreditos / cantidad) : 0;
-        const gratisPorGanador = cantidad > 0 ? Math.floor(totalGratis / cantidad) : 0;
+        const gratisPorGanador = cpObtenerCartonesGratisPorGanador(forma, cantidad);
         ganadores.forEach(carton=>{
           const claveUsuario = (carton?.userId || carton?.usuarioId || '').toString().trim();
           const correoCarton = (carton?.gmail || carton?.email || carton?.IDbilletera || '').toString().trim();

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4358,8 +4358,38 @@
   function obtenerCartonesGratisPorGanador(forma,totalGanadores){
     const totalCartones=obtenerCartonesGratisForma(forma);
     if(totalCartones<=0) return 0;
-    const ganadores=Math.max(1, Number(totalGanadores)||0);
-    return Math.max(0, Math.floor(totalCartones/ganadores));
+    let ganadoresNumero=Number(totalGanadores);
+    if(!Number.isFinite(ganadoresNumero)){
+      ganadoresNumero=1;
+    }else{
+      ganadoresNumero=Math.floor(ganadoresNumero);
+    }
+    if(ganadoresNumero<=0){
+      return 0;
+    }
+    if(ganadoresNumero===1){
+      return totalCartones;
+    }
+    if(totalCartones<ganadoresNumero){
+      return totalCartones;
+    }
+    const dividido=Math.floor(totalCartones/ganadoresNumero);
+    return dividido>0?dividido:totalCartones;
+  }
+
+  function obtenerCartonesGratisTotalEntregados(forma,totalGanadores){
+    const porGanador=obtenerCartonesGratisPorGanador(forma,totalGanadores);
+    if(porGanador<=0) return 0;
+    let ganadoresNumero=Number(totalGanadores);
+    if(!Number.isFinite(ganadoresNumero)){
+      ganadoresNumero=1;
+    }else{
+      ganadoresNumero=Math.floor(ganadoresNumero);
+    }
+    if(ganadoresNumero<=0){
+      return 0;
+    }
+    return porGanador*ganadoresNumero;
   }
 
   function actualizarHeader(){
@@ -5008,7 +5038,7 @@
       const premioFormaTotal=obtenerCreditosForma(forma);
       const totalGanadores=ordenados.length;
       const premioIndividual=totalGanadores>0?Math.floor(premioFormaTotal/totalGanadores):0;
-      const cartonesGratisTotales=obtenerCartonesGratisForma(forma);
+      const cartonesGratisTotales=obtenerCartonesGratisTotalEntregados(forma,totalGanadores);
       const cartonesGratisPorGanador=obtenerCartonesGratisPorGanador(forma,totalGanadores);
       ordenados.forEach(carton=>{
         const card=document.createElement('div');

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1772,10 +1772,10 @@
       const ganadores = Array.isArray(registro?.cartones) ? registro.cartones : [];
       if(!forma || !ganadores.length) return;
       const totalCreditos = obtenerCreditosForma(forma);
-      const totalGratis = obtenerCartonesGratisForma(forma);
       const cantidad = ganadores.length || 1;
+      const totalGratis = obtenerCartonesGratisTotalesEntregados(forma, cantidad);
       const creditosPorGanador = cantidad > 0 ? Math.floor(totalCreditos / cantidad) : 0;
-      const gratisPorGanador = cantidad > 0 ? Math.floor(totalGratis / cantidad) : 0;
+      const gratisPorGanador = obtenerCartonesGratisPorGanador(forma, cantidad);
       ganadores.forEach(carton=>{
         const claveUsuario = (carton?.userId || carton?.usuarioId || '').toString().trim();
         const correoCarton = (carton?.gmail || carton?.email || carton?.IDbilletera || '').toString().trim();
@@ -2071,6 +2071,43 @@
       }
     }
     return 0;
+  }
+
+  function obtenerCartonesGratisPorGanador(forma,totalGanadores){
+    const totalCartones = obtenerCartonesGratisForma(forma);
+    if(totalCartones <= 0) return 0;
+    let ganadoresNumero = Number(totalGanadores);
+    if(!Number.isFinite(ganadoresNumero)){
+      ganadoresNumero = 1;
+    }else{
+      ganadoresNumero = Math.floor(ganadoresNumero);
+    }
+    if(ganadoresNumero <= 0){
+      return 0;
+    }
+    if(ganadoresNumero === 1){
+      return totalCartones;
+    }
+    if(totalCartones < ganadoresNumero){
+      return totalCartones;
+    }
+    const dividido = Math.floor(totalCartones / ganadoresNumero);
+    return dividido > 0 ? dividido : totalCartones;
+  }
+
+  function obtenerCartonesGratisTotalesEntregados(forma,totalGanadores){
+    const porGanador = obtenerCartonesGratisPorGanador(forma,totalGanadores);
+    if(porGanador <= 0) return 0;
+    let ganadoresNumero = Number(totalGanadores);
+    if(!Number.isFinite(ganadoresNumero)){
+      ganadoresNumero = 1;
+    }else{
+      ganadoresNumero = Math.floor(ganadoresNumero);
+    }
+    if(ganadoresNumero <= 0){
+      return 0;
+    }
+    return porGanador * ganadoresNumero;
   }
 
   function obtenerNumeroCarton(carton){
@@ -2675,10 +2712,8 @@
       const cantidadGanadores = ganadores.length;
       const premioTotal = obtenerCreditosForma(forma);
       const premioIndividual = cantidadGanadores > 0 ? Math.floor(premioTotal / cantidadGanadores) : 0;
-      const totalCartonesGratis = obtenerCartonesGratisForma(forma);
-      const cartonesGratisPorGanador = cantidadGanadores > 0
-        ? Math.floor(totalCartonesGratis / cantidadGanadores)
-        : 0;
+      const totalCartonesGratis = obtenerCartonesGratisTotalesEntregados(forma, cantidadGanadores);
+      const cartonesGratisPorGanador = obtenerCartonesGratisPorGanador(forma, cantidadGanadores);
 
       const detallePremio = crearDetalleForma('Créditos ganados', premioTotal > 0
         ? `${formatearNumero(premioTotal)}`


### PR DESCRIPTION
## Summary
- update the free-card distribution helper to handle multiple winners without zeroing the award
- show the correct per-winner and total free-card amounts in the active game and cantar sorteos modals
- align payment center and PDF exports with the revised free-card calculations

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68fed76e6c90832697b6c5f4f238e83f