### PR TITLE
Ajustes visuales de premios y cartones gratis en vistas de juego

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -798,10 +798,10 @@
       display: none;
       align-items: center;
       justify-content: center;
-      gap: 10px;
+      gap: 12px;
       margin-bottom: 6px;
       font-family: 'Bangers', cursive;
-      font-size: clamp(1rem, 2.6vw, 1.28rem);
+      font-size: clamp(1.3rem, 3.4vw, 1.6rem);
       color: var(--modal-premio-color, #1f1f1f);
       text-transform: uppercase;
     }
@@ -814,6 +814,7 @@
     .modal-premio-forma__valor {
       font-family: 'Poppins', sans-serif;
       font-weight: 700;
+      font-size: 1.1em;
       animation: premioZoom 2s ease-in-out infinite;
       text-shadow: 0 0 8px rgba(255,255,255,0.85);
     }

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1027,14 +1027,18 @@
           display: none;
           align-items: center;
           justify-content: center;
+          flex-wrap: wrap;
           gap: 6px;
           margin: 4px auto 0;
           font-family: 'Bangers', cursive;
           font-size: clamp(0.6rem, 1.6vw, 0.78rem);
           letter-spacing: 0.8px;
           text-transform: uppercase;
-          color: var(--carton-premio-color, #1f1f1f);
-          text-shadow: 0 0 6px rgba(255,255,255,0.85);
+          color: #ffffff;
+          text-shadow:
+              0 0 6px rgba(0,0,0,0.92),
+              0 0 12px rgba(0,0,0,0.75),
+              0 0 14px var(--carton-premio-destello, rgba(255,255,255,0.45));
       }
       #carton-destacado-premio.visible {
           display: inline-flex;
@@ -1043,7 +1047,27 @@
           font-family: 'Poppins', sans-serif;
           font-weight: 700;
           animation: premioZoom 2s ease-in-out infinite;
-          text-shadow: 0 0 6px rgba(255,255,255,0.95), 0 0 12px rgba(255,255,255,0.5);
+          color: inherit;
+          text-shadow: inherit;
+      }
+      #carton-destacado-premio .carton-destacado-premio__label {
+          color: inherit;
+          text-shadow: inherit;
+      }
+      .carton-destacado-premio__gratis {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          font-family: 'Poppins', sans-serif;
+          font-size: clamp(0.48rem, 1.35vw, 0.68rem);
+          letter-spacing: 0.6px;
+          text-transform: uppercase;
+          color: #ffffff;
+          text-shadow: 0 0 5px rgba(0,0,0,0.95);
+      }
+      .carton-destacado-premio__gratis-valor {
+          font-weight: 700;
+          animation: premioZoom 2s ease-in-out infinite;
       }
       #carton-destacado-premio[hidden] {
           display: none !important;
@@ -2006,10 +2030,10 @@
           display: none;
           align-items: center;
           justify-content: center;
-          gap: 10px;
+          gap: 12px;
           margin-bottom: 6px;
           font-family: 'Bangers', cursive;
-          font-size: clamp(1rem, 2.8vw, 1.35rem);
+          font-size: clamp(1.3rem, 3.6vw, 1.6rem);
           color: var(--modal-premio-color, #1f1f1f);
           text-transform: uppercase;
       }
@@ -2022,6 +2046,7 @@
       .modal-premio-forma__valor {
           font-family: 'Poppins', sans-serif;
           font-weight: 700;
+          font-size: 1.1em;
           animation: premioZoom 2s ease-in-out infinite;
           text-shadow: 0 0 8px rgba(255,255,255,0.85);
       }
@@ -3142,6 +3167,9 @@
           <div id="carton-destacado-premio" class="carton-destacado-premio" hidden aria-hidden="true">
             <span id="carton-destacado-premio-label" class="carton-destacado-premio__label">PREMIO A REPARTIR:</span>
             <span id="carton-destacado-premio-valor" class="carton-destacado-premio__valor">0</span>
+            <span id="carton-destacado-premio-gratis" class="carton-destacado-premio__gratis" hidden aria-hidden="true">
+              CARTONES GRATIS: <span id="carton-destacado-premio-gratis-valor" class="carton-destacado-premio__gratis-valor">0</span>
+            </span>
           </div>
           <div id="sin-cartones-activos" class="sin-cartones-activos" hidden aria-hidden="true">
             <p class="sin-cartones-activos__mensaje">No jugaste cartones en este sorteo, puedes jugar en otro sorteo que esté activo.</p>
@@ -3271,6 +3299,8 @@
   const cartonDestacadoPremioEl = document.getElementById('carton-destacado-premio');
   const cartonDestacadoPremioValorEl = document.getElementById('carton-destacado-premio-valor');
   const cartonDestacadoPremioLabelEl = document.getElementById('carton-destacado-premio-label');
+  const cartonDestacadoPremioGratisEl = document.getElementById('carton-destacado-premio-gratis');
+  const cartonDestacadoPremioGratisValorEl = document.getElementById('carton-destacado-premio-gratis-valor');
   const modalGanadores = document.getElementById('modal-ganadores');
   const modalCerrarBtn = document.getElementById('modal-cerrar');
   const modalTituloEl = document.getElementById('modal-titulo');
@@ -4876,18 +4906,34 @@
       cartonDestacadoPremioEl.classList.remove('visible');
       cartonDestacadoPremioEl.setAttribute('hidden','');
       cartonDestacadoPremioEl.setAttribute('aria-hidden','true');
+      cartonDestacadoPremioEl.style.removeProperty('--carton-premio-destello');
+      if(cartonDestacadoPremioGratisEl){
+        cartonDestacadoPremioGratisEl.setAttribute('hidden','');
+        cartonDestacadoPremioGratisEl.setAttribute('aria-hidden','true');
+      }
       return;
     }
     const totalForma = Math.max(0, Math.round(obtenerCreditosForma(forma) || 0));
     const baseColor = colorHex || obtenerColorParaForma(forma.idx || 1);
     const colorOscuro = obtenerColorOscurecido(baseColor, 0.55);
-    cartonDestacadoPremioEl.style.setProperty('--carton-premio-color', colorOscuro);
-    cartonDestacadoPremioEl.style.color = colorOscuro;
+    cartonDestacadoPremioEl.style.color = '';
+    const colorDestello = colorOscuro || baseColor;
+    if(colorDestello){
+      cartonDestacadoPremioEl.style.setProperty('--carton-premio-destello', colorDestello);
+    }else{
+      cartonDestacadoPremioEl.style.removeProperty('--carton-premio-destello');
+    }
     if(cartonDestacadoPremioLabelEl){
-      cartonDestacadoPremioLabelEl.style.color = colorOscuro;
+      cartonDestacadoPremioLabelEl.style.color = '';
     }
     cartonDestacadoPremioValorEl.textContent = formatearCreditos(totalForma);
-    cartonDestacadoPremioValorEl.style.color = colorOscuro;
+    cartonDestacadoPremioValorEl.style.color = '';
+    if(cartonDestacadoPremioGratisEl && cartonDestacadoPremioGratisValorEl){
+      const cartonesGratisTotal = Math.max(0, Math.round(obtenerCartonesGratisForma(forma) || 0));
+      cartonDestacadoPremioGratisValorEl.textContent = formatearCreditos(cartonesGratisTotal);
+      cartonDestacadoPremioGratisEl.removeAttribute('hidden');
+      cartonDestacadoPremioGratisEl.setAttribute('aria-hidden','false');
+    }
     cartonDestacadoPremioEl.classList.add('visible');
     cartonDestacadoPremioEl.removeAttribute('hidden');
     cartonDestacadoPremioEl.setAttribute('aria-hidden','false');

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -183,7 +183,10 @@
     #stats-row{display:flex;justify-content:center;align-items:center;gap:20px;}
     .billete-icon{font-size:1.5rem;}
     .carton-icon{width:24px;height:24px;}
-    #premio-repartir{color:white;font-family:'Bangers',cursive;font-size:1.8rem;text-shadow:0 0 10px #004400;position:relative;}
+    #premio-repartir{color:white;font-family:'Bangers',cursive;font-size:1.8rem;text-shadow:0 0 10px #004400;position:relative;display:flex;flex-direction:column;align-items:center;gap:4px;}
+    #premio-repartir .premio-repartir-principal{display:flex;align-items:center;gap:6px;flex-wrap:wrap;justify-content:center;}
+    #premio-repartir .premio-cartones-gratis{font-family:'Poppins',sans-serif;font-size:clamp(0.48rem,1.4vw,0.68rem);letter-spacing:0.6px;color:#001b60;text-transform:uppercase;text-shadow:0 0 6px rgba(255,255,255,0.6);animation:zoomInOut 2.4s ease-in-out infinite;display:flex;align-items:center;gap:4px;}
+    #premio-repartir .premio-cartones-gratis-valor{font-weight:700;animation:inherit;}
     #forma-nombre{font-family:'Bangers',cursive;color:#4B0082;font-size:1rem;text-shadow:0 0 5px #fff;text-align:center;visibility:hidden;min-height:8px;margin:0;}
     .wallet-row{display:flex;align-items:center;gap:5px;margin:3px 0;font-size:1rem;font-weight:bold;}
     #gratis-label{
@@ -339,7 +342,15 @@
       </div>
     </div>
     <div class="datos-sorteo">
-      <div id="premio-repartir"><span id="premio-label">Premio a Repartir:</span> <span id="premio-valor">0</span></div>
+      <div id="premio-repartir">
+        <div class="premio-repartir-principal">
+          <span id="premio-label">Premio a Repartir:</span>
+          <span id="premio-valor">0</span>
+        </div>
+        <div id="premio-cartones-gratis" class="premio-cartones-gratis">
+          Cartones gratis: <span id="premio-cartones-gratis-valor" class="premio-cartones-gratis-valor">0</span>
+        </div>
+      </div>
       <div id="stats-row">
         <div id="valor-carton"><span class="billete-icon">💵</span> Cartón: <span id="valor-carton-valor">0</span></div>
         <div id="cartones-jugando"><img src="https://cdn-icons-png.flaticon.com/32/5065/5065890.png" class="carton-icon" alt="Cartón"> Jugando: <span id="cartones-jugando-valor">0</span> <span id="gratis-plus">+</span> <span id="cartones-gratis-jugando">0</span></div>
@@ -458,40 +469,43 @@
   iniciarControlSorteos();
 
   const ranges=[[1,15],[16,30],[31,45],[46,60],[61,75]];
-const board=document.getElementById('bingo-board');
-let currentCell=null;
-let sorteoInterval=null;
-let currentSorteo=null;
-let currentSorteoNombre='';
-let currentSorteoTipo='';
-let currentSorteoEstado='';
-let cartonesGuardados={};
-let sorteosActivos=[];
-let seleccionadoJugado=null;
-let seleccionadoGuardado=null;
-let consultando=false;
-let cookieKey='';
-let sorteoCookieKey='';
-let fechaActualInterval=null;
-let formasSorteo=[];
-let formaActiva=0;
-let premioActual=0;
-let maxCartonesGratis=0;
-let cartonesJugando=0;
-let cartonesGratisJugando=0;
-let cartonesGratisJugadorActual=0;
-const formColors=['#90ee90','#fffacd','#add8e6','#d8b0ff','#ffcc99'];
-const formGlows=['#006400','#b8860b','#00008b','#4b0082','#8b4513'];
-const COLOR_CARTONES_GRATIS_DISPONIBLE='#0b3d91';
-const COLOR_CARTONES_GRATIS_LIMITE='#c62828';
-let editandoTipo=null;
-let editandoId=null;
-const selladoOverlay=document.getElementById('sellado-overlay');
-const selladoCerrarBtn=document.getElementById('sellado-cerrar-btn');
-const CONSECUTIVOS_COLLECTION='ConsecutivosCarton';
-let unsubscribeConsecutivoCarton=null;
-let ultimoNumeroCartonAsignado=0;
-let siguienteNumeroCarton=1;
+  const board=document.getElementById('bingo-board');
+  let currentCell=null;
+  let sorteoInterval=null;
+  let currentSorteo=null;
+  let currentSorteoNombre='';
+  let currentSorteoTipo='';
+  let currentSorteoEstado='';
+  let cartonesGuardados={};
+  let sorteosActivos=[];
+  let seleccionadoJugado=null;
+  let seleccionadoGuardado=null;
+  let consultando=false;
+  let cookieKey='';
+  let sorteoCookieKey='';
+  let fechaActualInterval=null;
+  let formasSorteo=[];
+  let formaActiva=0;
+  let premioActual=0;
+  let maxCartonesGratis=0;
+  let cartonesJugando=0;
+  let cartonesGratisJugando=0;
+  let cartonesGratisJugadorActual=0;
+  const formColors=['#90ee90','#fffacd','#add8e6','#d8b0ff','#ffcc99'];
+  const formGlows=['#006400','#b8860b','#00008b','#4b0082','#8b4513'];
+  const COLOR_CARTONES_GRATIS_DISPONIBLE='#0b3d91';
+  const COLOR_CARTONES_GRATIS_LIMITE='#c62828';
+  const COLOR_CARTONES_GRATIS_MODAL='#001b60';
+  let editandoTipo=null;
+  let editandoId=null;
+  const selladoOverlay=document.getElementById('sellado-overlay');
+  const selladoCerrarBtn=document.getElementById('sellado-cerrar-btn');
+  const CONSECUTIVOS_COLLECTION='ConsecutivosCarton';
+  let unsubscribeConsecutivoCarton=null;
+  let ultimoNumeroCartonAsignado=0;
+  let siguienteNumeroCarton=1;
+  const premioCartonesGratisEl=document.getElementById('premio-cartones-gratis');
+  const premioCartonesGratisValorEl=document.getElementById('premio-cartones-gratis-valor');
 
 function obtenerColorCartonesGratisActual(){
   const limiteAlcanzado=maxCartonesGratis>0 && cartonesGratisJugadorActual>=maxCartonesGratis;
@@ -573,6 +587,48 @@ function toNumberSafe(value,fallback=0){
     return Number.isFinite(num)?num:fallback;
   }
   return fallback;
+}
+
+function formatearEnteroEs(valor){
+  const numero=Number(valor);
+  if(!Number.isFinite(numero)) return '0';
+  return Math.max(0,Math.round(numero)).toLocaleString('es-ES',{maximumFractionDigits:0});
+}
+
+function obtenerCartonesGratisForma(forma){
+  if(!forma) return 0;
+  const candidatos=[
+    forma?.cartonesGratis,
+    forma?.cartonesgratis,
+    forma?.cartones_gratis,
+    forma?.premioCartonesGratis,
+    forma?.premioCartonesgratis,
+    forma?.cartones
+  ];
+  for(const candidato of candidatos){
+    const numero=toNumberSafe(candidato,Number.NaN);
+    if(Number.isFinite(numero)){
+      return Math.max(0,Math.round(numero));
+    }
+  }
+  return 0;
+}
+
+function obtenerTotalCartonesGratisFormas(){
+  if(!Array.isArray(formasSorteo) || !formasSorteo.length) return 0;
+  return formasSorteo.reduce((total,forma)=>total+obtenerCartonesGratisForma(forma),0);
+}
+
+function actualizarIndicadorCartonesGratis(){
+  if(!premioCartonesGratisEl || !premioCartonesGratisValorEl) return;
+  let total=0;
+  if(formaActiva>0){
+    const activa=formasSorteo.find(f=>Number(f?.idx)===Number(formaActiva));
+    total=obtenerCartonesGratisForma(activa);
+  }else{
+    total=obtenerTotalCartonesGratisFormas();
+  }
+  premioCartonesGratisValorEl.textContent=formatearEnteroEs(total);
 }
 
 function actualizarNumeroCartonLocal(ultimo){
@@ -770,6 +826,7 @@ async function cargarFormasSorteo(){
     const snap=await db.collection('formas').where('sorteoId','==',currentSorteo).get();
     snap.forEach(doc=>formasSorteo.push(doc.data()));
   }catch(e){console.warn('No se pudieron cargar las formas');}
+  actualizarIndicadorCartonesGratis();
 }
 
 function resetForma(){
@@ -785,6 +842,7 @@ function resetForma(){
   const pr=document.getElementById('premio-repartir');
   pr.style.textShadow='0 0 10px #004400';
   document.getElementById('forma-nombre').style.visibility='hidden';
+  actualizarIndicadorCartonesGratis();
   actualizarDatosSorteo();
 }
 
@@ -816,6 +874,7 @@ function toggleForma(idx){
   const wrapper=document.getElementById('carton-wrapper');
   nombre.style.visibility=wrapper.classList.contains('flipped')?'hidden':'visible';
   pv.textContent=Math.round(premioActual*porcentaje/100);
+  actualizarIndicadorCartonesGratis();
 }
 
   function flipCard(){
@@ -988,6 +1047,7 @@ function toggleForma(idx){
   }else{
     pv.textContent=Math.round(premioActual);
   }
+  actualizarIndicadorCartonesGratis();
   refrescarNumeroCartonVisual();
   renderPremios('back-premios');
   }
@@ -1681,9 +1741,8 @@ function toggleForma(idx){
     infoNombre.style.color=currentSorteoTipo==='Sorteo Diario'?'green':'orange';
     const cj=document.getElementById('info-cartones-jugando');
     cj.innerHTML=`Cartones jugando: <strong style="color:purple;">${cartonesJugando}</strong>`;
-    const cg=document.getElementById('info-cartones-gratis');
-    const colorGratis=obtenerColorCartonesGratisActual();
-    cg.innerHTML=`Cartones Gratis jugando: <strong style="color:${colorGratis};">${cartonesGratisJugando}</strong>`;
+  const cg=document.getElementById('info-cartones-gratis');
+  cg.innerHTML=`Cartones Gratis jugando: <strong style="color:${COLOR_CARTONES_GRATIS_MODAL};">${formatearEnteroEs(cartonesGratisJugando)}</strong>`;
     document.getElementById('info-cartones-modal').style.display='flex';
   }
 


### PR DESCRIPTION
## Summary
- agranda las etiquetas de premios en los modales de ganadores y conserva el color según la forma
- muestra los cartones gratis asociados a una forma destacada en juegoactivo con estilo de alto contraste
- añade indicadores de cartones gratis en jugarcartones, incluyendo sumatoria general y detalle por forma, y fija el color del valor en el modal informativo

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690775acb310832682b6a758b6e82735