### PR TITLE
Actualizar estilos de premios en vistas de juego

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1028,46 +1028,81 @@
           align-items: center;
           justify-content: center;
           flex-wrap: wrap;
-          gap: 6px;
+          gap: 8px;
           margin: 4px auto 0;
-          font-family: 'Bangers', cursive;
-          font-size: clamp(0.6rem, 1.6vw, 0.78rem);
-          letter-spacing: 0.8px;
+          font-family: 'Poppins', sans-serif;
+          font-size: clamp(0.7rem, 1.9vw, 0.98rem);
+          font-weight: 500;
+          letter-spacing: 0.6px;
           text-transform: uppercase;
           color: #ffffff;
           text-shadow:
-              0 0 6px rgba(0,0,0,0.92),
-              0 0 12px rgba(0,0,0,0.75),
+              0 0 6px rgba(0,0,0,0.82),
+              0 0 12px rgba(0,0,0,0.62),
               0 0 14px var(--carton-premio-destello, rgba(255,255,255,0.45));
       }
       #carton-destacado-premio.visible {
           display: inline-flex;
       }
-      #carton-destacado-premio .carton-destacado-premio__valor {
+      #carton-destacado-premio .carton-destacado-premio__badge {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          padding: 2px 10px;
+          border: 2px solid #ffffff;
+          border-radius: 999px;
           font-family: 'Poppins', sans-serif;
-          font-weight: 700;
-          animation: premioZoom 2s ease-in-out infinite;
-          color: inherit;
+          font-weight: 600;
+          color: #ffffff;
           text-shadow: inherit;
+          background: rgba(0,0,0,0.15);
       }
-      #carton-destacado-premio .carton-destacado-premio__label {
-          color: inherit;
-          text-shadow: inherit;
+      #carton-destacado-premio .carton-destacado-premio__badge--creditos {
+          letter-spacing: 1px;
+      }
+      #carton-destacado-premio .carton-destacado-premio__valor {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          padding: 2px 12px;
+          border: 2px solid #ffffff;
+          border-radius: 999px;
+          font-family: 'Poppins', sans-serif;
+          font-weight: 600;
+          color: #19d46b;
+          background: rgba(0,0,0,0.18);
+          animation: premioZoom 2s ease-in-out infinite;
       }
       .carton-destacado-premio__gratis {
           display: inline-flex;
           align-items: center;
           gap: 4px;
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(0.48rem, 1.35vw, 0.68rem);
+          font-size: clamp(0.52rem, 1.45vw, 0.74rem);
           letter-spacing: 0.6px;
           text-transform: uppercase;
           color: #ffffff;
-          text-shadow: 0 0 5px rgba(0,0,0,0.95);
+          text-shadow: 0 0 5px rgba(0,0,0,0.85);
+      }
+      .carton-destacado-premio__gratis-label {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          padding: 1px 8px;
+          border: 2px solid #ffffff;
+          border-radius: 999px;
+          font-weight: 600;
+          color: #6a1b9a;
+          background: rgba(255,255,255,0.2);
       }
       .carton-destacado-premio__gratis-valor {
           font-weight: 700;
           animation: premioZoom 2s ease-in-out infinite;
+          color: #6a1b9a;
+          border: 2px solid #ffffff;
+          border-radius: 999px;
+          padding: 1px 8px;
+          background: rgba(255,255,255,0.18);
       }
       #carton-destacado-premio[hidden] {
           display: none !important;
@@ -3165,10 +3200,12 @@
         <div class="panel-columna-derecha__rejilla panel-columna-derecha__destacado">
           <aside id="carton-destacado" aria-live="polite"></aside>
           <div id="carton-destacado-premio" class="carton-destacado-premio" hidden aria-hidden="true">
-            <span id="carton-destacado-premio-label" class="carton-destacado-premio__label">PREMIO A REPARTIR:</span>
+            <span id="carton-destacado-premio-label" class="carton-destacado-premio__badge">A REPARTIR:</span>
             <span id="carton-destacado-premio-valor" class="carton-destacado-premio__valor">0</span>
+            <span id="carton-destacado-premio-creditos" class="carton-destacado-premio__badge carton-destacado-premio__badge--creditos">CREDITOS</span>
             <span id="carton-destacado-premio-gratis" class="carton-destacado-premio__gratis" hidden aria-hidden="true">
-              CARTONES GRATIS: <span id="carton-destacado-premio-gratis-valor" class="carton-destacado-premio__gratis-valor">0</span>
+              <span class="carton-destacado-premio__gratis-label">CARTONES</span>
+              <span id="carton-destacado-premio-gratis-valor" class="carton-destacado-premio__gratis-valor">0</span>
             </span>
           </div>
           <div id="sin-cartones-activos" class="sin-cartones-activos" hidden aria-hidden="true">
@@ -3197,7 +3234,7 @@
     <div class="modal-contenido">
       <button class="modal-cerrar" id="modal-cerrar">✖</button>
       <div id="modal-premio-forma" class="modal-premio-forma" hidden aria-hidden="true">
-        <span id="modal-premio-forma-label" class="modal-premio-forma__label">PREMIO A REPARTIR:</span>
+        <span id="modal-premio-forma-label" class="modal-premio-forma__label">A REPARTIR:</span>
         <span id="modal-premio-forma-valor" class="modal-premio-forma__valor">0</span>
       </div>
       <h2 id="modal-titulo">Ganadores</h2>
@@ -4911,6 +4948,9 @@
         cartonDestacadoPremioGratisEl.setAttribute('hidden','');
         cartonDestacadoPremioGratisEl.setAttribute('aria-hidden','true');
       }
+      if(cartonDestacadoPremioLabelEl){
+        cartonDestacadoPremioLabelEl.textContent = 'A REPARTIR:';
+      }
       return;
     }
     const totalForma = Math.max(0, Math.round(obtenerCreditosForma(forma) || 0));
@@ -4925,6 +4965,7 @@
     }
     if(cartonDestacadoPremioLabelEl){
       cartonDestacadoPremioLabelEl.style.color = '';
+      cartonDestacadoPremioLabelEl.textContent = 'PREMIO DE FORMA:';
     }
     cartonDestacadoPremioValorEl.textContent = formatearCreditos(totalForma);
     cartonDestacadoPremioValorEl.style.color = '';
@@ -4945,6 +4986,9 @@
       modalPremioFormaEl.classList.remove('visible');
       modalPremioFormaEl.setAttribute('hidden','');
       modalPremioFormaEl.setAttribute('aria-hidden','true');
+      if(modalPremioFormaLabelEl){
+        modalPremioFormaLabelEl.textContent = 'A REPARTIR:';
+      }
       return;
     }
     const totalForma = Math.max(0, Math.round(obtenerCreditosForma(forma) || 0));
@@ -4953,6 +4997,7 @@
     modalPremioFormaEl.style.setProperty('--modal-premio-color', colorOscuro);
     if(modalPremioFormaLabelEl){
       modalPremioFormaLabelEl.style.color = colorOscuro;
+      modalPremioFormaLabelEl.textContent = 'PREMIO DE FORMA:';
     }
     modalPremioFormaValorEl.textContent = formatearCreditos(totalForma);
     modalPremioFormaValorEl.style.color = colorOscuro;

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -170,11 +170,7 @@
     #sorteo-section{margin-bottom:5px;}
     .datos-sorteo div{font-weight:bold;font-size:1.2rem;}
     #valor-carton span,#cartones-jugando span{font-size:1.5rem;}
-    #valor-carton-valor,#premio-valor{animation:pulse 1s infinite;display:inline-block;}
-    #premio-valor{
-      font-family:'Poppins',sans-serif;
-      font-weight:600;
-    }
+    #valor-carton-valor,#premio-valor{display:inline-block;}
     #cartones-jugando-valor,#gratis-plus,#cartones-gratis-jugando{animation:wiggle 1s infinite;display:inline-block;}
     #cartones-gratis-jugando{color:#0b3d91;}
     #valor-carton{color:green;display:flex;align-items:center;gap:5px;}
@@ -183,10 +179,15 @@
     #stats-row{display:flex;justify-content:center;align-items:center;gap:20px;}
     .billete-icon{font-size:1.5rem;}
     .carton-icon{width:24px;height:24px;}
-    #premio-repartir{color:white;font-family:'Bangers',cursive;font-size:1.8rem;text-shadow:0 0 10px #004400;position:relative;display:flex;flex-direction:column;align-items:center;gap:4px;}
-    #premio-repartir .premio-repartir-principal{display:flex;align-items:center;gap:6px;flex-wrap:wrap;justify-content:center;}
-    #premio-repartir .premio-cartones-gratis{font-family:'Poppins',sans-serif;font-size:clamp(0.48rem,1.4vw,0.68rem);letter-spacing:0.6px;color:#001b60;text-transform:uppercase;text-shadow:0 0 6px rgba(255,255,255,0.6);animation:zoomInOut 2.4s ease-in-out infinite;display:flex;align-items:center;gap:4px;}
-    #premio-repartir .premio-cartones-gratis-valor{font-weight:700;animation:inherit;}
+    #premio-repartir{color:#001b60;font-family:'Bangers',cursive;font-size:clamp(2.1rem,6vw,2.9rem);text-shadow:0 0 12px rgba(0,27,96,0.4);position:relative;display:flex;flex-direction:column;align-items:center;gap:6px;}
+    #premio-repartir .premio-repartir-principal{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:center;}
+    #premio-repartir .premio-repartir-principal span{display:inline-flex;align-items:center;}
+    #premio-label{text-transform:uppercase;letter-spacing:1px;}
+    #premio-valor,#premio-extra-plus,#premio-extra-valor{font-size:inherit;color:#001b60;animation:zoomInOut 1.6s ease-in-out infinite;font-family:'Bangers',cursive;}
+    #premio-valor{font-weight:700;}
+    #premio-extra-plus{font-weight:700;padding:0 4px;}
+    #premio-extra-valor{font-weight:700;}
+    #premio-cartones-gratis{display:none !important;}
     #forma-nombre{font-family:'Bangers',cursive;color:#4B0082;font-size:1rem;text-shadow:0 0 5px #fff;text-align:center;visibility:hidden;min-height:8px;margin:0;}
     .wallet-row{display:flex;align-items:center;gap:5px;margin:3px 0;font-size:1rem;font-weight:bold;}
     #gratis-label{
@@ -344,8 +345,10 @@
     <div class="datos-sorteo">
       <div id="premio-repartir">
         <div class="premio-repartir-principal">
-          <span id="premio-label">Premio a Repartir:</span>
+          <span id="premio-label">PREMIO A REPARTIR:</span>
           <span id="premio-valor">0</span>
+          <span id="premio-extra-plus">+</span>
+          <span id="premio-extra-valor">0</span>
         </div>
         <div id="premio-cartones-gratis" class="premio-cartones-gratis">
           Cartones gratis: <span id="premio-cartones-gratis-valor" class="premio-cartones-gratis-valor">0</span>
@@ -506,6 +509,8 @@
   let siguienteNumeroCarton=1;
   const premioCartonesGratisEl=document.getElementById('premio-cartones-gratis');
   const premioCartonesGratisValorEl=document.getElementById('premio-cartones-gratis-valor');
+  const premioExtraPlusEl=document.getElementById('premio-extra-plus');
+  const premioExtraValorEl=document.getElementById('premio-extra-valor');
 
 function obtenerColorCartonesGratisActual(){
   const limiteAlcanzado=maxCartonesGratis>0 && cartonesGratisJugadorActual>=maxCartonesGratis;
@@ -620,7 +625,7 @@ function obtenerTotalCartonesGratisFormas(){
 }
 
 function actualizarIndicadorCartonesGratis(){
-  if(!premioCartonesGratisEl || !premioCartonesGratisValorEl) return;
+  if(!premioCartonesGratisEl && !premioCartonesGratisValorEl && !premioExtraValorEl) return;
   let total=0;
   if(formaActiva>0){
     const activa=formasSorteo.find(f=>Number(f?.idx)===Number(formaActiva));
@@ -628,7 +633,16 @@ function actualizarIndicadorCartonesGratis(){
   }else{
     total=obtenerTotalCartonesGratisFormas();
   }
-  premioCartonesGratisValorEl.textContent=formatearEnteroEs(total);
+  const totalFormateado=formatearEnteroEs(total);
+  if(premioCartonesGratisValorEl){
+    premioCartonesGratisValorEl.textContent=totalFormateado;
+  }
+  if(premioExtraValorEl){
+    premioExtraValorEl.textContent=totalFormateado;
+  }
+  if(premioExtraPlusEl){
+    premioExtraPlusEl.style.visibility='visible';
+  }
 }
 
 function actualizarNumeroCartonLocal(ultimo){
@@ -837,10 +851,21 @@ function resetForma(){
     th.style.textShadow='2px 2px 0 #000';
   });
   document.querySelectorAll('#bingo-board td').forEach(td=>{td.style.background='';});
-  document.getElementById('premio-label').textContent='Premio a Repartir:';
-  document.getElementById('premio-valor').style.textShadow='0 0 10px #004400';
+  document.getElementById('premio-label').textContent='PREMIO A REPARTIR:';
+  const premioValorEl=document.getElementById('premio-valor');
+  if(premioValorEl){
+    premioValorEl.style.textShadow='0 0 12px rgba(0,27,96,0.4)';
+  }
   const pr=document.getElementById('premio-repartir');
-  pr.style.textShadow='0 0 10px #004400';
+  if(pr){
+    pr.style.textShadow='0 0 12px rgba(0,27,96,0.4)';
+  }
+  if(premioExtraPlusEl){
+    premioExtraPlusEl.style.textShadow='0 0 12px rgba(0,27,96,0.4)';
+  }
+  if(premioExtraValorEl){
+    premioExtraValorEl.style.textShadow='0 0 12px rgba(0,27,96,0.4)';
+  }
   document.getElementById('forma-nombre').style.visibility='hidden';
   actualizarIndicadorCartonesGratis();
   actualizarDatosSorteo();
@@ -869,6 +894,12 @@ function toggleForma(idx){
   pl.textContent='PREMIO DE FORMA:';
   pr.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
   pv.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
+  if(premioExtraPlusEl){
+    premioExtraPlusEl.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
+  }
+  if(premioExtraValorEl){
+    premioExtraValorEl.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
+  }
   nombre.textContent=forma.nombre||'';
   nombre.style.textShadow=`0 0 5px ${formGlows[idx-1]}`;
   const wrapper=document.getElementById('carton-wrapper');


### PR DESCRIPTION
## Summary
- Actualicé la presentación del premio destacado en juegoactivo para mostrar etiquetas estilizadas, el texto "A REPARTIR" y "CREDITOS" con bordes blancos y los cartones gratis con color morado.
- Modifiqué la pantalla jugarcartones para ampliar el premio principal, añadir la suma de cartones gratis con animación y reutilizar esos valores al alternar las formas del sorteo.

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_690795b207848326b8e3b387ba686086