### PR TITLE
Update background animation for admin views

### DIFF
--- a/public/accederusuario.html
+++ b/public/accederusuario.html
@@ -14,10 +14,12 @@
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
   <style>
     body {
-      background: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
-                  url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
+      background-image: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
+                        url('img/fondo-dinero-porcentage.jpg');
       background-repeat: repeat;
       background-size: auto;
+      background-position: 0 0, 0 0;
+      animation: fondo-movimiento 120s linear infinite;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -27,6 +29,15 @@
       font-family: 'Bangers', cursive;
       margin: 0;
     }
+    @keyframes fondo-movimiento {
+      0% {
+        background-position: 0 0, 0 0;
+      }
+      100% {
+        background-position: 0 0, -600px 600px;
+      }
+    }
+
     .menu-btn {
       width: 250px;
       height: 60px;

--- a/public/admin.html
+++ b/public/admin.html
@@ -14,10 +14,12 @@
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
   <style>
     body {
-      background: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
-                  url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
+      background-image: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
+                        url('img/fondo-dinero-porcentage.jpg');
       background-repeat: repeat;
       background-size: auto;
+      background-position: 0 0, 0 0;
+      animation: fondo-movimiento 120s linear infinite;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -27,6 +29,15 @@
       font-family: 'Bangers', cursive;
       margin: 0;
     }
+    @keyframes fondo-movimiento {
+      0% {
+        background-position: 0 0, 0 0;
+      }
+      100% {
+        background-position: 0 0, -600px 600px;
+      }
+    }
+
     .menu-btn {
       width: 250px;
       height: 60px;

--- a/public/collab.html
+++ b/public/collab.html
@@ -14,10 +14,12 @@
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
   <style>
     body {
-      background: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
-                  url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
+      background-image: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
+                        url('img/fondo-dinero-porcentage.jpg');
       background-repeat: repeat;
       background-size: auto;
+      background-position: 0 0, 0 0;
+      animation: fondo-movimiento 120s linear infinite;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -27,6 +29,15 @@
       font-family: 'Bangers', cursive;
       margin: 0;
     }
+    @keyframes fondo-movimiento {
+      0% {
+        background-position: 0 0, 0 0;
+      }
+      100% {
+        background-position: 0 0, -600px 600px;
+      }
+    }
+
     .menu-btn {
       width: 250px;
       height: 60px;

--- a/public/player.html
+++ b/public/player.html
@@ -17,10 +17,12 @@
      		
       body {
           font-family: 'Poppins', sans-serif;
-          background: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
-                      url('https://img.freepik.com/vetores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
+          background-image: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
+                            url('img/fondo-dinero-porcentage.jpg');
           background-repeat: repeat;
           background-size: auto;
+          background-position: 0 0, 0 0;
+          animation: fondo-movimiento 120s linear infinite;
           display: flex;
           flex-direction: column;
           align-items: center;
@@ -30,6 +32,15 @@
           margin: 0;
       }
 		
+      @keyframes fondo-movimiento {
+          0% {
+              background-position: 0 0, 0 0;
+          }
+          100% {
+              background-position: 0 0, -600px 600px;
+          }
+      }
+
       h2 {
           font-size: 2.5rem;
           color: #ffcc00;

--- a/public/super.html
+++ b/public/super.html
@@ -14,10 +14,12 @@
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
   <style>
     body {
-      background: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
-                  url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
+      background-image: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
+                        url('img/fondo-dinero-porcentage.jpg');
       background-repeat: repeat;
       background-size: auto;
+      background-position: 0 0, 0 0;
+      animation: fondo-movimiento 120s linear infinite;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -27,6 +29,15 @@
       font-family: 'Bangers', cursive;
       margin: 0;
     }
+    @keyframes fondo-movimiento {
+      0% {
+        background-position: 0 0, 0 0;
+      }
+      100% {
+        background-position: 0 0, -600px 600px;
+      }
+    }
+
     .menu-btn {
       width: 250px;
       height: 60px;


### PR DESCRIPTION
## Summary
- switch the superadmin, admin, collaborator, access, and player pages to use the local `fondo-dinero-porcentage.jpg` asset as their background
- add a slow diagonal animation so the shared background texture moves continuously toward the bottom-left corner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690679d5c32083268aef12420566234b