### PR TITLE
Ajusta vista del conducto en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -21,6 +21,7 @@
           --canto-size: clamp(26px, 7vw, 44px);
           --mini-cell-size: clamp(20px, 4.4vw, 28px);
           --canto-cell-size: clamp(28px, 4.8vw, 44px);
+          --conducto-borde: clamp(2px, 0.35vw, 3px);
       }
       body {
           font-family: 'Poppins', sans-serif;
@@ -406,6 +407,9 @@
           border-radius: clamp(14px, 3vw, 22px);
           background: linear-gradient(160deg, rgba(255,255,255,0.98), rgba(243,244,248,0.9));
           box-shadow: 0 12px 28px rgba(0,0,0,0.18);
+          width: min(100%, calc(var(--canto-cell-size) * 5 + var(--conducto-padding) * 2));
+          box-sizing: border-box;
+          margin-inline: auto;
       }
       #cantos-conducto-grid {
           display: grid;
@@ -413,6 +417,8 @@
           gap: 0;
           position: relative;
           z-index: 1;
+          width: min(100%, calc(var(--canto-cell-size) * 5));
+          margin: 0 auto;
       }
       #cantos-conducto-track {
           position: absolute;
@@ -433,13 +439,12 @@
           font-family: 'Poppins', sans-serif;
           font-weight: 600;
           font-size: clamp(0.68rem, 2.2vw, 0.86rem);
-          color: #3a3a3a;
+          color: #d5dae6;
           background: #ffffff;
           border: var(--conducto-borde, 3px) solid transparent;
           box-sizing: border-box;
           border-radius: 0;
-          box-shadow: inset 0 0 0 1px rgba(0,0,0,0.04);
-          transition: border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+          transition: border-color 0.3s ease, color 0.3s ease;
       }
       .conducto-cell::after {
           content: '';
@@ -453,6 +458,7 @@
       .conducto-cell .conducto-cell-label {
           position: relative;
           z-index: 1;
+          text-shadow: 0 1px 3px rgba(0,0,0,0.14);
       }
       .conducto-borde-top { border-top-color: #cfd4dd; }
       .conducto-borde-bottom { border-bottom-color: #cfd4dd; }
@@ -479,7 +485,7 @@
       .conducto-cell.conducto-borde-bottom,
       .conducto-cell.conducto-borde-left,
       .conducto-cell.conducto-borde-right {
-          box-shadow: inset 0 0 0 1px rgba(255,255,255,0.82);
+          box-shadow: none;
       }
       .conducto-cell:hover {
           color: #1f1f1f;
@@ -493,13 +499,12 @@
           max-width: calc(var(--canto-cell-size) * 0.95);
           max-height: calc(var(--canto-cell-size) * 0.95);
           border-radius: 50%;
-          display: flex;
-          align-items: center;
-          justify-content: center;
+          display: grid;
+          place-items: center;
           font-family: 'Poppins', sans-serif;
           font-weight: 700;
           font-size: clamp(0.72rem, 2.6vw, 1rem);
-          color: #1b1b1b;
+          color: #050505;
           background: var(--conducto-esfera-bg, radial-gradient(circle at 30% 30%, #ffffff 0%, #e2e5ec 55%, #bec3ce 100%));
           box-shadow: 0 10px 22px rgba(0,0,0,0.28);
           transform: translate(-50%, -50%);
@@ -507,6 +512,12 @@
           opacity: 0;
           letter-spacing: 0.4px;
           pointer-events: none;
+          z-index: 0;
+      }
+      .conducto-sphere-label {
+          position: relative;
+          z-index: 1;
+          text-shadow: 0 2px 4px rgba(255,255,255,0.45);
       }
       .conducto-sphere::after {
           content: '';
@@ -515,6 +526,7 @@
           border-radius: 50%;
           background: radial-gradient(circle at 35% 35%, rgba(255,255,255,0.9), rgba(255,255,255,0));
           pointer-events: none;
+          z-index: 0;
       }
       .conducto-sphere::before {
           content: '';
@@ -524,6 +536,7 @@
           background: radial-gradient(circle, rgba(255,255,255,0.32), rgba(255,255,255,0));
           opacity: 0.9;
           pointer-events: none;
+          z-index: 0;
       }
       .conducto-sphere.activa {
           opacity: 1;
@@ -3636,11 +3649,8 @@
         celda.className='conducto-cell';
         celda.dataset.row=String(fila);
         celda.dataset.col=String(col);
-        const slot=fila*totalColumnas+col+1;
-        celda.dataset.slot=String(slot);
         const etiqueta=document.createElement('span');
         etiqueta.className='conducto-cell-label';
-        etiqueta.textContent=String(slot).padStart(2,'0');
         celda.appendChild(etiqueta);
         cantosConductoGridEl.appendChild(celda);
         filaCeldas.push(celda);
@@ -3650,6 +3660,15 @@
       const ordenFila=fila%2===0?filaCeldas:filaCeldas.slice().reverse();
       conductoCellsOrden.push(...ordenFila);
     }
+    conductoCellsOrden.forEach((celda, indice)=>{
+      if(!celda) return;
+      const numero=indice+1;
+      celda.dataset.slot=String(numero);
+      const etiqueta=celda.querySelector('.conducto-cell-label');
+      if(etiqueta){
+        etiqueta.textContent=String(numero).padStart(2,'0');
+      }
+    });
     aplicarCurvasConducto();
   }
 
@@ -3698,7 +3717,10 @@
     const esfera=document.createElement('div');
     esfera.className='conducto-sphere conducto-sphere--pre';
     esfera.dataset.numero=String(valor);
-    esfera.textContent=String(valor).padStart(2,'0');
+    const etiqueta=document.createElement('span');
+    etiqueta.className='conducto-sphere-label';
+    etiqueta.textContent=String(valor).padStart(2,'0');
+    esfera.appendChild(etiqueta);
     esfera.setAttribute('aria-label',`Canto ${String(valor).padStart(2,'0')}`);
     cantosConductoTrackEl.appendChild(esfera);
     return {numero:valor, element:esfera, destino:null, recienCreada:true, pendiente:false};


### PR DESCRIPTION
## Resumen
- ajusta el contenedor del conducto para que siga las dimensiones del tablero de cantos
- muestra la numeración del conducto en orden ascendente a lo largo del recorrido y con tipografía gris clara
- mejora el contraste de las esferas del conducto colocando los números en negro y manteniendo los degradados de fondo detrás del texto

## Pruebas
- No se ejecutaron pruebas (no aplica)


------
https://chatgpt.com/codex/tasks/task_e_6900069c4f2883269a5485052f5b9493