### PR TITLE
feat: mejorar flujo de confirmación al jugar cartones

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -202,6 +202,182 @@
       letter-spacing:1px;
       color:#0b1b4d;
     }
+
+    .carton-modal-overlay{
+      position:fixed;
+      inset:0;
+      display:none;
+      align-items:center;
+      justify-content:center;
+      padding:24px;
+      background:rgba(5,18,44,0.78);
+      backdrop-filter:blur(3px);
+      z-index:2500;
+    }
+    .carton-modal-overlay.visible{display:flex;}
+    .carton-modal-card{
+      width:min(420px,92%);
+      background:linear-gradient(165deg,#ffffff 0%,#f5f7ff 50%,#ffffff 100%);
+      border:4px solid #4facfe;
+      border-radius:22px;
+      box-shadow:0 26px 48px rgba(0,0,0,0.45);
+      padding:clamp(18px,4vw,26px);
+      display:flex;
+      flex-direction:column;
+      gap:clamp(16px,3vw,22px);
+      color:#05122c;
+      text-align:center;
+    }
+    .carton-modal-card.carton-modal-card--positivo{border-color:#2ecc71;}
+    .carton-modal-card.carton-modal-card--restriccion{border-color:#e53935;}
+    .carton-modal-card.carton-modal-card--creditos{border-color:#ffb300;}
+    .carton-modal-header{
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap:clamp(10px,2.4vw,16px);
+      flex-wrap:wrap;
+    }
+    .carton-modal-icons{display:flex;align-items:center;gap:clamp(10px,2.4vw,16px);}
+    .modal-icon{
+      width:clamp(46px,12vw,58px);
+      height:clamp(46px,12vw,58px);
+      border-radius:16px;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      font-size:clamp(1.8rem,6vw,2.4rem);
+      color:#ffffff;
+      box-shadow:0 12px 22px rgba(0,0,0,0.2);
+    }
+    .modal-icon--carton{
+      background:linear-gradient(160deg,#1976d2 0%,#42a5f5 70%);
+      position:relative;
+      font-size:clamp(1.6rem,5.6vw,2.1rem);
+    }
+    .modal-icon--carton::after{
+      content:'🎟️';
+    }
+    .modal-icon--aprobacion{
+      background:linear-gradient(160deg,#2e7d32 0%,#66bb6a 70%);
+      font-size:clamp(1.8rem,5.8vw,2.2rem);
+    }
+    .modal-icon--aprobacion::after{content:'✔️';}
+    .modal-icon--restriccion{
+      background:linear-gradient(160deg,#b71c1c 0%,#ef5350 80%);
+    }
+    .modal-icon--restriccion::after{content:'⛔';}
+    .modal-icon--creditos{
+      background:linear-gradient(160deg,#388e3c 0%,#c0ca33 85%);
+    }
+    .modal-icon--creditos::after{content:'💵';}
+    .modal-icon--error{
+      background:linear-gradient(160deg,#c62828 0%,#ef5350 85%);
+    }
+    .modal-icon--error::after{content:'❌';}
+    .modal-icon--sudor{
+      background:linear-gradient(160deg,#ff7043 0%,#ffab91 85%);
+    }
+    .modal-icon--sudor::after{content:'😅';}
+    .carton-modal-message{
+      font-size:clamp(1rem,3.2vw,1.2rem);
+      line-height:1.6;
+      margin:0;
+    }
+    .carton-modal-highlight{color:#0b6fca;font-weight:700;}
+    .carton-modal-extra-icon{
+      display:none;
+      justify-content:center;
+    }
+    .carton-modal-extra-icon.visible{display:flex;}
+    .carton-modal-actions{
+      display:flex;
+      justify-content:center;
+      gap:clamp(12px,3vw,18px);
+      flex-wrap:wrap;
+    }
+    .carton-modal-btn{
+      font-family:'Bangers',cursive;
+      font-size:clamp(1.05rem,3.4vw,1.3rem);
+      padding:10px 26px;
+      border-radius:14px;
+      border:3px solid transparent;
+      cursor:pointer;
+      letter-spacing:1px;
+      text-transform:uppercase;
+      transition:transform 0.2s ease,box-shadow 0.2s ease,filter 0.2s ease;
+      min-width:140px;
+    }
+    .carton-modal-btn:focus-visible{outline:3px solid #ffd54f;outline-offset:3px;}
+    .carton-modal-btn--primary{
+      background:linear-gradient(160deg,#1976d2 0%,#64b5f6 85%);
+      border-color:#0d47a1;
+      color:#ffffff;
+      box-shadow:0 12px 22px rgba(25,118,210,0.35);
+    }
+    .carton-modal-btn--primary:hover{transform:translateY(-2px);filter:brightness(1.05);}
+    .carton-modal-btn--secondary{
+      background:linear-gradient(160deg,#eceff1 0%,#ffffff 85%);
+      border-color:#90a4ae;
+      color:#455a64;
+      box-shadow:0 10px 18px rgba(69,90,100,0.25);
+    }
+    .carton-modal-btn--secondary:hover{transform:translateY(-2px);}
+    .carton-modal-btn--wallet{
+      background:linear-gradient(160deg,#ffb300 0%,#ffd54f 90%);
+      border-color:#ff6f00;
+      color:#4a2500;
+      box-shadow:0 12px 20px rgba(255,111,0,0.35);
+    }
+    .carton-modal-btn--wallet:hover{transform:translateY(-2px);}
+
+    .carton-processing-overlay{
+      position:fixed;
+      inset:0;
+      display:none;
+      align-items:center;
+      justify-content:center;
+      background:rgba(5,18,44,0.82);
+      backdrop-filter:blur(4px);
+      z-index:2550;
+      color:#ffffff;
+      text-align:center;
+      padding:24px;
+    }
+    .carton-processing-overlay.visible{display:flex;}
+    .carton-processing-card{
+      width:min(360px,88%);
+      padding:28px 24px;
+      border-radius:22px;
+      background:rgba(11,27,77,0.92);
+      box-shadow:0 28px 48px rgba(0,0,0,0.5);
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      gap:18px;
+      font-family:'Poppins',sans-serif;
+      font-size:1.1rem;
+    }
+    .carton-processing-spinner{
+      width:64px;
+      height:64px;
+      border-radius:50%;
+      border:6px solid rgba(255,255,255,0.18);
+      border-top-color:#ffeb3b;
+      animation:giroLoading 1s linear infinite;
+    }
+    @keyframes giroLoading{to{transform:rotate(360deg);}}
+    .carton-processing-overlay.success .carton-processing-card{
+      background:rgba(7,53,23,0.92);
+      border:3px solid #2ecc71;
+    }
+    .carton-processing-overlay.success .carton-processing-spinner{display:none;}
+    .carton-processing-overlay.success .carton-processing-text{font-weight:700;color:#c8ffdf;}
+
+    body.carton-blur > *:not(.carton-processing-overlay):not(.carton-modal-overlay){
+      filter:blur(4px);
+      pointer-events:none;
+    }
     .datos-bancarios-mensaje{
       font-size:clamp(1rem,3.4vw,1.2rem);
       margin:0;
@@ -612,6 +788,26 @@
           <button type="button" id="datos-bancarios-ir" class="datos-bancarios-boton">GUARDAR DATOS BANCARIOS</button>
       </div>
   </div>
+  <div id="carton-confirm-modal" class="carton-modal-overlay" aria-hidden="true" role="dialog" aria-modal="true">
+      <div class="carton-modal-card" id="carton-modal-card" role="document">
+          <div class="carton-modal-header">
+              <div class="carton-modal-icons" id="carton-modal-header-icons" aria-hidden="true"></div>
+          </div>
+          <p id="carton-modal-message" class="carton-modal-message"></p>
+          <div id="carton-modal-extra-icon" class="carton-modal-extra-icon" aria-hidden="true"></div>
+          <div class="carton-modal-actions">
+              <button type="button" id="carton-modal-accept" class="carton-modal-btn carton-modal-btn--primary">Aceptar</button>
+              <button type="button" id="carton-modal-cancel" class="carton-modal-btn carton-modal-btn--secondary">Cancelar</button>
+              <button type="button" id="carton-modal-wallet" class="carton-modal-btn carton-modal-btn--wallet">IR A BILLETERA</button>
+          </div>
+      </div>
+  </div>
+  <div id="carton-processing-overlay" class="carton-processing-overlay" aria-hidden="true" role="dialog" aria-modal="true">
+      <div class="carton-processing-card" role="document">
+          <div class="carton-processing-spinner" aria-hidden="true"></div>
+          <p id="carton-processing-text" class="carton-processing-text">Jugando Cartón... Por favor espera</p>
+      </div>
+  </div>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -672,6 +868,16 @@
   let billeteraDatosExiste=false;
   const datosBancariosModal=document.getElementById('datos-bancarios-modal');
   const datosBancariosIrBtn=document.getElementById('datos-bancarios-ir');
+  const cartonModalOverlay=document.getElementById('carton-confirm-modal');
+  const cartonModalCard=document.getElementById('carton-modal-card');
+  const cartonModalHeaderIcons=document.getElementById('carton-modal-header-icons');
+  const cartonModalMessage=document.getElementById('carton-modal-message');
+  const cartonModalExtraIcon=document.getElementById('carton-modal-extra-icon');
+  const cartonModalAccept=document.getElementById('carton-modal-accept');
+  const cartonModalCancel=document.getElementById('carton-modal-cancel');
+  const cartonModalWallet=document.getElementById('carton-modal-wallet');
+  const cartonProcessingOverlay=document.getElementById('carton-processing-overlay');
+  const cartonProcessingText=document.getElementById('carton-processing-text');
 
   function normalizarAliasPerfil(valor){
     return (valor||'').toString().trim().slice(0,20);
@@ -717,6 +923,192 @@
     billeteraDatosCache=billeteraDoc.exists?(billeteraDoc.data()||{}):{};
     datosBancariosCompletos=datosBancariosEstanCompletos(billeteraDatosCache);
     return {data:billeteraDatosCache,exists:billeteraDatosExiste};
+  }
+
+  const CARTON_MODAL_CARD_CLASSES=['carton-modal-card--positivo','carton-modal-card--restriccion','carton-modal-card--creditos'];
+  const CARTON_MODAL_VARIANTS={
+    'gratis_disponible':{cardClass:'carton-modal-card--positivo',headerIcons:['carton','aprobacion']},
+    'limite_gratis':{cardClass:'carton-modal-card--restriccion',headerIcons:['carton','restriccion'],extraIcon:'creditos'},
+    'solo_creditos':{cardClass:'carton-modal-card--creditos',headerIcons:['carton','creditos']},
+    'sin_recursos':{cardClass:'carton-modal-card--restriccion',headerIcons:['sudor','error','creditos','carton']},
+    'error':{cardClass:'carton-modal-card--restriccion',headerIcons:['carton','error']}
+  };
+  let cartonModalAcceptHandler=null;
+  let cartonModalCancelHandler=null;
+  let cartonModalWalletHandler=null;
+  let cartonSuccessTimeout=null;
+
+  function crearIconoCarton(tipo){
+    const span=document.createElement('span');
+    span.className=`modal-icon modal-icon--${tipo}`;
+    span.setAttribute('aria-hidden','true');
+    return span;
+  }
+
+  function limpiarClasesCartonModal(){
+    if(!cartonModalCard) return;
+    CARTON_MODAL_CARD_CLASSES.forEach(cls=>cartonModalCard.classList.remove(cls));
+  }
+
+  function cerrarModalCarton(){
+    if(!cartonModalOverlay) return;
+    cartonModalOverlay.classList.remove('visible');
+    cartonModalOverlay.setAttribute('aria-hidden','true');
+    cartonModalAcceptHandler=null;
+    cartonModalCancelHandler=null;
+    cartonModalWalletHandler=null;
+  }
+
+  function mostrarModalCarton(config={}){
+    if(!cartonModalOverlay||!cartonModalCard) return;
+    const variante=CARTON_MODAL_VARIANTS[config.caseType]||CARTON_MODAL_VARIANTS.error;
+    limpiarClasesCartonModal();
+    if(variante.cardClass){
+      cartonModalCard.classList.add(variante.cardClass);
+    }
+    if(cartonModalHeaderIcons){
+      cartonModalHeaderIcons.innerHTML='';
+      (variante.headerIcons||[]).forEach(icono=>{
+        cartonModalHeaderIcons.appendChild(crearIconoCarton(icono));
+      });
+      if(Array.isArray(config.headerIcons)){
+        config.headerIcons.forEach(icono=>{
+          cartonModalHeaderIcons.appendChild(crearIconoCarton(icono));
+        });
+      }
+    }
+    if(cartonModalMessage){
+      const mensaje=(config.message||'').toString();
+      cartonModalMessage.innerHTML=mensaje.replace(/\n/g,'<br>');
+    }
+    if(cartonModalExtraIcon){
+      const iconoExtra=config.extraIcon||variante.extraIcon;
+      cartonModalExtraIcon.innerHTML='';
+      if(iconoExtra){
+        cartonModalExtraIcon.appendChild(crearIconoCarton(iconoExtra));
+        cartonModalExtraIcon.classList.add('visible');
+      }else{
+        cartonModalExtraIcon.classList.remove('visible');
+      }
+    }
+    if(cartonModalAccept){
+      cartonModalAccept.textContent=config.acceptLabel||'Aceptar';
+      cartonModalAccept.style.display=config.hideAccept?'none':'inline-flex';
+    }
+    if(cartonModalCancel){
+      const mostrarCancel=config.showCancel!==false;
+      cartonModalCancel.textContent=config.cancelLabel||'Cancelar';
+      cartonModalCancel.style.display=mostrarCancel?'inline-flex':'none';
+    }
+    if(cartonModalWallet){
+      cartonModalWallet.style.display=config.showWallet?'inline-flex':'none';
+    }
+    cartonModalAcceptHandler=typeof config.onAccept==='function'?config.onAccept:null;
+    cartonModalCancelHandler=typeof config.onCancel==='function'?config.onCancel:null;
+    cartonModalWalletHandler=typeof config.onWallet==='function'?config.onWallet:null;
+    cartonModalOverlay.classList.add('visible');
+    cartonModalOverlay.setAttribute('aria-hidden','false');
+    const focoObjetivo=config.hideAccept?cartonModalCancel:(cartonModalAccept&&cartonModalAccept.style.display!=='none'?cartonModalAccept:cartonModalCancel);
+    if(focoObjetivo){
+      setTimeout(()=>focoObjetivo.focus(),0);
+    }
+  }
+
+  function mostrarCartonAviso(mensaje,variante='error'){
+    mostrarModalCarton({
+      caseType:variante,
+      message:mensaje,
+      showCancel:false,
+      acceptLabel:'Entendido'
+    });
+  }
+
+  function mostrarProcesandoCarton(){
+    if(!cartonProcessingOverlay) return;
+    clearTimeout(cartonSuccessTimeout);
+    cartonProcessingOverlay.classList.remove('success');
+    cartonProcessingOverlay.classList.add('visible');
+    cartonProcessingOverlay.setAttribute('aria-hidden','false');
+    if(cartonProcessingText){
+      cartonProcessingText.textContent='Jugando Cartón... Por favor espera';
+    }
+    document.body.classList.add('carton-blur');
+  }
+
+  function mostrarExitoCarton(){
+    if(!cartonProcessingOverlay) return;
+    cartonProcessingOverlay.classList.add('success');
+    if(cartonProcessingText){
+      cartonProcessingText.textContent='Cartón jugado correctamente';
+    }
+    cartonProcessingOverlay.classList.add('visible');
+    cartonProcessingOverlay.setAttribute('aria-hidden','false');
+    document.body.classList.add('carton-blur');
+    clearTimeout(cartonSuccessTimeout);
+    cartonSuccessTimeout=setTimeout(()=>{
+      ocultarProcesandoCarton();
+    },2000);
+  }
+
+  function ocultarProcesandoCarton(){
+    if(!cartonProcessingOverlay) return;
+    clearTimeout(cartonSuccessTimeout);
+    cartonProcessingOverlay.classList.remove('visible');
+    cartonProcessingOverlay.classList.remove('success');
+    cartonProcessingOverlay.setAttribute('aria-hidden','true');
+    document.body.classList.remove('carton-blur');
+  }
+
+  if(cartonModalOverlay){
+    cartonModalOverlay.addEventListener('click',event=>{
+      if(event.target===cartonModalOverlay){
+        cerrarModalCarton();
+        if(cartonModalCancelHandler){
+          cartonModalCancelHandler();
+        }
+      }
+    });
+  }
+  if(cartonModalAccept){
+    cartonModalAccept.addEventListener('click',()=>{
+      cerrarModalCarton();
+      if(cartonModalAcceptHandler){
+        cartonModalAcceptHandler();
+      }
+    });
+  }
+  if(cartonModalCancel){
+    cartonModalCancel.addEventListener('click',()=>{
+      cerrarModalCarton();
+      if(cartonModalCancelHandler){
+        cartonModalCancelHandler();
+      }
+    });
+  }
+  if(cartonModalWallet){
+    cartonModalWallet.addEventListener('click',()=>{
+      cerrarModalCarton();
+      if(cartonModalWalletHandler){
+        cartonModalWalletHandler();
+      }else{
+        window.location.href='billetera.html';
+      }
+    });
+  }
+  document.addEventListener('keydown',event=>{
+    if(event.key==='Escape' && cartonModalOverlay && cartonModalOverlay.classList.contains('visible')){
+      cerrarModalCarton();
+      if(cartonModalCancelHandler){
+        cartonModalCancelHandler();
+      }
+    }
+  });
+  if(cartonProcessingOverlay){
+    cartonProcessingOverlay.addEventListener('click',()=>{
+      if(cartonProcessingOverlay.classList.contains('success')){
+        ocultarProcesandoCarton();
+      }
+    });
   }
 
   function mostrarModalPerfilPendiente(){
@@ -867,6 +1259,16 @@ function formatearEnteroEs(valor){
   const numero=Number(valor);
   if(!Number.isFinite(numero)) return '0';
   return Math.max(0,Math.round(numero)).toLocaleString('es-ES',{maximumFractionDigits:0});
+}
+
+function formatearValorCartonMoneda(valor){
+  const numero=Number(valor);
+  if(!Number.isFinite(numero)) return '0';
+  try{
+    return new Intl.NumberFormat('es-CO',{style:'currency',currency:'COP',maximumFractionDigits:0}).format(numero);
+  }catch(error){
+    return '$'+formatearEnteroEs(numero);
+  }
 }
 
 function obtenerCartonesGratisForma(forma){
@@ -1585,13 +1987,19 @@ function toggleForma(idx){
   async function enviarDatos(){
     const alias=document.getElementById('alias-jugador').value.trim();
     const user=auth.currentUser;
-    if(alias===''||!user){ alert('Por favor, ingresa tu Alias.'); return; }
-    if(!validateBoard(true)){ alert('Debes llenar las celdas vacías del cratón primero'); return; }
-    if(!currentSorteo){ alert('Debes selecionar primero un sorteo'); abrirSorteosModal(); return; }
+    if(alias===''||!user){
+      throw new Error('Por favor, ingresa tu Alias.');
+    }
+    if(!validateBoard(true)){
+      throw new Error('Debes llenar las celdas vacías del cartón primero');
+    }
+    if(!currentSorteo){
+      abrirSorteosModal();
+      throw new Error('Debes seleccionar primero un sorteo');
+    }
     if(consultando){
-      alert('Este cartón ya está jugando y no se puede jugar nuevamente.');
       limpiarcarton();
-      return;
+      throw new Error('Este cartón ya está jugando y no se puede jugar nuevamente.');
     }
 
     const billeteraRef=db.collection('Billetera').doc(user.email);
@@ -1602,21 +2010,18 @@ function toggleForma(idx){
     const sorteoRef=db.collection('sorteos').doc(currentSorteo);
     const sorteoDoc=await sorteoRef.get();
     if(!sorteoDoc.exists){
-      alert('No se encontró la información del sorteo seleccionado.');
-      return;
+      throw new Error('No se encontró la información del sorteo seleccionado.');
     }
     const sorteoData=sorteoDoc.data();
     const estadoSorteo=(sorteoData?.estado||currentSorteoEstado||'').toString();
     currentSorteoEstado=estadoSorteo;
     const estadoSorteoLower=estadoSorteo.toLowerCase();
     if(estadoSorteoLower==='finalizado'){
-      alert('Ya no se pueden jugar cartones en este sorteo porque está FINALIZADO.');
       await cargarSorteosActivos();
-      return;
+      throw new Error('Ya no se pueden jugar cartones en este sorteo porque está FINALIZADO.');
     }
     if(estadoSorteoLower==='sellado'){
-      mostrarMensajeSellado(currentSorteoNombre||sorteoData?.nombre||'este sorteo');
-      return;
+      throw new Error('SORTEO_SELLADO');
     }
 
     const posiciones=[];
@@ -1640,8 +2045,7 @@ function toggleForma(idx){
       if(firmaDoc===firmaActual) cartonDuplicado=true;
     });
     if(cartonDuplicado){
-      alert(`No se puede jugar este cartón, ya que en este sorteo ${currentSorteoNombre} estas jugando uno idéntico`);
-      return;
+      throw new Error(`No se puede jugar este cartón, ya que en este sorteo ${currentSorteoNombre} estás jugando uno idéntico`);
     }
 
     const valor=toNumberSafe(sorteoData.valorCarton,0);
@@ -1657,19 +2061,16 @@ function toggleForma(idx){
       if(creditos>=valor){
         jugarGratis=false;
       }else{
-        alert('No tienes créditos suficientes.');
-        return;
+        throw new Error('No tienes créditos suficientes.');
       }
     }else if(gratis<=0){
       if(creditos>=valor){
         jugarGratis=false;
       }else{
-        alert('No tienes créditos suficientes.');
-        return;
+        throw new Error('No tienes créditos suficientes.');
       }
     }else{
-      alert('No tienes créditos ni cartones gratis disponibles.');
-      return;
+      throw new Error('No tienes créditos ni cartones gratis disponibles.');
     }
 
     await initServerTime();
@@ -1780,11 +2181,10 @@ function toggleForma(idx){
       }
       await actualizarDatosSorteo();
       await actualizarCartonesJugador();
-      alert('Jugada de Cartón enviada correctamente.');
       limpiarcarton();
+      return true;
     }catch(error){
       let mensaje='No se pudo registrar tu cartón. Inténtalo nuevamente.';
-      let mostrarAlerta=true;
       if(error?.message==='SIN_CREDITOS'){
         mensaje='No tienes créditos suficientes.';
       }else if(error?.message==='SIN_GRATIS'){
@@ -1792,8 +2192,7 @@ function toggleForma(idx){
       }else if(error?.message==='LIMITE_GRATIS'){
         mensaje='Se alcanzó el límite de cartones gratis para este sorteo.';
       }else if(error?.message==='SORTEO_SELLADO'){
-        mostrarAlerta=false;
-        mostrarMensajeSellado(currentSorteoNombre||sorteoData?.nombre||'este sorteo');
+        throw new Error('SORTEO_SELLADO');
       }else if(error?.message==='SORTEO_FINALIZADO'){
         mensaje='Ya no se pueden jugar cartones en este sorteo porque está FINALIZADO.';
         await cargarSorteosActivos();
@@ -1808,26 +2207,23 @@ function toggleForma(idx){
       }else{
         console.error('Error registrando cartón',error);
       }
-      if(mostrarAlerta){
-        alert(mensaje);
-      }
-      return;
+      throw new Error(mensaje);
     }
   }
 
   async function confirmarCompra(){
     const user=auth.currentUser;
     if(!user){
-      alert('Por favor, inicia sesión.');
+      mostrarCartonAviso('Por favor, inicia sesión.');
       return;
     }
     if(!validateBoard(true)){
-      alert('Debes llenar las celdas vacías del cratón primero');
+      mostrarCartonAviso('Debes llenar las celdas vacías del cartón primero');
       return;
     }
     if(!currentSorteo){
-      alert('Debes selecionar primero un sorteo');
       abrirSorteosModal();
+      mostrarCartonAviso('Debes seleccionar primero un sorteo');
       return;
     }
     const billeteraInfo=await cargarDatosBilleteraUsuario(true);
@@ -1844,8 +2240,8 @@ function toggleForma(idx){
     currentSorteoEstado=estadoActual;
     const estadoActualLower=estadoActual.toLowerCase();
     if(estadoActualLower==='finalizado'){
-      alert('Este sorteo ya está FINALIZADO. Selecciona otro sorteo disponible.');
       await cargarSorteosActivos();
+      mostrarCartonAviso('Este sorteo ya está FINALIZADO. Selecciona otro sorteo disponible.');
       return;
     }
     if(estadoActualLower==='sellado'){
@@ -1853,6 +2249,7 @@ function toggleForma(idx){
       return;
     }
     const valor=toNumberSafe(sorteoData.valorCarton,0);
+    const valorMoneda=formatearValorCartonMoneda(valor);
     const jugadosJugador=await db.collection('CartonJugado')
       .where('sorteoId','==',currentSorteo)
       .where('userId','==',user.uid)
@@ -1862,35 +2259,69 @@ function toggleForma(idx){
       const dataDoc=doc.data()||{};
       if((dataDoc.tipocarton||'').toString().toLowerCase()==='gratis') gratisUsadosJugador++;
     });
-    const gratisJugando=toNumberSafe(sorteoData.cartonesgratisjugando,0);
     const maxGratis=toNumberSafe(sorteoData.maxcartongratis,0);
-    let mensaje='';
-    let continuar=false;
+    let casoModal='solo_creditos';
+    let mensajeModal='';
+    let puedeJugar=false;
     if(gratis>0 && (maxGratis<=0 || gratisUsadosJugador<maxGratis)){
-      mensaje=`¿Estas seguro de jugar el cartón?\nEstarás usando uno de tus cartones gratis disponible`;
-      continuar=true;
+      casoModal='gratis_disponible';
+      mensajeModal='Tienes cartones gratis disponibles para este sorteo.<br><span class="carton-modal-highlight">¿Deseas jugar este cartón usando uno gratis?</span>';
+      puedeJugar=true;
     }else if(gratis>0 && maxGratis>0 && gratisUsadosJugador>=maxGratis){
       if(creditos>=valor){
-        mensaje=`¿Estas seguro de jugar el cartón?\nTienes cartones gratis, pero ya se llego al máximo permitido para este sorteo. se descontaran de tus creditos: ${valor} por el valor del cartón`;
-        continuar=true;
+        casoModal='limite_gratis';
+        mensajeModal=`Alcanzaste el máximo de cartones gratis para este sorteo.<br>Podrás jugarlo descontando <strong>${valorMoneda}</strong> de tus créditos.`;
+        puedeJugar=true;
       }else{
-        mensaje=`No tienes créditos ni cartones gratis disponibles\nEntra en tu billetera para solicitar depósitos que hayas realizado desde tu banco. El valor para el cartón de este sorteo es: ${valor}`;
-      }
-    }else if(gratis<=0){
-      if(creditos>=valor){
-        mensaje=`¿Estas seguro de jugar el cartón?\nNo tienes cartones gratis, se descontaran de tus créditos: ${valor} por el valor del cartón`;
-        continuar=true;
-      }else{
-        mensaje=`No tienes créditos ni cartones gratis disponibles\nEntra en tu billetera para solicitar depósitos que hayas realizado desde tu banco. El valor para el cartón de este sorteo es: ${valor}`;
-      }
-    }
-    if(continuar){
-      if(await confirm(mensaje)){
-        await enviarDatos();
+        casoModal='sin_recursos';
+        mensajeModal='Alcanzaste el máximo de cartones gratis para este sorteo y no tienes créditos disponibles.<br>Ingresa a tu billetera para recargar y seguir jugando.';
       }
     }else{
-      alert(mensaje);
+      if(creditos>=valor){
+        casoModal='solo_creditos';
+        mensajeModal=`No tienes cartones gratis para este sorteo.<br>Se descontarán de tus créditos <strong>${valorMoneda}</strong>.`;
+        puedeJugar=true;
+      }else{
+        casoModal='sin_recursos';
+        mensajeModal='No tienes cartones gratis ni créditos disponibles para este sorteo.<br>Ingresa a tu billetera para solicitar tus depósitos y recargar saldo.';
+      }
     }
+
+    if(!puedeJugar){
+      mostrarModalCarton({
+        caseType:casoModal,
+        message:mensajeModal,
+        showCancel:false,
+        acceptLabel:'Aceptar',
+        showWallet:true,
+        onWallet:()=>{ window.location.href='billetera.html'; }
+      });
+      return;
+    }
+
+    mostrarModalCarton({
+      caseType:casoModal,
+      message:mensajeModal,
+      showCancel:true,
+      onAccept:async()=>{
+        try{
+          mostrarProcesandoCarton();
+          await enviarDatos();
+          mostrarExitoCarton();
+        }catch(error){
+          ocultarProcesandoCarton();
+          if(error?.message==='SORTEO_SELLADO'){
+            mostrarMensajeSellado(currentSorteoNombre||sorteoData?.nombre||'este sorteo');
+            return;
+          }
+          if(error?.message){
+            mostrarCartonAviso(error.message);
+          }else{
+            mostrarCartonAviso('No se pudo registrar tu cartón. Inténtalo nuevamente.');
+          }
+        }
+      }
+    });
   }
 
   async function guardarCarton(){


### PR DESCRIPTION
## Summary
- reemplazar las ventanas nativas de confirmación en jugarcartones.html por modales con íconos, colores y botones estilizados
- incorporar una capa de procesamiento con efecto blur, animación de carga y mensaje de éxito automático para asegurar el guardado del cartón
- ajustar la lógica de confirmación y envío de jugadas para reutilizar los modales personalizados y validar los recursos disponibles

## Testing
- Not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dfb191ec48326b80d8a636bebdbc9)