### PR TITLE
Alinea el footer del login con el de juego activo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,36 +62,17 @@
       box-shadow: 0 0 15px rgba(255, 215, 0, 0.8);
     }
     #login-footer {
-      margin-top: auto;
-      margin-bottom: 10px;
+      margin: 30px 0 10px;
       text-align: center;
     }
-    #fecha-hora {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 6px;
-      flex-wrap: wrap;
+    #fecha-hora,
+    #derechos {
       font-family: 'Poppins', sans-serif;
-      font-size: 0.75rem;
+      font-size: 0.7rem;
       color: #000;
-    }
-    #fecha-hora .pais-actual {
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-    }
-    #fecha-hora .fecha-actual-icono::before {
-      content: '📅';
-      margin-right: 4px;
-    }
-    #fecha-hora .hora-actual-icono::before {
-      content: '⏰';
-      margin-right: 4px;
     }
     #derechos {
       font-size: 0.6rem;
-      color: #000;
     }
     .back-btn {
       position: fixed;

--- a/public/js/timezone.js
+++ b/public/js/timezone.js
@@ -8,7 +8,8 @@ const serverTime = {
   baseEpochMs: null,
   baseMonotonicMs: null,
   ultimaSync: null,
-  origen: 'desconocido'
+  origen: 'desconocido',
+  intervaloSync: null
 };
 
 const IANA_OVERRIDES = {
@@ -179,23 +180,46 @@ async function initServerTime() {
     const doc = await database.collection('Variablesglobales').doc('Parametros').get();
     if (!doc.exists) throw new Error('Documento Parametros no existe');
     const { Pais = '', ZonaHoraria = '' } = doc.data();
-    serverTime.Pais = Pais;
-    const locales = {
-      Venezuela: 'es-VE',
-      España: 'es-ES',
-      Mexico: 'es-MX',
-      Colombia: 'es-CO',
-      Argentina: 'es-AR'
-    };
-    serverTime.locale = locales[Pais] || 'es-ES';
-    serverTime.offsetMinutos = obtenerOffsetMinutos(ZonaHoraria);
-    const override = IANA_OVERRIDES[Pais];
-    const zonaNormalizada = override || parseZona(ZonaHoraria);
-    serverTime.zonaIana = typeof zonaNormalizada === 'string' ? zonaNormalizada : '';
-    await sincronizarHora();
-    setInterval(sincronizarHora, 300000);
+    aplicarParametrosZona(Pais, ZonaHoraria);
   } catch (e) {
     console.error('Error obteniendo parámetros', e);
+    aplicarParametrosZona();
+  }
+  await sincronizarHora();
+  if (!serverTime.intervaloSync) {
+    serverTime.intervaloSync = setInterval(sincronizarHora, 300000);
+  }
+}
+
+function aplicarParametrosZona(Pais = 'Venezuela', ZonaHoraria = 'UTC-04:00') {
+  const locales = {
+    Venezuela: 'es-VE',
+    España: 'es-ES',
+    Mexico: 'es-MX',
+    Colombia: 'es-CO',
+    Argentina: 'es-AR'
+  };
+  const paisNormalizado = typeof Pais === 'string' && Pais.trim() ? Pais : 'Venezuela';
+  serverTime.Pais = paisNormalizado;
+  serverTime.locale = locales[paisNormalizado] || 'es-ES';
+
+  const zona = typeof ZonaHoraria === 'string' && ZonaHoraria.trim() ? ZonaHoraria : 'UTC-04:00';
+  const override = IANA_OVERRIDES[paisNormalizado];
+  const zonaNormalizada = override || parseZona(zona);
+  serverTime.zonaIana = typeof zonaNormalizada === 'string' && zonaNormalizada ? zonaNormalizada : override || 'America/Caracas';
+
+  const offset = obtenerOffsetMinutos(zona);
+  if (typeof offset === 'number' && !Number.isNaN(offset)) {
+    serverTime.offsetMinutos = offset;
+  } else if (serverTime.zonaIana) {
+    const offsetZona = obtenerOffsetDesdeIana(serverTime.zonaIana);
+    if (offsetZona !== null) {
+      serverTime.offsetMinutos = offsetZona;
+    }
+  }
+
+  if (serverTime.offsetMinutos === null) {
+    serverTime.offsetMinutos = obtenerOffsetMinutos('UTC-04:00');
   }
 }
 


### PR DESCRIPTION
## Summary
- unifica el estilo del footer en la pantalla de inicio con el utilizado en juegoactivo
- añade parámetros predeterminados para la zona horaria y país cuando no se puede leer Firestore

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690ca7cd653083268f4552420add6d1d