### PR TITLE
Ajustes visuales del indicador de cartones gratis en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1132,7 +1132,7 @@
           flex-direction: column;
           align-items: flex-start;
           justify-content: flex-start;
-          gap: clamp(0px, 0.3vw, 2px);
+          gap: 0;
           font-family: 'Bangers', cursive;
           color: #ffffff;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
@@ -1162,41 +1162,31 @@
           margin-left: 0;
           text-align: left;
       }
-      #carton-destacado .carton-back-cartones {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          gap: clamp(6px, 1vw, 12px);
-          width: 100%;
-          margin-top: clamp(2px, 0.6vw, 8px);
-          padding: clamp(6px, 1.1vw, 12px) clamp(10px, 1.6vw, 18px);
-          font-family: 'Bangers', cursive;
-          background: linear-gradient(135deg, rgba(236, 233, 254, 0.85), rgba(221, 214, 254, 0.92));
-          border-radius: clamp(10px, 2.4vw, 18px);
-          border: 1px solid rgba(124, 58, 237, 0.25);
-          box-shadow: 0 4px 12px rgba(76, 29, 149, 0.18);
-          color: #2f106a;
-      }
       #carton-destacado .carton-back-cartones-label {
-          font-size: clamp(0.98rem, 3.2vw, 1.2rem);
+          font-size: clamp(1rem, 3.4vw, 1.3rem);
           letter-spacing: 0.8px;
           line-height: 1.05;
-          color: #2f106a;
-          text-shadow: none;
+          color: #ffffff;
+          margin-top: 4px;
+          display: inline-flex;
+          align-items: center;
+          gap: clamp(6px, 1.4vw, 14px);
+          text-shadow: 0 0 16px rgba(255,255,255,0.9), 0 0 28px rgba(255,255,255,0.75);
       }
       #carton-destacado .carton-back-cartones-valor {
           font-family: 'Poppins', sans-serif;
           font-weight: 700;
-          font-size: clamp(1.2rem, 3.6vw, 1.6rem);
+          font-size: clamp(1.24rem, 3.8vw, 1.7rem);
           color: #ffffff;
           line-height: 1.05;
-          text-shadow: none;
+          text-shadow: 0 0 18px rgba(255,255,255,0.95), 0 0 32px rgba(255,255,255,0.75);
           margin-left: 0;
           text-align: center;
           padding: clamp(2px, 0.6vw, 6px) clamp(12px, 1.8vw, 20px);
           border-radius: 999px;
-          background: linear-gradient(135deg, #7c3aed, #8b5cf6);
-          box-shadow: 0 6px 16px rgba(124, 58, 237, 0.32);
+          background: linear-gradient(135deg, rgba(255,255,255,0.24), rgba(255,255,255,0.08));
+          border: 1px solid rgba(255,255,255,0.4);
+          box-shadow: 0 6px 16px rgba(255,255,255,0.25);
           min-width: clamp(56px, 12vw, 92px);
       }
       #panel-botones-formas {
@@ -6067,17 +6057,15 @@
       totalFila.appendChild(totalLabel);
       totalFila.appendChild(totalValor);
       totalContenedor.appendChild(totalFila);
-      const cartonesGratisFila=document.createElement('div');
-      cartonesGratisFila.className='carton-back-cartones';
       const cartonesGratisLabel=document.createElement('span');
       cartonesGratisLabel.className='carton-back-cartones-label';
       cartonesGratisLabel.textContent='CARTONES GRATIS:';
       const cartonesGratisValor=document.createElement('span');
       cartonesGratisValor.className='carton-back-cartones-valor';
       cartonesGratisValor.textContent=formatearCreditos(resumenGanancias.cartonesGratis || 0);
-      cartonesGratisFila.appendChild(cartonesGratisLabel);
-      cartonesGratisFila.appendChild(cartonesGratisValor);
-      totalContenedor.appendChild(cartonesGratisFila);
+      cartonesGratisLabel.appendChild(document.createTextNode(' '));
+      cartonesGratisLabel.appendChild(cartonesGratisValor);
+      totalContenedor.appendChild(cartonesGratisLabel);
       backContent.appendChild(totalContenedor);
       const backLogo=document.createElement('img');
       backLogo.src='https://i.imgur.com/twjhNtZ.png';


### PR DESCRIPTION
## Summary
- actualicé el estilo del reverso del cartón destacado para resaltar la sección de cartones gratis con un brillo blanco
- eliminé el contenedor adicional para mostrar la etiqueta de cartones gratis seguida directamente de su valor y ajusté la separación solicitada

## Testing
- No se ejecutaron pruebas (no aplica)

------
https://chatgpt.com/codex/tasks/task_e_6901055785ec8326b827669ca52d0d06