### PR TITLE
Ajustar animaciones y escalado del conducto de cantos

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -505,18 +505,20 @@
           color: #1f1f1f;
       }
       .conducto-sphere {
+          --conducto-esfera-base: clamp(calc(var(--conducto-cell-size) * 0.6), 32px, calc(var(--conducto-cell-size) * 0.85));
+          --conducto-esfera-font-base: clamp(0.72rem, 2.6vw, 1rem);
           position: absolute;
-          width: clamp(calc(var(--conducto-cell-size) * 0.6), 32px, calc(var(--conducto-cell-size) * 0.85));
+          width: var(--conducto-esfera-base);
+          height: var(--conducto-esfera-base);
           aspect-ratio: 1 / 1;
           min-width: 0;
           min-height: 0;
-          max-width: calc(var(--conducto-cell-size) * 0.92);
           border-radius: 50%;
           display: grid;
           place-items: center;
           font-family: 'Poppins', sans-serif;
           font-weight: 700;
-          font-size: clamp(0.72rem, 2.6vw, 1rem);
+          font-size: var(--conducto-esfera-font-base);
           color: #0b0b0f;
           background: var(--conducto-esfera-bg, radial-gradient(circle at 30% 30%, #ffffff 0%, #e2e5ec 55%, #bec3ce 100%));
           box-shadow: 0 10px 22px rgba(0,0,0,0.28), 0 0 6px rgba(0,0,0,0.45);
@@ -600,16 +602,16 @@
           outline-offset: 4px;
       }
       .conducto-sphere--ingreso {
-          width: clamp(calc(var(--conducto-cell-size) * 4.6), 180px, calc(var(--conducto-cell-size) * 5));
-          height: clamp(calc(var(--conducto-cell-size) * 4.6), 180px, calc(var(--conducto-cell-size) * 5));
-          font-size: clamp(2rem, 12vw, 3.4rem);
-          border-radius: clamp(18px, 3.4vw, 28px);
-          box-shadow: 0 18px 42px rgba(0,0,0,0.35), 0 0 18px rgba(255,255,255,0.85);
+          width: calc(var(--conducto-esfera-base) * 1.35);
+          height: calc(var(--conducto-esfera-base) * 1.35);
+          font-size: calc(var(--conducto-esfera-font-base) * 2);
+          border-radius: 50%;
+          box-shadow: 0 14px 32px rgba(0,0,0,0.28), 0 0 18px rgba(255,255,255,0.85);
           z-index: 6;
           pointer-events: none;
       }
       .conducto-sphere--ingreso::after {
-          inset: 10% 10%;
+          inset: 12% 12%;
           border-radius: inherit;
           background: radial-gradient(circle at 36% 30%, rgba(255,255,255,0.85), rgba(255,255,255,0));
       }


### PR DESCRIPTION
## Resumen
- armonicé el cálculo del tamaño base de las esferas del conducto mediante variables reutilizables
- actualicé la animación de ingreso para mostrar la esfera ligeramente más grande sin desplazar otras bolitas hasta completar el canto
- dupliqué el tamaño del número durante la presentación inicial del canto y mantuve una transición suave hacia la celda inicial

## Pruebas
- No se ejecutaron pruebas (no aplica)


------
https://chatgpt.com/codex/tasks/task_e_69004046cb1c8326b80bfa8db2ec58a9