### PR TITLE
Remove winner highlight styling from cantos table

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -5554,7 +5554,6 @@
         if(!Array.isArray(lista) || !lista.length) return;
         const celda=cantoCellsMap.get(numero);
         if(!celda) return;
-        celda.classList.add('ganador');
         const etiquetasFormas=lista
           .map(info=>{
             const idx=Number(info?.idx);


### PR DESCRIPTION
## Summary
- avoid adding the `ganador` style to cantos table cells so they no longer get the black text highlight
- keep the metadata updates so the table retains existing accessibility information

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69029f7ca4808326be102e299c99669d