### PR TITLE
Ensure manual completion of Google user registration

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -512,7 +512,8 @@
         let rolActual = window.currentRole || '';
         if(!rolActual){
           try{
-            rolActual = await getUserRole(user);
+            const infoRol = await getUserRole(user);
+            rolActual = infoRol.role;
           }catch(err){
             console.error('No se pudo determinar el rol del usuario para el filtro de transacciones', err);
           }

--- a/public/index.html
+++ b/public/index.html
@@ -151,7 +151,11 @@
             if(doc.exists){
               termsContainer.style.display='none';
               registerContainer.style.display='none';
-              const role = doc.data().role || await getUserRole(user);
+              let role = doc.data().role;
+              if(!role){
+                const info = await getUserRole(user);
+                role = info.role;
+              }
               redirectByRole(role);
             }else{
               termsContainer.style.display='block';

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -228,7 +228,11 @@ async function handleRedirect(){
   try {
     const result = await auth.getRedirectResult();
     if(result.user){
-      const role = await getUserRole(result.user);
+      const { role, exists } = await getUserRole(result.user, { createIfMissing: false });
+      if(!exists && role === 'Jugador'){
+        window.location.href = 'registrarse.html';
+        return;
+      }
       redirectByRole(role);
     }
   } catch(err){
@@ -239,7 +243,8 @@ async function handleRedirect(){
   }
 }
 
-async function getUserRole(user){
+async function getUserRole(user, options = {}){
+  const { createIfMissing = true } = options;
   try{
     await initFirebase();
   }catch(e){
@@ -260,15 +265,21 @@ async function getUserRole(user){
   const doc = await ref.get();
   if(!doc.exists){
     const role = persistentRole || 'Jugador';
-    await ref.set({ email:user.email, alias:user.displayName||user.email, role });
-    return role;
+    let recordExists = false;
+    if(createIfMissing || role !== 'Jugador'){
+      await ref.set({ email:user.email, alias:user.displayName||user.email, role });
+      recordExists = true;
+    }
+    return { role, exists: recordExists };
   }
-  const dataRole = doc.data().role || 'Jugador';
+  const data = doc.data() || {};
+  const dataRole = data.role || 'Jugador';
+  let finalRole = persistentRole || dataRole;
   if(persistentRole && dataRole !== persistentRole){
     await ref.update({ role: persistentRole });
-    return persistentRole;
+    finalRole = persistentRole;
   }
-  return persistentRole || dataRole;
+  return { role: finalRole, exists: true };
 }
 
 function redirectByRole(role){
@@ -306,7 +317,7 @@ function setupSuperadminExit(buttonSelector = '#salir-super-btn', redirect = 'su
           return;
         }
         try{
-          const role = await getUserRole(user);
+          const { role } = await getUserRole(user);
           if(role === 'Superadmin'){
             bindRedirect();
             button.style.display = 'flex';
@@ -330,7 +341,11 @@ function ensureAuth(roleExpected){
     .then(() => {
       auth.onAuthStateChanged(async user => {
         if(!user){ window.location.href='index.html'; return; }
-        const role = await getUserRole(user);
+        const { role, exists } = await getUserRole(user, { createIfMissing: false });
+        if(!exists && role === 'Jugador'){
+          window.location.href = 'registrarse.html';
+          return;
+        }
         if(roleExpected && role !== roleExpected && role !== 'Superadmin'){
           redirectByRole(role);
           return;

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -102,11 +102,36 @@
   <script src="js/auth.js"></script>
   <script src="js/timezone.js"></script>
   <script>
-    ensureAuth();
-    auth.onAuthStateChanged(user=>{
-      if(!user) return;
-      document.getElementById('email').textContent = user.email;
-    });
+    (async()=>{
+      try{
+        await initFirebase();
+      }catch(err){
+        console.error('No se pudo inicializar Firebase en registrarse.html', err);
+        alert('No se pudo preparar el registro. Intenta nuevamente.');
+        window.location.href='index.html';
+        return;
+      }
+      auth.onAuthStateChanged(async user=>{
+        if(!user){
+          window.location.href='index.html';
+          return;
+        }
+        document.getElementById('email').textContent = user.email || '';
+        try{
+          const doc = await db.collection('users').doc(user.email).get();
+          if(doc.exists){
+            const data = doc.data() || {};
+            if(data.name) document.getElementById('nombre').value = data.name;
+            if(data.apellido) document.getElementById('apellido').value = data.apellido;
+            if(data.alias) document.getElementById('alias').value = data.alias;
+            const celularGuardado = data.celular || data.numerocel;
+            if(celularGuardado) document.getElementById('celular').value = celularGuardado;
+          }
+        }catch(loadErr){
+          console.error('No se pudieron cargar datos previos del usuario', loadErr);
+        }
+      });
+    })();
     function validarTexto(txt,max){
       return txt && txt.length<=max && /^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/.test(txt);
     }
@@ -127,6 +152,11 @@
         return;
       }
       const user = auth.currentUser;
+      if(!user){
+        alert('Tu sesión ha expirado. Vuelve a iniciar sesión con Google para registrarte.');
+        window.location.href='index.html';
+        return;
+      }
       await db.collection('users').doc(user.email).set({
         name:nombre,
         apellido:apellido,


### PR DESCRIPTION
## Summary
- evitar que la página de registro cree usuarios automáticamente al cargar y precargar datos solo si ya existen
- actualizar la lógica de roles para distinguir entre cuentas sin registro y redirigirlas correctamente hacia el formulario
- ajustar las páginas dependientes para usar la nueva respuesta de rol sin recrear registros involuntarios

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690bd7450d288326b7f7e4d378b8d737