### PR TITLE
Ajustar espaciados en la cara posterior del cartón destacado

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1071,7 +1071,7 @@
           flex-direction: column;
           align-items: stretch;
           justify-content: flex-start;
-          gap: 4px;
+          gap: clamp(2px, 0.9vw, 4px);
           height: 100%;
       }
       #carton-destacado .carton-back-title {
@@ -1132,7 +1132,7 @@
           flex-direction: column;
           align-items: flex-start;
           justify-content: flex-start;
-          gap: 4px;
+          gap: clamp(2px, 0.9vw, 4px);
           font-family: 'Bangers', cursive;
           color: #ffffff;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
@@ -1142,7 +1142,7 @@
           flex-direction: column;
           align-items: flex-start;
           justify-content: flex-start;
-          gap: 4px;
+          gap: clamp(1px, 0.6vw, 3px);
           width: 100%;
       }
       #carton-destacado .carton-back-total-label {
@@ -2539,8 +2539,8 @@
               --destacado-cell-size: clamp(40px, 14vw, 120px);
           }
         #carton-destacado .carton-back-content {
-            margin: clamp(10px, 3vw, 18px) clamp(14px, 4vw, 22px);
-            gap: 4px;
+            margin: clamp(10px, 3vw, 18px) clamp(12px, 3.4vw, 20px) clamp(10px, 3vw, 18px) clamp(9px, 2.8vw, 18px);
+            gap: clamp(2px, 0.9vw, 4px);
             align-items: stretch;
         }
         #carton-destacado .carton-back-title {
@@ -2564,7 +2564,7 @@
         #carton-destacado .carton-back-total {
             flex-direction: column;
             align-items: flex-start;
-            gap: 4px;
+            gap: clamp(2px, 0.9vw, 4px);
         }
         #carton-destacado .carton-back-total-valor {
             text-align: left;
@@ -2713,8 +2713,8 @@
               height: 100%;
           }
           #carton-destacado .carton-back-content {
-              padding: clamp(12px, 3vw, 24px) clamp(16px, 4vw, 28px);
-              gap: 4px;
+              padding: clamp(12px, 3vw, 24px) clamp(15px, 3.8vw, 26px) clamp(12px, 3vw, 24px) clamp(11px, 3.2vw, 22px);
+              gap: clamp(2px, 0.9vw, 4px);
               align-items: stretch;
           }
           #carton-destacado .carton-back-formas {
@@ -2751,7 +2751,7 @@
           #carton-destacado .carton-back-total {
               flex-direction: column;
               align-items: flex-start;
-              gap: 4px;
+              gap: clamp(2px, 0.9vw, 4px);
           }
           #carton-destacado .carton-back-total-valor {
               text-align: left;


### PR DESCRIPTION
## Summary
- Reducir la separación entre la etiqueta y el valor del total ganado y los cartones gratis en la cara posterior del cartón destacado.
- Ajustar los márgenes y rellenos responsivos para acercar el título "GANANCIAS DEL CARTÓN" al borde izquierdo sin afectar otras vistas.

## Testing
- No se ejecutaron pruebas automatizadas (no aplica).


------
https://chatgpt.com/codex/tasks/task_e_6900e935a5688326a9b2992745779f33