### PR TITLE
Ajusta el tamaño de las bolitas del conducto en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -508,8 +508,8 @@
           --conducto-esfera-base: clamp(calc(var(--conducto-cell-size) * 0.6), 32px, calc(var(--conducto-cell-size) * 0.85));
           --conducto-esfera-font-base: clamp(0.72rem, 2.6vw, 1rem);
           position: absolute;
-          width: var(--conducto-esfera-base);
-          height: var(--conducto-esfera-base);
+          width: min(var(--conducto-esfera-base), var(--conducto-cell-size));
+          height: min(var(--conducto-esfera-base), var(--conducto-cell-size));
           aspect-ratio: 1 / 1;
           min-width: 0;
           min-height: 0;
@@ -602,8 +602,8 @@
           outline-offset: 4px;
       }
       .conducto-sphere--ingreso {
-          width: calc(var(--conducto-esfera-base) * 1.35);
-          height: calc(var(--conducto-esfera-base) * 1.35);
+          width: min(calc(var(--conducto-esfera-base) * 1.35), var(--conducto-cell-size));
+          height: min(calc(var(--conducto-esfera-base) * 1.35), var(--conducto-cell-size));
           font-size: calc(var(--conducto-esfera-font-base) * 2);
           border-radius: 50%;
           box-shadow: 0 14px 32px rgba(0,0,0,0.28), 0 0 18px rgba(255,255,255,0.85);


### PR DESCRIPTION
## Resumen
- limita el diámetro de las esferas del conducto al tamaño de la celda para conservar su forma circular
- evita que la esfera de ingreso supere el alto disponible en la celda

## Pruebas
- no se realizaron pruebas

------
https://chatgpt.com/codex/tasks/task_e_690042bc1acc832697f5fe4e3e672c6a