### PR TITLE
Actualizar estilos de gestión de bancos y carga de WhatsApp

### DIFF
--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -130,6 +130,17 @@
       font-size: 0.9rem;
       margin-top: 0;
     }
+    #gestionar-header {
+      font-family: 'Bangers', cursive;
+      color: #ff7a00;
+      letter-spacing: 0.5px;
+    }
+    #gestionar-header h3 {
+      margin: 0;
+      font-family: inherit;
+      color: inherit;
+      text-transform: uppercase;
+    }
     .switch {
       position: relative;
       display: inline-block;
@@ -449,6 +460,11 @@
       font-size: 0.82rem;
       font-weight: 600;
       color: #6a1b9a;
+    }
+    #numero-whatsapp-label {
+      font-family: 'Bangers', cursive;
+      color: #6a1b9a;
+      letter-spacing: 0.4px;
     }
     .whatsapp-number-row {
       display: flex;
@@ -859,11 +875,13 @@
           if(nombreApp){
             etiquetaNumeroWhatsapp.textContent=`Número WhatsApp para ${nombreApp}`;
           }
-          if(data.numeroWhatsapp){
-            campoNumeroWhatsapp.value=data.numeroWhatsapp;
+          const numeroGuardado=data.numeroWhatsapp??data.numero_whatsapp??'';
+          if(numeroGuardado){
+            campoNumeroWhatsapp.value=numeroGuardado;
           }
-          if(data.linkwhatsapp){
-            campoLinkWhatsapp.value=data.linkwhatsapp;
+          const linkGuardado=data.linkWhatsapp??data.linkwhatsapp??'';
+          if(linkGuardado){
+            campoLinkWhatsapp.value=linkGuardado;
           }
         }
       } catch(err){


### PR DESCRIPTION
## Summary
- alinear la cabecera de Gestión de Bancos con la tipografía Bangers y color naranja para igualar la sección de asignación
- resaltar la etiqueta del número de WhatsApp usando la fuente Bangers en morado
- cargar automáticamente los valores guardados en Firebase para número y enlace de WhatsApp considerando claves alternativas

## Testing
- no tests

------
https://chatgpt.com/codex/tasks/task_e_6903c3eea8e48326a7cf7035d01d227a