### PR TITLE
Mejorar presentación del conducto y del reverso del cartón

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -485,10 +485,10 @@
           z-index: 1;
           text-shadow: 0 1px 3px rgba(0,0,0,0.14);
       }
-      .conducto-borde-top::before { border-top: var(--conducto-borde, 3px) solid #cfd4dd; }
-      .conducto-borde-bottom::before { border-bottom: var(--conducto-borde, 3px) solid #cfd4dd; }
-      .conducto-borde-left::before { border-left: var(--conducto-borde, 3px) solid #cfd4dd; }
-      .conducto-borde-right::before { border-right: var(--conducto-borde, 3px) solid #cfd4dd; }
+      .conducto-borde-top::before { border-top: var(--conducto-borde, 3px) solid #1d4ed8; }
+      .conducto-borde-bottom::before { border-bottom: var(--conducto-borde, 3px) solid #1d4ed8; }
+      .conducto-borde-left::before { border-left: var(--conducto-borde, 3px) solid #1d4ed8; }
+      .conducto-borde-right::before { border-right: var(--conducto-borde, 3px) solid #1d4ed8; }
       .conducto-curva-top-right::before { border-top-right-radius: clamp(12px, 2.6vw, 18px); }
       .conducto-curva-bottom-right::before { border-bottom-right-radius: clamp(12px, 2.6vw, 18px); }
       .conducto-curva-top-left::before { border-top-left-radius: clamp(12px, 2.6vw, 18px); }
@@ -1126,12 +1126,19 @@
       #carton-destacado .carton-back-total {
           margin-top: 4px;
           display: flex;
-          align-items: baseline;
+          flex-direction: column;
+          align-items: center;
           justify-content: center;
           gap: 10px;
           font-family: 'Bangers', cursive;
           color: #ffffff;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
+      }
+      #carton-destacado .carton-back-total-row {
+          display: flex;
+          align-items: baseline;
+          justify-content: center;
+          gap: 12px;
       }
       #carton-destacado .carton-back-total-label {
           font-size: clamp(1.1rem, 3.8vw, 1.4rem);
@@ -1144,6 +1151,26 @@
           margin: 0;
           font-weight: 700;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
+      }
+      #carton-destacado .carton-back-cartones {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 10px;
+          font-family: 'Bangers', cursive;
+          color: #ffffff;
+          text-shadow: 0 0 16px rgba(147, 51, 234, 0.95), 0 0 32px rgba(168, 85, 247, 0.75);
+      }
+      #carton-destacado .carton-back-cartones-label {
+          font-size: clamp(0.98rem, 3.2vw, 1.2rem);
+          letter-spacing: 0.8px;
+      }
+      #carton-destacado .carton-back-cartones-valor {
+          font-family: 'Poppins', sans-serif;
+          font-weight: 700;
+          font-size: clamp(1.2rem, 3.6vw, 1.6rem);
+          color: #ffffff;
+          text-shadow: 0 0 18px rgba(147, 51, 234, 0.95), 0 0 36px rgba(196, 181, 253, 0.75);
       }
       #panel-botones-formas {
           grid-area: botones;
@@ -4498,7 +4525,7 @@
   }
 
   function obtenerResumenGananciasCarton(carton, limiteFormas=5){
-    const resultado={formas:[], total:0};
+    const resultado={formas:[], total:0, cartonesGratis:0};
     if(!carton) return resultado;
     const gananciasPorForma=new Map();
     const lista=formasPorCarton.get(carton.id)||[];
@@ -4506,13 +4533,23 @@
       const idx=Number(item?.forma?.idx);
       if(!Number.isFinite(idx)) return;
       const valor=obtenerCreditosForma(item.forma);
-      if(!Number.isFinite(valor) || valor<=0) return;
-      gananciasPorForma.set(idx,(gananciasPorForma.get(idx)||0)+valor);
+      const cartonesGratisForma=obtenerCartonesGratisForma(item.forma);
+      const registro=gananciasPorForma.get(idx) || {valor:0, cartonesGratis:0};
+      if(Number.isFinite(valor) && valor>0){
+        registro.valor+=valor;
+      }
+      if(Number.isFinite(cartonesGratisForma) && cartonesGratisForma>0){
+        registro.cartonesGratis+=cartonesGratisForma;
+      }
+      gananciasPorForma.set(idx, registro);
     });
     for(let i=1;i<=limiteFormas;i++){
-      const valor=gananciasPorForma.get(i)||0;
-      resultado.formas.push({idx:i, valor});
+      const datos=gananciasPorForma.get(i) || {valor:0, cartonesGratis:0};
+      const valor=datos.valor||0;
+      const cartonesGratis=datos.cartonesGratis||0;
+      resultado.formas.push({idx:i, valor, cartonesGratis});
       resultado.total+=valor;
+      resultado.cartonesGratis+=cartonesGratis;
     }
     return resultado;
   }
@@ -5975,14 +6012,28 @@
       }
       const totalContenedor=document.createElement('div');
       totalContenedor.className='carton-back-total';
+      const totalFila=document.createElement('div');
+      totalFila.className='carton-back-total-row';
       const totalLabel=document.createElement('span');
       totalLabel.className='carton-back-total-label';
       totalLabel.textContent='TOTAL GANADO CARTÓN:';
       const totalValor=document.createElement('span');
       totalValor.className='carton-back-total-valor';
       totalValor.textContent=formatearCreditos(resumenGanancias.total);
-      totalContenedor.appendChild(totalLabel);
-      totalContenedor.appendChild(totalValor);
+      totalFila.appendChild(totalLabel);
+      totalFila.appendChild(totalValor);
+      totalContenedor.appendChild(totalFila);
+      const cartonesGratisFila=document.createElement('div');
+      cartonesGratisFila.className='carton-back-cartones';
+      const cartonesGratisLabel=document.createElement('span');
+      cartonesGratisLabel.className='carton-back-cartones-label';
+      cartonesGratisLabel.textContent='CARTONES GRATIS:';
+      const cartonesGratisValor=document.createElement('span');
+      cartonesGratisValor.className='carton-back-cartones-valor';
+      cartonesGratisValor.textContent=formatearCreditos(resumenGanancias.cartonesGratis || 0);
+      cartonesGratisFila.appendChild(cartonesGratisLabel);
+      cartonesGratisFila.appendChild(cartonesGratisValor);
+      totalContenedor.appendChild(cartonesGratisFila);
       backContent.appendChild(totalContenedor);
       const backLogo=document.createElement('img');
       backLogo.src='https://i.imgur.com/twjhNtZ.png';


### PR DESCRIPTION
## Resumen
- actualizar el color de los bordes del conducto a un tono azul consistente con la interfaz
- reorganizar el resumen del reverso del cartón destacado para acercar el valor al total y mostrar los cartones gratis ganados
- ampliar el cálculo del resumen del cartón para acumular la cantidad total de cartones gratuitos

## Pruebas
- No se ejecutaron pruebas automatizadas (no aplica)


------
https://chatgpt.com/codex/tasks/task_e_6900d588371883268dc42d600d4bde1b