### PR TITLE
Ajusta vistas de jugador y perfil

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -164,7 +164,6 @@
     #fecha-hora-sorteo{display:flex;flex-wrap:wrap;align-items:flex-start;justify-content:center;gap:12px;font-family:'Poppins',sans-serif;text-transform:none;}
     #fecha-hora-sorteo .fecha-col{display:flex;flex-direction:column;align-items:flex-start;gap:2px;min-width:120px;}
     #fecha-hora-sorteo .sorteo-line{display:flex;align-items:center;gap:4px;font-weight:600;font-size:1rem;}
-    #fecha-hora-sorteo .actual-line{font-size:0.7rem;color:#0b5394;font-weight:600;display:block;margin-top:-2px;}
     #fecha-hora-sorteo .cal-icon,#fecha-hora-sorteo .clock-icon{font-size:1.1rem;}
     .datos-sorteo{display:flex;flex-direction:column;align-items:center;gap:4px;justify-content:center;margin-top:2px;flex-wrap:wrap;font-family:'Bangers',cursive;}
     #sorteo-section{margin-bottom:5px;}
@@ -179,13 +178,13 @@
     #stats-row{display:flex;justify-content:center;align-items:center;gap:20px;}
     .billete-icon{font-size:1.5rem;}
     .carton-icon{width:24px;height:24px;}
-    #premio-repartir{font-family:'Bangers',cursive;font-size:clamp(2.1rem,6vw,3.1rem);position:relative;display:flex;flex-direction:column;align-items:center;gap:6px;color:#ffffff;text-shadow:0 0 14px rgba(0,255,153,0.85),0 0 26px rgba(0,140,70,0.65);}
+    #premio-repartir{font-family:'Bangers',cursive;font-size:clamp(2.1rem,6vw,3.1rem);position:relative;display:flex;flex-direction:column;align-items:center;gap:6px;color:#ffffff;text-shadow:0 0 16px rgba(85,107,47,0.85),0 0 30px rgba(60,80,30,0.7);}
     #premio-repartir .premio-repartir-principal{display:flex;align-items:baseline;gap:clamp(10px,2.4vw,18px);flex-wrap:wrap;justify-content:center;}
     #premio-repartir .premio-repartir-principal span{display:inline-flex;align-items:baseline;}
     #premio-label{color:#ffffff;text-shadow:inherit;font-size:clamp(1.6rem,4.8vw,2.6rem);letter-spacing:0.06em;}
-    #premio-valores{display:inline-flex;align-items:baseline;gap:0;}
+    #premio-valores{display:inline-flex;align-items:baseline;gap:clamp(10px,2vw,18px);}
     #premio-valor{color:#ffffff;text-shadow:inherit;font-size:clamp(2rem,5.6vw,3.2rem);line-height:1;}
-    #premio-extra-plus,#premio-extra-valor{color:#001b60;text-shadow:0 0 12px rgba(0,27,96,0.5);font-size:clamp(1.55rem,4.4vw,2.6rem);line-height:1;}
+    #premio-extra-plus,#premio-extra-valor{color:#ffffff;text-shadow:inherit;font-size:clamp(2rem,5.6vw,3.2rem);line-height:1;}
     #premio-label{text-transform:uppercase;letter-spacing:1px;}
     #premio-valor{animation:zoomInOut 1.6s ease-in-out infinite;font-family:'Bangers',cursive;font-weight:700;}
     #premio-extra-plus,#premio-extra-valor{animation:zoomInOut 1.6s ease-in-out infinite;font-family:'Bangers',cursive;}
@@ -277,16 +276,17 @@
     #player-container{position:relative;border:2px solid green;border-radius:10px;background:linear-gradient(135deg,#d3d3d3,#ffffff);padding:10px;margin:10px auto 0;width:100%;max-width:320px;box-sizing:border-box;transition:background 0.3s ease,border-color 0.3s ease;}
     #alias-row{display:flex;align-items:center;justify-content:center;gap:5px;}
     #alias-jugador{font-size:1.2rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:220px;color:orange;}
-    #editar-alias{background:none;border:none;color:#4B0082;font-size:1.5rem;cursor:pointer;border-radius:5px;text-shadow:0 0 4px #fff,0 0 8px #fff;}
+    #editar-alias{background:none;border:none;color:#4B0082;font-size:1.5rem;cursor:pointer;border-radius:5px;text-shadow:0 0 4px #fff,0 0 8px #fff;padding:2px;display:flex;align-items:center;justify-content:center;}
+    #editar-alias img{width:26px;height:26px;display:block;}
     #guardar-carton-btn{background:none;border:none;font-size:1.4rem;cursor:pointer;margin-left:5px;display:none;}
     #nombre-carton{display:none;padding:5px;border-radius:5px;border:1px solid #ccc;}
     .guardar-row{justify-content:center;}
     #mis-cartones-icon{width:24px;height:24px;cursor:pointer;}
     #mis-cartones-btn-container{position:relative;display:inline-block;margin-left:5px;}
     #guardados-count{position:absolute;top:-8px;right:-8px;background:#006400;color:white;border-radius:50%;width:20px;height:20px;display:flex;align-items:center;justify-content:center;font-size:0.8rem;font-family:'Bangers',cursive;z-index:10;}
-    #login-footer{margin-top:20px;}
-    #fecha-hora,#derechos{font-size:0.7rem;text-align:center;color:#000;}
-    #derechos{font-size:0.6rem;}
+    #fecha-hora,#derechos{font-size:0.7rem;text-align:center;color:#000;margin:0;}
+    #fecha-hora{margin-top:auto;padding-top:12px;}
+    #derechos{font-size:0.6rem;padding-bottom:12px;}
     .info-line{font-family:'Bangers',cursive;font-size:1.5rem;text-align:center;}
     .text-forma-gratis{font-family:'Bangers',cursive;font-weight:bold;color:purple;font-size:1.1rem;text-align:center;}
     #premios-titulo,#info-cartones-titulo,#back-premios-titulo{font-size:1.1rem;text-align:center;font-family:'Bangers',cursive;}
@@ -327,6 +327,13 @@
     .back-forma-nombre{font-family:'Poppins',sans-serif;font-size:0.7rem;font-weight:600;text-shadow:0 0 4px #fff,0 0 8px #fff;align-self:flex-start;margin-top:-4px;margin-bottom:6px;}
     #back-premios-content{display:flex;flex-direction:column;align-items:center;position:relative;z-index:1;}
     @media (max-width:480px){#fecha-hora-sorteo .fecha-col{align-items:center;text-align:center;}}
+    @media (orientation:landscape) and (max-height:600px){
+      body{padding-left:clamp(40px,12vw,160px);padding-right:clamp(40px,12vw,160px);}
+      .sorteo-info{flex-direction:column;align-items:center;gap:12px;}
+      #fecha-hora-sorteo{flex-direction:column;align-items:center;}
+      #fecha-hora-sorteo .fecha-col{align-items:center;text-align:center;}
+      .datos-sorteo,#alias-section,.carton-box{max-width:560px;width:100%;}
+    }
   </style>
 </head>
 <body>
@@ -338,11 +345,9 @@
       <div id="fecha-hora-sorteo">
         <div class="fecha-col">
           <div id="fecha-sorteo" class="sorteo-line"></div>
-          <div id="fecha-actual" class="actual-line"></div>
         </div>
         <div class="fecha-col">
           <div id="hora-sorteo" class="sorteo-line"></div>
-          <div id="hora-actual" class="actual-line"></div>
         </div>
       </div>
     </div>
@@ -366,7 +371,7 @@
     <div id="player-container">
       <div id="alias-row">
         <input type="text" id="alias-jugador" readonly placeholder="Alias">
-        <button id="editar-alias" onclick="window.location.href='perfil.html'">&#9998;</button>
+        <button id="editar-alias" onclick="window.location.href='perfil.html'"><img src="img/boton-perfiles300p.png" alt="Editar perfil"></button>
       </div>
         <div class="wallet-row"><strong><span class="credit-icon">$</span> Créditos:</strong> <span id="creditos-label">0</span></div>
         <div class="wallet-row"><strong><img src="https://cdn-icons-png.flaticon.com/32/5065/5065890.png" class="carton-icon" alt="Cartón"> gratis:</strong> <span id="gratis-label">0</span></div>
@@ -401,10 +406,8 @@
     <div class="wallet-row guardar-row"><label><input type="checkbox" id="guardar-check"><span id="guardar-titulo"> Guardar cartón</span></label><input type="text" id="nombre-carton" placeholder="Nombra el Cartón"><button id="guardar-carton-btn" title="Guardar cartón">💾</button><div id="mis-cartones-btn-container"><img id="mis-cartones-icon" class="carton-icon" src="https://cdn-icons-png.flaticon.com/32/5065/5065890.png" alt="Mis Cartones" title="Mis Cartones"><span id="guardados-count" style="display:none;">0</span></div></div>
     <button id="jugar-carton-btn" class="action-btn">JUGAR CARTÓN</button>
   </section>
-  <div id="login-footer">
-    <div id="fecha-hora"></div>
-    <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
-  </div>
+  <div id="fecha-hora"></div>
+  <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
   <div id="number-modal" class="modal" onclick="this.style.display='none'">
     <div id="number-modal-content" class="modal-content" onclick="event.stopPropagation();">
       <div id="number-modal-title">Elige tu jugada</div>
@@ -513,7 +516,7 @@
   const premioCartonesGratisValorEl=document.getElementById('premio-cartones-gratis-valor');
   const premioExtraPlusEl=document.getElementById('premio-extra-plus');
   const premioExtraValorEl=document.getElementById('premio-extra-valor');
-  const RESPLANDOR_PREMIO_REPARTIR='0 0 14px rgba(0,255,153,0.85),0 0 26px rgba(0,140,70,0.65)';
+  const RESPLANDOR_PREMIO_REPARTIR='0 0 16px rgba(85,107,47,0.85),0 0 30px rgba(60,80,30,0.7)';
   const COLOR_PREMIO_TEXTO='#ffffff';
 
 function obtenerColorCartonesGratisActual(){

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -47,9 +47,16 @@
           justify-content:center;
           gap:5px;
       }
-      input, select {font-size:1rem;padding:5px;text-align:center;border-radius:5px;border:1px solid #ccc;width:250px;display:block;margin:5px auto;}
-      .menu-btn { width:120px; }
-      #login-footer { margin-top:20px; }
+      main#perfil-contenido {
+          width: min(420px, 90vw);
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 10px;
+          margin-top: clamp(70px, 14vh, 130px);
+      }
+      input, select {font-size:1rem;padding:8px;text-align:center;border-radius:8px;border:1px solid #ccc;width:100%;box-sizing:border-box;display:block;}
+      .menu-btn { width:140px; }
       h3, h4 { margin:5px 0; }
       #session-info {
           position: fixed;
@@ -74,16 +81,33 @@
       #perfil-nombre, #perfil-apellido, #perfil-alias {font-weight:bold;}
       #perfil-nombre, #perfil-apellido {color:#00008B;}
       #perfil-alias {color:#FF8C00;}
+      #perfil-titulo {
+          font-family: 'Bangers', cursive;
+          font-size: clamp(2rem, 5vw, 2.6rem);
+          color: #ffffff;
+          text-shadow: 0 0 14px rgba(0, 26, 95, 0.8);
+          letter-spacing: 1px;
+      }
+      #perfil-subtitulo {
+          font-family: 'Poppins', sans-serif;
+          color: #0b1b4d;
+          margin-bottom: 4px;
+      }
       #guardar-perfil-btn {
           font-family: 'Bangers', cursive;
           font-size: 1.2rem;
-          background: #0a8800;
+          background: linear-gradient(135deg, #0a8800, #48c752);
           color: white;
           border: 3px solid #FFD700;
-          border-radius: 8px;
+          border-radius: 10px;
           text-shadow: 2px 2px 4px #000;
-          width: 200px;
+          width: 220px;
           cursor: pointer;
+          transition: background 0.3s ease, box-shadow 0.3s ease;
+      }
+      #guardar-perfil-btn.modo-edicion {
+          background: linear-gradient(135deg, #083cbe, #3aa2ff);
+          box-shadow: 0 0 14px rgba(8, 60, 190, 0.45);
       }
       #jugar-carton-btn{
           font-family:'Bangers',cursive;
@@ -97,8 +121,9 @@
           cursor:pointer;
           margin-top:10px;
       }
-      #fecha-hora, #derechos { font-size:0.7rem; text-align:center; color:#000; }
-      #derechos { font-size:0.6rem; }
+      #fecha-hora, #derechos { font-size:0.7rem; text-align:center; color:#000; margin:0; }
+      #fecha-hora { margin-top:auto; padding-top:12px; }
+      #derechos { font-size:0.6rem; padding-bottom:12px; }
   </style>
 </head>
 <body>
@@ -107,18 +132,18 @@
     <a href="#" id="logout-link">Cerrar sesión</a>
   </div>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true">&#9664; Volver</button>
-  <h3>Perfil del Jugador</h3>
-  <h4>Tus Datos Personales</h4>
-  <input type="text" id="perfil-nombre" placeholder="Nombre" />
-  <input type="text" id="perfil-apellido" placeholder="Apellido" />
-  <input type="text" id="perfil-alias" placeholder="Alias" />
-  <button id="guardar-perfil-btn" class="menu-btn">Guardar</button>
-  <button id="jugar-carton-btn" class="menu-btn" onclick="window.location.href='jugarcartones.html'">Jugar Cartón</button>
+  <main id="perfil-contenido">
+    <h3 id="perfil-titulo">Perfil del Jugador</h3>
+    <h4 id="perfil-subtitulo">Tus Datos Personales</h4>
+    <input type="text" id="perfil-nombre" placeholder="Nombre" />
+    <input type="text" id="perfil-apellido" placeholder="Apellido" />
+    <input type="text" id="perfil-alias" placeholder="Alias" />
+    <button id="guardar-perfil-btn" class="menu-btn" data-modo="guardar">Guardar</button>
+    <button id="jugar-carton-btn" class="menu-btn" onclick="window.location.href='jugarcartones.html'">Jugar Cartón</button>
+  </main>
 
-  <div id="login-footer">
-    <div id="fecha-hora"></div>
-    <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
-  </div>
+  <div id="fecha-hora"></div>
+  <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
 
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
@@ -129,32 +154,118 @@
   ensureAuth();
   initFechaHora('fecha-hora');
 
+  const nombreInput=document.getElementById('perfil-nombre');
+  const apellidoInput=document.getElementById('perfil-apellido');
+  const aliasInput=document.getElementById('perfil-alias');
+  const guardarBtn=document.getElementById('guardar-perfil-btn');
+
+  let valoresOriginales={name:'',apellido:'',alias:''};
+  let tieneDatosGuardados=false;
+
   document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='player.html';});
-  document.getElementById('guardar-perfil-btn').addEventListener('click',guardarPerfil);
+  guardarBtn.addEventListener('click',guardarPerfil);
+
+  [nombreInput,apellidoInput,aliasInput].forEach(input=>{
+    input.addEventListener('input',evaluarCambios);
+  });
+
+  function obtenerValoresPerfil(){
+    return {
+      name:nombreInput.value.trim(),
+      apellido:apellidoInput.value.trim(),
+      alias:aliasInput.value.trim()
+    };
+  }
+
+  function establecerEstadoBoton(modo){
+    if(modo==='editar'){
+      guardarBtn.textContent='Editar';
+      guardarBtn.dataset.modo='editar';
+      guardarBtn.classList.add('modo-edicion');
+    }else{
+      guardarBtn.textContent='Guardar';
+      guardarBtn.dataset.modo='guardar';
+      guardarBtn.classList.remove('modo-edicion');
+    }
+  }
+
+  function evaluarCambios(){
+    const actuales=obtenerValoresPerfil();
+    const hayCambios=['name','apellido','alias'].some(campo=>actuales[campo]!==valoresOriginales[campo]);
+    if(tieneDatosGuardados && hayCambios){
+      establecerEstadoBoton('editar');
+    }else{
+      establecerEstadoBoton('guardar');
+    }
+  }
 
   async function guardarPerfil(){
     const user = auth.currentUser;
-    const data = {
-      name: document.getElementById('perfil-nombre').value.trim(),
-      apellido: document.getElementById('perfil-apellido').value.trim(),
-      alias: document.getElementById('perfil-alias').value.trim(),
-      email: user.email,
-      photoURL: user.photoURL,
-      role: 'Jugador'
+    if(!user) return;
+    const modo=(guardarBtn.dataset.modo||'guardar')==='editar'?'editar':'guardar';
+    const confirmar=window.confirm(modo==='editar'?'¿Deseas EDITAR los datos?':'¿Deseas GUARDAR los datos?');
+    if(!confirmar) return;
+    const valores=obtenerValoresPerfil();
+    const baseDatos={
+      email:user.email,
+      photoURL:user.photoURL||'',
+      role:'Jugador'
     };
-    await db.collection('users').doc(user.email).set(data,{merge:true});
-    alert('Datos guardados correctamente');
+    try{
+      if(modo==='editar'){
+        const cambios={};
+        ['name','apellido','alias'].forEach(campo=>{
+          if(valores[campo]!==valoresOriginales[campo]){
+            cambios[campo]=valores[campo];
+          }
+        });
+        if(Object.keys(cambios).length===0){
+          alert('No se detectaron cambios para editar.');
+          evaluarCambios();
+          return;
+        }
+        await db.collection('users').doc(user.email).set({...baseDatos,...cambios},{merge:true});
+        alert('Datos editados correctamente');
+        tieneDatosGuardados=Object.values(valores).some(valor=>valor.length>0);
+      }else{
+        await db.collection('users').doc(user.email).set({...baseDatos,...valores},{merge:true});
+        alert('Datos guardados correctamente');
+        tieneDatosGuardados=Object.values(valores).some(valor=>valor.length>0);
+      }
+      valoresOriginales=valores;
+      evaluarCambios();
+    }catch(error){
+      console.error('No se pudieron guardar los datos del perfil',error);
+      alert('Ocurrió un error al guardar los datos. Intenta nuevamente.');
+    }
   }
 
   auth.onAuthStateChanged(async user=>{
     if(user){
-      const doc=await db.collection('users').doc(user.email).get();
-      if(doc.exists){
-        const d=doc.data();
-        document.getElementById('perfil-nombre').value=d.name||user.displayName||'';
-        document.getElementById('perfil-apellido').value=d.apellido||'';
-        document.getElementById('perfil-alias').value=d.alias||'';
+      try{
+        const doc=await db.collection('users').doc(user.email).get();
+        if(doc.exists){
+          const d=doc.data()||{};
+          valoresOriginales={
+            name:(d.name||'').trim(),
+            apellido:(d.apellido||'').trim(),
+            alias:(d.alias||'').trim()
+          };
+          nombreInput.value=valoresOriginales.name;
+          apellidoInput.value=valoresOriginales.apellido;
+          aliasInput.value=valoresOriginales.alias;
+          tieneDatosGuardados=Object.values(valoresOriginales).some(valor=>valor.length>0);
+        }else{
+          valoresOriginales={name:'',apellido:'',alias:''};
+          nombreInput.value='';
+          apellidoInput.value='';
+          aliasInput.value='';
+          tieneDatosGuardados=false;
+        }
+      }catch(error){
+        console.error('No se pudo cargar la información del perfil',error);
       }
+      evaluarCambios();
     } else { window.location.href='index.html'; }
   });
   </script>

--- a/public/player.html
+++ b/public/player.html
@@ -178,16 +178,6 @@
           height: auto;
           margin-bottom: clamp(0px, 1vh, 8px);
       }
-      #login-footer {
-          position: relative;
-          margin-top: auto;
-          text-align: center;
-          color: #000000;
-          text-shadow: none;
-          background: rgba(255, 255, 255, 0.6);
-          padding: 6px 10px;
-          border-radius: 8px;
-      }
       #login-btn {
           width: 220px;
           height: 80px;
@@ -412,18 +402,21 @@
           right: 10px;
           display: flex;
           align-items: center;
-          gap: 6px;
+          justify-content: center;
+          gap: 10px;
           font-size: 0.8rem;
           z-index: 1000;
-          padding: 6px 9px;
-          border-radius: 12px;
+          padding: 6px 10px;
+          border-radius: 14px;
           background: rgba(0, 0, 0, 0.55);
           box-shadow: 0 0 12px rgba(0, 0, 0, 0.35);
+          flex-wrap: nowrap;
       }
       #user-data {
           display: flex;
           flex-direction: column;
           align-items: flex-end;
+          text-align: right;
           gap: 2px;
       }
       #user-name, #user-email {
@@ -431,28 +424,36 @@
           text-shadow: 0 0 6px rgba(0, 0, 0, 0.8);
           font-family: Calibri, Arial, sans-serif;
           font-size: 0.7rem;
+          max-width: 170px;
+          word-break: break-word;
       }
       #user-pic {
-          width: 46px !important;
-          height: 46px !important;
+          width: 40px !important;
+          height: 40px !important;
           border-radius: 50%;
           border: 2px solid #ffd700;
-          box-shadow: 0 0 10px rgba(255, 215, 0, 0.6);
+          box-shadow: 0 0 9px rgba(255, 215, 0, 0.55);
       }
       #session-avatar {
           display: flex;
           flex-direction: column;
           align-items: center;
-          gap: 3px;
+          gap: 4px;
       }
       #fecha-hora, #derechos {
           font-size: 0.7rem;
           text-align: center;
           color: #000000;
           text-shadow: none;
+          margin: 0;
+      }
+      #fecha-hora {
+          margin-top: auto;
+          padding-top: 10px;
       }
       #derechos {
           font-size: 0.6rem;
+          padding-bottom: 10px;
       }
       @media (max-width: 600px) {
           table {
@@ -480,6 +481,17 @@
               padding-inline: clamp(40px, 16vw, 160px);
           }
       }
+      @media (max-width: 480px) {
+          #session-info {
+              flex-wrap: wrap;
+              justify-content: flex-end;
+              row-gap: 6px;
+          }
+          #user-data {
+              align-items: flex-end;
+              text-align: right;
+          }
+      }
       .modal-whatsapp {
           position: fixed;
           top: 0;
@@ -500,11 +512,12 @@
           background: #ffffff;
           border-radius: 18px;
           padding: clamp(20px, 4vw, 36px);
-          max-width: 420px;
-          width: 100%;
+          width: min(420px, 92vw);
+          max-height: min(80vh, 520px);
           box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
           text-align: center;
           border: 4px solid #ffd700;
+          overflow: auto;
       }
       .modal-whatsapp .modal-contenido h2 {
           font-family: 'Bangers', cursive;
@@ -552,13 +565,13 @@
   </div>
 
   <div id="session-info" style="display:none;">
-      <div id="session-avatar">
-        <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Foto del jugador">
-        <a id="logout-link" href="#">Cerrar sesión</a>
-      </div>
       <div id="user-data">
         <div id="user-name"></div>
         <div id="user-email"></div>
+      </div>
+      <div id="session-avatar">
+        <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Foto del jugador">
+        <a id="logout-link" href="#">Cerrar sesión</a>
       </div>
   </div>
   <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
@@ -618,10 +631,8 @@
 
 
 
-  <div id="login-footer">
-    <div id="fecha-hora"></div>
-    <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
-  </div>
+  <div id="fecha-hora"></div>
+  <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
 
   <!-- Importar el SDK de Firebase (compatibilidad para evitar problemas de CORS al abrir el archivo localmente) -->
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>


### PR DESCRIPTION
## Summary
- Reorganize the player header to shrink the Google avatar, right-align account data, and make the WhatsApp modal more responsive while showing footer data without a wrapper
- Refine the cartón play screen by removing duplicate date/time labels, giving the prize glow an olive tone, matching the profile shortcut image, enlarging extra prize values, adapting layout in mobile landscape, and moving footer data outside its container
- Update the profile view styling, keep the footer at the bottom, and load/sync stored player data so the save button switches to edit mode with confirmation prompts when fields change

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6908d187f0c0832680d121e61b4d41f9