### PR TITLE
Adjust modal currency formatting and improve iOS player menu spacing

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -1324,9 +1324,9 @@ function formatearValorCartonMoneda(valor){
   const numero=Number(valor);
   if(!Number.isFinite(numero)) return '0';
   try{
-    return new Intl.NumberFormat('es-CO',{style:'currency',currency:'COP',maximumFractionDigits:0}).format(numero);
+    return new Intl.NumberFormat('es-CO',{maximumFractionDigits:0}).format(numero);
   }catch(error){
-    return '$'+formatearEnteroEs(numero);
+    return formatearEnteroEs(numero);
   }
 }
 

--- a/public/player.html
+++ b/public/player.html
@@ -492,6 +492,20 @@
               text-align: right;
           }
       }
+      @supports (-webkit-touch-callout: none) {
+          body {
+              padding-top: calc(env(safe-area-inset-top, 0px) + clamp(12px, 3vh, 36px));
+          }
+          #menu-buttons {
+              gap: clamp(0px, 0.8vh, 6px);
+          }
+          #menu-logo {
+              margin-bottom: clamp(-2px, 0.4vh, 6px);
+          }
+          #menu-tabla-wrapper {
+              padding-top: clamp(4px, 0.8vh, 12px);
+          }
+      }
       .modal-whatsapp {
           position: fixed;
           top: 0;


### PR DESCRIPTION
## Summary
- remove the currency symbol from the saved play confirmation messaging so the amounts display without `$`
- tweak iOS-specific spacing so the player menu table sits closer to the heading while preserving Android and desktop layouts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea72e3ab0832690e600c9ffdbda25)