### PR TITLE
Ajusta estilos de premio en jugarcartones

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -184,11 +184,11 @@
     #premio-label{color:#ffffff;text-shadow:inherit;font-size:clamp(1.6rem,4.8vw,2.6rem);letter-spacing:0.06em;}
     #premio-valores{display:inline-flex;align-items:baseline;gap:clamp(10px,2vw,18px);}
     #premio-valor{color:#ffffff;text-shadow:inherit;font-size:clamp(2rem,5.6vw,3.2rem);line-height:1;}
-    #premio-extra-valor{color:#ffffff;text-shadow:inherit;font-size:clamp(2rem,5.6vw,3.2rem);line-height:1;}
+    #premio-extra-valor{color:#0b1b4d;text-shadow:0 0 8px rgba(255,255,255,0.6);font-size:clamp(2rem,5.6vw,3.2rem);line-height:1;}
     #premio-label{text-transform:uppercase;letter-spacing:1px;}
     #premio-valor{animation:zoomInOut 1.6s ease-in-out infinite;font-family:'Bangers',cursive;font-weight:700;}
     #premio-extra-plus,#premio-extra-valor{animation:zoomInOut 1.6s ease-in-out infinite;font-family:'Bangers',cursive;}
-    #premio-extra-plus{font-weight:700;padding:0;color:#000;text-shadow:0 0 6px rgba(0,0,0,0.35);}
+    #premio-extra-plus{font-weight:700;padding:0;color:#000;text-shadow:0 0 6px rgba(0,0,0,0.35);font-size:1.5rem;}
     #premio-cartones-gratis-valor{color:#0b1b4d;font-weight:700;}
     #premio-extra-valor{font-weight:700;}
     #premio-cartones-gratis{display:none !important;}


### PR DESCRIPTION
## Resumen
- aumenta el tamaño del símbolo "+" del premio a repartir para igualarlo al indicador de cartones jugando
- actualiza el color del valor de cartones gratis del premio a repartir a un azul oscuro para destacar la información

## Pruebas
- No se realizaron pruebas automatizadas; los cambios son de estilos CSS

------
https://chatgpt.com/codex/tasks/task_e_6909053bde608326b8edc41edd521c13