### PR TITLE
Ajusta interacciones táctiles en la asignación de usuarios

### DIFF
--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -346,6 +346,17 @@
       text-transform: uppercase;
       white-space: normal;
       word-break: break-word;
+      cursor: pointer;
+      background-color: #fff;
+      transition: background-color 0.3s ease, color 0.3s ease;
+    }
+    .asignacion-table th.col-creditos.vista-actual {
+      background-color: #2e7d32;
+      color: #ffffff;
+    }
+    .asignacion-table th.col-cartones.vista-actual {
+      background-color: #6a1b9a;
+      color: #ffffff;
     }
     .asignacion-input {
       width: 100%;
@@ -1358,7 +1369,8 @@
     });
 
     tablaAsignacion.addEventListener('click',e=>{
-      if(e.target.closest('.asignacion-input')) return;
+      const inputObjetivo=e.target.closest('.asignacion-input');
+      if(inputObjetivo && !inputObjetivo.disabled) return;
       const celdaGmail=e.target.closest('td.col-gmail');
       if(celdaGmail){
         const fila=celdaGmail.closest('tr');
@@ -1404,17 +1416,32 @@
     const encabezadoCreditos=document.getElementById('asignacion-encabezado-creditos');
     const encabezadoCartones=document.getElementById('asignacion-encabezado-cartones');
 
+    function actualizarEncabezadoCreditos(){
+      if(!encabezadoCreditos) return;
+      encabezadoCreditos.textContent=vistaCreditosActuales?'CREDITOS ACTUALES':'CREDITOS ASIGNADOS';
+      encabezadoCreditos.classList.toggle('vista-actual',vistaCreditosActuales);
+    }
+
+    function actualizarEncabezadoCartones(){
+      if(!encabezadoCartones) return;
+      encabezadoCartones.textContent=vistaCartonesActuales?'CARTONES GRATIS':'CARTONES ASIGNADOS';
+      encabezadoCartones.classList.toggle('vista-actual',vistaCartonesActuales);
+    }
+
     encabezadoCreditos?.addEventListener('click',()=>{
       vistaCreditosActuales=!vistaCreditosActuales;
-      encabezadoCreditos.textContent=vistaCreditosActuales?'CREDITOS ACTUALES':'CREDITOS ASIGNADOS';
+      actualizarEncabezadoCreditos();
       actualizarVistaColumnasAsignacion();
     });
 
     encabezadoCartones?.addEventListener('click',()=>{
       vistaCartonesActuales=!vistaCartonesActuales;
-      encabezadoCartones.textContent=vistaCartonesActuales?'CARTONES GRATIS':'CARTONES ASIGNADOS';
+      actualizarEncabezadoCartones();
       actualizarVistaColumnasAsignacion();
     });
+
+    actualizarEncabezadoCreditos();
+    actualizarEncabezadoCartones();
 
     const toggleAsignacion=document.getElementById('toggle-asignacion');
     const contenidoAsignacion=document.getElementById('asignacion-content');


### PR DESCRIPTION
## Summary
- amplía el área táctil de las celdas de créditos y cartones para alternar valores incluso cuando el campo está deshabilitado
- añade indicadores visuales al encabezado cuando se muestran créditos y cartones actuales
- reutiliza funciones auxiliares para mantener sincronizados los encabezados y su estilo

## Testing
- no se ejecutaron pruebas

------
https://chatgpt.com/codex/tasks/task_e_6902546961fc83268071d00fefe9aabe