### PR TITLE
Improve player menu visuals

### DIFF
--- a/public/img/avatar-generico.svg
+++ b/public/img/avatar-generico.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <radialGradient id="grad" cx="50%" cy="35%" r="60%">
+      <stop offset="0%" stop-color="#ffe082" />
+      <stop offset="100%" stop-color="#ffb300" />
+    </radialGradient>
+  </defs>
+  <circle cx="64" cy="64" r="62" fill="url(#grad)" stroke="#ffeb3b" stroke-width="4" />
+  <circle cx="64" cy="50" r="26" fill="#fff3e0" />
+  <path d="M26 110c6-24 24-38 38-38s32 14 38 38" fill="#fff3e0" />
+</svg>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -341,7 +341,13 @@ function ensureAuth(roleExpected){
         const emailEl = document.getElementById('user-email');
         if (emailEl) emailEl.textContent = user.email;
         const picEl = document.getElementById('user-pic');
-        if (picEl) picEl.src = user.photoURL;
+        if (picEl) {
+          if (typeof asignarFotoUsuario === 'function') {
+            asignarFotoUsuario(picEl, user.photoURL || '');
+          } else {
+            picEl.src = user.photoURL || picEl.src;
+          }
+        }
         const infoEl = document.getElementById('session-info');
         if (infoEl) infoEl.style.display = 'flex';
         const logoutEl = document.getElementById('logout-link');

--- a/public/player.html
+++ b/public/player.html
@@ -174,14 +174,16 @@
           margin-bottom: 15px;
       }
       #menu-logo {
-          width: clamp(180px, 28vw, 280px);
+          width: clamp(220px, 34vw, 360px);
           height: auto;
-          margin-bottom: clamp(6px, 2vh, 20px);
+          margin-bottom: clamp(4px, 1.6vh, 14px);
       }
       #login-footer {
           position: relative;
           margin-top: 20px;
           text-align: center;
+          color: #ffffff;
+          text-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
       }
       #login-btn {
           width: 220px;
@@ -245,20 +247,21 @@
           display: flex;
           flex-direction: column;
           align-items: center;
-          gap: clamp(12px, 3vh, 36px);
+          gap: clamp(6px, 1.8vh, 20px);
       }
       #menu-buttons h3 {
-          margin: 0;
-          font-size: clamp(1.6rem, 2.4vw, 2.2rem);
+          margin: clamp(-4px, -0.8vh, 0) 0 0;
+          font-size: clamp(1.8rem, 2.8vw, 2.6rem);
           font-family: 'Bangers', cursive;
-          color: #0056ff;
-          text-shadow: 0 0 8px #ffd700, 0 0 16px rgba(255, 215, 0, 0.8);
+          color: #ffffff;
+          text-shadow: 0 0 10px rgba(179, 71, 0, 0.8), 0 0 18px rgba(255, 140, 0, 0.9);
           text-align: center;
+          letter-spacing: 1px;
       }
 
       #menu-tabla-wrapper {
           width: 100%;
-          padding: 20px;
+          padding: clamp(8px, 1.8vw, 16px);
           box-sizing: border-box;
           display: flex;
           justify-content: center;
@@ -266,9 +269,9 @@
 
       .menu-tabla {
           width: 100%;
-          max-width: 620px;
+          max-width: 640px;
           border-collapse: separate;
-          border-spacing: clamp(10px, 2.5vw, 24px);
+          border-spacing: clamp(6px, 1.6vw, 14px);
           margin: 0 auto;
           background: transparent;
           border: none;
@@ -279,12 +282,12 @@
           aspect-ratio: 3 / 2;
       }
 
-      .menu-tabla col.col-30 {
-          width: 30%;
+      .menu-tabla col.col-24 {
+          width: 24%;
       }
 
-      .menu-tabla col.col-40 {
-          width: 40%;
+      .menu-tabla col.col-52 {
+          width: 52%;
       }
 
       .menu-tabla tr:first-child {
@@ -302,6 +305,16 @@
           vertical-align: middle;
           width: auto;
           height: auto;
+      }
+
+      .menu-opcion {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: clamp(4px, 1vh, 10px);
+      }
+      .menu-opcion--sorteo .menu-imagen {
+          max-width: 115%;
       }
 
       .menu-tabla td.celda-vacia {
@@ -327,6 +340,33 @@
           width: 100%;
       }
 
+      .menu-label {
+          font-family: 'Bangers', cursive;
+          font-size: clamp(1rem, 2.2vw, 1.4rem);
+          color: #ffffff;
+          letter-spacing: 1px;
+      }
+
+      .menu-label--carton {
+          text-shadow: 0 0 8px rgba(0, 51, 153, 0.8), 0 0 14px rgba(0, 34, 102, 0.9);
+      }
+
+      .menu-label--sorteo {
+          text-shadow: 0 0 8px rgba(32, 0, 77, 0.85), 0 0 14px rgba(64, 0, 128, 0.9);
+      }
+
+      .menu-label--billetera {
+          text-shadow: 0 0 8px rgba(0, 77, 26, 0.85), 0 0 14px rgba(0, 128, 51, 0.9);
+      }
+
+      .menu-label--perfil {
+          text-shadow: 0 0 8px rgba(102, 51, 0, 0.8), 0 0 14px rgba(153, 76, 0, 0.85);
+      }
+
+      .menu-label--mensajes {
+          text-shadow: 0 0 8px rgba(179, 71, 0, 0.85), 0 0 14px rgba(230, 115, 0, 0.9);
+      }
+
       #carton-screen {
           position: relative;
           width: 100%;
@@ -350,11 +390,11 @@
       #salir-super-btn { background: red; border:4px solid orange; }
       #logout-link {
           font-family: Calibri, Arial, sans-serif;
-          color: #007bff;
+          color: #ffffff;
           text-decoration: underline;
           cursor: pointer;
-          font-size: 0.7rem;
-          margin-left: 5px;
+          font-size: 0.8rem;
+          margin-left: 8px;
       }
       #session-info {
           position: fixed;
@@ -362,8 +402,12 @@
           right: 10px;
           display: flex;
           align-items: center;
-          font-size: 0.7rem;
+          font-size: 0.8rem;
           z-index: 1000;
+          padding: 6px 10px;
+          border-radius: 24px;
+          background: rgba(0, 0, 0, 0.55);
+          box-shadow: 0 0 12px rgba(0, 0, 0, 0.35);
       }
       #user-data {
           display: flex;
@@ -372,15 +416,44 @@
           margin-right: 5px;
       }
       #user-name, #user-email {
-          color: #333;
-          text-shadow: 1px 1px 2px #0000;
+          color: #ffffff;
+          text-shadow: 0 0 6px rgba(0, 0, 0, 0.8);
           font-family: Calibri, Arial, sans-serif;
-          font-size: 0.7rem;
+          font-size: 0.75rem;
+      }
+      #user-pic {
+          width: 46px !important;
+          height: 46px !important;
+          border-radius: 50%;
+          border: 2px solid #ffd700;
+          box-shadow: 0 0 10px rgba(255, 215, 0, 0.6);
+      }
+      #salir-player-btn {
+          position: fixed;
+          top: 12px;
+          left: 12px;
+          font-family: 'Bangers', cursive;
+          font-size: 1rem;
+          letter-spacing: 1px;
+          padding: 10px 18px;
+          border: 3px solid #ffcc00;
+          border-radius: 24px;
+          background: linear-gradient(135deg, rgba(220, 0, 0, 0.95), rgba(255, 90, 0, 0.95));
+          color: #ffffff;
+          text-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
+          cursor: pointer;
+          z-index: 1100;
+          transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      #salir-player-btn:hover {
+          transform: scale(1.05);
+          box-shadow: 0 0 14px rgba(255, 204, 0, 0.8);
       }
       #fecha-hora, #derechos {
-          font-size: 0.7rem;
+          font-size: 0.85rem;
           text-align: center;
-          color: #000;
+          color: #ffffff;
+          text-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
       }
       #derechos {
           font-size: 0.6rem;
@@ -482,14 +555,15 @@
     <button id="registrar-btn">Registrar</button>
   </div>
 
-  <div id="session-info">
+  <div id="session-info" style="display:none;">
       <div id="user-data">
         <div id="user-name"></div>
         <div id="user-email"></div>
       </div>
-      <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" style="width:40px;height:40px;border-radius:50%;">
+      <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Foto del jugador">
       <a id="logout-link" href="#">Cerrar sesión</a>
   </div>
+  <button id="salir-player-btn" type="button">SALIR</button>
   <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
 
   <div id="main-menu" class="view">
@@ -499,29 +573,44 @@
       <div id="menu-tabla-wrapper">
         <table class="menu-tabla" aria-label="Accesos del menú principal">
           <colgroup>
-            <col class="col-30" />
-            <col class="col-40" />
-            <col class="col-30" />
+            <col class="col-24" />
+            <col class="col-52" />
+            <col class="col-24" />
           </colgroup>
           <tbody>
             <tr>
               <td>
-                <img id="boton-jugar" class="menu-imagen" src="img/boton-jugar-carton-bingo-300p.png" alt="Ir a jugar cartón" role="button" tabindex="0" loading="lazy" />
+                <div class="menu-opcion menu-opcion--carton">
+                  <img id="boton-jugar" class="menu-imagen" src="img/boton-jugar-carton-bingo-300p.png" alt="Ir a jugar cartón" role="button" tabindex="0" loading="lazy" />
+                  <span class="menu-label menu-label--carton">JUGAR CARTÓN</span>
+                </div>
               </td>
               <td>
-                <img id="boton-sorteo" class="menu-imagen" src="img/boton-sorteo-en-vivo400p.png" alt="Ir al sorteo en vivo" role="button" tabindex="0" />
+                <div class="menu-opcion menu-opcion--sorteo">
+                  <img id="boton-sorteo" class="menu-imagen" src="img/boton-sorteo-en-vivo400p.png" alt="Ir al sorteo en vivo" role="button" tabindex="0" />
+                  <span class="menu-label menu-label--sorteo">SORTEO EN VIVO</span>
+                </div>
               </td>
               <td>
-                <img id="boton-billetera" class="menu-imagen" src="img/boton-billetera300p.png" alt="Ir a la billetera" role="button" tabindex="0" loading="lazy" />
+                <div class="menu-opcion menu-opcion--billetera">
+                  <img id="boton-billetera" class="menu-imagen" src="img/boton-billetera300p.png" alt="Ir a la billetera" role="button" tabindex="0" loading="lazy" />
+                  <span class="menu-label menu-label--billetera">BILLETERA</span>
+                </div>
               </td>
             </tr>
             <tr>
               <td>
-                <img id="boton-perfil" class="menu-imagen" src="img/boton-perfiles300p.png" alt="Ir al perfil del jugador" role="button" tabindex="0" loading="lazy" />
+                <div class="menu-opcion menu-opcion--perfil">
+                  <img id="boton-perfil" class="menu-imagen" src="img/boton-perfiles300p.png" alt="Ir al perfil del jugador" role="button" tabindex="0" loading="lazy" />
+                  <span class="menu-label menu-label--perfil">PERFIL</span>
+                </div>
               </td>
               <td class="celda-vacia" aria-hidden="true"></td>
               <td>
-                <img id="boton-mensajes" class="menu-imagen" src="img/boton-mensajes300p.png" alt="Abrir el grupo de WhatsApp" role="button" tabindex="0" loading="lazy" />
+                <div class="menu-opcion menu-opcion--mensajes">
+                  <img id="boton-mensajes" class="menu-imagen" src="img/boton-mensajes300p.png" alt="Abrir el grupo de WhatsApp" role="button" tabindex="0" loading="lazy" />
+                  <span class="menu-label menu-label--mensajes">MENSAJES</span>
+                </div>
               </td>
             </tr>
           </tbody>
@@ -559,10 +648,25 @@ initFechaHora('fecha-hora');
 const db = firebase.firestore();
 let whatsappLinkValor = '';
 let whatsappLinkCargado = false;
+const AVATAR_FALLBACK = 'img/avatar-generico.svg';
 
 const whatsappModalEl = document.getElementById('modal-whatsapp');
 const whatsappModalMensajeEl = document.getElementById('modal-whatsapp-mensaje');
 const whatsappModalAceptarBtn = document.getElementById('modal-whatsapp-aceptar');
+const salirPlayerBtn = document.getElementById('salir-player-btn');
+
+function asignarFotoUsuario(elemento, url){
+  if(!elemento) return;
+  const aplicarFallback = ()=>{
+    elemento.src = AVATAR_FALLBACK;
+  };
+  elemento.addEventListener('error', aplicarFallback, { once: true });
+  const urlValida = typeof url === 'string' && url.trim().length > 0;
+  elemento.src = urlValida ? url : AVATAR_FALLBACK;
+  if(!urlValida){
+    elemento.removeEventListener('error', aplicarFallback);
+  }
+}
 
 function configurarAccionImagen(id, accion){
   const elemento = document.getElementById(id);
@@ -635,6 +739,9 @@ if(whatsappModalEl){
       cerrarModalWhatsapp();
     }
   });
+}
+if(salirPlayerBtn){
+  salirPlayerBtn.addEventListener('click', ()=>{ window.location.href = 'accederusuario.html'; });
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- enlarge the BingOnline logo, update the player menu heading styling, and add glowing labels beneath each action icon
- ensure the Gmail avatar loads with a new fallback asset, expose the player exit button, and surface the footer time display with improved contrast
- keep the WhatsApp access logic while adjusting layout proportions so each icon navigates to its destination reliably

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_6907c68a50f88326b5872b4ab3aff063