### PR TITLE
Actualizar footer de inicio y flujo de términos

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -66,12 +66,32 @@
       margin-bottom: 10px;
       text-align: center;
     }
-    #fecha-hora, #derechos {
-      font-size: 0.7rem;
+    #fecha-hora {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      flex-wrap: wrap;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.75rem;
       color: #000;
+    }
+    #fecha-hora .pais-actual {
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    #fecha-hora .fecha-actual-icono::before {
+      content: '📅';
+      margin-right: 4px;
+    }
+    #fecha-hora .hora-actual-icono::before {
+      content: '⏰';
+      margin-right: 4px;
     }
     #derechos {
       font-size: 0.6rem;
+      color: #000;
     }
     .back-btn {
       position: fixed;
@@ -92,10 +112,7 @@
       justify-content:center;
       gap:5px;
     }
-    #terms-container,
     #register-container,
-    #terms-container label,
-    #terms-container a,
     #register-container a {
       font-family: 'Poppins', sans-serif;
     }
@@ -105,7 +122,6 @@
   <div id="login-container">
     <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" />
     <button id="login-btn">Iniciar Sesión</button>
-    <div id="terms-container"><input type="checkbox" id="accept-terms"> <label for="accept-terms">Acepto los <a href="#" id="terms-link">términos y condiciones</a></label></div>
     <div id="register-container" style="margin-top:10px;font-size:1rem;">¿Aún no tienes cuenta? <a href="#" id="register-link">Regístrate</a></div>
   </div>
   <div id="login-footer">
@@ -133,19 +149,15 @@
       }
       await handleRedirect();
       initFechaHora('fecha-hora');
-      const termsContainer=document.getElementById('terms-container');
       const registerContainer=document.getElementById('register-container');
       document.getElementById('login-btn').addEventListener('click', () => {
-        if(termsContainer.style.display!=='none' && !document.getElementById('accept-terms').checked){
-          alert('Debe aceptar los términos y condiciones');
-          return;
-        }
         loginGoogle();
       });
       document.getElementById('register-link').addEventListener('click', e => {
         e.preventDefault();
-        if(termsContainer.style.display!=='none' && !document.getElementById('accept-terms').checked){
-          alert('Debe aceptar los términos y condiciones');
+        const user = auth.currentUser;
+        if(user){
+          window.location.href='registrarse.html';
           return;
         }
         loginGoogle();
@@ -157,25 +169,18 @@
           logout();
         });
       }
-      document.getElementById('terms-link').addEventListener('click', e => { e.preventDefault(); window.location.href='terminos.html'; });
       auth.onAuthStateChanged(async user => {
         if(user){
           try{
-            const doc = await db.collection('users').doc(user.email).get();
-            if(doc.exists){
-              termsContainer.style.display='none';
-              registerContainer.style.display='none';
-              let role = doc.data().role;
-              if(!role){
-                const info = await getUserRole(user, { createIfMissing: false });
-                role = info.role;
-              }
-              redirectByRole(role);
-            }else{
-              termsContainer.style.display='block';
-              registerContainer.style.display='block';
+            const { role, exists } = await getUserRole(user, { createIfMissing: false });
+            if(!exists && role === 'Jugador'){
               window.location.href='registrarse.html';
+              return;
             }
+            if(registerContainer){
+              registerContainer.style.display='none';
+            }
+            redirectByRole(role);
           }catch(err){
             console.error('No se pudo validar la sesión existente', err);
           }


### PR DESCRIPTION
## Resumen
- Ajusté el estilo del footer en la página de inicio para que muestre país y hora en el mismo formato que el juego activo.
- Eliminé el requisito de aceptar términos en la pantalla de login y trasladé la aceptación al registro, actualizando la lógica de inicio y registro en consecuencia.

## Pruebas
- No se ejecutaron pruebas automatizadas; los cambios son en HTML y lógica de autenticación de la pantalla de inicio.


------
https://chatgpt.com/codex/tasks/task_e_690ca3cfb7cc832698eba2d910a30414