### PR TITLE
Ajustar aviso de alias y resaltar etiquetas en perfil

### DIFF
--- a/public/perfil.html
+++ b/public/perfil.html
@@ -118,6 +118,7 @@
           margin: 0;
           color: #000;
           text-align: center;
+          text-shadow: 0 0 6px rgba(255, 255, 255, 0.9);
       }
       .nota-campos strong {
           color: #b71c1c;
@@ -127,6 +128,7 @@
           margin: 4px 0 0 0;
           color: #000;
           text-align: center;
+          text-shadow: 0 0 6px rgba(255, 255, 255, 0.9);
       }
       .nota-celular strong {
           color: #d50000;
@@ -264,10 +266,10 @@
         <input type="text" id="perfil-apellido" placeholder="Apellido" autocomplete="family-name" required />
       </div>
     </div>
-    <p class="nota-campos">Nota: Tu Nombre y Apellido no serán visibles para ningún otro jugador, sólo será visible tu Alias.</p>
     <div class="campo-wrap campo-completo">
       <input type="text" id="perfil-alias" placeholder="Alias" maxlength="20" autocomplete="nickname" required />
     </div>
+    <p class="nota-campos">Nota: Tu Nombre y Apellido no serán visibles para ningún otro jugador, sólo será visible tu Alias.</p>
     <div class="campo-wrap campo-completo">
       <input type="tel" id="perfil-celular" placeholder="Número Celular" autocomplete="tel" inputmode="tel" maxlength="20" pattern="\+?[0-9]+" title="Ingresa un número válido (solo dígitos y un signo + inicial)" required />
     </div>


### PR DESCRIPTION
## Summary
- mover la nota informativa debajo del campo de alias en la página de perfil
- añadir un resplandor blanco a los textos "Nota" e "IMPORTANTE" para enfatizar la visibilidad

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690a4d039e80832688490de9e909a9e1