### PR TITLE
Actualizar tablas de centro de pagos y filtros de transacciones

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -448,7 +448,7 @@
         const opcionPago = document.getElementById('filtro-tipo-pago');
         if(opcionPago && filtroTipoSelect){
           const rolActual = (window.currentRole || '').toLowerCase();
-          const visible = rolActual === 'colaborador';
+          const visible = ['colaborador','administrador','superadmin'].includes(rolActual);
           opcionPago.hidden = !visible;
           if(!visible && filtroTipoSelect.value === 'pago'){
             filtroTipoSelect.value = '';

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -150,20 +150,44 @@
       background: rgba(255,255,255,0.7);
     }
     @media (orientation: portrait) {
-      #tabla-colaboradores col:nth-child(5) {
-        width: 16%;
-      }
-      #tabla-colaboradores col:nth-child(7) {
-        width: 6%;
-      }
+      #tabla-premios col:nth-child(1) { width: 7%; }
+      #tabla-premios col:nth-child(2) { width: calc(26% - 6px); }
+      #tabla-premios col:nth-child(3) { width: calc(16% - 4px); }
+      #tabla-premios col:nth-child(4) { width: calc(12% - 4px); }
+      #tabla-premios col:nth-child(5) { width: calc(19% - 4px); }
+      #tabla-premios col:nth-child(6) { width: calc(18% - 4px); }
+      #tabla-premios col:nth-child(7) { width: 8%; }
+
+      #tabla-pagos col:nth-child(1) { width: 7%; }
+      #tabla-pagos col:nth-child(2) { width: calc(36% - 8px); }
+      #tabla-pagos col:nth-child(3) { width: calc(18% - 4px); }
+      #tabla-pagos col:nth-child(4) { width: calc(20% - 4px); }
+      #tabla-pagos col:nth-child(5) { width: calc(17% - 4px); }
+      #tabla-pagos col:nth-child(6) { width: 8%; }
+
+      #tabla-colaboradores col:nth-child(1) { width: 7%; }
+      #tabla-colaboradores col:nth-child(2) { width: calc(38% - 8px); }
+      #tabla-colaboradores col:nth-child(3) { width: calc(17% - 4px); }
+      #tabla-colaboradores col:nth-child(4) { width: calc(18% - 4px); }
+      #tabla-colaboradores col:nth-child(5) { width: calc(18% - 4px); }
+      #tabla-colaboradores col:nth-child(6) { width: 8%; }
     }
     @media (max-width: 600px) and (orientation: portrait) {
-      #tabla-colaboradores col:nth-child(5) {
-        width: 14%;
-      }
-      #tabla-colaboradores col:nth-child(7) {
-        width: 7%;
-      }
+      #tabla-premios col:nth-child(2) { width: calc(28% - 6px); }
+      #tabla-premios col:nth-child(3) { width: calc(15% - 4px); }
+      #tabla-premios col:nth-child(4) { width: calc(11% - 4px); }
+      #tabla-premios col:nth-child(5) { width: calc(20% - 4px); }
+      #tabla-premios col:nth-child(6) { width: calc(17% - 4px); }
+
+      #tabla-pagos col:nth-child(2) { width: calc(40% - 8px); }
+      #tabla-pagos col:nth-child(3) { width: calc(16% - 4px); }
+      #tabla-pagos col:nth-child(4) { width: calc(18% - 4px); }
+      #tabla-pagos col:nth-child(5) { width: calc(18% - 4px); }
+
+      #tabla-colaboradores col:nth-child(2) { width: calc(40% - 8px); }
+      #tabla-colaboradores col:nth-child(3) { width: calc(16% - 4px); }
+      #tabla-colaboradores col:nth-child(4) { width: calc(18% - 4px); }
+      #tabla-colaboradores col:nth-child(5) { width: calc(18% - 4px); }
       #tabla-colaboradores td.creditos-actuales {
         font-size: clamp(0.7rem, 4vw, 0.95rem);
       }
@@ -472,19 +496,17 @@
       <table id="tabla-premios">
         <colgroup>
           <col style="width:6%">
+          <col style="width:24%">
+          <col style="width:16%">
+          <col style="width:12%">
           <col style="width:18%">
-          <col style="width:18%">
-          <col style="width:15%">
-          <col style="width:10%">
-          <col style="width:15%">
-          <col style="width:11%">
+          <col style="width:14%">
           <col style="width:4%">
         </colgroup>
         <thead>
           <tr class="filtros">
             <th>N°</th>
-            <th><input type="text" id="filtro-premios-gmail" placeholder="Gmail"></th>
-            <th><input type="text" id="filtro-premios-alias" placeholder="Alias"></th>
+            <th><input type="text" id="filtro-premios-gmail" placeholder="Gmail/Alias"></th>
             <th><input type="text" id="filtro-premios-creditos" placeholder="Créditos"></th>
             <th><input type="text" id="filtro-premios-cartones" placeholder="Cart"></th>
             <th><input type="date" id="filtro-premios-fecha"></th>
@@ -520,18 +542,16 @@
       <table id="tabla-pagos">
         <colgroup>
           <col style="width:6%">
-          <col style="width:22%">
-          <col style="width:22%">
+          <col style="width:30%">
           <col style="width:18%">
+          <col style="width:20%">
           <col style="width:16%">
-          <col style="width:12%">
-          <col style="width:4%">
+          <col style="width:10%">
         </colgroup>
         <thead>
           <tr class="filtros">
             <th>N°</th>
-            <th><input type="text" id="filtro-pagos-gmail" placeholder="Gmail"></th>
-            <th><input type="text" id="filtro-pagos-nombre" placeholder="Nombre"></th>
+            <th><input type="text" id="filtro-pagos-gmail" placeholder="Gmail/Nombre"></th>
             <th><input type="text" id="filtro-pagos-creditos" placeholder="Créditos"></th>
             <th><input type="date" id="filtro-pagos-fecha"></th>
             <th>
@@ -559,29 +579,29 @@
     </div>
     <div id="colaboradores-content">
       <div class="acciones">
-        <button class="icon-btn" id="colaboradores-aprobar"><span class="icon check">&#10004;</span><span>Aprobar</span></button>
         <select id="colaboradores-filtro-tipo" class="filtro-tipo">
           <option value="">Todos</option>
           <option value="Colaborador">Colaborador</option>
           <option value="Administrador">Administrador</option>
           <option value="Superadmin">Superadmin</option>
         </select>
+        <button class="icon-btn" id="colaboradores-aprobar"><span class="icon check">&#10004;</span><span>Aprobar</span></button>
+        <button class="icon-btn" id="colaboradores-archivar"><span class="icon">&#128194;</span><span>Archivar</span></button>
+        <button class="icon-btn" id="colaboradores-ver-archivo"><span class="icon">&#128230;</span><span>Archivo</span></button>
       </div>
       <table id="tabla-colaboradores">
         <colgroup>
           <col style="width:6%">
-          <col style="width:22%">
-          <col style="width:22%">
-          <col style="width:16%">
+          <col style="width:32%">
           <col style="width:18%">
-          <col style="width:12%">
-          <col style="width:4%">
+          <col style="width:18%">
+          <col style="width:20%">
+          <col style="width:6%">
         </colgroup>
         <thead>
           <tr class="filtros">
             <th>N°</th>
-            <th><input type="text" id="filtro-colab-gmail" placeholder="Gmail"></th>
-            <th><input type="text" id="filtro-colab-nombre" placeholder="Nombre"></th>
+            <th><input type="text" id="filtro-colab-gmail" placeholder="Gmail/Nombre"></th>
             <th><input type="text" id="filtro-colab-creditos" placeholder="C. Actuales"></th>
             <th class="th-asignados">C. Asignados</th>
             <th>Rol</th>
@@ -613,14 +633,16 @@
     const dbRef = ()=>firebase.firestore();
     const authInstance = ()=>firebase.auth();
 
-    const filtrosPremios = { gmail:'', alias:'', creditos:'', cartones:'', fecha:'', estado:'' };
-    const filtrosPagos = { gmail:'', nombre:'', creditos:'', fecha:'', estado:'' };
-    const filtrosColaboradores = { gmail:'', nombre:'', creditos:'', tipo:'' };
+    const filtrosPremios = { gmail:'', creditos:'', cartones:'', fecha:'', estado:'' };
+    const filtrosPagos = { gmail:'', creditos:'', fecha:'', estado:'' };
+    const filtrosColaboradores = { gmail:'', creditos:'', tipo:'' };
 
     let mostrarPremiosArchivo = false;
     let mostrarPagosArchivo = false;
     let mostrarColaboradoresArchivo = false;
 
+    const colaboradoresBase = [];
+    const colaboradoresArchivadosSet = new Set();
     const premiosActivos = [];
     const premiosArchivados = [];
     const pagosAdminActivos = [];
@@ -632,6 +654,7 @@
     const pagosAdminMapa = new Map();
     const pagosAdminArchivoMapa = new Map();
     const pagosColaboradoresMapa = new Map();
+    const pagosColaboradoresArchivoMapa = new Map();
     const pagosColaboradoresEdicion = new Map();
     const usuariosInfoCache = new Map();
 
@@ -1856,7 +1879,7 @@
       if(!tbody) return;
       const { mostrarArchivo = false, tipo } = opciones;
       if(!lista.length){
-        const columnasTabla = tipo==='premios' ? 8 : (tipo==='colaboradores' ? 7 : 7);
+        const columnasTabla = tipo==='premios' ? 7 : (tipo==='colaboradores' ? 6 : 6);
         tbody.innerHTML = `<tr><td colspan="${columnasTabla}"><div class="mensaje-tabla">No hay registros para mostrar.</div></td></tr>`;
         return;
       }
@@ -1868,11 +1891,13 @@
         ? construirRolBadgeHtml(rolNormalizado)
         : `<span class="${estadoClase}">${escapeHtml(item.estado)}</span>`;
         const disabled = mostrarArchivo ? 'disabled' : '';
+        const gmailAttr = escapeHtml(item.gmail || '');
+        const aliasAttr = escapeHtml(item.alias || '');
+        const nombreAttr = escapeHtml(item.nombre || '');
         if(tipo === 'premios'){
           return `<tr data-id="${item.id}">
             <td>${numero}</td>
-            <td class="gmail">${construirGmailHtml(item.gmail)}</td>
-            <td class="alias">${escapeHtml(item.alias)}</td>
+            <td class="gmail" data-gmail="${gmailAttr}" data-alias="${aliasAttr}">${construirGmailHtml(item.gmail)}</td>
             <td class="creditos">${formatNumber.format(item.creditos)}</td>
             <td class="cart">${formatNumber.format(item.cartones)}</td>
             <td>${escapeHtml(item.fechaMostrar)}</td>
@@ -1891,8 +1916,7 @@
           const creditosActuales = Number(item.creditosActuales ?? item.creditos ?? 0);
           return `<tr data-id="${item.id}">
             <td>${numero}</td>
-            <td class="gmail">${construirGmailHtml(item.gmail)}</td>
-            <td class="alias">${escapeHtml(item.nombre)}</td>
+            <td class="gmail" data-gmail="${gmailAttr}" data-nombre="${nombreAttr}" data-alias="${aliasAttr}">${construirGmailHtml(item.gmail)}</td>
             <td class="creditos-actuales">${formatNumber.format(creditosActuales)}</td>
             <td class="colab-asignar"><input type="number" class="colab-input" step="1" inputmode="numeric" data-id="${item.id}" value="${valorInput}" placeholder="0" disabled${archivoAttr}></td>
             <td class="estado">${estadoHtml}</td>
@@ -1901,8 +1925,7 @@
         }
         return `<tr data-id="${item.id}">
           <td>${numero}</td>
-          <td class="gmail">${construirGmailHtml(item.gmail)}</td>
-          <td class="alias">${escapeHtml(item.nombre)}</td>
+          <td class="gmail" data-gmail="${gmailAttr}" data-nombre="${nombreAttr}">${construirGmailHtml(item.gmail)}</td>
           <td class="creditos">${formatNumberEntero.format(Math.round(item.creditos))}</td>
           <td>${escapeHtml(item.fechaMostrar)}</td>
           <td class="estado">${estadoHtml}</td>
@@ -1914,8 +1937,11 @@
 
     function aplicarFiltrosPremios(origen){
       return origen.filter(item=>{
-        if(filtrosPremios.gmail && !item.gmail.toLowerCase().includes(filtrosPremios.gmail)) return false;
-        if(filtrosPremios.alias && !item.alias.toLowerCase().includes(filtrosPremios.alias)) return false;
+        if(filtrosPremios.gmail){
+          const termino = filtrosPremios.gmail;
+          const aliasLower = (item.alias || '').toLowerCase();
+          if(!item.gmail.toLowerCase().includes(termino) && !aliasLower.includes(termino)) return false;
+        }
         if(filtrosPremios.creditos && !item.creditos.toString().includes(filtrosPremios.creditos)) return false;
         if(filtrosPremios.cartones && !item.cartones.toString().includes(filtrosPremios.cartones)) return false;
         if(filtrosPremios.fecha && item.fechaFiltro !== filtrosPremios.fecha) return false;
@@ -1926,8 +1952,11 @@
 
     function aplicarFiltrosPagos(origen){
       return origen.filter(item=>{
-        if(filtrosPagos.gmail && !item.gmail.toLowerCase().includes(filtrosPagos.gmail)) return false;
-        if(filtrosPagos.nombre && !item.nombre.toLowerCase().includes(filtrosPagos.nombre)) return false;
+        if(filtrosPagos.gmail){
+          const termino = filtrosPagos.gmail;
+          const nombreLower = (item.nombre || '').toLowerCase();
+          if(!item.gmail.toLowerCase().includes(termino) && !nombreLower.includes(termino)) return false;
+        }
         if(filtrosPagos.creditos && !item.creditos.toString().includes(filtrosPagos.creditos)) return false;
         if(filtrosPagos.fecha && item.fechaFiltro !== filtrosPagos.fecha) return false;
         if(filtrosPagos.estado && item.estado !== filtrosPagos.estado) return false;
@@ -1937,8 +1966,12 @@
 
     function aplicarFiltrosColaboradores(origen){
       return origen.filter(item=>{
-        if(filtrosColaboradores.gmail && !item.gmail.toLowerCase().includes(filtrosColaboradores.gmail)) return false;
-        if(filtrosColaboradores.nombre && !item.nombre.toLowerCase().includes(filtrosColaboradores.nombre)) return false;
+        if(filtrosColaboradores.gmail){
+          const termino = filtrosColaboradores.gmail;
+          const aliasLower = (item.alias || '').toLowerCase();
+          const nombreLower = (item.nombre || '').toLowerCase();
+          if(!item.gmail.toLowerCase().includes(termino) && !aliasLower.includes(termino) && !nombreLower.includes(termino)) return false;
+        }
         const creditosTexto = String(item.creditosActuales ?? item.creditos ?? '');
         if(filtrosColaboradores.creditos && !creditosTexto.includes(filtrosColaboradores.creditos)) return false;
         if(filtrosColaboradores.tipo){
@@ -1964,6 +1997,20 @@
       renderTabla(lista, 'tabla-pagos', { mostrarArchivo: mostrarPagosArchivo, tipo: 'pagos' });
       actualizarBadge('pagos', pagosAdminActivos.filter(item=>item.estado === 'PENDIENTE').length);
       actualizarEstadoBotones();
+    }
+
+    function actualizarColaboradoresDesdeBase(){
+      const visibles = [];
+      pagosColaboradoresMapa.clear();
+      colaboradoresBase.forEach(registro => {
+        const clave = cpNormalizarEmail(registro.gmail);
+        if(clave && colaboradoresArchivadosSet.has(clave)) return;
+        visibles.push(registro);
+        pagosColaboradoresMapa.set(registro.id, registro);
+      });
+      visibles.sort((a,b)=> (a.nombre || a.alias || '').localeCompare(b.nombre || b.alias || ''));
+      pagosColaboradoresActivos.length = 0;
+      pagosColaboradoresActivos.push(...visibles);
     }
 
     function renderColaboradores(){
@@ -2009,9 +2056,9 @@
       document.getElementById('premios-ver-archivo').classList.toggle('archivo-activo', mostrarPremiosArchivo);
       document.getElementById('pagos-ver-archivo').classList.toggle('archivo-activo', mostrarPagosArchivo);
       const colabAprobar = document.getElementById('colaboradores-aprobar');
-      if(colabAprobar) colabAprobar.disabled = false;
+      if(colabAprobar) colabAprobar.disabled = mostrarColaboradoresArchivo;
       const colabArchivar = document.getElementById('colaboradores-archivar');
-      if(colabArchivar) colabArchivar.disabled = true;
+      if(colabArchivar) colabArchivar.disabled = mostrarColaboradoresArchivo;
       const colabVerArchivo = document.getElementById('colaboradores-ver-archivo');
       if(colabVerArchivo) colabVerArchivo.classList.toggle('archivo-activo', mostrarColaboradoresArchivo);
     }
@@ -2141,7 +2188,7 @@
               rolGestor: window.currentRole || ''
             });
           });
-          await acreditarPago(registro);
+          await acreditarPago({ ...registro, tipotrans: 'pago' });
         } catch (err) {
           console.error('Error aprobando pago', err);
           alert('Ocurrió un error al aprobar un pago. Revisa la consola para más detalles.');
@@ -2233,14 +2280,51 @@
       if(!ids.length) return;
       const db = dbRef();
       await initServerTime();
+      if(tipo === 'colaboradores'){
+        const coleccionArchivo = db.collection('PagosColaboradoresArchivo');
+        const idsNormalizados = new Set();
+        for(const id of ids){
+          const registro = pagosColaboradoresMapa.get(id);
+          if(!registro) continue;
+          try {
+            const datosArchivo = {
+              gmail: registro.gmail,
+              nombre: registro.nombre || '',
+              alias: registro.alias || '',
+              tipo: registro.tipo || registro.estado || '',
+              telefono: registro.telefono || '',
+              creditosActuales: Number(registro.creditosActuales ?? registro.creditos ?? 0),
+              creditos: Number(registro.creditosActuales ?? registro.creditos ?? 0),
+              archivadoEn: fechaServidor(),
+              horaArchivado: horaServidor(),
+              archivadoPor: authInstance().currentUser?.email || '',
+              estado: 'ARCHIVADO'
+            };
+            await coleccionArchivo.doc(id).set(datosArchivo, { merge: true });
+            pagosColaboradoresEdicion.delete(id);
+            pagosColaboradoresMapa.delete(id);
+            const normalizado = cpNormalizarEmail(registro.gmail || id);
+            if(normalizado){
+              idsNormalizados.add(normalizado);
+              colaboradoresArchivadosSet.add(normalizado);
+            }
+          } catch (err) {
+            console.error('Error archivando registro', tipo, err);
+            alert('No se pudo archivar uno de los registros seleccionados.');
+            break;
+          }
+        }
+        if(idsNormalizados.size){
+          actualizarColaboradoresDesdeBase();
+        }
+        renderColaboradores();
+        return;
+      }
       let coleccionBase = db.collection('PagosAdministracion');
       let coleccionArchivo = db.collection('PagosAdministracionArchivo');
       if(tipo === 'premios'){
         coleccionBase = db.collection('PremiosSorteos');
         coleccionArchivo = db.collection('PremiosSorteosArchivo');
-      } else if(tipo === 'colaboradores'){
-        coleccionBase = db.collection('PagosColaboradores');
-        coleccionArchivo = db.collection('PagosColaboradoresArchivo');
       }
       for(const id of ids){
         try {
@@ -2269,20 +2353,17 @@
 
     function configurarFiltros(){
       document.getElementById('filtro-premios-gmail').addEventListener('input', e=>{ filtrosPremios.gmail = e.target.value.toLowerCase().trim(); renderPremios(); });
-      document.getElementById('filtro-premios-alias').addEventListener('input', e=>{ filtrosPremios.alias = e.target.value.toLowerCase().trim(); renderPremios(); });
       document.getElementById('filtro-premios-creditos').addEventListener('input', e=>{ filtrosPremios.creditos = e.target.value.replace(/[^0-9.]/g,''); renderPremios(); });
       document.getElementById('filtro-premios-cartones').addEventListener('input', e=>{ filtrosPremios.cartones = e.target.value.replace(/[^0-9]/g,''); renderPremios(); });
       document.getElementById('filtro-premios-fecha').addEventListener('change', e=>{ filtrosPremios.fecha = e.target.value; renderPremios(); });
       document.getElementById('filtro-premios-estado').addEventListener('change', e=>{ filtrosPremios.estado = e.target.value; renderPremios(); });
 
       document.getElementById('filtro-pagos-gmail').addEventListener('input', e=>{ filtrosPagos.gmail = e.target.value.toLowerCase().trim(); renderPagos(); });
-      document.getElementById('filtro-pagos-nombre').addEventListener('input', e=>{ filtrosPagos.nombre = e.target.value.toLowerCase().trim(); renderPagos(); });
       document.getElementById('filtro-pagos-creditos').addEventListener('input', e=>{ filtrosPagos.creditos = e.target.value.replace(/[^0-9.]/g,''); renderPagos(); });
       document.getElementById('filtro-pagos-fecha').addEventListener('change', e=>{ filtrosPagos.fecha = e.target.value; renderPagos(); });
       document.getElementById('filtro-pagos-estado').addEventListener('change', e=>{ filtrosPagos.estado = e.target.value; renderPagos(); });
 
       document.getElementById('filtro-colab-gmail').addEventListener('input', e=>{ filtrosColaboradores.gmail = e.target.value.toLowerCase().trim(); renderColaboradores(); });
-      document.getElementById('filtro-colab-nombre').addEventListener('input', e=>{ filtrosColaboradores.nombre = e.target.value.toLowerCase().trim(); renderColaboradores(); });
       document.getElementById('filtro-colab-creditos').addEventListener('input', e=>{ filtrosColaboradores.creditos = e.target.value.replace(/[^0-9.]/g,''); renderColaboradores(); });
       document.getElementById('colaboradores-filtro-tipo').addEventListener('change', e=>{
         filtrosColaboradores.tipo = (e.target.value || '').toLowerCase();
@@ -2336,6 +2417,19 @@
         const seleccion = obtenerSeleccion('tabla-colaboradores');
         if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }
         await aprobarPagosColaboradores(seleccion);
+      });
+      document.getElementById('colaboradores-archivar').addEventListener('click', async()=>{
+        const seleccion = obtenerSeleccion('tabla-colaboradores');
+        if(!seleccion.length){ alert('Selecciona registros para archivar.'); return; }
+        if(!(await confirm('¿Deseas archivar los registros seleccionados?'))) return;
+        await archivarRegistros(seleccion, 'colaboradores');
+      });
+      document.getElementById('colaboradores-ver-archivo').addEventListener('click', ()=>{
+        mostrarColaboradoresArchivo = !mostrarColaboradoresArchivo;
+        if(mostrarColaboradoresArchivo){
+          pagosColaboradoresEdicion.clear();
+        }
+        renderColaboradores();
       });
       const tablaColaboradores = document.getElementById('tabla-colaboradores');
       tablaColaboradores.addEventListener('change', e=>{
@@ -2398,8 +2492,17 @@
           const fila = e.target.closest('tr[data-id]');
           if(!fila) return;
           const id = fila.dataset.id;
-          const registro = pagosColaboradoresMapa.get(id);
+          const registro = pagosColaboradoresMapa.get(id) || pagosColaboradoresArchivoMapa.get(id);
           if(!registro) return;
+          if(e.target.closest('td.gmail')){
+            let nombre = registro.nombre || registro.alias || '';
+            if(!nombre){
+              const info = await obtenerInfoUsuarioDetallada(registro.gmail, registro.alias || registro.nombre);
+              nombre = info?.nombre || info?.alias || '';
+            }
+            mostrarModalInfo('Nombre del usuario', nombre || 'Sin nombre registrado.');
+            return;
+          }
           if(e.target.closest('td.creditos-actuales')){
             const info = await obtenerInfoUsuarioDetallada(registro.gmail, registro.alias || registro.nombre);
             const cartones = Number(info?.cartonesGratis ?? registro.cartonesGratis ?? 0);
@@ -2422,16 +2525,13 @@
             mostrarModalInfo('Sorteo asignado', sorteo || 'Sin sorteo asociado.');
             return;
           }
-          if(e.target.closest('td.alias')){
-            const info = await obtenerInfoUsuarioDetallada(registro.gmail, registro.alias);
-            const tipo = info?.tipo || 'Sin tipo registrado.';
-            mostrarModalInfo('Tipo de usuario', tipo || 'Sin tipo registrado.');
-            return;
-          }
           if(e.target.closest('td.gmail')){
-            const info = await obtenerInfoUsuarioDetallada(registro.gmail, registro.alias);
-            const telefono = info?.telefono || 'Sin número registrado.';
-            mostrarModalInfo('Teléfono del usuario', telefono || 'Sin número registrado.');
+            let alias = registro.alias;
+            if(!alias){
+              const info = await obtenerInfoUsuarioDetallada(registro.gmail, registro.alias);
+              alias = info?.alias || '';
+            }
+            mostrarModalInfo('Alias del usuario', alias || 'Sin alias registrado.');
             return;
           }
           if(e.target.closest('td.cart')){
@@ -2456,16 +2556,13 @@
             mostrarModalInfo('Sorteo asignado', sorteo || 'Sin sorteo asociado.');
             return;
           }
-          if(e.target.closest('td.alias')){
-            const info = await obtenerInfoUsuarioDetallada(registro.gmail, registro.alias || registro.nombre);
-            const tipo = info?.tipo || 'Sin tipo registrado.';
-            mostrarModalInfo('Tipo de usuario', tipo || 'Sin tipo registrado.');
-            return;
-          }
           if(e.target.closest('td.gmail')){
-            const info = await obtenerInfoUsuarioDetallada(registro.gmail, registro.alias || registro.nombre);
-            const telefono = info?.telefono || 'Sin número registrado.';
-            mostrarModalInfo('Teléfono del usuario', telefono || 'Sin número registrado.');
+            let nombre = registro.nombre || '';
+            if(!nombre){
+              const info = await obtenerInfoUsuarioDetallada(registro.gmail, registro.alias || registro.nombre);
+              nombre = info?.nombre || info?.alias || '';
+            }
+            mostrarModalInfo('Nombre del usuario', nombre || 'Sin nombre registrado.');
           }
         });
       }
@@ -2543,8 +2640,7 @@
         if(mostrarPagosArchivo) renderPagos();
       });
       unsubscribeUsuariosCentro = db.collection('users').onSnapshot(async snapshot => {
-        const registros = [];
-        pagosColaboradoresMapa.clear();
+        colaboradoresBase.length = 0;
         pagosColaboradoresEdicion.clear();
         const tareas = [];
         snapshot.forEach(doc => {
@@ -2560,20 +2656,21 @@
           const registro = {
             id: email,
             gmail: email,
-            nombre: nombre,
+            nombre,
             alias,
             creditos: 0,
+            creditosActuales: 0,
             fechaMostrar: '-',
             fechaFiltro: '',
             fechaOrden: 0,
             estado: tipo,
             tipo,
             billetera: email,
-            telefono
+            telefono,
+            cartonesGratis: 0
           };
+          colaboradoresBase.push(registro);
           guardarInfoUsuarioCache({ email, alias, nombre, tipo, telefono, completo: false });
-          pagosColaboradoresMapa.set(email, registro);
-          registros.push(registro);
           tareas.push((async()=>{
             const billetera = await obtenerDatosBilletera(email);
             registro.creditosActuales = billetera.creditos;
@@ -2591,13 +2688,61 @@
             });
           })());
         });
-        try {
-          await Promise.all(tareas);
-        } catch (err) {
-          console.warn('No se pudieron sincronizar algunas billeteras', err);
+        actualizarColaboradoresDesdeBase();
+        renderColaboradores();
+        if(tareas.length){
+          try {
+            await Promise.all(tareas);
+          } catch (err) {
+            console.warn('No se pudieron sincronizar algunas billeteras', err);
+          }
+          actualizarColaboradoresDesdeBase();
+          renderColaboradores();
         }
-        pagosColaboradoresActivos.length = 0;
-        pagosColaboradoresActivos.push(...registros.sort((a,b)=> (a.nombre || a.alias || '').localeCompare(b.nombre || b.alias || '')));
+      });
+      unsubscribeColaboradoresArchivo = db.collection('PagosColaboradoresArchivo').onSnapshot(snapshot => {
+        const nuevosArchivados = new Set();
+        pagosColaboradoresArchivados.length = 0;
+        pagosColaboradoresArchivoMapa.clear();
+        snapshot.forEach(doc => {
+          const data = doc.data() || {};
+          const email = cpNormalizarEmail(data.gmail || doc.id);
+          if(email) nuevosArchivados.add(email);
+          const tipo = normalizarTipoUsuario(data.tipo || data.estado || 'Archivado');
+          const fechaInfo = normalizarFecha(data.archivadoEn || data.fechaArchivado || data.fechaGestion || '');
+          const creditosActuales = Number(data.creditosActuales ?? data.creditos ?? 0);
+          const registro = {
+            id: doc.id,
+            gmail: email || doc.id,
+            nombre: (data.nombre || data.alias || '').toString(),
+            alias: (data.alias || '').toString(),
+            creditos: creditosActuales,
+            creditosActuales,
+            fechaMostrar: fechaInfo.mostrar,
+            fechaFiltro: fechaInfo.filtro,
+            fechaOrden: fechaInfo.orden,
+            estado: tipo || 'Archivado',
+            tipo: tipo || 'Archivado',
+            billetera: email || doc.id,
+            telefono: (data.telefono || '').toString(),
+            cartonesGratis: Number(data.cartonesGratis ?? 0)
+          };
+          pagosColaboradoresArchivados.push(registro);
+          pagosColaboradoresArchivoMapa.set(doc.id, registro);
+          guardarInfoUsuarioCache({
+            email: registro.gmail,
+            alias: registro.alias,
+            nombre: registro.nombre,
+            tipo: registro.tipo,
+            telefono: registro.telefono,
+            creditos: registro.creditosActuales,
+            cartonesGratis: registro.cartonesGratis,
+            completo: false
+          });
+        });
+        colaboradoresArchivadosSet.clear();
+        nuevosArchivados.forEach(valor => colaboradoresArchivadosSet.add(valor));
+        actualizarColaboradoresDesdeBase();
         renderColaboradores();
       });
     }
@@ -2608,7 +2753,8 @@
         unsubscribePremiosArchivo,
         unsubscribePagos,
         unsubscribePagosArchivo,
-        unsubscribeUsuariosCentro
+        unsubscribeUsuariosCentro,
+        unsubscribeColaboradoresArchivo
       ].forEach(unsub=>{
         if(typeof unsub === 'function') unsub();
       });


### PR DESCRIPTION
## Summary
- reorganize las tablas de premios, pagos y colaboradores para eliminar columnas redundantes, habilitar modales sobre Gmail y adaptar los estilos responsivos
- añadir controles de archivo para colaboradores incluyendo persistencia en Firestore y búsqueda extendida por alias o nombre
- clasificar los pagos administrativos como transacciones de tipo "pago" y exponer el filtro correspondiente según el rol en Mis transacciones

## Testing
- no se ejecutaron pruebas (no requerido)


------
https://chatgpt.com/codex/tasks/task_e_68ff745ca8c48326b4ebf46676cf4304