### PR TITLE
Update collaborator and wallet transaction filters

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -366,7 +366,6 @@
                 <option value="deposito">DEPOSITO</option>
                 <option value="retiro">RETIRO</option>
                 <option value="premio">PREMIO</option>
-                <option value="pago" id="filtro-tipo-pago">PAGO</option>
               </select>
             </th>
             <th><input id="filtro-monto" type="number" placeholder="MONTO"></th>
@@ -445,13 +444,26 @@
       auth.onAuthStateChanged(async user => {
         if(!user) return;
         const filtroTipoSelect = document.getElementById('filtro-tipo');
-        const opcionPago = document.getElementById('filtro-tipo-pago');
-        if(opcionPago && filtroTipoSelect){
+        if(filtroTipoSelect){
           const rolActual = (window.currentRole || '').toLowerCase();
-          const visible = ['administrador','superadmin'].includes(rolActual);
-          opcionPago.hidden = !visible;
-          if(!visible && filtroTipoSelect.value === 'pago'){
-            filtroTipoSelect.value = '';
+          const permitirPago = ['administrador','superadmin'].includes(rolActual);
+          let opcionPago = document.getElementById('filtro-tipo-pago');
+          if(permitirPago){
+            if(!opcionPago){
+              opcionPago = document.createElement('option');
+              opcionPago.value = 'pago';
+              opcionPago.id = 'filtro-tipo-pago';
+              opcionPago.textContent = 'PAGO';
+              filtroTipoSelect.appendChild(opcionPago);
+            } else {
+              opcionPago.disabled = false;
+              opcionPago.hidden = false;
+            }
+          } else if(opcionPago){
+            if(opcionPago.selected){
+              filtroTipoSelect.value = '';
+            }
+            opcionPago.remove();
           }
         }
         cargarBancosBilletera();
@@ -561,6 +573,8 @@
       const origen = (data.origen || '').toString().trim().toLowerCase();
       const referencia = (data.referencia || '').toString().trim().toUpperCase();
       const sorteoNombre = (data.sorteoNombre || '').toString().trim().toLowerCase();
+      const rolInterno = (data.rolInterno || data.rolinterno || '').toString().trim().toLowerCase();
+      const esRolEspecial = ['desarrolladores','desarrollador','agencia'].includes(rolInterno);
 
       if(['retiro','deposito','ajuste_colaborador'].includes(tipoCrudo)){
         return tipoCrudo;
@@ -573,6 +587,14 @@
       } else if(origen === 'premios_jugadores'){
         if(!tipo || tipo === 'pago'){
           tipo = 'premio';
+        }
+      }
+
+      if(esRolEspecial && tipo !== 'ajuste_colaborador'){
+        if(!tipo || tipo === 'premio' || tipo === 'pago' || !tipoCrudo){
+          if(!origen || origen === 'pagos_administracion' || sorteoNombre.includes('pago') || referencia === 'PAGO'){
+            tipo = 'pago';
+          }
         }
       }
 

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -2084,6 +2084,7 @@
         }
         const origen = (enRegistro.origen || '').toString().toLowerCase();
         let tipoTransaccion = (enRegistro.tipotrans || '').toString().toLowerCase();
+        const rolInterno = (enRegistro.rolInterno || enRegistro.rolinterno || '').toString();
         if(origen === 'pagos_administracion' && tipoTransaccion !== 'ajuste_colaborador'){
           tipoTransaccion = 'pago';
         } else if(origen === 'premios_jugadores'){
@@ -2119,7 +2120,9 @@
           rolusuario: window.currentRole || '',
           referencia,
           sorteoId: enRegistro.sorteoId || '',
-          sorteoNombre
+          sorteoNombre,
+          rolInterno,
+          rolinterno: rolInterno
         });
       } catch (err) {
         console.error('No se pudo registrar la transacción de premio', err);

--- a/public/pagoscollab.html
+++ b/public/pagoscollab.html
@@ -405,6 +405,7 @@
               <select id="filtro-tipo">
                 <option value="">TIPO</option>
                 <option value="pago">PAGO</option>
+                <option value="retiro">RETIRO</option>
               </select>
             </th>
             <th><input id="filtro-monto" type="number" placeholder="MONTO"></th>
@@ -528,7 +529,8 @@
       transacciones.length = 0;
       snap.forEach(doc => {
         const data = doc.data();
-        if((data.tipotrans || '').toLowerCase() !== 'pago') return;
+        const tipoTransaccion = (data.tipotrans || '').toLowerCase();
+        if(!['pago','retiro'].includes(tipoTransaccion)) return;
         data.fechasolicitud = formatearFecha(data.fechasolicitud || '');
         data.fechagestion = formatearFecha(data.fechagestion || '');
         transacciones.push({ id: doc.id, ...data });


### PR DESCRIPTION
## Summary
- add the RETIRO option to the collaborator payments filter and include withdrawal transactions in the data set
- ensure the wallet type filter only exposes the PAGO option to administrators and superadmins
- propagate the internal role metadata into transactions and normalize special administrator payments as type PAGO

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690396c499d8832690954d277ab098d9