### PR TITLE
Replace bingo logo asset across public views

### DIFF
--- a/public/accederusuario.html
+++ b/public/accederusuario.html
@@ -45,6 +45,8 @@
     }
     #logo-bingo {
       width: 250px;
+      max-width: 80vw;
+      height: auto;
       margin-bottom: 15px;
     }
     #session-info {
@@ -96,7 +98,7 @@
   </style>
 </head>
 <body>
-  <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" alt="logo" />
+  <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" alt="logo" />
   <h2>Acceder como Usuario</h2>
   <div id="session-info">
     <div id="user-data">

--- a/public/admin.html
+++ b/public/admin.html
@@ -45,6 +45,8 @@
     }
     #logo-bingo {
       width: 250px;
+      max-width: 80vw;
+      height: auto;
       margin-bottom: 15px;
     }
     #session-info {
@@ -117,7 +119,7 @@
   </style>
 </head>
 <body>
-  <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" alt="logo" />
+  <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" alt="logo" />
   <h2>Menú Administrador</h2>
   <div id="session-info">
     <div id="user-line">

--- a/public/collab.html
+++ b/public/collab.html
@@ -45,6 +45,8 @@
     }
     #logo-bingo {
       width: 250px;
+      max-width: 80vw;
+      height: auto;
       margin-bottom: 15px;
     }
     #session-info {
@@ -95,7 +97,7 @@
   </style>
 </head>
 <body>
-  <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" alt="logo" />
+  <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" alt="logo" />
   <h2>Menú Colaborador</h2>
   <div id="session-info">
     <div id="user-data">

--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -281,7 +281,7 @@
     }
     window.location.href=fallbackUrl;
   }
-  const LOGO_URL='https://i.imgur.com/twjhNtZ.png';
+  const LOGO_URL='img/Logo-BingOnline-nuevo500p.png';
   const preloadLogo=new Image();
   preloadLogo.src=LOGO_URL;
   const FORMA_COLORES={1:'#90ee90',2:'#fffacd',3:'#add8e6',4:'#d8b0ff',5:'#ffcc99'};

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,8 @@
     }
     #logo-bingo {
       width: 250px;
+      max-width: 80vw;
+      height: auto;
       margin-bottom: 15px;
     }
     #login-btn {
@@ -80,7 +82,7 @@
 </head>
 <body>
   <div id="login-container">
-    <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" />
+    <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" />
     <button id="login-btn">Iniciar Sesión</button>
     <div id="terms-container"><input type="checkbox" id="accept-terms"> <label for="accept-terms">Acepto los <a href="#" id="terms-link">términos y condiciones</a></label></div>
     <div id="register-container" style="margin-top:10px;font-size:1rem;">¿Aún no tienes cuenta? <a href="#" id="register-link">Regístrate</a></div>

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -6478,7 +6478,7 @@
       totalContenedor.appendChild(cartonesGratisLabel);
       backContent.appendChild(totalContenedor);
       const backLogo=document.createElement('img');
-      backLogo.src='https://i.imgur.com/twjhNtZ.png';
+      backLogo.src='img/Logo-BingOnline-nuevo500p.png';
       backLogo.alt='Logo HexaBingo';
       cartonBack.appendChild(backLogo);
       insertarBotonesFormas(botonesFormas);

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -371,7 +371,7 @@
             <div id="back-premios-total" class="text-premio-total"></div>
             <div id="back-premios-formas"></div>
           </div>
-          <img src="https://i.imgur.com/twjhNtZ.png" alt="logo">
+          <img src="img/Logo-BingOnline-nuevo500p.png" alt="logo">
         </div>
       </div>
     </div>

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -281,7 +281,7 @@
     }
     window.location.href=fallbackUrl;
   }
-  const LOGO_URL='https://i.imgur.com/twjhNtZ.png';
+  const LOGO_URL='img/Logo-BingOnline-nuevo500p.png';
   const preloadLogo=new Image();
   preloadLogo.src=LOGO_URL;
   const FORMA_COLORES={1:'#90ee90',2:'#fffacd',3:'#add8e6',4:'#d8b0ff',5:'#ffcc99'};

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -289,6 +289,8 @@
     }
     #logo {
       width: 110px;
+      max-width: 35vw;
+      height: auto;
       display: block;
     }
     #resumen-header .header-info {
@@ -1145,6 +1147,7 @@
     }
     body.pdf-captura #logo {
       width: clamp(86px, 12vw, 108px);
+      height: auto;
     }
     body.pdf-captura #resumen-header .header-info {
       align-items: flex-start;
@@ -1330,7 +1333,7 @@
       <div id="resumen-layout">
         <div id="resumen-header" class="resumen-bloque">
           <div class="header-logo">
-            <img id="logo" src="https://i.imgur.com/twjhNtZ.png" alt="Bingo Online">
+            <img id="logo" src="img/Logo-BingOnline-nuevo500p.png" alt="Bingo Online">
           </div>
           <div class="header-info">
             <h1 id="nombre-sorteo">Sorteo</h1>

--- a/public/pdfsorteo.html
+++ b/public/pdfsorteo.html
@@ -230,6 +230,8 @@
     }
     #logo {
       width: 110px;
+      max-width: 35vw;
+      height: auto;
       display: block;
     }
     #resumen-header .header-info {
@@ -1065,7 +1067,7 @@
       <div id="resumen-layout">
         <div id="resumen-header" class="resumen-bloque">
           <div class="header-logo">
-            <img id="logo" src="https://i.imgur.com/twjhNtZ.png" alt="Bingo Online">
+            <img id="logo" src="img/Logo-BingOnline-nuevo500p.png" alt="Bingo Online">
           </div>
           <div class="header-info">
           <h1 id="nombre-sorteo">Sorteo</h1>

--- a/public/player.html
+++ b/public/player.html
@@ -150,10 +150,14 @@
       }
       #logo-bingo {
           width: 250px;
+          max-width: 80vw;
+          height: auto;
           margin-bottom: 15px;
       }
       #menu-logo {
           width: 250px;
+          max-width: 80vw;
+          height: auto;
           margin-bottom: 15px;
       }
       #login-footer {
@@ -327,7 +331,7 @@
 
   <div id="main-menu" class="view">
     <div id="menu-buttons">
-      <img id="menu-logo" src="https://i.imgur.com/twjhNtZ.png" />
+      <img id="menu-logo" src="img/Logo-BingOnline-nuevo500p.png" />
       <h3>Menú Jugador</h3>
       <button id="carton-btn" class="menu-btn" onclick="mostrarCarton()">Jugar Cartón</button>
       <button id="jugando-btn" class="menu-btn">Sorteo en Vivo</button>

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -36,7 +36,7 @@
     input[type="checkbox"]{width:auto;margin:0;}
     #alias{color:#ff6600;}
     #email{margin:10px;font-weight:bold;color:#006400;}
-    #logo-bingo{width:200px;margin-bottom:5px;}
+    #logo-bingo{width:200px;max-width:80vw;height:auto;margin-bottom:5px;}
     .action-btn{
       font-family:'Bangers',cursive;
       background:linear-gradient(#0a8800,#ffffff);
@@ -62,7 +62,7 @@
   </style>
 </head>
 <body>
-  <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" />
+  <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" />
   <h2>Registro de Jugador</h2>
   <input type="text" id="nombre" placeholder="Nombre">
   <input type="text" id="apellido" placeholder="Apellido">

--- a/public/super.html
+++ b/public/super.html
@@ -45,6 +45,8 @@
     }
     #logo-bingo {
       width: 250px;
+      max-width: 80vw;
+      height: auto;
       margin-bottom: 15px;
     }
     #session-info {
@@ -157,7 +159,7 @@
   </style>
 </head>
 <body>
-  <img id="logo-bingo" src="https://i.imgur.com/twjhNtZ.png" alt="logo" />
+  <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" alt="logo" />
   <h2>Menú Superadmin</h2>
   <div id="session-info">
     <div id="user-data">


### PR DESCRIPTION
## Summary
- replace all remaining references to the old hosted logo with the new `public/img/Logo-BingOnline-nuevo500p.png` asset across login, admin, and gameplay pages
- adjust inline logo styles so the new artwork scales responsively in standard screens and PDF exports
- update bingo card generators to preload and render the refreshed logo on card backs and generated documents

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69064b9c643c8326a2422c2551eac640