### PR TITLE
Add user assignment controls in configurations and simplify collaborator approvals

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -613,8 +613,6 @@
           <option value="Superadmin">Superadmin</option>
         </select>
         <button class="icon-btn" id="colaboradores-aprobar"><span class="icon check">&#10004;</span><span>Aprobar</span></button>
-        <button class="icon-btn" id="colaboradores-archivar"><span class="icon">&#128194;</span><span>Archivar</span></button>
-        <button class="icon-btn" id="colaboradores-ver-archivo"><span class="icon">&#128230;</span><span>Archivo</span></button>
       </div>
       <table id="tabla-colaboradores">
         <colgroup>
@@ -666,22 +664,18 @@
 
     let mostrarPremiosArchivo = false;
     let mostrarPagosArchivo = false;
-    let mostrarColaboradoresArchivo = false;
 
     const colaboradoresBase = [];
-    const colaboradoresArchivadosSet = new Set();
     const premiosActivos = [];
     const premiosArchivados = [];
     const pagosAdminActivos = [];
     const pagosAdminArchivados = [];
     const pagosColaboradoresActivos = [];
-    const pagosColaboradoresArchivados = [];
     const premiosMapa = new Map();
     const premiosArchivoMapa = new Map();
     const pagosAdminMapa = new Map();
     const pagosAdminArchivoMapa = new Map();
     const pagosColaboradoresMapa = new Map();
-    const pagosColaboradoresArchivoMapa = new Map();
     const pagosColaboradoresEdicion = new Map();
     const usuariosInfoCache = new Map();
 
@@ -690,7 +684,6 @@
     let unsubscribePagos = null;
     let unsubscribePagosArchivo = null;
     let unsubscribeColaboradores = null;
-    let unsubscribeColaboradoresArchivo = null;
     let unsubscribeUsuariosCentro = null;
 
     const formatNumber = new Intl.NumberFormat('es-ES', { maximumFractionDigits: 2, minimumFractionDigits: 0 });
@@ -2030,8 +2023,6 @@
       const visibles = [];
       pagosColaboradoresMapa.clear();
       colaboradoresBase.forEach(registro => {
-        const clave = cpNormalizarEmail(registro.gmail);
-        if(clave && colaboradoresArchivadosSet.has(clave)) return;
         visibles.push(registro);
         pagosColaboradoresMapa.set(registro.id, registro);
       });
@@ -2041,10 +2032,8 @@
     }
 
     function renderColaboradores(){
-      const lista = mostrarColaboradoresArchivo
-        ? aplicarFiltrosColaboradores(pagosColaboradoresArchivados)
-        : aplicarFiltrosColaboradores(pagosColaboradoresActivos);
-      renderTabla(lista, 'tabla-colaboradores', { mostrarArchivo: mostrarColaboradoresArchivo, tipo: 'colaboradores' });
+      const lista = aplicarFiltrosColaboradores(pagosColaboradoresActivos);
+      renderTabla(lista, 'tabla-colaboradores', { mostrarArchivo: false, tipo: 'colaboradores' });
       actualizarBadge('colaboradores', 0);
       actualizarEstadoBotones();
     }
@@ -2083,11 +2072,7 @@
       document.getElementById('premios-ver-archivo').classList.toggle('archivo-activo', mostrarPremiosArchivo);
       document.getElementById('pagos-ver-archivo').classList.toggle('archivo-activo', mostrarPagosArchivo);
       const colabAprobar = document.getElementById('colaboradores-aprobar');
-      if(colabAprobar) colabAprobar.disabled = mostrarColaboradoresArchivo;
-      const colabArchivar = document.getElementById('colaboradores-archivar');
-      if(colabArchivar) colabArchivar.disabled = mostrarColaboradoresArchivo;
-      const colabVerArchivo = document.getElementById('colaboradores-ver-archivo');
-      if(colabVerArchivo) colabVerArchivo.classList.toggle('archivo-activo', mostrarColaboradoresArchivo);
+      if(colabAprobar) colabAprobar.disabled = false;
     }
 
     async function registrarTransaccionPremio(enRegistro){
@@ -2307,46 +2292,6 @@
       if(!ids.length) return;
       const db = dbRef();
       await initServerTime();
-      if(tipo === 'colaboradores'){
-        const coleccionArchivo = db.collection('PagosColaboradoresArchivo');
-        const idsNormalizados = new Set();
-        for(const id of ids){
-          const registro = pagosColaboradoresMapa.get(id);
-          if(!registro) continue;
-          try {
-            const datosArchivo = {
-              gmail: registro.gmail,
-              nombre: registro.nombre || '',
-              alias: registro.alias || '',
-              tipo: registro.tipo || registro.estado || '',
-              telefono: registro.telefono || '',
-              creditosActuales: Number(registro.creditosActuales ?? registro.creditos ?? 0),
-              creditos: Number(registro.creditosActuales ?? registro.creditos ?? 0),
-              archivadoEn: fechaServidor(),
-              horaArchivado: horaServidor(),
-              archivadoPor: authInstance().currentUser?.email || '',
-              estado: 'ARCHIVADO'
-            };
-            await coleccionArchivo.doc(id).set(datosArchivo, { merge: true });
-            pagosColaboradoresEdicion.delete(id);
-            pagosColaboradoresMapa.delete(id);
-            const normalizado = cpNormalizarEmail(registro.gmail || id);
-            if(normalizado){
-              idsNormalizados.add(normalizado);
-              colaboradoresArchivadosSet.add(normalizado);
-            }
-          } catch (err) {
-            console.error('Error archivando registro', tipo, err);
-            alert('No se pudo archivar uno de los registros seleccionados.');
-            break;
-          }
-        }
-        if(idsNormalizados.size){
-          actualizarColaboradoresDesdeBase();
-        }
-        renderColaboradores();
-        return;
-      }
       let coleccionBase = db.collection('PagosAdministracion');
       let coleccionArchivo = db.collection('PagosAdministracionArchivo');
       if(tipo === 'premios'){
@@ -2445,19 +2390,6 @@
         if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }
         await aprobarPagosColaboradores(seleccion);
       });
-      document.getElementById('colaboradores-archivar').addEventListener('click', async()=>{
-        const seleccion = obtenerSeleccion('tabla-colaboradores');
-        if(!seleccion.length){ alert('Selecciona registros para archivar.'); return; }
-        if(!(await confirm('¿Deseas archivar los registros seleccionados?'))) return;
-        await archivarRegistros(seleccion, 'colaboradores');
-      });
-      document.getElementById('colaboradores-ver-archivo').addEventListener('click', ()=>{
-        mostrarColaboradoresArchivo = !mostrarColaboradoresArchivo;
-        if(mostrarColaboradoresArchivo){
-          pagosColaboradoresEdicion.clear();
-        }
-        renderColaboradores();
-      });
       const tablaColaboradores = document.getElementById('tabla-colaboradores');
       tablaColaboradores.addEventListener('change', e=>{
         if(e.target.matches('tbody input[type="checkbox"]')){
@@ -2519,7 +2451,7 @@
           const fila = e.target.closest('tr[data-id]');
           if(!fila) return;
           const id = fila.dataset.id;
-          const registro = pagosColaboradoresMapa.get(id) || pagosColaboradoresArchivoMapa.get(id);
+          const registro = pagosColaboradoresMapa.get(id);
           if(!registro) return;
           if(e.target.closest('td.gmail')){
             let nombre = registro.nombre || registro.alias || '';
@@ -2727,51 +2659,6 @@
           renderColaboradores();
         }
       });
-      unsubscribeColaboradoresArchivo = db.collection('PagosColaboradoresArchivo').onSnapshot(snapshot => {
-        const nuevosArchivados = new Set();
-        pagosColaboradoresArchivados.length = 0;
-        pagosColaboradoresArchivoMapa.clear();
-        snapshot.forEach(doc => {
-          const data = doc.data() || {};
-          const email = cpNormalizarEmail(data.gmail || doc.id);
-          if(email) nuevosArchivados.add(email);
-          const tipo = normalizarTipoUsuario(data.tipo || data.estado || 'Archivado');
-          const fechaInfo = normalizarFecha(data.archivadoEn || data.fechaArchivado || data.fechaGestion || '');
-          const creditosActuales = Number(data.creditosActuales ?? data.creditos ?? 0);
-          const registro = {
-            id: doc.id,
-            gmail: email || doc.id,
-            nombre: (data.nombre || data.alias || '').toString(),
-            alias: (data.alias || '').toString(),
-            creditos: creditosActuales,
-            creditosActuales,
-            fechaMostrar: fechaInfo.mostrar,
-            fechaFiltro: fechaInfo.filtro,
-            fechaOrden: fechaInfo.orden,
-            estado: tipo || 'Archivado',
-            tipo: tipo || 'Archivado',
-            billetera: email || doc.id,
-            telefono: (data.telefono || '').toString(),
-            cartonesGratis: Number(data.cartonesGratis ?? 0)
-          };
-          pagosColaboradoresArchivados.push(registro);
-          pagosColaboradoresArchivoMapa.set(doc.id, registro);
-          guardarInfoUsuarioCache({
-            email: registro.gmail,
-            alias: registro.alias,
-            nombre: registro.nombre,
-            tipo: registro.tipo,
-            telefono: registro.telefono,
-            creditos: registro.creditosActuales,
-            cartonesGratis: registro.cartonesGratis,
-            completo: false
-          });
-        });
-        colaboradoresArchivadosSet.clear();
-        nuevosArchivados.forEach(valor => colaboradoresArchivadosSet.add(valor));
-        actualizarColaboradoresDesdeBase();
-        renderColaboradores();
-      });
     }
 
     window.addEventListener('beforeunload', ()=>{
@@ -2780,8 +2667,7 @@
         unsubscribePremiosArchivo,
         unsubscribePagos,
         unsubscribePagosArchivo,
-        unsubscribeUsuariosCentro,
-        unsubscribeColaboradoresArchivo
+        unsubscribeUsuariosCentro
       ].forEach(unsub=>{
         if(typeof unsub === 'function') unsub();
       });

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -169,6 +169,131 @@
       font-family: Calibri, Arial, sans-serif;
       font-size: 0.9rem;
     }
+    .asignacion-section {
+      width: 95%;
+      margin-top: 20px;
+      background: rgba(255,255,255,0.4);
+      border-radius: 12px;
+      padding: 10px 12px 14px;
+      box-sizing: border-box;
+    }
+    .asignacion-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      color: #4a148c;
+    }
+    .asignacion-header h3 {
+      margin: 0;
+      font-size: 1.2rem;
+    }
+    .asignacion-acciones {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: center;
+      margin: 10px 0;
+    }
+    .asignacion-acciones select,
+    .asignacion-acciones button {
+      font-family: Calibri, Arial, sans-serif;
+      font-size: 0.8rem;
+      font-weight: 600;
+      padding: 4px 10px;
+      border-radius: 6px;
+      border: 1px solid #b39ddb;
+      background: rgba(255,255,255,0.85);
+      cursor: pointer;
+    }
+    .asignacion-acciones button {
+      background: #6a1b9a;
+      color: #fff;
+      border-color: #4a148c;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .asignacion-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-family: Calibri, Arial, sans-serif;
+      font-size: 0.78rem;
+      background: rgba(255,255,255,0.65);
+    }
+    .asignacion-table th,
+    .asignacion-table td {
+      border: 1px solid #d1c4e9;
+      padding: 4px 6px;
+      font-weight: bold;
+      white-space: nowrap;
+    }
+    .asignacion-table th {
+      background: rgba(255,255,255,0.85);
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+    .asignacion-table td.gmail {
+      word-break: break-word;
+      white-space: normal;
+    }
+    .asignacion-table td.col-creditos,
+    .asignacion-table td.col-cartones {
+      text-align: right;
+      position: relative;
+    }
+    .asignacion-table td.col-rol {
+      text-align: center;
+    }
+    .asignacion-table th.col-creditos,
+    .asignacion-table td.col-creditos {
+      color: #2e7d32;
+    }
+    .asignacion-table th.col-cartones,
+    .asignacion-table td.col-cartones {
+      color: #6a1b9a;
+    }
+    .asignacion-input {
+      width: 100%;
+      box-sizing: border-box;
+      border: none;
+      background: transparent;
+      color: inherit;
+      font-weight: bold;
+      text-align: right;
+      font-size: 0.78rem;
+      padding: 2px 0;
+    }
+    .asignacion-input:disabled {
+      color: inherit;
+      opacity: 0.85;
+    }
+    .valor-temporal {
+      position: absolute;
+      inset: 50% auto auto 50%;
+      transform: translate(-50%, -50%);
+      background: rgba(255,255,255,0.95);
+      border-radius: 6px;
+      padding: 2px 6px;
+      box-shadow: 0 0 6px rgba(0,0,0,0.25);
+      font-size: 0.75rem;
+      color: #283593;
+      pointer-events: none;
+    }
+    .check-header {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      cursor: pointer;
+    }
+    .mensaje-tabla {
+      text-align: center;
+      padding: 12px 8px;
+      color: #283593;
+      font-family: Calibri, Arial, sans-serif;
+      font-size: 0.9rem;
+    }
   </style>
 </head>
 <body>
@@ -236,6 +361,40 @@
       </thead>
       <tbody></tbody>
     </table>
+    </div>
+  </section>
+  <section class="asignacion-section" id="asignacion-usuarios-section">
+    <div class="asignacion-header">
+      <h3>ASIGNACION USUARIOS</h3>
+      <label class="switch">
+        <input type="checkbox" id="toggle-asignacion">
+        <span class="slider"></span>
+      </label>
+    </div>
+    <div id="asignacion-content" style="display:none;">
+      <div class="asignacion-acciones">
+        <select id="asignacion-filtro-rol">
+          <option value="">ROL</option>
+          <option value="jugador">JUGADOR</option>
+          <option value="colaborador">COLABORADOR</option>
+          <option value="administrador">ADMINISTRADOR</option>
+          <option value="superadmin">SUPERADMIN</option>
+        </select>
+        <button id="asignacion-aprobar" type="button">Aprobar</button>
+      </div>
+      <table class="asignacion-table" id="tabla-asignacion">
+        <thead>
+          <tr class="filtros">
+            <th>N°</th>
+            <th><input type="text" id="asignacion-filtro-gmail" placeholder="Gmail/Nombre" style="width:100%;box-sizing:border-box;"></th>
+            <th class="col-creditos">CREDITOS ASIGNADOS</th>
+            <th class="col-cartones">CARTONES GRATIS</th>
+            <th>Rol</th>
+            <th><span id="asignacion-marcar" class="check-header">✔</span></th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
     </div>
   </section>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
@@ -388,6 +547,368 @@
     toggle.addEventListener('change',()=>{
       cont.style.display=toggle.checked?'block':'none';
       if(toggle.checked) cargarDatos();
+    });
+    // ---- Sección de asignación de usuarios ----
+    const asignacionFiltros={texto:'',rol:''};
+    const asignacionUsuarios=[];
+    const asignacionMapa=new Map();
+    const asignacionEdicion=new Map();
+    const asignacionSeleccion=new Set();
+    const asignacionTemporales=new WeakMap();
+    const formatoAsignacionEntero=new Intl.NumberFormat('es-ES',{maximumFractionDigits:0,minimumFractionDigits:0});
+    let unsubscribeAsignacionUsuarios=null;
+    let asignacionInicializada=false;
+
+    function normalizarRolUsuario(valor){
+      const texto=(valor||'').toString().trim().toLowerCase();
+      if(texto.includes('super')) return {etiqueta:'Superadmin',clave:'superadmin'};
+      if(texto.includes('admin')) return {etiqueta:'Administrador',clave:'administrador'};
+      if(texto.includes('colab')) return {etiqueta:'Colaborador',clave:'colaborador'};
+      if(texto.includes('juga')) return {etiqueta:'Jugador',clave:'jugador'};
+      if(!texto) return {etiqueta:'Jugador',clave:'jugador'};
+      const etiqueta=texto.charAt(0).toUpperCase()+texto.slice(1);
+      return {etiqueta,clave:texto};
+    }
+
+    async function obtenerDatosBilleteraAsignacion(email){
+      if(!email) return {creditos:0,cartonesGratis:0};
+      try {
+        const snap=await db.collection('Billetera').doc(email).get();
+        if(!snap.exists) return {creditos:0,cartonesGratis:0};
+        const data=snap.data()||{};
+        return {
+          creditos:Number(data.creditos)||0,
+          cartonesGratis:Number(data.CartonesGratis??data.cartonesGratis??0)||0
+        };
+      } catch(err){
+        console.warn('No se pudo obtener la billetera de',email,err);
+        return {creditos:0,cartonesGratis:0};
+      }
+    }
+
+    function obtenerAsignacionFiltrada(){
+      const termino=asignacionFiltros.texto;
+      const rol=asignacionFiltros.rol;
+      return asignacionUsuarios.filter(usuario=>{
+        if(termino){
+          const base=termino;
+          const nombre=(usuario.nombre||'').toLowerCase();
+          const alias=(usuario.alias||'').toLowerCase();
+          if(!usuario.gmail.toLowerCase().includes(base) && !nombre.includes(base) && !alias.includes(base)) return false;
+        }
+        if(rol && usuario.rolClave!==rol) return false;
+        return true;
+      });
+    }
+
+    function crearCeldaTexto(texto,clase){
+      const td=document.createElement('td');
+      if(clase) td.className=clase;
+      td.textContent=texto;
+      return td;
+    }
+
+    function crearCeldaInput(usuario,idCampo){
+      const td=document.createElement('td');
+      td.className=idCampo==='creditos'?'col-creditos':'col-cartones';
+      const input=document.createElement('input');
+      input.type='number';
+      input.step='1';
+      input.placeholder='0';
+      input.className='asignacion-input';
+      input.dataset.id=usuario.id;
+      input.dataset.campo=idCampo;
+      const edicion=asignacionEdicion.get(usuario.id)||{};
+      const valor=(edicion[idCampo]??'').toString();
+      if(valor) input.value=valor;
+      input.disabled=!asignacionSeleccion.has(usuario.id);
+      td.appendChild(input);
+      return td;
+    }
+
+    function renderAsignacionTabla(){
+      const cuerpo=document.querySelector('#tabla-asignacion tbody');
+      if(!cuerpo) return;
+      const lista=obtenerAsignacionFiltrada();
+      if(!lista.length){
+        cuerpo.innerHTML='<tr><td colspan="6"><div class="mensaje-tabla">No hay usuarios disponibles.</div></td></tr>';
+        return;
+      }
+      const frag=document.createDocumentFragment();
+      lista.forEach((usuario,indice)=>{
+        const tr=document.createElement('tr');
+        tr.dataset.id=usuario.id;
+        const tdNumero=crearCeldaTexto(String(indice+1));
+        const tdGmail=crearCeldaTexto(usuario.gmail,'gmail');
+        const tdCreditos=crearCeldaInput(usuario,'creditos');
+        const tdCartones=crearCeldaInput(usuario,'cartones');
+        const tdRol=crearCeldaTexto(usuario.rol.toUpperCase(),'col-rol');
+        const tdCheck=document.createElement('td');
+        tdCheck.style.textAlign='center';
+        const check=document.createElement('input');
+        check.type='checkbox';
+        check.dataset.id=usuario.id;
+        check.checked=asignacionSeleccion.has(usuario.id);
+        tdCheck.appendChild(check);
+        tr.append(tdNumero,tdGmail,tdCreditos,tdCartones,tdRol,tdCheck);
+        frag.appendChild(tr);
+      });
+      cuerpo.innerHTML='';
+      cuerpo.appendChild(frag);
+    }
+
+    function mostrarValorTemporal(celda,valor){
+      if(!celda) return;
+      if(!celda.isConnected) return;
+      let aviso=celda.querySelector('.valor-temporal');
+      if(!aviso){
+        aviso=document.createElement('div');
+        aviso.className='valor-temporal';
+        celda.appendChild(aviso);
+      }
+      aviso.textContent=formatoAsignacionEntero.format(Math.round(Number(valor)||0));
+      if(asignacionTemporales.has(celda)){
+        clearTimeout(asignacionTemporales.get(celda));
+      }
+      const timeout=setTimeout(()=>{
+        if(celda.isConnected && aviso.parentNode===celda){
+          celda.removeChild(aviso);
+        }
+        asignacionTemporales.delete(celda);
+      },3000);
+      asignacionTemporales.set(celda,timeout);
+    }
+
+    async function procesarAsignacionesUsuarios(ids){
+      if(!ids.length){
+        alert('Selecciona al menos un usuario.');
+        return;
+      }
+      let procesados=0;
+      const procesadosIds=[];
+      for(const id of ids){
+        const registro=asignacionMapa.get(id);
+        if(!registro) continue;
+        const edicion=asignacionEdicion.get(id)||{};
+        const creditosTexto=(edicion.creditos??'').toString().trim();
+        const cartonesTexto=(edicion.cartones??'').toString().trim();
+        if(!creditosTexto || !cartonesTexto){
+          continue;
+        }
+        const creditosValor=Number(creditosTexto);
+        const cartonesValor=Number(cartonesTexto);
+        if(!Number.isFinite(creditosValor) || creditosValor===0){
+          alert('Ingresa un número distinto de cero en CREDITOS ASIGNADOS.');
+          return;
+        }
+        if(!Number.isFinite(cartonesValor) || cartonesValor===0){
+          alert('Ingresa un número distinto de cero en CARTONES GRATIS.');
+          return;
+        }
+        try {
+          await db.runTransaction(async tx=>{
+            const billeteraRef=db.collection('Billetera').doc(id);
+            const snap=await tx.get(billeteraRef);
+            const datos=snap.exists?(snap.data()||{}):{};
+            let creditosActuales=Number(datos.creditos)||0;
+            let cartonesActuales=Number(datos.CartonesGratis??datos.cartonesGratis??0)||0;
+            creditosActuales=Math.max(0,creditosActuales+creditosValor);
+            cartonesActuales=Math.max(0,cartonesActuales+cartonesValor);
+            tx.set(billeteraRef,{creditos:creditosActuales,CartonesGratis:cartonesActuales},{merge:true});
+            registro.creditos=creditosActuales;
+            registro.cartonesGratis=cartonesActuales;
+          });
+          procesados++;
+          procesadosIds.push(id);
+        } catch(err){
+          console.error('No se pudo actualizar la billetera de',id,err);
+          alert('Ocurrió un error al actualizar un usuario. Revisa la consola para más detalles.');
+          return;
+        }
+      }
+      if(procesados){
+        alert(`Se actualizaron ${procesados} usuario(s) correctamente.`);
+        procesadosIds.forEach(id=>{
+          asignacionSeleccion.delete(id);
+          asignacionEdicion.delete(id);
+        });
+      } else {
+        alert('No se registraron cambios porque hay columnas sin completar.');
+      }
+      renderAsignacionTabla();
+    }
+
+    function iniciarSuscripcionAsignacion(){
+      if(unsubscribeAsignacionUsuarios) return;
+      unsubscribeAsignacionUsuarios=db.collection('users').onSnapshot(async snapshot=>{
+        asignacionMapa.clear();
+        const tareas=[];
+        const lista=[];
+        const ids=new Set();
+        snapshot.forEach(doc=>{
+          const data=doc.data()||{};
+          const email=(data.email||doc.id||'').toString().trim().toLowerCase();
+          if(!email) return;
+          const rolInfo=normalizarRolUsuario(data.role||data.rol||data.rolinterno||data.tipo||'');
+          const registro={
+            id:email,
+            gmail:email,
+            nombre:(data.nombre||data.name||'').toString(),
+            alias:(data.alias||'').toString(),
+            rol:rolInfo.etiqueta,
+            rolClave:rolInfo.clave,
+            creditos:0,
+            cartonesGratis:0
+          };
+          ids.add(registro.id);
+          asignacionMapa.set(registro.id,registro);
+          lista.push(registro);
+          tareas.push((async()=>{
+            const billetera=await obtenerDatosBilleteraAsignacion(email);
+            registro.creditos=billetera.creditos;
+            registro.cartonesGratis=billetera.cartonesGratis;
+          })());
+        });
+        asignacionUsuarios.length=0;
+        lista.sort((a,b)=>{
+          const textoA=(a.nombre||a.alias||a.gmail).toLowerCase();
+          const textoB=(b.nombre||b.alias||b.gmail).toLowerCase();
+          return textoA.localeCompare(textoB);
+        });
+        asignacionUsuarios.push(...lista);
+        asignacionSeleccion.forEach(id=>{ if(!ids.has(id)) asignacionSeleccion.delete(id); });
+        Array.from(asignacionEdicion.keys()).forEach(id=>{ if(!ids.has(id)) asignacionEdicion.delete(id); });
+        renderAsignacionTabla();
+        if(tareas.length){
+          try {
+            await Promise.all(tareas);
+          } catch(err){
+            console.warn('No se pudieron sincronizar algunas billeteras',err);
+          }
+          renderAsignacionTabla();
+        }
+      });
+    }
+
+    function marcarTodosAsignacion(){
+      const tabla=document.getElementById('tabla-asignacion');
+      if(!tabla) return;
+      const checks=tabla.querySelectorAll('tbody input[type="checkbox"]');
+      if(!checks.length) return;
+      const marcar=Array.from(checks).some(chk=>!chk.checked);
+      checks.forEach(chk=>{
+        chk.checked=marcar;
+        const id=chk.dataset.id;
+        if(!id) return;
+        if(marcar){
+          asignacionSeleccion.add(id);
+        } else {
+          asignacionSeleccion.delete(id);
+          asignacionEdicion.delete(id);
+        }
+        const fila=chk.closest('tr');
+        if(fila){
+          fila.querySelectorAll('.asignacion-input').forEach(input=>{
+            input.disabled=!marcar;
+            if(!marcar){ input.value=''; }
+          });
+        }
+      });
+    }
+
+    document.getElementById('asignacion-filtro-gmail').addEventListener('input',e=>{
+      asignacionFiltros.texto=e.target.value.toLowerCase().trim();
+      renderAsignacionTabla();
+    });
+    document.getElementById('asignacion-filtro-rol').addEventListener('change',e=>{
+      asignacionFiltros.rol=e.target.value;
+      renderAsignacionTabla();
+    });
+    document.getElementById('asignacion-marcar').addEventListener('click',marcarTodosAsignacion);
+    document.getElementById('asignacion-aprobar').addEventListener('click',()=>{
+      procesarAsignacionesUsuarios(Array.from(asignacionSeleccion));
+    });
+
+    const tablaAsignacion=document.getElementById('tabla-asignacion');
+    tablaAsignacion.addEventListener('change',e=>{
+      if(e.target.matches('tbody input[type="checkbox"]')){
+        const id=e.target.dataset.id;
+        const fila=e.target.closest('tr');
+        if(!id || !fila) return;
+        if(e.target.checked){
+          asignacionSeleccion.add(id);
+        }else{
+          asignacionSeleccion.delete(id);
+          asignacionEdicion.delete(id);
+        }
+        fila.querySelectorAll('.asignacion-input').forEach(input=>{
+          input.disabled=!e.target.checked;
+          if(!e.target.checked){ input.value=''; }
+        });
+      }
+    });
+
+    tablaAsignacion.addEventListener('input',e=>{
+      if(e.target.matches('.asignacion-input')){
+        let valor=e.target.value.replace(/[^0-9-]/g,'');
+        if(valor.includes('-')){
+          const negativo=valor.startsWith('-');
+          valor=valor.replace(/-/g,'');
+          if(negativo) valor='-'+valor;
+        }
+        e.target.value=valor;
+        const id=e.target.dataset.id;
+        const campo=e.target.dataset.campo;
+        if(!id || !campo) return;
+        const actual=asignacionEdicion.get(id)||{};
+        actual[campo]=valor;
+        asignacionEdicion.set(id,actual);
+      }
+    });
+
+    tablaAsignacion.addEventListener('click',e=>{
+      if(e.target.closest('.asignacion-input')) return;
+      const celdaCred=e.target.closest('td.col-creditos');
+      if(celdaCred){
+        const fila=celdaCred.closest('tr');
+        const id=fila ? fila.dataset.id : null;
+        const check=fila ? fila.querySelector('input[type="checkbox"]') : null;
+        if(id && check && !check.checked){
+          const registro=asignacionMapa.get(id);
+          if(registro) mostrarValorTemporal(celdaCred,registro.creditos);
+        }
+        return;
+      }
+      const celdaCart=e.target.closest('td.col-cartones');
+      if(celdaCart){
+        const fila=celdaCart.closest('tr');
+        const id=fila ? fila.dataset.id : null;
+        const check=fila ? fila.querySelector('input[type="checkbox"]') : null;
+        if(id && check && !check.checked){
+          const registro=asignacionMapa.get(id);
+          if(registro) mostrarValorTemporal(celdaCart,registro.cartonesGratis);
+        }
+      }
+    });
+
+    const toggleAsignacion=document.getElementById('toggle-asignacion');
+    const contenidoAsignacion=document.getElementById('asignacion-content');
+    toggleAsignacion.addEventListener('change',()=>{
+      const activo=toggleAsignacion.checked;
+      contenidoAsignacion.style.display=activo?'block':'none';
+      if(activo && !asignacionInicializada){
+        asignacionInicializada=true;
+        iniciarSuscripcionAsignacion();
+      }
+    });
+    contenidoAsignacion.style.display='none';
+    if(toggleAsignacion.checked){
+      contenidoAsignacion.style.display='block';
+      asignacionInicializada=true;
+      iniciarSuscripcionAsignacion();
+    }
+    window.addEventListener('beforeunload',()=>{
+      if(typeof unsubscribeAsignacionUsuarios==='function') unsubscribeAsignacionUsuarios();
     });
     document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='admin.html';});
     auth.onAuthStateChanged(user=>{


### PR DESCRIPTION
## Summary
- remove the collaborator archive controls from Centro de Pagos and keep only active assignments
- add an "Asignacion Usuarios" section in configuraciones with styling, filters, and editable columns for créditos/cartones
- implement the approval workflow to update billeteras directly with validation and temporary value previews

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69012f01f3148326a4497c6940788ea1