### PR TITLE
Add prize payout displays and improve free card indicators

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -794,6 +794,29 @@
       gap: 12px;
       box-sizing: border-box;
     }
+    .modal-premio-forma {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      margin-bottom: 6px;
+      font-family: 'Bangers', cursive;
+      font-size: clamp(1rem, 2.6vw, 1.28rem);
+      color: var(--modal-premio-color, #1f1f1f);
+      text-transform: uppercase;
+    }
+    .modal-premio-forma.visible {
+      display: inline-flex;
+    }
+    .modal-premio-forma__label {
+      letter-spacing: 1px;
+    }
+    .modal-premio-forma__valor {
+      font-family: 'Poppins', sans-serif;
+      font-weight: 700;
+      animation: premioZoom 2s ease-in-out infinite;
+      text-shadow: 0 0 8px rgba(255,255,255,0.85);
+    }
     .modal-nuevos-ganadores .modal-contenido {
       background: linear-gradient(160deg, rgba(24,24,24,0.94), rgba(96,24,24,0.94));
       border-radius: 20px;
@@ -839,6 +862,10 @@
       color: #fff;
       text-shadow: 0 0 14px rgba(255,140,0,0.9);
       margin-left: 6px;
+    }
+    @keyframes premioZoom {
+      0%, 100% { transform: scale(1); }
+      50% { transform: scale(1.12); }
     }
     #nuevos-ganadores-aceptar {
       font-family: 'Bangers', cursive;
@@ -1641,6 +1668,10 @@
   <div id="modal-ganadores" class="modal modal-ganadores" role="dialog" aria-modal="true" aria-labelledby="modal-ganadores-titulo" aria-hidden="true">
     <div class="modal-contenido">
       <button id="modal-ganadores-cerrar" class="modal-cerrar" type="button" aria-label="Cerrar">✖</button>
+      <div id="modal-premio-forma" class="modal-premio-forma" hidden aria-hidden="true">
+        <span id="modal-premio-forma-label" class="modal-premio-forma__label">PREMIO A REPARTIR:</span>
+        <span id="modal-premio-forma-valor" class="modal-premio-forma__valor">0</span>
+      </div>
       <h2 id="modal-ganadores-titulo">Ganadores</h2>
       <div id="modal-ganadores-subtitulo" class="mensaje"></div>
       <div id="modal-ganadores-lista"></div>
@@ -1768,6 +1799,9 @@
   const modalGanadoresSubtituloEl = document.getElementById('modal-ganadores-subtitulo');
   const modalGanadoresListaEl = document.getElementById('modal-ganadores-lista');
   const modalGanadoresSinEl = document.getElementById('modal-ganadores-sin');
+  const modalPremioFormaEl = document.getElementById('modal-premio-forma');
+  const modalPremioFormaValorEl = document.getElementById('modal-premio-forma-valor');
+  const modalPremioFormaLabelEl = document.getElementById('modal-premio-forma-label');
   const nuevosGanadoresModalEl = document.getElementById('nuevos-ganadores-modal');
   const nuevosGanadoresListaEl = document.getElementById('nuevos-ganadores-lista');
   const nuevosGanadoresAceptarBtn = document.getElementById('nuevos-ganadores-aceptar');
@@ -3382,6 +3416,28 @@
     return 0;
   }
 
+  function actualizarModalPremioForma(forma){
+    if(!modalPremioFormaEl || !modalPremioFormaValorEl) return;
+    if(!forma){
+      modalPremioFormaEl.classList.remove('visible');
+      modalPremioFormaEl.setAttribute('hidden','');
+      modalPremioFormaEl.setAttribute('aria-hidden','true');
+      return;
+    }
+    const total = Math.max(0, Math.round(obtenerCreditosForma(forma) || 0));
+    const colorBase = obtenerColorParaForma(forma?.idx || 1);
+    const colorOscuro = obtenerColorOscurecido(colorBase, 0.55);
+    modalPremioFormaEl.style.setProperty('--modal-premio-color', colorOscuro);
+    if(modalPremioFormaLabelEl){
+      modalPremioFormaLabelEl.style.color = colorOscuro;
+    }
+    modalPremioFormaValorEl.textContent = formatearNumero(total);
+    modalPremioFormaValorEl.style.color = colorOscuro;
+    modalPremioFormaEl.classList.add('visible');
+    modalPremioFormaEl.removeAttribute('hidden');
+    modalPremioFormaEl.setAttribute('aria-hidden','false');
+  }
+
   function obtenerCartonesGratisForma(forma){
     if(!forma) return 0;
     const candidatos = [
@@ -3910,6 +3966,7 @@
     const nombreForma = forma?.nombre ? forma.nombre : '';
     modalGanadoresTituloEl.textContent = `Ganadores Forma ${String(idxNumero).padStart(2,'0')}`;
     modalGanadoresSubtituloEl.textContent = nombreForma;
+    actualizarModalPremioForma(forma);
     modalGanadoresListaEl.innerHTML = '';
     modalGanadoresSinEl.textContent = '';
     const ganadores = registro?.cartones ? [...registro.cartones] : [];
@@ -3940,6 +3997,7 @@
     if(!modalGanadoresEl) return;
     modalGanadoresEl.classList.remove('activa');
     modalGanadoresEl.setAttribute('aria-hidden', 'true');
+    actualizarModalPremioForma(null);
   }
 
   function manejarClickModalGanadores(event){

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1023,6 +1023,31 @@
       #carton-destacado.activo {
           display: flex;
       }
+      #carton-destacado-premio {
+          display: none;
+          align-items: center;
+          justify-content: center;
+          gap: 6px;
+          margin: 4px auto 0;
+          font-family: 'Bangers', cursive;
+          font-size: clamp(0.6rem, 1.6vw, 0.78rem);
+          letter-spacing: 0.8px;
+          text-transform: uppercase;
+          color: var(--carton-premio-color, #1f1f1f);
+          text-shadow: 0 0 6px rgba(255,255,255,0.85);
+      }
+      #carton-destacado-premio.visible {
+          display: inline-flex;
+      }
+      #carton-destacado-premio .carton-destacado-premio__valor {
+          font-family: 'Poppins', sans-serif;
+          font-weight: 700;
+          animation: premioZoom 2s ease-in-out infinite;
+          text-shadow: 0 0 6px rgba(255,255,255,0.95), 0 0 12px rgba(255,255,255,0.5);
+      }
+      #carton-destacado-premio[hidden] {
+          display: none !important;
+      }
       #carton-destacado .carton-tabla thead th {
           cursor: default;
       }
@@ -1977,6 +2002,29 @@
           gap: 12px;
           box-sizing: border-box;
       }
+      .modal-premio-forma {
+          display: none;
+          align-items: center;
+          justify-content: center;
+          gap: 10px;
+          margin-bottom: 6px;
+          font-family: 'Bangers', cursive;
+          font-size: clamp(1rem, 2.8vw, 1.35rem);
+          color: var(--modal-premio-color, #1f1f1f);
+          text-transform: uppercase;
+      }
+      .modal-premio-forma.visible {
+          display: inline-flex;
+      }
+      .modal-premio-forma__label {
+          letter-spacing: 1px;
+      }
+      .modal-premio-forma__valor {
+          font-family: 'Poppins', sans-serif;
+          font-weight: 700;
+          animation: premioZoom 2s ease-in-out infinite;
+          text-shadow: 0 0 8px rgba(255,255,255,0.85);
+      }
       .modal-whatsapp .modal-contenido {
           max-width: min(360px, calc(100vw - 40px));
           width: min(360px, calc(100vw - 40px));
@@ -2029,6 +2077,14 @@
       #modal-whatsapp-aceptar:active {
           transform: translateY(1px) scale(0.98);
           box-shadow: 0 4px 12px rgba(56,142,60,0.4);
+      }
+      @keyframes premioZoom {
+          0%, 100% {
+              transform: scale(1);
+          }
+          50% {
+              transform: scale(1.12);
+          }
       }
       .modal-cerrar {
           align-self: flex-end;
@@ -3083,6 +3139,10 @@
       <div id="panel-columna-derecha">
         <div class="panel-columna-derecha__rejilla panel-columna-derecha__destacado">
           <aside id="carton-destacado" aria-live="polite"></aside>
+          <div id="carton-destacado-premio" class="carton-destacado-premio" hidden aria-hidden="true">
+            <span id="carton-destacado-premio-label" class="carton-destacado-premio__label">PREMIO A REPARTIR:</span>
+            <span id="carton-destacado-premio-valor" class="carton-destacado-premio__valor">0</span>
+          </div>
           <div id="sin-cartones-activos" class="sin-cartones-activos" hidden aria-hidden="true">
             <p class="sin-cartones-activos__mensaje">No jugaste cartones en este sorteo, puedes jugar en otro sorteo que esté activo.</p>
             <button id="jugar-otro-sorteo-btn" type="button" class="sin-cartones-activos__boton">JUGAR CARTÓN EN OTRO SORTEO</button>
@@ -3108,6 +3168,10 @@
   <div id="modal-ganadores" class="modal">
     <div class="modal-contenido">
       <button class="modal-cerrar" id="modal-cerrar">✖</button>
+      <div id="modal-premio-forma" class="modal-premio-forma" hidden aria-hidden="true">
+        <span id="modal-premio-forma-label" class="modal-premio-forma__label">PREMIO A REPARTIR:</span>
+        <span id="modal-premio-forma-valor" class="modal-premio-forma__valor">0</span>
+      </div>
       <h2 id="modal-titulo">Ganadores</h2>
       <div id="modal-subtitulo" class="mensaje"></div>
       <div id="modal-ganadores-lista"></div>
@@ -3204,12 +3268,18 @@
   const cartonesMensajeEl = document.getElementById('cartones-mensaje');
   const cartonDestacadoEl = document.getElementById('carton-destacado');
   const panelDestacadoWrapperEl = document.querySelector('.panel-columna-derecha__destacado');
+  const cartonDestacadoPremioEl = document.getElementById('carton-destacado-premio');
+  const cartonDestacadoPremioValorEl = document.getElementById('carton-destacado-premio-valor');
+  const cartonDestacadoPremioLabelEl = document.getElementById('carton-destacado-premio-label');
   const modalGanadores = document.getElementById('modal-ganadores');
   const modalCerrarBtn = document.getElementById('modal-cerrar');
   const modalTituloEl = document.getElementById('modal-titulo');
   const modalSubtituloEl = document.getElementById('modal-subtitulo');
   const modalListaEl = document.getElementById('modal-ganadores-lista');
   const modalSinGanadoresEl = document.getElementById('modal-sin-ganadores');
+  const modalPremioFormaEl = document.getElementById('modal-premio-forma');
+  const modalPremioFormaValorEl = document.getElementById('modal-premio-forma-valor');
+  const modalPremioFormaLabelEl = document.getElementById('modal-premio-forma-label');
   const modalSorteosFinalizadosEl = document.getElementById('modal-sorteos-finalizados');
   const modalSorteosFinalizadosListaEl = document.getElementById('modal-sorteos-finalizados-lista');
   const modalSorteosFinalizadosMensajeEl = document.getElementById('modal-sorteos-finalizados-mensaje');
@@ -4800,11 +4870,57 @@
     return `${reducir(rgb.r)},${reducir(rgb.g)},${reducir(rgb.b)}`;
   }
 
+  function actualizarPremioFormaDestacada(forma, colorHex){
+    if(!cartonDestacadoPremioEl || !cartonDestacadoPremioValorEl) return;
+    if(!forma){
+      cartonDestacadoPremioEl.classList.remove('visible');
+      cartonDestacadoPremioEl.setAttribute('hidden','');
+      cartonDestacadoPremioEl.setAttribute('aria-hidden','true');
+      return;
+    }
+    const totalForma = Math.max(0, Math.round(obtenerCreditosForma(forma) || 0));
+    const baseColor = colorHex || obtenerColorParaForma(forma.idx || 1);
+    const colorOscuro = obtenerColorOscurecido(baseColor, 0.55);
+    cartonDestacadoPremioEl.style.setProperty('--carton-premio-color', colorOscuro);
+    cartonDestacadoPremioEl.style.color = colorOscuro;
+    if(cartonDestacadoPremioLabelEl){
+      cartonDestacadoPremioLabelEl.style.color = colorOscuro;
+    }
+    cartonDestacadoPremioValorEl.textContent = formatearCreditos(totalForma);
+    cartonDestacadoPremioValorEl.style.color = colorOscuro;
+    cartonDestacadoPremioEl.classList.add('visible');
+    cartonDestacadoPremioEl.removeAttribute('hidden');
+    cartonDestacadoPremioEl.setAttribute('aria-hidden','false');
+  }
+
+  function actualizarModalPremioForma(forma){
+    if(!modalPremioFormaEl || !modalPremioFormaValorEl) return;
+    if(!forma){
+      modalPremioFormaEl.classList.remove('visible');
+      modalPremioFormaEl.setAttribute('hidden','');
+      modalPremioFormaEl.setAttribute('aria-hidden','true');
+      return;
+    }
+    const totalForma = Math.max(0, Math.round(obtenerCreditosForma(forma) || 0));
+    const colorBase = obtenerColorParaForma(forma.idx || 1);
+    const colorOscuro = obtenerColorOscurecido(colorBase, 0.55);
+    modalPremioFormaEl.style.setProperty('--modal-premio-color', colorOscuro);
+    if(modalPremioFormaLabelEl){
+      modalPremioFormaLabelEl.style.color = colorOscuro;
+    }
+    modalPremioFormaValorEl.textContent = formatearCreditos(totalForma);
+    modalPremioFormaValorEl.style.color = colorOscuro;
+    modalPremioFormaEl.classList.add('visible');
+    modalPremioFormaEl.removeAttribute('hidden');
+    modalPremioFormaEl.setAttribute('aria-hidden','false');
+  }
+
   function actualizarEncabezadoForma(info, indice, colorHex){
     if(!info || !Array.isArray(info.letras)) return;
     const indiceNormalizado=Number(indice);
     const idxActivo=Number.isInteger(indiceNormalizado)?indiceNormalizado:null;
     const esPrincipal=info?.contenedor?.classList?.contains('carton-visual--principal');
+    let formaActiva=null;
     info.letras.forEach((span, idx)=>{
       if(!span) return;
       const letraBase=BINGO_LETRAS[idx] || '';
@@ -4826,9 +4942,15 @@
           th.style.removeProperty('--forma-rgb-vivo');
         }
       }
+      if(activo){
+        formaActiva = formasActivas.find(f=>Number(f.idx)===idxActivo) || null;
+      }
     });
     if(esPrincipal && !Number.isInteger(idxActivo)){
       info.contenedor.classList.remove('forma-manual-activa');
+      actualizarPremioFormaDestacada(null);
+    }else if(esPrincipal){
+      actualizarPremioFormaDestacada(formaActiva, colorHex);
     }
   }
 
@@ -6084,6 +6206,7 @@
       sinCartonesActivosEl.removeAttribute('hidden');
       sinCartonesActivosEl.setAttribute('aria-hidden','false');
       cartonDestacadoEl.setAttribute('hidden','');
+      actualizarPremioFormaDestacada(null);
       requestAnimationFrame(()=>{
         actualizarDimensionSinCartones();
       });
@@ -6517,6 +6640,7 @@
     const info=cartonesGanadoresPorForma.get(forma.idx);
     const ganadores=info&&Array.isArray(info.cartones)?info.cartones:[];
     modalTituloEl.textContent=`Ganadores Forma ${String(forma.idx).padStart(2,'0')}`;
+    actualizarModalPremioForma(forma);
     const nombreBase=forma.nombre?forma.nombre:'';
     if(modalSubtituloEl){
       modalSubtituloEl.textContent=nombreBase;
@@ -6608,6 +6732,7 @@
 
   function cerrarModal(){
     modalGanadores.classList.remove('activa');
+    actualizarModalPremioForma(null);
   }
 
   if(modalCerrarBtn){

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -231,7 +231,7 @@
     .carton td{cursor:pointer;font-size:1.8rem;text-shadow:0 0 3px green;}
     .carton td.free{background:#ffeb3b;display:flex;align-items:center;justify-content:center;font-size:1.2rem;color:#4B0082;box-shadow:inset 0 0 6px rgba(0,0,0,0.18);}
     .carton-center-info{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px;line-height:1;font-weight:bold;text-transform:none;}
-    #carton-num-max{font-size:1.4rem;color:#006400;text-shadow:0 0 4px #fff,0 0 6px rgba(0,0,0,0.2);font-family:'Poppins',sans-serif;display:block;animation:wiggle 1s infinite;}
+    #carton-num-max{font-size:1.2rem;color:#006400;text-shadow:0 0 4px #fff,0 0 6px rgba(0,0,0,0.2);font-family:'Poppins',sans-serif;display:block;animation:wiggle 1s infinite;}
     .carton td.error{border:2px solid red;}
     .carton-back{position:absolute;top:0;left:0;right:0;bottom:0;border-radius:10px;backface-visibility:hidden;transform:rotateY(180deg);background:linear-gradient(white,gray);display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:5px;overflow:hidden;}
     .carton-back img{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:80%;height:auto;opacity:0.15;object-fit:contain;pointer-events:none;z-index:0;}
@@ -479,6 +479,7 @@ let premioActual=0;
 let maxCartonesGratis=0;
 let cartonesJugando=0;
 let cartonesGratisJugando=0;
+let cartonesGratisJugadorActual=0;
 const formColors=['#90ee90','#fffacd','#add8e6','#d8b0ff','#ffcc99'];
 const formGlows=['#006400','#b8860b','#00008b','#4b0082','#8b4513'];
 const COLOR_CARTONES_GRATIS_DISPONIBLE='#0b3d91';
@@ -493,14 +494,14 @@ let ultimoNumeroCartonAsignado=0;
 let siguienteNumeroCarton=1;
 
 function obtenerColorCartonesGratisActual(){
-  const limiteAlcanzado=maxCartonesGratis>0 && cartonesGratisJugando>=maxCartonesGratis;
+  const limiteAlcanzado=maxCartonesGratis>0 && cartonesGratisJugadorActual>=maxCartonesGratis;
   return limiteAlcanzado?COLOR_CARTONES_GRATIS_LIMITE:COLOR_CARTONES_GRATIS_DISPONIBLE;
 }
 
 function actualizarEstadoCartonesGratis(){
   const gratisLabel=document.getElementById('gratis-label');
   if(!gratisLabel) return;
-  const limiteAlcanzado=maxCartonesGratis>0 && cartonesGratisJugando>=maxCartonesGratis;
+  const limiteAlcanzado=maxCartonesGratis>0 && cartonesGratisJugadorActual>=maxCartonesGratis;
   const colorActual=obtenerColorCartonesGratisActual();
   gratisLabel.style.color=colorActual;
   const gratisJugandoEl=document.getElementById('cartones-gratis-jugando');
@@ -996,8 +997,10 @@ function toggleForma(idx){
     const elGratis=document.getElementById('jugados-gratis-count');
     const user=auth.currentUser;
     if(!user||!currentSorteo){
+      cartonesGratisJugadorActual=0;
       if(elPag){elPag.textContent='0';elPag.style.display='none';}
       if(elGratis){elGratis.textContent='0';elGratis.style.display='none';}
+      actualizarEstadoCartonesGratis();
       return;
     }
     const snap=await db.collection('CartonJugado').where('userId','==',user.uid).where('sorteoId','==',currentSorteo).get();
@@ -1005,6 +1008,8 @@ function toggleForma(idx){
     snap.forEach(doc=>{ const t=doc.data().tipocarton; if(t==='gratis') gratis++; else pagados++; });
     if(elPag){elPag.textContent=pagados;elPag.style.display=pagados>0?'flex':'none';}
     if(elGratis){elGratis.textContent=gratis;elGratis.style.display=gratis>0?'flex':'none';}
+    cartonesGratisJugadorActual=gratis;
+    actualizarEstadoCartonesGratis();
   }
 
   function iniciarIntervalo(){
@@ -1100,11 +1105,14 @@ function toggleForma(idx){
     currentSorteoNombre=s.nombre;
     currentSorteoTipo=s.tipo;
     currentSorteoEstado=s.estado||'';
+    cartonesGratisJugadorActual=0;
+    actualizarEstadoCartonesGratis();
     escucharConsecutivoCarton(currentSorteo);
     refrescarNumeroCartonVisual();
     ocultarMensajeSellado();
     const btn=document.getElementById('sorteo-btn');
     btn.textContent=s.nombre;
+    btn.style.fontWeight='700';
     btn.classList.remove('diario','especial');
     if(s.tipo==='Sorteo Diario'){ btn.classList.add('diario'); }
     else if(s.tipo==='Sorteo Especial'){ btn.classList.add('especial'); }


### PR DESCRIPTION
## Summary
- show each forma's prize pool in the juegoactivo and cantarsorteos winner modals with animated totals
- expose the highlighted forma prize beneath the featured bingo card in juegoactivo
- adjust jugarcartones free-card colouring, bold the selected sorteo button, and slightly shrink the central board number

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69076a6067e48326bd5533f7481d877f