### PR TITLE
Adjust player view layout and live draw animation

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -174,16 +174,19 @@
           margin-bottom: 15px;
       }
       #menu-logo {
-          width: clamp(220px, 34vw, 360px);
+          width: clamp(260px, 36vw, 420px);
           height: auto;
-          margin-bottom: clamp(4px, 1.6vh, 14px);
+          margin-bottom: clamp(0px, 1vh, 8px);
       }
       #login-footer {
           position: relative;
-          margin-top: 20px;
+          margin-top: auto;
           text-align: center;
-          color: #ffffff;
-          text-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
+          color: #000000;
+          text-shadow: none;
+          background: rgba(255, 255, 255, 0.6);
+          padding: 6px 10px;
+          border-radius: 8px;
       }
       #login-btn {
           width: 220px;
@@ -247,10 +250,10 @@
           display: flex;
           flex-direction: column;
           align-items: center;
-          gap: clamp(6px, 1.8vh, 20px);
+          gap: clamp(2px, 1vh, 10px);
       }
       #menu-buttons h3 {
-          margin: clamp(-4px, -0.8vh, 0) 0 0;
+          margin: clamp(-14px, -2.4vh, -6px) 0 clamp(2px, 0.6vh, 6px);
           font-size: clamp(1.8rem, 2.8vw, 2.6rem);
           font-family: 'Bangers', cursive;
           color: #ffffff;
@@ -330,6 +333,13 @@
           filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.35));
           object-fit: contain;
       }
+      .menu-imagen--jugando {
+          animation: pulso-sorteo 1.5s ease-in-out infinite;
+      }
+      @keyframes pulso-sorteo {
+          0%, 100% { transform: scale(1); }
+          50% { transform: scale(1.08); }
+      }
       .menu-imagen:focus,
       .menu-imagen:hover {
           transform: scale(1.04);
@@ -393,8 +403,8 @@
           color: #ffffff;
           text-decoration: underline;
           cursor: pointer;
-          font-size: 0.8rem;
-          margin-left: 8px;
+          font-size: 0.7rem;
+          margin: 0;
       }
       #session-info {
           position: fixed;
@@ -402,10 +412,11 @@
           right: 10px;
           display: flex;
           align-items: center;
+          gap: 6px;
           font-size: 0.8rem;
           z-index: 1000;
-          padding: 6px 10px;
-          border-radius: 24px;
+          padding: 6px 9px;
+          border-radius: 12px;
           background: rgba(0, 0, 0, 0.55);
           box-shadow: 0 0 12px rgba(0, 0, 0, 0.35);
       }
@@ -413,13 +424,13 @@
           display: flex;
           flex-direction: column;
           align-items: flex-end;
-          margin-right: 5px;
+          gap: 2px;
       }
       #user-name, #user-email {
           color: #ffffff;
           text-shadow: 0 0 6px rgba(0, 0, 0, 0.8);
           font-family: Calibri, Arial, sans-serif;
-          font-size: 0.75rem;
+          font-size: 0.7rem;
       }
       #user-pic {
           width: 46px !important;
@@ -428,32 +439,17 @@
           border: 2px solid #ffd700;
           box-shadow: 0 0 10px rgba(255, 215, 0, 0.6);
       }
-      #salir-player-btn {
-          position: fixed;
-          top: 12px;
-          left: 12px;
-          font-family: 'Bangers', cursive;
-          font-size: 1rem;
-          letter-spacing: 1px;
-          padding: 10px 18px;
-          border: 3px solid #ffcc00;
-          border-radius: 24px;
-          background: linear-gradient(135deg, rgba(220, 0, 0, 0.95), rgba(255, 90, 0, 0.95));
-          color: #ffffff;
-          text-shadow: 0 0 8px rgba(0, 0, 0, 0.6);
-          cursor: pointer;
-          z-index: 1100;
-          transition: transform 0.2s ease, box-shadow 0.2s ease;
-      }
-      #salir-player-btn:hover {
-          transform: scale(1.05);
-          box-shadow: 0 0 14px rgba(255, 204, 0, 0.8);
+      #session-avatar {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 3px;
       }
       #fecha-hora, #derechos {
-          font-size: 0.85rem;
+          font-size: 0.7rem;
           text-align: center;
-          color: #ffffff;
-          text-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
+          color: #000000;
+          text-shadow: none;
       }
       #derechos {
           font-size: 0.6rem;
@@ -556,14 +552,15 @@
   </div>
 
   <div id="session-info" style="display:none;">
+      <div id="session-avatar">
+        <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Foto del jugador">
+        <a id="logout-link" href="#">Cerrar sesión</a>
+      </div>
       <div id="user-data">
         <div id="user-name"></div>
         <div id="user-email"></div>
       </div>
-      <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Foto del jugador">
-      <a id="logout-link" href="#">Cerrar sesión</a>
   </div>
-  <button id="salir-player-btn" type="button">SALIR</button>
   <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
 
   <div id="main-menu" class="view">
@@ -646,9 +643,10 @@
   const whatsappModalEl = document.getElementById('modal-whatsapp');
   const whatsappModalMensajeEl = document.getElementById('modal-whatsapp-mensaje');
   const whatsappModalAceptarBtn = document.getElementById('modal-whatsapp-aceptar');
-  const salirPlayerBtn = document.getElementById('salir-player-btn');
+  const sorteoImagen = document.getElementById('boton-sorteo');
   const whatsappState = { enlace:'', cargado:false };
   let firestoreRef = null;
+  let sorteoUnsubscribe = null;
 
   function asignarFotoUsuario(elemento, url){
     if(!elemento) return;
@@ -722,6 +720,26 @@
     }
   }
 
+  function observarEstadoSorteo(){
+    if(!firestoreRef || !sorteoImagen || sorteoUnsubscribe){
+      return;
+    }
+    try {
+      sorteoUnsubscribe = firestoreRef.collection('sorteos')
+        .where('estado', '==', 'Jugando')
+        .limit(1)
+        .onSnapshot(snapshot => {
+          const enJuego = snapshot && !snapshot.empty;
+          sorteoImagen.classList.toggle('menu-imagen--jugando', !!enJuego);
+        }, error => {
+          console.error('Error al observar sorteos en vivo:', error);
+          sorteoImagen.classList.remove('menu-imagen--jugando');
+        });
+    } catch (error) {
+      console.error('No se pudo iniciar la observación de sorteos en vivo', error);
+    }
+  }
+
   async function inicializarVistaJugador(){
     try {
       await initFirebase();
@@ -753,9 +771,8 @@
         }
       });
     }
-    if(salirPlayerBtn){
-      salirPlayerBtn.addEventListener('click', () => { window.location.href = 'accederusuario.html'; });
-    }
+
+    observarEstadoSorteo();
   }
 
   inicializarVistaJugador();


### PR DESCRIPTION
## Summary
- enlarge the BingOnline logo and tighten spacing around the player menu
- streamline the Google session panel, removing the extra exit button and matching footer styling
- add a live draw animation that activates only while a draw is in the "Jugando" state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907ced981588326bf7d4ac5501b3a84