### PR TITLE
Permitir guardar múltiples formas por pestaña

### DIFF
--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -812,16 +812,17 @@ firebase.auth().onAuthStateChanged(u=>{
         posiciones,
         actualizado:firebase.firestore.FieldValue.serverTimestamp()
       };
-      let savedId=editingId;
+      let mensaje='Forma guardada correctamente';
       if(editingId){
         await db.collection(FORMAS_COLLECTION).doc(editingId).set(payload,{merge:true});
+        formaEdicionPorTab[idx]=editingId;
+        mensaje='Forma actualizada correctamente';
       }else{
         payload.creado=firebase.firestore.FieldValue.serverTimestamp();
-        const ref=await db.collection(FORMAS_COLLECTION).add(payload);
-        savedId=ref.id;
+        await db.collection(FORMAS_COLLECTION).add(payload);
+        formaEdicionPorTab[idx]=null;
       }
-      formaEdicionPorTab[idx]=savedId;
-      alert('Forma guardada correctamente');
+      alert(mensaje);
       if(document.getElementById('formas-modal')?.classList.contains('visible') && modalFormaIdx===idx){
         await cargarFormasModal(idx);
       }

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -792,16 +792,17 @@
         posiciones,
         actualizado:firebase.firestore.FieldValue.serverTimestamp()
       };
-      let savedId=editingId;
+      let mensaje='Forma guardada correctamente';
       if(editingId){
         await db.collection(FORMAS_COLLECTION).doc(editingId).set(payload,{merge:true});
+        formaEdicionPorTab[idx]=editingId;
+        mensaje='Forma actualizada correctamente';
       }else{
         payload.creado=firebase.firestore.FieldValue.serverTimestamp();
-        const ref=await db.collection(FORMAS_COLLECTION).add(payload);
-        savedId=ref.id;
+        await db.collection(FORMAS_COLLECTION).add(payload);
+        formaEdicionPorTab[idx]=null;
       }
-      formaEdicionPorTab[idx]=savedId;
-      alert('Forma guardada correctamente');
+      alert(mensaje);
       if(document.getElementById('formas-modal')?.classList.contains('visible') && modalFormaIdx===idx){
         await cargarFormasModal(idx);
       }


### PR DESCRIPTION
## Summary
- evitar que los formularios de nuevas formas queden vinculados permanentemente a un solo registro
- permitir guardar múltiples combinaciones por pestaña y mantener la edición explícita en nuevosorteo y editarsorte
- ajustar los mensajes al actualizar vs. crear nuevas formas

## Testing
- no se agregaron pruebas


------
https://chatgpt.com/codex/tasks/task_e_69057a5fc5a08326a9e53c256f2fceba