### PR TITLE
Fix carton modal modal handlers to execute actions before closing

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -1111,34 +1111,38 @@
   if(cartonModalOverlay){
     cartonModalOverlay.addEventListener('click',event=>{
       if(event.target===cartonModalOverlay){
+        const handler=cartonModalCancelHandler;
         cerrarModalCarton();
-        if(cartonModalCancelHandler){
-          cartonModalCancelHandler();
+        if(handler){
+          handler();
         }
       }
     });
   }
   if(cartonModalAccept){
     cartonModalAccept.addEventListener('click',()=>{
+      const handler=cartonModalAcceptHandler;
       cerrarModalCarton();
-      if(cartonModalAcceptHandler){
-        cartonModalAcceptHandler();
+      if(handler){
+        handler();
       }
     });
   }
   if(cartonModalCancel){
     cartonModalCancel.addEventListener('click',()=>{
+      const handler=cartonModalCancelHandler;
       cerrarModalCarton();
-      if(cartonModalCancelHandler){
-        cartonModalCancelHandler();
+      if(handler){
+        handler();
       }
     });
   }
   if(cartonModalWallet){
     cartonModalWallet.addEventListener('click',()=>{
+      const handler=cartonModalWalletHandler;
       cerrarModalCarton();
-      if(cartonModalWalletHandler){
-        cartonModalWalletHandler();
+      if(handler){
+        handler();
       }else{
         window.location.href='billetera.html';
       }
@@ -1146,9 +1150,10 @@
   }
   document.addEventListener('keydown',event=>{
     if(event.key==='Escape' && cartonModalOverlay && cartonModalOverlay.classList.contains('visible')){
+      const handler=cartonModalCancelHandler;
       cerrarModalCarton();
-      if(cartonModalCancelHandler){
-        cartonModalCancelHandler();
+      if(handler){
+        handler();
       }
     }
   });


### PR DESCRIPTION
## Summary
- preservar los manejadores de acciones del modal de cartón antes de cerrar la ventana
- garantizar que aceptar, cancelar y la tecla Escape ejecuten las acciones correspondientes
- asegurar que el botón de billetera respete el manejador personalizado cuando exista

## Testing
- no se ejecutaron pruebas (cambio de frontend)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e246453a48326bd4cd4dbb93a25ea)