### PR TITLE
Corregir bloqueo de inicialización en parámetros superadmin

### DIFF
--- a/public/parametros.html
+++ b/public/parametros.html
@@ -450,14 +450,6 @@
       toggleEdicion(true);
     });
     document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='super.html';});
-    auth.onAuthStateChanged(user=>{
-      if(user){
-        const pic=document.getElementById('user-pic');
-        if(pic) pic.src=user.photoURL;
-        const logout=document.getElementById('logout-link');
-        if(logout){logout.addEventListener('click',e=>{e.preventDefault();logout();});}
-      }
-    });
     async function iniciarParametros(){
       try{
         await initFirebase();


### PR DESCRIPTION
## Summary
- elimina la suscripción redundante a auth en parametros.html que usaba el objeto antes de inicializarse y detenía la carga del formulario

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ff90cc96348326a36ec4670f7fa7ab