### PR TITLE
Mantiene azul el contador de cartones gratis jugados

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -498,7 +498,7 @@ function actualizarEstadoCartonesGratis(){
   gratisLabel.style.color=colorActual;
   const gratisJugandoEl=document.getElementById('cartones-gratis-jugando');
   if(gratisJugandoEl){
-    gratisJugandoEl.style.color=colorActual;
+    gratisJugandoEl.style.color=COLOR_CARTONES_GRATIS_DISPONIBLE;
   }
   if(limiteAlcanzado){
     gratisLabel.style.animation='none';


### PR DESCRIPTION
## Summary
- evita que el total de cartones gratis jugados cambie a color rojo cuando se alcanza el límite
- mantiene el color del indicador principal de cartones gratis en rojo al agotarse las partidas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ffa84578608326a0d569a7378cd99c