### PR TITLE
Ajustar espaciado del reverso del cartón destacado

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1071,7 +1071,7 @@
           flex-direction: column;
           align-items: stretch;
           justify-content: flex-start;
-          gap: clamp(2px, 0.9vw, 4px);
+          gap: clamp(1px, 0.4vw, 3px);
           height: 100%;
       }
       #carton-destacado .carton-back-title {
@@ -1084,8 +1084,8 @@
           grid-column: 1 / -1;
           text-align: center;
           align-self: center;
-          width: 100%;
-          margin-inline: 0 auto;
+          width: auto;
+          margin-inline: auto;
           max-width: 100%;
       }
       #carton-destacado .carton-back-formas {
@@ -1132,7 +1132,7 @@
           flex-direction: column;
           align-items: flex-start;
           justify-content: flex-start;
-          gap: clamp(2px, 0.9vw, 4px);
+          gap: clamp(1px, 0.4vw, 3px);
           font-family: 'Bangers', cursive;
           color: #ffffff;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
@@ -1142,7 +1142,7 @@
           flex-direction: column;
           align-items: flex-start;
           justify-content: flex-start;
-          gap: clamp(1px, 0.6vw, 3px);
+          gap: clamp(1px, 0.4vw, 3px);
           width: 100%;
       }
       #carton-destacado .carton-back-total-label {


### PR DESCRIPTION
## Summary
- Reducir los espacios verticales entre el total ganado, su valor y el bloque de cartones gratis en el reverso del cartón destacado.
- Asegurar que el título "GANANCIAS DEL CARTÓN" se centre horizontalmente dentro de sus contenedores.

## Testing
- No se realizaron pruebas automatizadas (cambios de estilo).


------
https://chatgpt.com/codex/tasks/task_e_6900efdb979c8326bcea6a51b406af28