### PR TITLE
Ajustes de estilos de premios en vistas de juego

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1025,84 +1025,65 @@
       }
       #carton-destacado-premio {
           display: none;
-          align-items: center;
+          align-items: baseline;
           justify-content: center;
           flex-wrap: wrap;
-          gap: 8px;
-          margin: 4px auto 0;
+          gap: clamp(6px, 1.6vw, 14px);
+          margin: 6px auto 0;
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(0.7rem, 1.9vw, 0.98rem);
-          font-weight: 500;
-          letter-spacing: 0.6px;
+          font-size: clamp(0.92rem, 2.6vw, 1.4rem);
+          font-weight: 600;
+          letter-spacing: 0.05em;
           text-transform: uppercase;
           color: #ffffff;
           text-shadow:
               0 0 6px rgba(0,0,0,0.82),
-              0 0 12px rgba(0,0,0,0.62),
+              0 0 14px rgba(0,0,0,0.55),
               0 0 14px var(--carton-premio-destello, rgba(255,255,255,0.45));
       }
       #carton-destacado-premio.visible {
-          display: inline-flex;
+          display: flex;
       }
-      #carton-destacado-premio .carton-destacado-premio__badge {
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-          padding: 2px 10px;
-          border: 2px solid #ffffff;
-          border-radius: 999px;
-          font-family: 'Poppins', sans-serif;
-          font-weight: 600;
-          color: #ffffff;
-          text-shadow: inherit;
-          background: rgba(0,0,0,0.15);
-      }
-      #carton-destacado-premio .carton-destacado-premio__badge--creditos {
-          letter-spacing: 1px;
-      }
+      #carton-destacado-premio .carton-destacado-premio__badge,
       #carton-destacado-premio .carton-destacado-premio__valor {
           display: inline-flex;
-          align-items: center;
+          align-items: baseline;
           justify-content: center;
-          padding: 2px 12px;
-          border: 2px solid #ffffff;
-          border-radius: 999px;
-          font-family: 'Poppins', sans-serif;
-          font-weight: 600;
+          padding: 0;
+          border: none;
+          border-radius: 0;
+          background: none;
+          text-shadow: inherit;
+      }
+      #carton-destacado-premio .carton-destacado-premio__badge {
+          font-weight: 700;
+      }
+      #carton-destacado-premio .carton-destacado-premio__valor {
+          font-size: clamp(1.3rem, 3.2vw, 1.9rem);
+          font-weight: 700;
           color: #19d46b;
-          background: rgba(0,0,0,0.18);
           animation: premioZoom 2s ease-in-out infinite;
       }
       .carton-destacado-premio__gratis {
           display: inline-flex;
-          align-items: center;
-          gap: 4px;
+          align-items: baseline;
+          gap: clamp(4px, 1.2vw, 10px);
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(0.52rem, 1.45vw, 0.74rem);
-          letter-spacing: 0.6px;
+          font-size: clamp(0.92rem, 2.6vw, 1.4rem);
+          letter-spacing: 0.05em;
           text-transform: uppercase;
           color: #ffffff;
-          text-shadow: 0 0 5px rgba(0,0,0,0.85);
+          text-shadow: inherit;
       }
       .carton-destacado-premio__gratis-label {
-          display: inline-flex;
-          align-items: center;
-          justify-content: center;
-          padding: 1px 8px;
-          border: 2px solid #ffffff;
-          border-radius: 999px;
-          font-weight: 600;
+          font-weight: 700;
           color: #6a1b9a;
-          background: rgba(255,255,255,0.2);
       }
       .carton-destacado-premio__gratis-valor {
           font-weight: 700;
-          animation: premioZoom 2s ease-in-out infinite;
           color: #6a1b9a;
-          border: 2px solid #ffffff;
-          border-radius: 999px;
-          padding: 1px 8px;
-          background: rgba(255,255,255,0.18);
+          font-size: clamp(1.3rem, 3.2vw, 1.9rem);
+          animation: premioZoom 2s ease-in-out infinite;
       }
       #carton-destacado-premio[hidden] {
           display: none !important;
@@ -3202,7 +3183,6 @@
           <div id="carton-destacado-premio" class="carton-destacado-premio" hidden aria-hidden="true">
             <span id="carton-destacado-premio-label" class="carton-destacado-premio__badge">A REPARTIR:</span>
             <span id="carton-destacado-premio-valor" class="carton-destacado-premio__valor">0</span>
-            <span id="carton-destacado-premio-creditos" class="carton-destacado-premio__badge carton-destacado-premio__badge--creditos">CREDITOS</span>
             <span id="carton-destacado-premio-gratis" class="carton-destacado-premio__gratis" hidden aria-hidden="true">
               <span class="carton-destacado-premio__gratis-label">CARTONES</span>
               <span id="carton-destacado-premio-gratis-valor" class="carton-destacado-premio__gratis-valor">0</span>
@@ -4965,7 +4945,7 @@
     }
     if(cartonDestacadoPremioLabelEl){
       cartonDestacadoPremioLabelEl.style.color = '';
-      cartonDestacadoPremioLabelEl.textContent = 'PREMIO DE FORMA:';
+      cartonDestacadoPremioLabelEl.textContent = 'A REPARTIR:';
     }
     cartonDestacadoPremioValorEl.textContent = formatearCreditos(totalForma);
     cartonDestacadoPremioValorEl.style.color = '';

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -179,13 +179,17 @@
     #stats-row{display:flex;justify-content:center;align-items:center;gap:20px;}
     .billete-icon{font-size:1.5rem;}
     .carton-icon{width:24px;height:24px;}
-    #premio-repartir{color:#001b60;font-family:'Bangers',cursive;font-size:clamp(2.1rem,6vw,2.9rem);text-shadow:0 0 12px rgba(0,27,96,0.4);position:relative;display:flex;flex-direction:column;align-items:center;gap:6px;}
-    #premio-repartir .premio-repartir-principal{display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:center;}
-    #premio-repartir .premio-repartir-principal span{display:inline-flex;align-items:center;}
+    #premio-repartir{font-family:'Bangers',cursive;font-size:clamp(2.1rem,6vw,3.1rem);position:relative;display:flex;flex-direction:column;align-items:center;gap:6px;color:#ffffff;text-shadow:0 0 14px rgba(0,255,153,0.85),0 0 26px rgba(0,140,70,0.65);}
+    #premio-repartir .premio-repartir-principal{display:flex;align-items:baseline;gap:clamp(10px,2.4vw,18px);flex-wrap:wrap;justify-content:center;}
+    #premio-repartir .premio-repartir-principal span{display:inline-flex;align-items:baseline;}
+    #premio-label{color:#ffffff;text-shadow:inherit;font-size:clamp(1.6rem,4.8vw,2.6rem);letter-spacing:0.06em;}
+    #premio-valores{display:inline-flex;align-items:baseline;gap:0;}
+    #premio-valor{color:#ffffff;text-shadow:inherit;font-size:clamp(2rem,5.6vw,3.2rem);line-height:1;}
+    #premio-extra-plus,#premio-extra-valor{color:#001b60;text-shadow:0 0 12px rgba(0,27,96,0.5);font-size:clamp(1.55rem,4.4vw,2.6rem);line-height:1;}
     #premio-label{text-transform:uppercase;letter-spacing:1px;}
-    #premio-valor,#premio-extra-plus,#premio-extra-valor{font-size:inherit;color:#001b60;animation:zoomInOut 1.6s ease-in-out infinite;font-family:'Bangers',cursive;}
-    #premio-valor{font-weight:700;}
-    #premio-extra-plus{font-weight:700;padding:0 4px;}
+    #premio-valor{animation:zoomInOut 1.6s ease-in-out infinite;font-family:'Bangers',cursive;font-weight:700;}
+    #premio-extra-plus,#premio-extra-valor{animation:zoomInOut 1.6s ease-in-out infinite;font-family:'Bangers',cursive;}
+    #premio-extra-plus{font-weight:700;padding:0;}
     #premio-extra-valor{font-weight:700;}
     #premio-cartones-gratis{display:none !important;}
     #forma-nombre{font-family:'Bangers',cursive;color:#4B0082;font-size:1rem;text-shadow:0 0 5px #fff;text-align:center;visibility:hidden;min-height:8px;margin:0;}
@@ -346,9 +350,7 @@
       <div id="premio-repartir">
         <div class="premio-repartir-principal">
           <span id="premio-label">PREMIO A REPARTIR:</span>
-          <span id="premio-valor">0</span>
-          <span id="premio-extra-plus">+</span>
-          <span id="premio-extra-valor">0</span>
+          <span id="premio-valores"><span id="premio-valor">0</span><span id="premio-extra-plus">+</span><span id="premio-extra-valor">0</span></span>
         </div>
         <div id="premio-cartones-gratis" class="premio-cartones-gratis">
           Cartones gratis: <span id="premio-cartones-gratis-valor" class="premio-cartones-gratis-valor">0</span>
@@ -511,6 +513,8 @@
   const premioCartonesGratisValorEl=document.getElementById('premio-cartones-gratis-valor');
   const premioExtraPlusEl=document.getElementById('premio-extra-plus');
   const premioExtraValorEl=document.getElementById('premio-extra-valor');
+  const RESPLANDOR_PREMIO_REPARTIR='0 0 14px rgba(0,255,153,0.85),0 0 26px rgba(0,140,70,0.65)';
+  const COLOR_PREMIO_TEXTO='#ffffff';
 
 function obtenerColorCartonesGratisActual(){
   const limiteAlcanzado=maxCartonesGratis>0 && cartonesGratisJugadorActual>=maxCartonesGratis;
@@ -851,20 +855,20 @@ function resetForma(){
     th.style.textShadow='2px 2px 0 #000';
   });
   document.querySelectorAll('#bingo-board td').forEach(td=>{td.style.background='';});
-  document.getElementById('premio-label').textContent='PREMIO A REPARTIR:';
+  const premioLabelEl=document.getElementById('premio-label');
+  if(premioLabelEl){
+    premioLabelEl.textContent='PREMIO A REPARTIR:';
+    premioLabelEl.style.color=COLOR_PREMIO_TEXTO;
+    premioLabelEl.style.textShadow=RESPLANDOR_PREMIO_REPARTIR;
+  }
   const premioValorEl=document.getElementById('premio-valor');
   if(premioValorEl){
-    premioValorEl.style.textShadow='0 0 12px rgba(0,27,96,0.4)';
+    premioValorEl.style.color=COLOR_PREMIO_TEXTO;
+    premioValorEl.style.textShadow=RESPLANDOR_PREMIO_REPARTIR;
   }
   const pr=document.getElementById('premio-repartir');
   if(pr){
-    pr.style.textShadow='0 0 12px rgba(0,27,96,0.4)';
-  }
-  if(premioExtraPlusEl){
-    premioExtraPlusEl.style.textShadow='0 0 12px rgba(0,27,96,0.4)';
-  }
-  if(premioExtraValorEl){
-    premioExtraValorEl.style.textShadow='0 0 12px rgba(0,27,96,0.4)';
+    pr.style.textShadow=RESPLANDOR_PREMIO_REPARTIR;
   }
   document.getElementById('forma-nombre').style.visibility='hidden';
   actualizarIndicadorCartonesGratis();
@@ -891,14 +895,17 @@ function toggleForma(idx){
   const pl=document.getElementById('premio-label');
   const nombre=document.getElementById('forma-nombre');
   const porcentaje=parseFloat(forma.porcentaje)||0;
-  pl.textContent='PREMIO DE FORMA:';
-  pr.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
-  pv.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
-  if(premioExtraPlusEl){
-    premioExtraPlusEl.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
+  if(pl){
+    pl.textContent='PREMIO DE FORMA:';
+    pl.style.color=COLOR_PREMIO_TEXTO;
+    pl.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
   }
-  if(premioExtraValorEl){
-    premioExtraValorEl.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
+  if(pr){
+    pr.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
+  }
+  if(pv){
+    pv.style.color=COLOR_PREMIO_TEXTO;
+    pv.style.textShadow=`0 0 10px ${formGlows[idx-1]}`;
   }
   nombre.textContent=forma.nombre||'';
   nombre.style.textShadow=`0 0 5px ${formGlows[idx-1]}`;


### PR DESCRIPTION
## Summary
- mejora la visualización del premio a repartir en la vista de jugar cartones con texto blanco, resplandor verde y valores agrupados
- ajusta la presentación del premio de forma para conservar la tipografía blanca y respetar los destellos por forma
- reorganiza la sección de premios del cartón destacado en juego activo para un diseño más limpio y sin la insignia de créditos

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6907b0482a94832680618b172f8a5e4a