### PR TITLE
Adjust spacing below cantos grid

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -350,6 +350,9 @@
           padding: 0;
           box-sizing: border-box;
       }
+      #cantos-panel:not(.conducto-activo) #cantos-grid {
+          margin-bottom: clamp(14px, 3vw, 34px);
+      }
       .canto-cell {
           width: var(--canto-cell-size);
           height: var(--canto-cell-size);


### PR DESCRIPTION
## Summary
- add responsive margin below the cantos grid when the vista tradicional está activa para mantener alineados la etiqueta y el botón del último canto

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69010a7ddc008326bbdbfc8dad27e01e