### PR TITLE
Evitar doble solicitud de contraseña al abrir parámetros

### DIFF
--- a/public/parametros.html
+++ b/public/parametros.html
@@ -478,13 +478,7 @@
       }
 
       const contrasenaEsperada = obtenerContrasenaSuperadmin(datosParametros);
-      if(contrasenaEsperada){
-        const accesoPermitido = await solicitarPassword(contrasenaEsperada);
-        if(!accesoPermitido){
-          window.location.href='super.html';
-          return;
-        }
-      }else{
+      if(!contrasenaEsperada){
         alert('No hay una contraseña configurada para Superadmin. Configúrala en este formulario y guarda los cambios.');
       }
 


### PR DESCRIPTION
## Summary
- omitir la segunda verificación de contraseña al cargar la vista de parámetros para superadmin

## Testing
- no se ejecutaron pruebas automatizadas (no aplicaba)


------
https://chatgpt.com/codex/tasks/task_e_68ff95153ea0832694c66e6ed2c69164