### PR TITLE
Tweak mobile layout widths in centro pagos tables

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -164,10 +164,10 @@
       #tabla-premios col:nth-child(1) { width: 7%; }
       #tabla-premios col:nth-child(2) { width: calc(26% - 6px); }
       #tabla-premios col:nth-child(3) { width: calc(16% - 4px); }
-      #tabla-premios col:nth-child(4) { width: calc(12% - 4px); }
+      #tabla-premios col:nth-child(4) { width: calc(10% - 4px); }
       #tabla-premios col:nth-child(5) { width: calc(19% - 4px); }
       #tabla-premios col:nth-child(6) { width: calc(17% - 4px); }
-      #tabla-premios col:nth-child(7) { width: 9%; }
+      #tabla-premios col:nth-child(7) { width: 11%; }
 
       #tabla-pagos col:nth-child(1) { width: 7%; }
       #tabla-pagos col:nth-child(2) { width: calc(36% - 8px); }
@@ -186,7 +186,7 @@
     @media (max-width: 600px) and (orientation: portrait) {
       #tabla-premios col:nth-child(2) { width: calc(28% - 6px); }
       #tabla-premios col:nth-child(3) { width: calc(15% - 4px); }
-      #tabla-premios col:nth-child(4) { width: calc(11% - 4px); }
+      #tabla-premios col:nth-child(4) { width: calc(9% - 4px); }
       #tabla-premios col:nth-child(5) { width: calc(20% - 4px); }
       #tabla-premios col:nth-child(6) { width: calc(17% - 4px); }
 
@@ -369,10 +369,12 @@
     }
     .th-asignados {
       font-family: Calibri, Arial, sans-serif;
-      font-size: 0.75rem;
+      font-size: clamp(0.65rem, 2.2vw, 0.75rem);
       font-weight: 700;
-      letter-spacing: 0.5px;
+      letter-spacing: 0.2px;
       text-transform: uppercase;
+      white-space: normal;
+      word-break: break-word;
     }
     .estado-pendiente { color: orange; }
     .estado-aprobado { color: green; }


### PR DESCRIPTION
## Summary
- adjust the mobile cart column width in the PREMIOS JUGADORES table so the checkbox column stays visible
- update the "C. ASIGNADOS" header styling to scale and wrap within the collaborators table column

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff83b9265083268b0855ced61ee124