### PR TITLE
Ajusta espaciado de totales en la vista juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1132,7 +1132,7 @@
           flex-direction: column;
           align-items: flex-start;
           justify-content: flex-start;
-          gap: clamp(1px, 0.4vw, 3px);
+          gap: clamp(0px, 0.3vw, 2px);
           font-family: 'Bangers', cursive;
           color: #ffffff;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
@@ -1142,12 +1142,13 @@
           flex-direction: column;
           align-items: flex-start;
           justify-content: flex-start;
-          gap: clamp(1px, 0.4vw, 3px);
+          gap: clamp(0px, 0.3vw, 2px);
           width: 100%;
       }
       #carton-destacado .carton-back-total-label {
           font-size: clamp(1.1rem, 3.8vw, 1.4rem);
           margin: 0;
+          line-height: 1.05;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
           display: block;
       }
@@ -1156,6 +1157,7 @@
           font-size: clamp(1.6rem, 5vw, 2.2rem);
           margin: 0;
           font-weight: 700;
+          line-height: 1.05;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
           margin-left: 0;
           text-align: left;
@@ -1166,6 +1168,7 @@
           justify-content: space-between;
           gap: 4px;
           width: 100%;
+          margin-top: clamp(0px, 0.3vw, 2px);
           font-family: 'Bangers', cursive;
           color: #ffffff;
           text-shadow: 0 0 16px rgba(147, 51, 234, 0.95), 0 0 32px rgba(168, 85, 247, 0.75);
@@ -1173,12 +1176,14 @@
       #carton-destacado .carton-back-cartones-label {
           font-size: clamp(0.98rem, 3.2vw, 1.2rem);
           letter-spacing: 0.8px;
+          line-height: 1.05;
       }
       #carton-destacado .carton-back-cartones-valor {
           font-family: 'Poppins', sans-serif;
           font-weight: 700;
           font-size: clamp(1.2rem, 3.6vw, 1.6rem);
           color: #ffffff;
+          line-height: 1.05;
           text-shadow: 0 0 18px rgba(147, 51, 234, 0.95), 0 0 36px rgba(196, 181, 253, 0.75);
           margin-left: 0;
           text-align: right;


### PR DESCRIPTION
## Summary
- reduce el espacio vertical en la sección de totales del cartón destacado para alinear la distancia con la de las formas
- ajusta las alturas de línea de las etiquetas y valores para que la información de premios se perciba más compacta sin afectar otras vistas

## Testing
- no se ejecutaron pruebas (no estaban disponibles)


------
https://chatgpt.com/codex/tasks/task_e_6900f3941a6c832694d2d99eb670bf8b