### PR TITLE
Ajusta estilos móviles en centropagos

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -150,27 +150,38 @@
       background: rgba(255,255,255,0.7);
     }
     @media (orientation: portrait) {
+      body { padding: 2px; }
+      .section {
+        margin: 4px 0;
+        padding: 4px 4px 8px;
+        width: 100%;
+        box-sizing: border-box;
+      }
+      .section-header { margin-bottom: 2px; }
+      .acciones { margin: 2px 0; }
+      table { margin: 2px 0; }
+
       #tabla-premios col:nth-child(1) { width: 7%; }
       #tabla-premios col:nth-child(2) { width: calc(26% - 6px); }
       #tabla-premios col:nth-child(3) { width: calc(16% - 4px); }
       #tabla-premios col:nth-child(4) { width: calc(12% - 4px); }
       #tabla-premios col:nth-child(5) { width: calc(19% - 4px); }
-      #tabla-premios col:nth-child(6) { width: calc(18% - 4px); }
-      #tabla-premios col:nth-child(7) { width: 8%; }
+      #tabla-premios col:nth-child(6) { width: calc(17% - 4px); }
+      #tabla-premios col:nth-child(7) { width: 9%; }
 
       #tabla-pagos col:nth-child(1) { width: 7%; }
       #tabla-pagos col:nth-child(2) { width: calc(36% - 8px); }
       #tabla-pagos col:nth-child(3) { width: calc(18% - 4px); }
-      #tabla-pagos col:nth-child(4) { width: calc(20% - 4px); }
+      #tabla-pagos col:nth-child(4) { width: calc(19% - 4px); }
       #tabla-pagos col:nth-child(5) { width: calc(17% - 4px); }
-      #tabla-pagos col:nth-child(6) { width: 8%; }
+      #tabla-pagos col:nth-child(6) { width: 9%; }
 
       #tabla-colaboradores col:nth-child(1) { width: 7%; }
       #tabla-colaboradores col:nth-child(2) { width: calc(38% - 8px); }
       #tabla-colaboradores col:nth-child(3) { width: calc(17% - 4px); }
-      #tabla-colaboradores col:nth-child(4) { width: calc(18% - 4px); }
-      #tabla-colaboradores col:nth-child(5) { width: calc(18% - 4px); }
-      #tabla-colaboradores col:nth-child(6) { width: 8%; }
+      #tabla-colaboradores col:nth-child(4) { width: calc(17% - 4px); }
+      #tabla-colaboradores col:nth-child(5) { width: calc(17% - 4px); }
+      #tabla-colaboradores col:nth-child(6) { width: 9%; }
     }
     @media (max-width: 600px) and (orientation: portrait) {
       #tabla-premios col:nth-child(2) { width: calc(28% - 6px); }
@@ -276,6 +287,19 @@
     }
     td.gmail { word-break: break-word; white-space: normal; }
     td.estado { white-space: normal; }
+    #tabla-premios th:last-child, #tabla-premios td:last-child,
+    #tabla-pagos th:last-child, #tabla-pagos td:last-child,
+    #tabla-colaboradores th:last-child, #tabla-colaboradores td:last-child {
+      text-align: center;
+    }
+    #tabla-premios td:last-child input[type="checkbox"],
+    #tabla-pagos td:last-child input[type="checkbox"],
+    #tabla-colaboradores td:last-child input[type="checkbox"] {
+      width: 18px;
+      height: 18px;
+      margin: 0 auto;
+      display: block;
+    }
     #tabla-premios th:nth-child(2), #tabla-premios td:nth-child(2),
     #tabla-premios th:nth-child(3), #tabla-premios td:nth-child(3),
     #tabla-premios th:nth-child(4), #tabla-premios td:nth-child(4),


### PR DESCRIPTION
## Summary
- reduce los márgenes laterales en vista vertical de centropagos para que las tablas ocupen todo el ancho disponible
- homologa el ancho de las columnas de selección y centra los checkboxes para evitar recortes en móviles

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ff7e1a2efc8326b8e9aa50ef72581d