### PR TITLE
Ajusta boton y modal de WhatsApp en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -77,7 +77,7 @@
       }
       .whatsapp-flotante {
           position: fixed;
-          top: clamp(4px, 3vw, 14px);
+          bottom: clamp(12px, 4vw, 24px);
           right: clamp(10px, 4vw, 18px);
           width: clamp(52px, 13vw, 72px);
           height: clamp(52px, 13vw, 72px);
@@ -1980,7 +1980,16 @@
           font-family: 'Bangers', cursive;
           font-size: clamp(1.3rem, 5vw, 1.6rem);
           letter-spacing: 1px;
-          color: #1a1a1a;
+          color: #00c853;
+          text-shadow:
+              -3px 0 0 #ffffff,
+              3px 0 0 #ffffff,
+              0 -3px 0 #ffffff,
+              0 3px 0 #ffffff,
+              -2px -2px 0 #ffffff,
+              2px -2px 0 #ffffff,
+              -2px 2px 0 #ffffff,
+              2px 2px 0 #ffffff;
       }
       .modal-whatsapp .modal-mensaje {
           margin: 0;
@@ -3130,7 +3139,7 @@
 
   <div id="modal-whatsapp" class="modal modal-whatsapp" role="dialog" aria-modal="true" aria-labelledby="modal-whatsapp-titulo" aria-hidden="true">
     <div class="modal-contenido" role="document">
-      <h2 id="modal-whatsapp-titulo">Grupos de WhatsApp</h2>
+      <h2 id="modal-whatsapp-titulo">GRUPO DE WHATSAPP NO DISPONIBLE</h2>
       <p id="modal-whatsapp-mensaje" class="modal-mensaje">Aún no hay grupos disponibles de WhatsApp</p>
       <div class="modal-whatsapp-acciones">
         <button type="button" id="modal-whatsapp-aceptar">Aceptar</button>


### PR DESCRIPTION
## Summary
- reubico el botón flotante de WhatsApp en la esquina inferior derecha de juegoactivo
- actualizo el título del modal de WhatsApp cuando no hay grupos, aplicando el nuevo texto y estilo solicitado

## Testing
- no se ejecutaron pruebas (no aplicaba)


------
https://chatgpt.com/codex/tasks/task_e_6902d0170938832695c20a829c90da61