### PR TITLE
Tweak mobile layout in centropagos view

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -164,10 +164,10 @@
       #tabla-premios col:nth-child(1) { width: 7%; }
       #tabla-premios col:nth-child(2) { width: calc(26% - 6px); }
       #tabla-premios col:nth-child(3) { width: calc(16% - 4px); }
-      #tabla-premios col:nth-child(4) { width: calc(10% - 4px); }
+      #tabla-premios col:nth-child(4) { width: calc(10% - 10px); }
       #tabla-premios col:nth-child(5) { width: calc(19% - 4px); }
       #tabla-premios col:nth-child(6) { width: calc(17% - 4px); }
-      #tabla-premios col:nth-child(7) { width: 11%; }
+      #tabla-premios col:nth-child(7) { width: calc(11% + 6px); }
 
       #tabla-pagos col:nth-child(1) { width: 7%; }
       #tabla-pagos col:nth-child(2) { width: calc(36% - 8px); }
@@ -186,7 +186,8 @@
     @media (max-width: 600px) and (orientation: portrait) {
       #tabla-premios col:nth-child(2) { width: calc(28% - 6px); }
       #tabla-premios col:nth-child(3) { width: calc(15% - 4px); }
-      #tabla-premios col:nth-child(4) { width: calc(9% - 4px); }
+      #tabla-premios col:nth-child(4) { width: calc(9% - 10px); }
+      #tabla-premios col:nth-child(7) { width: calc(11% + 6px); }
       #tabla-premios col:nth-child(5) { width: calc(20% - 4px); }
       #tabla-premios col:nth-child(6) { width: calc(17% - 4px); }
 
@@ -369,7 +370,7 @@
     }
     .th-asignados {
       font-family: Calibri, Arial, sans-serif;
-      font-size: clamp(0.65rem, 2.2vw, 0.75rem);
+      font-size: clamp(0.6rem, 2vw, 0.7rem);
       font-weight: 700;
       letter-spacing: 0.2px;
       text-transform: uppercase;
@@ -629,7 +630,7 @@
             <th>N°</th>
             <th><input type="text" id="filtro-colab-gmail" placeholder="Gmail/Nombre"></th>
             <th><input type="text" id="filtro-colab-creditos" placeholder="C. Actuales"></th>
-            <th class="th-asignados">C. Asignados</th>
+            <th class="th-asignados">CREDITOS ASIGNADOS</th>
             <th>Rol</th>
             <th><span id="colaboradores-marcar" class="check-header">✔</span></th>
           </tr>


### PR DESCRIPTION
## Summary
- adjust the portrait layout widths for the Cart and check columns in the player prizes table
- rename the collaborator credit assignment header and slightly reduce its font size for readability

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ff8ad9b1d8832691b8856607b51b35