### PR TITLE
Evitar ventanas emergentes en enlaces de WhatsApp

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -3429,13 +3429,31 @@
     whatsappModalEl.setAttribute('aria-hidden','true');
   }
 
+  function normalizarEnlaceWhatsapp(link){
+    if(typeof link !== 'string') return '';
+    const valor = link.trim();
+    if(!valor) return '';
+    if(/^https?:\/\//i.test(valor) || /^whatsapp:\/\//i.test(valor)){
+      return valor;
+    }
+    if(valor.startsWith('wa.me/') || valor.startsWith('chat.whatsapp.com/')){
+      return `https://${valor}`;
+    }
+    return `https://${valor}`;
+  }
+
   function abrirWhatsappConLink(){
     if(!whatsappLinkValor){
       mostrarModalWhatsapp(MENSAJE_WHATSAPP_NO_DISPONIBLE);
       return;
     }
     try{
-      window.open(whatsappLinkValor, '_blank');
+      const enlaceNormalizado = normalizarEnlaceWhatsapp(whatsappLinkValor);
+      if(!enlaceNormalizado){
+        mostrarModalWhatsapp(MENSAJE_WHATSAPP_NO_DISPONIBLE);
+        return;
+      }
+      window.location.href = enlaceNormalizado;
     }catch(e){
       console.error('No se pudo abrir el enlace de WhatsApp', e);
       mostrarModalWhatsapp(MENSAJE_WHATSAPP_NO_DISPONIBLE);

--- a/public/player.html
+++ b/public/player.html
@@ -704,6 +704,19 @@
     whatsappModalEl.setAttribute('aria-hidden','true');
   }
 
+  function normalizarEnlaceWhatsapp(valor){
+    if(typeof valor !== 'string') return '';
+    const enlace = valor.trim();
+    if(!enlace) return '';
+    if(/^https?:\/\//i.test(enlace) || /^whatsapp:\/\//i.test(enlace)){
+      return enlace;
+    }
+    if(enlace.startsWith('wa.me/') || enlace.startsWith('chat.whatsapp.com/')){
+      return `https://${enlace}`;
+    }
+    return `https://${enlace}`;
+  }
+
   async function obtenerLinkWhatsapp(){
     if(whatsappState.cargado) return whatsappState.enlace;
     if(!firestoreRef) return '';
@@ -724,9 +737,16 @@
   async function manejarClickWhatsapp(){
     const enlace = await obtenerLinkWhatsapp();
     if(enlace){
-      const nuevaVentana = window.open(enlace, '_blank', 'noopener');
-      if(!nuevaVentana){
-        mostrarModalWhatsapp('No pudimos abrir el grupo de WhatsApp. Verifica que el navegador permita ventanas emergentes.');
+      try {
+        const enlaceNormalizado = normalizarEnlaceWhatsapp(enlace);
+        if(!enlaceNormalizado){
+          mostrarModalWhatsapp('Aún no hay grupos disponibles de WhatsApp');
+          return;
+        }
+        window.location.href = enlaceNormalizado;
+      } catch (error) {
+        console.error('No se pudo abrir el enlace de WhatsApp:', error);
+        mostrarModalWhatsapp('No pudimos abrir el grupo de WhatsApp. Intenta nuevamente más tarde.');
       }
     } else {
       mostrarModalWhatsapp('Aún no hay grupos disponibles de WhatsApp');


### PR DESCRIPTION
## Summary
- normalicé los enlaces de WhatsApp para reutilizarlos sin abrir ventanas emergentes
- actualicé las vistas de juego activo y menú del jugador para redirigir directamente al enlace disponible

## Testing
- no se ejecutaron pruebas (no aplicable)


------
https://chatgpt.com/codex/tasks/task_e_6909109983548326ba2222d4f0cdc348