### PR TITLE
Implementa sincronización horaria global

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Cada secreto debe contener el valor correspondiente del proyecto de Firebase. Si
 - Evite depender de la fecha u hora del dispositivo cliente; utilice siempre fuentes sincronizadas con el huso horario seleccionado para garantizar coherencia entre servicios.
 - Mantenga todas las credenciales y endpoints sensibles en variables de entorno (`GOOGLE_APPLICATION_CREDENTIALS`, `FIREBASE_STORAGE_BUCKET`, `UPLOAD_ENDPOINT`, `PORT`). Nunca incluya archivos de claves en el repositorio; documente en despliegue dónde obtenerlos.
 - Proteja cada nuevo endpoint o script de backend reutilizando el middleware `verificarToken` de `uploadServer.js` (o uno equivalente) para validar el ID token de Firebase antes de ejecutar acciones administrativas.
-- Calcule fechas y horas apoyándose en `public/js/timezone.js` y en el desfase `serverTime.diferencia`; evite usar directamente `Date.now()` sin normalizar al huso horario configurado, tanto en el cliente como en los procesos automáticos.
+- Calcule fechas y horas apoyándose en `public/js/timezone.js` (métodos `serverTime.now()`, `serverTime.nowMs()` y `serverTime.serverTimestamp()`) y evite usar directamente `Date.now()` sin normalizar al huso horario configurado, tanto en el cliente como en los procesos automáticos.
 - Cuando cree o actualice sorteos, guarde los campos `fecha`, `hora` y `horacierre` en formato `DD/MM/YYYY` y `HH:mm` (24 horas) para asegurar que `cronActualizarEstadosSorteos.js` pueda interpretar los datos sin errores.
 - Documente cualquier ajuste en la colección `Variablesglobales/Parametros` (especialmente `ZonaHoraria`, `Pais` y `Aplicacion`) y coordínelo con los responsables del cron para mantener sincronizados el frontend y las tareas programadas.
 

--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -2409,10 +2409,32 @@
 
   function getServerNow(){
     const st = obtenerServerTime();
+    if (st && typeof st.now === 'function') {
+      const fecha = st.now();
+      if (fecha instanceof Date && !Number.isNaN(fecha.getTime())) {
+        return fecha;
+      }
+    }
+    if (st && typeof st.nowMs === 'function') {
+      const millis = st.nowMs();
+      if (Number.isFinite(millis)) {
+        return new Date(millis);
+      }
+    }
     return new Date(Date.now() + (st?.diferencia || 0));
   }
 
   function getServerTimestamp(){
+    const st = obtenerServerTime();
+    if(st && typeof st.serverTimestamp === 'function'){
+      const marca = st.serverTimestamp();
+      if(marca) return marca;
+    }
+    const fieldValue = firebase?.firestore?.FieldValue;
+    if(fieldValue && typeof fieldValue.serverTimestamp === 'function'){
+      const marca = fieldValue.serverTimestamp();
+      if(marca) return marca;
+    }
     const timestampCtor = firebase?.firestore?.Timestamp;
     if(!timestampCtor){
       return null;
@@ -2448,8 +2470,8 @@
     if(!fechaActualValorEl || !horaActualValorEl) return;
     try {
       const st = obtenerServerTime();
-      const diferencia = st?.diferencia || 0;
-      const ahora = new Date(Date.now() + diferencia);
+      const ahora = getServerNow();
+      if(!(ahora instanceof Date) || Number.isNaN(ahora.getTime())) return;
       const zona = st?.zonaIana;
       const opcionesFecha = { day: '2-digit', month: '2-digit', year: 'numeric' };
       const opcionesHora = { hour: '2-digit', minute: '2-digit', hour12: true };
@@ -2457,7 +2479,8 @@
         opcionesFecha.timeZone = zona;
         opcionesHora.timeZone = zona;
       }
-      const fechaFormatter = new Intl.DateTimeFormat('es-ES', opcionesFecha);
+      const localeFecha = st?.locale || 'es-ES';
+      const fechaFormatter = new Intl.DateTimeFormat(localeFecha, opcionesFecha);
       const horaFormatter = new Intl.DateTimeFormat('en-US', opcionesHora);
       const fechaStr = fechaFormatter.format(ahora);
       const horaStr = horaFormatter.format(ahora).toUpperCase();
@@ -2475,11 +2498,15 @@
     function renderFooter(){
       try {
         const st = obtenerServerTime();
-        const diferencia = Number.isFinite(st?.diferencia) ? st.diferencia : 0;
-        const ahora = new Date(Date.now() + diferencia);
+        const ahora = getServerNow();
+        if(!(ahora instanceof Date) || Number.isNaN(ahora.getTime())) return;
         const locale = st?.locale || 'es-ES';
         const opcionesFecha = { year: 'numeric', month: 'long', day: 'numeric' };
         const opcionesHora = { hour: '2-digit', minute: '2-digit', hour12: true };
+        if(st?.zonaIana){
+          opcionesFecha.timeZone = st.zonaIana;
+          opcionesHora.timeZone = st.zonaIana;
+        }
         const fechaStr = ahora.toLocaleDateString(locale, opcionesFecha);
         let horaStr = ahora.toLocaleTimeString(locale, opcionesHora);
         horaStr = horaStr

--- a/public/js/estadoSorteos.js
+++ b/public/js/estadoSorteos.js
@@ -56,7 +56,10 @@ function obtenerFechaHoraCierre(d,sorteoDate){
 
 async function actualizarEstadosSorteos(){
   await initServerTime();
-  const ahora = new Date(Date.now() + serverTime.diferencia);
+  let ahora = serverTime?.now?.();
+  if (!(ahora instanceof Date) || Number.isNaN(ahora?.getTime?.())) {
+    ahora = new Date(Date.now() + (serverTime?.diferencia || 0));
+  }
   try{
     const snap = await db.collection('sorteos').where('estado','in',['Activo','Sellado']).get();
     const updates=[];

--- a/public/js/timezone.js
+++ b/public/js/timezone.js
@@ -4,7 +4,11 @@ const serverTime = {
   locale: 'es-ES',
   zonaIana: '',
   diferencia: 0,
-  offsetMinutos: null
+  offsetMinutos: null,
+  baseEpochMs: null,
+  baseMonotonicMs: null,
+  ultimaSync: null,
+  origen: 'desconocido'
 };
 
 const IANA_OVERRIDES = {
@@ -30,6 +34,64 @@ function diferenciaPorOffset(offsetMinutos) {
   if (typeof offsetMinutos !== 'number' || Number.isNaN(offsetMinutos)) return 0;
   const localOffset = new Date().getTimezoneOffset();
   return (localOffset - offsetMinutos) * 60000;
+}
+
+function monotonicNow() {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function fijarBaseTemporal(epochMs) {
+  if (typeof epochMs !== 'number' || Number.isNaN(epochMs)) return;
+  serverTime.baseEpochMs = epochMs;
+  serverTime.baseMonotonicMs = monotonicNow();
+  serverTime.ultimaSync = Date.now();
+  serverTime.diferencia = epochMs - Date.now();
+}
+
+function obtenerEpochActual() {
+  if (typeof serverTime.baseEpochMs === 'number' && typeof serverTime.baseMonotonicMs === 'number') {
+    const transcurrido = monotonicNow() - serverTime.baseMonotonicMs;
+    return serverTime.baseEpochMs + transcurrido;
+  }
+  return Date.now() + (serverTime.diferencia || 0);
+}
+
+function obtenerFechaServidor() {
+  const epoch = obtenerEpochActual();
+  return new Date(epoch);
+}
+
+async function obtenerEpochDesdeFirestore(database) {
+  if (typeof firebase === 'undefined') return null;
+  const fieldValue = firebase?.firestore?.FieldValue;
+  if (!fieldValue || typeof fieldValue.serverTimestamp !== 'function') return null;
+  try {
+    const ref = database.collection('Variablesglobales').doc('HoraServidor');
+    await ref.set({ ultimaSync: fieldValue.serverTimestamp() }, { merge: true });
+    const snap = await ref.get({ source: 'server' });
+    if (!snap.exists) return null;
+    const data = snap.data() || {};
+    const marca = data.ultimaSync;
+    if (marca && typeof marca.toMillis === 'function') {
+      return marca.toMillis();
+    }
+  } catch (err) {
+    console.error('No se pudo obtener la hora del servidor desde Firestore', err);
+  }
+  return null;
+}
+
+async function obtenerEpochServidor(database) {
+  const epochFirestore = await obtenerEpochDesdeFirestore(database);
+  if (typeof epochFirestore === 'number' && !Number.isNaN(epochFirestore)) {
+    serverTime.origen = 'firestore';
+    return epochFirestore;
+  }
+  serverTime.origen = 'offset';
+  return null;
 }
 
 function parseZona(zona) {
@@ -76,7 +138,20 @@ async function sincronizarHora() {
     }
   }
   const fallback = diferenciaPorOffset(offsetUsado);
+
+  try {
+    const database = await asegurarDb();
+    const epochServidor = await obtenerEpochServidor(database);
+    if (typeof epochServidor === 'number' && !Number.isNaN(epochServidor)) {
+      fijarBaseTemporal(epochServidor);
+      return;
+    }
+  } catch (err) {
+    console.error('No se pudo sincronizar la hora con el servidor', err);
+  }
+
   serverTime.diferencia = fallback;
+  fijarBaseTemporal(Date.now() + fallback);
 }
 
 async function asegurarDb() {
@@ -118,7 +193,7 @@ async function initServerTime() {
     const zonaNormalizada = override || parseZona(ZonaHoraria);
     serverTime.zonaIana = typeof zonaNormalizada === 'string' ? zonaNormalizada : '';
     await sincronizarHora();
-    setInterval(sincronizarHora, 3600000);
+    setInterval(sincronizarHora, 300000);
   } catch (e) {
     console.error('Error obteniendo parámetros', e);
   }
@@ -130,8 +205,11 @@ function obtenerFecha() {
     month: '2-digit',
     year: 'numeric'
   };
-  const fechaBase = new Date(Date.now() + serverTime.diferencia);
-  const formatter = new Intl.DateTimeFormat(serverTime.locale || 'es-ES', opciones);
+  const fechaBase = obtenerFechaServidor();
+  const formatter = new Intl.DateTimeFormat(serverTime.locale || 'es-ES', {
+    ...opciones,
+    ...(serverTime.zonaIana ? { timeZone: serverTime.zonaIana } : {})
+  });
   return formatter.format(fechaBase);
 }
 
@@ -145,7 +223,8 @@ function obtenerHora() {
     minute: '2-digit',
     hour12: true
   };
-  const d = new Date(Date.now() + serverTime.diferencia);
+  if (serverTime.zonaIana) opciones.timeZone = serverTime.zonaIana;
+  const d = obtenerFechaServidor();
   const hora = d.toLocaleTimeString(serverTime.locale, opciones);
   return limpiarMeridiano(hora);
 }
@@ -194,3 +273,17 @@ window.initServerTime = initServerTime;
 window.fechaServidor = obtenerFecha;
 window.horaServidor = obtenerHora;
 window.initFechaHora = initFechaHora;
+serverTime.now = function () {
+  return obtenerFechaServidor();
+};
+serverTime.nowMs = function () {
+  return obtenerEpochActual();
+};
+serverTime.serverTimestamp = function () {
+  if (typeof firebase === 'undefined') return null;
+  const fieldValue = firebase?.firestore?.FieldValue;
+  if (fieldValue && typeof fieldValue.serverTimestamp === 'function') {
+    return fieldValue.serverTimestamp();
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary
- Sincroniza la hora del cliente con Firestore en `public/js/timezone.js`, conservando el huso horario configurado y evitando depender del reloj del dispositivo.
- Expone utilidades globales (`serverTime.now`, `serverTime.nowMs`, `serverTime.serverTimestamp`) y actualiza los flujos de cantos y control de sorteos para usarlas al registrar movimientos.
- Documenta en el README el uso de los nuevos métodos de tiempo para futuras contribuciones.

## Testing
- No se ejecutaron pruebas automatizadas; los cambios afectan principalmente a lógica de frontend dependiente de Firebase.


------
https://chatgpt.com/codex/tasks/task_e_68ff9db8bc7c83269896b59ab1bff5a2