### PR TITLE
Ajustes visuales en juegoactivo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -485,10 +485,10 @@
           z-index: 1;
           text-shadow: 0 1px 3px rgba(0,0,0,0.14);
       }
-      .conducto-borde-top::before { border-top: var(--conducto-borde, 3px) solid #1d4ed8; }
-      .conducto-borde-bottom::before { border-bottom: var(--conducto-borde, 3px) solid #1d4ed8; }
-      .conducto-borde-left::before { border-left: var(--conducto-borde, 3px) solid #1d4ed8; }
-      .conducto-borde-right::before { border-right: var(--conducto-borde, 3px) solid #1d4ed8; }
+      .conducto-borde-top::before { border-top: var(--conducto-borde, 3px) solid #60a5fa; }
+      .conducto-borde-bottom::before { border-bottom: var(--conducto-borde, 3px) solid #60a5fa; }
+      .conducto-borde-left::before { border-left: var(--conducto-borde, 3px) solid #60a5fa; }
+      .conducto-borde-right::before { border-right: var(--conducto-borde, 3px) solid #60a5fa; }
       .conducto-curva-top-right::before { border-top-right-radius: clamp(12px, 2.6vw, 18px); }
       .conducto-curva-bottom-right::before { border-bottom-right-radius: clamp(12px, 2.6vw, 18px); }
       .conducto-curva-top-left::before { border-top-left-radius: clamp(12px, 2.6vw, 18px); }
@@ -1083,6 +1083,7 @@
           letter-spacing: 1px;
           grid-column: 1 / -1;
           text-align: center;
+          align-self: center;
       }
       #carton-destacado .carton-back-formas {
           display: flex;
@@ -1124,21 +1125,22 @@
               2px 2px 0 #ffffff;
       }
       #carton-destacado .carton-back-total {
-          margin-top: 4px;
+          margin-top: 12px;
           display: flex;
           flex-direction: column;
-          align-items: center;
+          align-items: stretch;
           justify-content: center;
-          gap: 10px;
+          gap: 12px;
           font-family: 'Bangers', cursive;
           color: #ffffff;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
       }
       #carton-destacado .carton-back-total-row {
           display: flex;
-          align-items: baseline;
-          justify-content: center;
+          align-items: center;
+          justify-content: flex-start;
           gap: 12px;
+          width: 100%;
       }
       #carton-destacado .carton-back-total-label {
           font-size: clamp(1.1rem, 3.8vw, 1.4rem);
@@ -1151,12 +1153,15 @@
           margin: 0;
           font-weight: 700;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
+          margin-left: auto;
+          text-align: right;
       }
       #carton-destacado .carton-back-cartones {
           display: flex;
           align-items: center;
-          justify-content: center;
-          gap: 10px;
+          justify-content: flex-start;
+          gap: 12px;
+          width: 100%;
           font-family: 'Bangers', cursive;
           color: #ffffff;
           text-shadow: 0 0 16px rgba(147, 51, 234, 0.95), 0 0 32px rgba(168, 85, 247, 0.75);
@@ -1171,6 +1176,8 @@
           font-size: clamp(1.2rem, 3.6vw, 1.6rem);
           color: #ffffff;
           text-shadow: 0 0 18px rgba(147, 51, 234, 0.95), 0 0 36px rgba(196, 181, 253, 0.75);
+          margin-left: auto;
+          text-align: right;
       }
       #panel-botones-formas {
           grid-area: botones;
@@ -2535,7 +2542,8 @@
         #carton-destacado .carton-back-title {
             margin: 0;
             text-align: center;
-            align-self: stretch;
+            align-self: center;
+            width: 100%;
         }
         #carton-destacado .carton-back-formas {
             gap: clamp(6px, 2vw, 12px);
@@ -2552,14 +2560,13 @@
         #carton-destacado .carton-back-total {
             flex-direction: column;
             align-items: stretch;
-            gap: clamp(2px, 1.6vw, 6px);
-            text-align: center;
+            gap: 12px;
         }
-        #carton-destacado .carton-back-total-label,
+        #carton-destacado .carton-back-total-label {
+            text-align: left;
+        }
         #carton-destacado .carton-back-total-valor {
-            display: block;
-            width: 100%;
-            text-align: center;
+            text-align: right;
         }
         #carton-destacado .back-forma-line .back-forma-etiqueta,
         #carton-destacado .back-forma-line .back-forma-valor {
@@ -2743,14 +2750,13 @@
           #carton-destacado .carton-back-total {
               flex-direction: column;
               align-items: stretch;
-              gap: clamp(2px, 1.2vw, 6px);
-              text-align: center;
+              gap: 12px;
           }
-          #carton-destacado .carton-back-total-label,
+          #carton-destacado .carton-back-total-label {
+              text-align: left;
+          }
           #carton-destacado .carton-back-total-valor {
-              display: block;
-              width: 100%;
-              text-align: center;
+              text-align: right;
           }
           #formas-mensaje {
               grid-area: mensaje;


### PR DESCRIPTION
## Summary
- actualicé el color de los bordes del conducto para alinearlo con el tono azul claro solicitado
- reorganicé la sección posterior del cartón destacado para espaciar 12px entre las etiquetas y alinear los valores a la derecha
- centré visualmente el título "GANANCIAS DEL CARTÓN" en la vista posterior

## Testing
- no se ejecutaron pruebas (cambios de estilos)


------
https://chatgpt.com/codex/tasks/task_e_6900de524b888326b9a32f2e0278bf88