### PR TITLE
Enhance conducto canto entry animation

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -603,9 +603,19 @@
           width: clamp(calc(var(--conducto-cell-size) * 4.6), 180px, calc(var(--conducto-cell-size) * 5));
           height: clamp(calc(var(--conducto-cell-size) * 4.6), 180px, calc(var(--conducto-cell-size) * 5));
           font-size: clamp(2rem, 12vw, 3.4rem);
+          border-radius: clamp(18px, 3.4vw, 28px);
           box-shadow: 0 18px 42px rgba(0,0,0,0.35), 0 0 18px rgba(255,255,255,0.85);
           z-index: 6;
           pointer-events: none;
+      }
+      .conducto-sphere--ingreso::after {
+          inset: 10% 10%;
+          border-radius: inherit;
+          background: radial-gradient(circle at 36% 30%, rgba(255,255,255,0.85), rgba(255,255,255,0));
+      }
+      .conducto-sphere--ingreso::before {
+          inset: -3%;
+          border-radius: inherit;
       }
       .conducto-sphere--ingreso .conducto-sphere-label {
           text-shadow: 0 0 18px rgba(255,255,255,0.85), 0 0 24px rgba(255,255,255,0.75);
@@ -3071,7 +3081,7 @@
   let conductoAnimacionBloqueada = false;
   let conductoActualizacionProgramada = false;
   const CONDUCTO_DESTACADO_DURACION = 2000;
-  const CONDUCTO_INSERCION_DURACION = 800;
+  const CONDUCTO_INSERCION_DURACION = 1000;
   const CONDUCTO_TRANSICION_DURACION = 1500;
   let cantoColorMap = new Map();
   let formasSinGanadoresAlertaClave = '';
@@ -3819,7 +3829,7 @@
     const centroX=trackRect.width/2;
     const alturaDisponible=trackRect.height;
     const mitadCelda=cellSize/2;
-    const centroY=Math.max(mitadCelda, Math.min(alturaDisponible-mitadCelda, cellSize*2.5));
+    const centroY=Math.max(mitadCelda, Math.min(alturaDisponible-mitadCelda, gridRect.height/2));
     return {left: centroX, top: centroY};
   }
 


### PR DESCRIPTION
## Summary
- show the incoming canto as a centered floating square before it joins the conducto
- stretch the insertion animation to one second after the two-second pause and keep the 1.5s push transition
- ensure the highlighted canto centers itself using the conducto grid height

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69003d4a30d88326b425cef91ef1ab6a