### PR TITLE
Implementar centro de notificaciones por rol

### DIFF
--- a/public/accederusuario.html
+++ b/public/accederusuario.html
@@ -137,6 +137,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script>
     ensureAuth('Superadmin');
     document.getElementById('admin-btn').addEventListener('click', () => { window.location.href = 'admin.html'; });

--- a/public/admin.html
+++ b/public/admin.html
@@ -159,6 +159,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script>
   ensureAuth('Administrador');
   setupSuperadminExit('#salir-super-btn');

--- a/public/billetera.html
+++ b/public/billetera.html
@@ -398,6 +398,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
     ensureAuth();

--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -1749,6 +1749,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
   ensureAuth('Administrador');

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -657,6 +657,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
     ensureAuth('Administrador');

--- a/public/collab.html
+++ b/public/collab.html
@@ -135,6 +135,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script>
   ensureAuth('Colaborador');
   setupSuperadminExit('#salir-super-btn');

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -720,6 +720,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script>
     ensureAuth('Administrador');
     const datos = [];

--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -276,6 +276,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script type="module">
   import { UPLOAD_ENDPOINT } from './js/config.js';
   ensureAuth('Administrador');

--- a/public/gestionarusuarios.html
+++ b/public/gestionarusuarios.html
@@ -287,6 +287,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script type="module">
     import { UPLOAD_ENDPOINT } from './js/config.js';
     const datos = [];

--- a/public/gestionsorteos.html
+++ b/public/gestionsorteos.html
@@ -232,6 +232,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script>
   const datos=[];
   const tbody=document.querySelector('#tabla-sorteos tbody');

--- a/public/index.html
+++ b/public/index.html
@@ -114,6 +114,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', async () => {

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -347,7 +347,14 @@ function ensureAuth(roleExpected){
   initFirebase()
     .then(() => {
       auth.onAuthStateChanged(async user => {
-        if(!user){ window.location.href='index.html'; return; }
+        if(!user){
+          if(window.notificationCenter && typeof window.notificationCenter.desvincularUsuario === 'function'){
+            try{ window.notificationCenter.desvincularUsuario(); }
+            catch(err){ console.error('No se pudo desvincular el centro de notificaciones', err); }
+          }
+          window.location.href='index.html';
+          return;
+        }
         const { role, exists } = await getUserRole(user, { createIfMissing: false });
         if(!exists && role === 'Jugador'){
           window.location.href = 'registrarse.html';
@@ -381,6 +388,10 @@ function ensureAuth(roleExpected){
           });
         }
         startUserStatusWatcher();
+        if(window.notificationCenter && typeof window.notificationCenter.vincularUsuario === 'function'){
+          try{ window.notificationCenter.vincularUsuario(user, role); }
+          catch(err){ console.error('No se pudo vincular el centro de notificaciones', err); }
+        }
       });
     })
     .catch(err => {

--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -1,0 +1,824 @@
+(function(){
+  if(typeof window === 'undefined') return;
+  if(window.notificationCenter) return;
+
+  const GRUPOS_NOTIFICACIONES = {
+    Jugador: {
+      etiqueta: 'Jugador',
+      items: [
+        { clave: 'sorteoNuevo', titulo: 'Notificación Sorteo Nuevo', descripcion: 'Se envía cuando se crea un sorteo.' },
+        { clave: 'sorteoJugando', titulo: 'Notificación Sorteo Jugando', descripcion: 'Te avisa cuando un sorteo inicia la partida.' },
+        { clave: 'estatusDeposito', titulo: 'Notificación Estatus Depósito', descripcion: 'Recibe cambios de estado de tus depósitos.' },
+        { clave: 'premio', titulo: 'Notificación Premio', descripcion: 'Recibe aviso cuando un premio se acredita en tu billetera.' }
+      ]
+    },
+    Colaborador: {
+      etiqueta: 'Colaborador',
+      items: [
+        { clave: 'depositosPendientes', titulo: 'Notificación Depósitos Pendientes', descripcion: 'Se repite cada 10 minutos si hay depósitos por gestionar.' },
+        { clave: 'retirosPendientes', titulo: 'Notificación Retiros Pendientes', descripcion: 'Se repite cada 10 minutos si hay retiros por gestionar.' }
+      ]
+    },
+    Administrador: {
+      etiqueta: 'Administrador',
+      items: [
+        { clave: 'selladoSorteo', titulo: 'Notificación Sellado Sorteo', descripcion: 'Cuando llega la hora de sellado de un sorteo.' },
+        { clave: 'juegoEnVivoSorteo', titulo: 'Notificación Juego en vivo Sorteo', descripcion: 'Cuando llega la hora de inicio de un sorteo.' },
+        { clave: 'gestionPagos', titulo: 'Notificación Gestión Pagos', descripcion: 'Recordatorio cada 10 minutos si hay gestiones de pagos pendientes.' }
+      ]
+    }
+  };
+
+  const INTERVALOS_REPETICION = {
+    depositosPendientes: 600000,
+    retirosPendientes: 600000,
+    gestionPagos: 600000
+  };
+
+  const HISTORIAL_FABRICAS = {
+    sorteoNuevo: () => ({ ids: {} }),
+    sorteoJugando: () => ({ ids: {} }),
+    estatusDeposito: () => ({ ids: {} }),
+    premio: () => ({ ids: {} }),
+    depositosPendientes: () => ({ ultimoEnvio: 0 }),
+    retirosPendientes: () => ({ ultimoEnvio: 0 }),
+    gestionPagos: () => ({ ultimoEnvio: 0 }),
+    selladoSorteo: () => ({ ids: {} }),
+    juegoEnVivoSorteo: () => ({ ids: {} })
+  };
+
+  function clonar(obj){
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  function historialVacio(){
+    const base = {};
+    Object.keys(HISTORIAL_FABRICAS).forEach(clave => {
+      base[clave] = HISTORIAL_FABRICAS[clave]();
+    });
+    return base;
+  }
+
+  function clavesPorRol(role){
+    const claves = new Set();
+    if(role === 'Superadmin'){
+      Object.values(GRUPOS_NOTIFICACIONES).forEach(grupo => grupo.items.forEach(item => claves.add(item.clave)));
+      return Array.from(claves);
+    }
+    if(role === 'Colaborador'){
+      GRUPOS_NOTIFICACIONES.Colaborador.items.forEach(item => claves.add(item.clave));
+      GRUPOS_NOTIFICACIONES.Jugador.items.forEach(item => claves.add(item.clave));
+      return Array.from(claves);
+    }
+    if(role === 'Administrador'){
+      GRUPOS_NOTIFICACIONES.Administrador.items.forEach(item => claves.add(item.clave));
+      GRUPOS_NOTIFICACIONES.Jugador.items.forEach(item => claves.add(item.clave));
+      return Array.from(claves);
+    }
+    GRUPOS_NOTIFICACIONES.Jugador.items.forEach(item => claves.add(item.clave));
+    return Array.from(claves);
+  }
+
+  function crearModalPermiso({ titulo, mensaje, onSi, onNo, onNoMostrar }){
+    if(typeof document === 'undefined') return;
+    const overlay = document.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.inset = '0';
+    overlay.style.background = 'rgba(0,0,0,0.55)';
+    overlay.style.display = 'flex';
+    overlay.style.alignItems = 'center';
+    overlay.style.justifyContent = 'center';
+    overlay.style.zIndex = '12000';
+
+    const caja = document.createElement('div');
+    caja.style.background = '#fff';
+    caja.style.borderRadius = '18px';
+    caja.style.padding = '24px';
+    caja.style.boxSizing = 'border-box';
+    caja.style.maxWidth = '420px';
+    caja.style.width = '90%';
+    caja.style.fontFamily = "'Poppins', sans-serif";
+    caja.style.textAlign = 'center';
+    caja.style.boxShadow = '0 12px 30px rgba(0,0,0,0.25)';
+
+    const h2 = document.createElement('h2');
+    h2.textContent = titulo;
+    h2.style.margin = '0 0 12px';
+    h2.style.color = '#0b1b4d';
+
+    const p = document.createElement('p');
+    p.textContent = mensaje;
+    p.style.margin = '0 0 20px';
+    p.style.color = '#333';
+
+    const contenedorBotones = document.createElement('div');
+    contenedorBotones.style.display = 'flex';
+    contenedorBotones.style.flexDirection = 'column';
+    contenedorBotones.style.gap = '10px';
+
+    function crearBoton(texto, color, accion){
+      const btn = document.createElement('button');
+      btn.textContent = texto;
+      btn.style.padding = '10px 16px';
+      btn.style.borderRadius = '10px';
+      btn.style.border = 'none';
+      btn.style.cursor = 'pointer';
+      btn.style.background = color;
+      btn.style.color = '#fff';
+      btn.style.fontSize = '1rem';
+      btn.style.fontFamily = "'Poppins', sans-serif";
+      btn.addEventListener('click', ()=>{
+        overlay.remove();
+        accion();
+      }, { once: true });
+      return btn;
+    }
+
+    contenedorBotones.appendChild(crearBoton('Sí, activar', '#0a8800', onSi));
+    contenedorBotones.appendChild(crearBoton('No por ahora', '#c62828', onNo));
+    contenedorBotones.appendChild(crearBoton('No mostrar de nuevo', '#616161', onNoMostrar));
+
+    caja.appendChild(h2);
+    caja.appendChild(p);
+    caja.appendChild(contenedorBotones);
+    overlay.appendChild(caja);
+
+    document.body.appendChild(overlay);
+  }
+
+  class CentroNotificaciones {
+    constructor(){
+      this.usuario = null;
+      this.rol = null;
+      this.config = {
+        global: false,
+        ultimaRespuesta: '',
+        preferencias: {},
+        historial: historialVacio(),
+        fechaUltimoPrompt: null
+      };
+      this.listeners = new Set();
+      this.desuscriptores = [];
+      this.temporizadores = {};
+      this.inicializaciones = {
+        sorteos: false,
+        transJugador: false
+      };
+      this.cache = {
+        sorteos: new Map(),
+        pendientes: {
+          depositosPendientes: new Set(),
+          retirosPendientes: new Set(),
+          gestionPagos: 0
+        },
+        resumenPagos: { premios: 0, pagos: 0 },
+        verificadorSorteos: null
+      };
+      this.guardadoPreferencias = null;
+      this.pendienteHistorial = null;
+      this.timerHistorial = null;
+      this.rolesActivos = new Set();
+      this.resetReady();
+    }
+
+    resetReady(){
+      this.readyPromise = new Promise(resolve => {
+        this.readyResolver = resolve;
+      });
+    }
+
+    cuandoListo(){
+      return this.readyPromise;
+    }
+
+    obtenerConfiguracion(){
+      return clonar(this.config);
+    }
+
+    onChange(callback){
+      if(typeof callback !== 'function') return ()=>{};
+      this.listeners.add(callback);
+      callback(this.obtenerConfiguracion());
+      return ()=>this.listeners.delete(callback);
+    }
+
+    notificarCambios(){
+      const copia = this.obtenerConfiguracion();
+      this.listeners.forEach(cb => {
+        try{ cb(copia); }
+        catch(err){ console.error('Error notificando cambios de configuración', err); }
+      });
+    }
+
+    async vincularUsuario(user, role){
+      if(!user){
+        this.desvincularUsuario();
+        return;
+      }
+      const mismo = this.usuario && this.usuario.email === user.email && this.rol === role;
+      if(mismo) return this.cuandoListo();
+      this.desvincularUsuario();
+      this.resetReady();
+      this.usuario = user;
+      this.rol = role;
+      try{
+        if(typeof initFirebase === 'function'){
+          await initFirebase();
+        }
+        const doc = await db.collection('users').doc(user.email).get();
+        const data = doc.exists ? (doc.data() || {}) : {};
+        await this.cargarConfiguracion(data.notificationSettings || {});
+        await this.verificarSolicitudInicial();
+        this.iniciarMonitoreos();
+      }catch(err){
+        console.error('No se pudo configurar el centro de notificaciones', err);
+      }finally{
+        this.readyResolver();
+        this.notificarCambios();
+      }
+      return this.cuandoListo();
+    }
+
+    desvincularUsuario(){
+      this.usuario = null;
+      this.rol = null;
+      this.config = {
+        global: false,
+        ultimaRespuesta: '',
+        preferencias: {},
+        historial: historialVacio(),
+        fechaUltimoPrompt: null
+      };
+      this.cancelarMonitoreos();
+      this.rolesActivos.clear();
+      this.inicializaciones = { sorteos: false, transJugador: false };
+      this.cache = {
+        sorteos: new Map(),
+        pendientes: {
+          depositosPendientes: new Set(),
+          retirosPendientes: new Set(),
+          gestionPagos: 0
+        },
+        resumenPagos: { premios: 0, pagos: 0 },
+        verificadorSorteos: null
+      };
+      if(this.timerHistorial){
+        clearTimeout(this.timerHistorial);
+        this.timerHistorial = null;
+      }
+      this.resetReady();
+    }
+
+    cancelarMonitoreos(){
+      this.desuscriptores.forEach(fn => {
+        try{ fn(); }catch(err){ console.warn('No se pudo desuscribir un monitor de notificaciones', err); }
+      });
+      this.desuscriptores = [];
+      Object.values(this.temporizadores).forEach(id => clearInterval(id));
+      this.temporizadores = {};
+      if(this.cache.verificadorSorteos){
+        clearInterval(this.cache.verificadorSorteos);
+        this.cache.verificadorSorteos = null;
+      }
+    }
+
+    async cargarConfiguracion(raw){
+      const claves = clavesPorRol(this.rol);
+      const preferencias = {};
+      const origenPreferencias = raw.preferencias || {};
+      let requiereGuardado = false;
+      claves.forEach(clave => {
+        if(typeof origenPreferencias[clave] === 'boolean'){
+          preferencias[clave] = origenPreferencias[clave];
+        }else{
+          preferencias[clave] = false;
+          requiereGuardado = true;
+        }
+      });
+      this.config = {
+        global: Boolean(raw.global),
+        ultimaRespuesta: raw.ultimaRespuesta || raw.lastChoice || '',
+        preferencias,
+        historial: historialVacio(),
+        fechaUltimoPrompt: raw.fechaUltimoPrompt || raw.lastPromptAt || null
+      };
+      const origenHistorial = raw.historial || raw.history || {};
+      Object.keys(this.config.historial).forEach(clave => {
+        if(origenHistorial[clave]){
+          this.config.historial[clave] = { ...this.config.historial[clave], ...origenHistorial[clave] };
+        }
+      });
+      if(requiereGuardado){
+        await this.guardarPreferencias();
+      }
+    }
+
+    async verificarSolicitudInicial(){
+      if(!this.usuario) return;
+      if(!hasWindow()) return;
+      if(this.config.global) return;
+      if(this.config.ultimaRespuesta === 'no_mostrar') return;
+      await new Promise(resolve => {
+        crearModalPermiso({
+          titulo: '¿Deseas recibir notificaciones?',
+          mensaje: 'Activa las notificaciones para estar informado en tiempo real.',
+          onSi: async ()=>{
+            this.config.global = true;
+            this.config.ultimaRespuesta = 'si';
+            this.config.fechaUltimoPrompt = Date.now();
+            this.establecerPreferenciasIniciales(true);
+            await this.guardarPreferencias();
+            await this.solicitarPermisoNavegador();
+            resolve();
+            this.notificarCambios();
+          },
+          onNo: async ()=>{
+            this.config.global = false;
+            this.config.ultimaRespuesta = 'no';
+            this.config.fechaUltimoPrompt = Date.now();
+            this.establecerPreferenciasIniciales(false);
+            await this.guardarPreferencias();
+            resolve();
+            this.notificarCambios();
+          },
+          onNoMostrar: async ()=>{
+            this.config.global = false;
+            this.config.ultimaRespuesta = 'no_mostrar';
+            this.config.fechaUltimoPrompt = Date.now();
+            this.establecerPreferenciasIniciales(false);
+            await this.guardarPreferencias();
+            resolve();
+            this.notificarCambios();
+          }
+        });
+      });
+    }
+
+    establecerPreferenciasIniciales(valor){
+      Object.keys(this.config.preferencias).forEach(clave => {
+        this.config.preferencias[clave] = Boolean(valor);
+      });
+    }
+
+    async solicitarPermisoNavegador(){
+      if(typeof Notification === 'undefined') return;
+      try{
+        if(Notification.permission !== 'granted'){
+          await Notification.requestPermission();
+        }
+      }catch(err){
+        console.warn('No se pudo solicitar el permiso de notificaciones del navegador', err);
+      }
+    }
+
+    async guardarPreferencias(){
+      if(!this.usuario) return;
+      if(typeof db === 'undefined') return;
+      const payload = {
+        notificationSettings: {
+          global: this.config.global,
+          ultimaRespuesta: this.config.ultimaRespuesta,
+          preferencias: this.config.preferencias,
+          historial: this.config.historial,
+          fechaUltimoPrompt: this.config.fechaUltimoPrompt || Date.now()
+        }
+      };
+      try{
+        await db.collection('users').doc(this.usuario.email).set(payload, { merge: true });
+      }catch(err){
+        console.error('Error guardando las preferencias de notificaciones', err);
+      }
+    }
+
+    programarGuardadoHistorial(){
+      if(this.timerHistorial) return;
+      this.timerHistorial = setTimeout(()=>{
+        this.timerHistorial = null;
+        this.guardarHistorial();
+      }, 500);
+    }
+
+    async guardarHistorial(){
+      if(!this.usuario || typeof db === 'undefined') return;
+      try{
+        await db.collection('users').doc(this.usuario.email).set({
+          notificationSettings: { historial: this.config.historial }
+        }, { merge: true });
+      }catch(err){
+        console.error('No se pudo guardar el historial de notificaciones', err);
+      }
+    }
+
+    async actualizarGlobal(valor){
+      this.config.global = Boolean(valor);
+      if(!this.config.global && this.config.ultimaRespuesta !== 'no_mostrar'){
+        this.config.ultimaRespuesta = 'no';
+      }
+      await this.guardarPreferencias();
+      this.notificarCambios();
+      if(this.config.global){
+        await this.solicitarPermisoNavegador();
+      }
+    }
+
+    async actualizarPreferencia(clave, valor){
+      if(!(clave in this.config.preferencias)) return;
+      this.config.preferencias[clave] = Boolean(valor);
+      await this.guardarPreferencias();
+      this.notificarCambios();
+    }
+
+    obtenerGruposUI(role){
+      if(role === 'Superadmin'){
+        return [GRUPOS_NOTIFICACIONES.Colaborador, GRUPOS_NOTIFICACIONES.Jugador, GRUPOS_NOTIFICACIONES.Administrador].filter(Boolean);
+      }
+      if(role === 'Colaborador'){
+        return [GRUPOS_NOTIFICACIONES.Colaborador, GRUPOS_NOTIFICACIONES.Jugador].filter(Boolean);
+      }
+      if(role === 'Administrador'){
+        return [GRUPOS_NOTIFICACIONES.Administrador, GRUPOS_NOTIFICACIONES.Jugador].filter(Boolean);
+      }
+      return [GRUPOS_NOTIFICACIONES.Jugador];
+    }
+
+    iniciarMonitoreos(){
+      if(!this.usuario) return;
+      const roles = new Set();
+      roles.add('Jugador');
+      if(this.rol === 'Colaborador' || this.rol === 'Superadmin') roles.add('Colaborador');
+      if(this.rol === 'Administrador' || this.rol === 'Superadmin') roles.add('Administrador');
+      roles.forEach(role => this.iniciarRol(role));
+    }
+
+    iniciarRol(role){
+      if(this.rolesActivos.has(role)) return;
+      switch(role){
+        case 'Jugador':
+          this.iniciarMonitoreoJugador();
+          break;
+        case 'Colaborador':
+          this.iniciarMonitoreoColaborador();
+          break;
+        case 'Administrador':
+          this.iniciarMonitoreoAdministrador();
+          break;
+      }
+      this.rolesActivos.add(role);
+    }
+
+    iniciarMonitoreoJugador(){
+      if(typeof db === 'undefined') return;
+      try{
+        const unsubSorteos = db.collection('sorteos').onSnapshot(snapshot => {
+          if(!this.inicializaciones.sorteos){
+            snapshot.forEach(doc => this.cache.sorteos.set(doc.id, doc.data() || {}));
+            this.inicializaciones.sorteos = true;
+            return;
+          }
+          snapshot.docChanges().forEach(cambio => {
+            const id = cambio.doc.id;
+            if(cambio.type === 'removed'){
+              this.cache.sorteos.delete(id);
+              return;
+            }
+            const data = cambio.doc.data() || {};
+            const anterior = this.cache.sorteos.get(id);
+            this.cache.sorteos.set(id, data);
+            if(cambio.type === 'added'){
+              this.notificarSorteoNuevo(id, data);
+            }
+            if(cambio.type === 'modified'){
+              if(anterior && anterior.estado !== data.estado && data.estado === 'Jugando'){
+                this.notificarSorteoJugando(id, data);
+              }
+            }
+          });
+        }, err => console.error('Error escuchando sorteos para notificaciones', err));
+        this.desuscriptores.push(unsubSorteos);
+      }catch(err){
+        console.error('No se pudo iniciar el monitoreo de sorteos', err);
+      }
+
+      try{
+        const correo = this.usuario.email;
+        const unsubTrans = db.collection('transacciones')
+          .where('IDbilletera','==', correo)
+          .where('tipotrans','in',['deposito','premio'])
+          .onSnapshot(snapshot => {
+            if(!this.inicializaciones.transJugador){
+              this.inicializaciones.transJugador = true;
+              return;
+            }
+            snapshot.docChanges().forEach(cambio => {
+              const data = cambio.doc.data() || {};
+              const tipo = (data.tipotrans || '').toLowerCase();
+              const estado = (data.estado || '').toUpperCase();
+              if(tipo === 'deposito' && (estado === 'APROBADO' || estado === 'ANULADO')){
+                this.notificarCambioDeposito(cambio.doc.id, data, estado);
+              }
+              if(tipo === 'premio' && estado === 'APROBADO'){
+                this.notificarPremio(cambio.doc.id, data);
+              }
+            });
+          }, err => console.error('Error escuchando transacciones del jugador', err));
+        this.desuscriptores.push(unsubTrans);
+      }catch(err){
+        console.error('No se pudo observar las transacciones del jugador', err);
+      }
+    }
+
+    iniciarMonitoreoColaborador(){
+      if(typeof db === 'undefined') return;
+      try{
+        const unsub = db.collection('transacciones')
+          .where('estado','==','PENDIENTE')
+          .where('tipotrans','in',['deposito','retiro'])
+          .onSnapshot(snapshot => {
+            const depositos = new Set();
+            const retiros = new Set();
+            snapshot.forEach(doc => {
+              const data = doc.data() || {};
+              const tipo = (data.tipotrans || '').toLowerCase();
+              if(tipo === 'deposito') depositos.add(doc.id);
+              if(tipo === 'retiro') retiros.add(doc.id);
+            });
+            this.gestionarPendientes('depositosPendientes', depositos, conteo => `Tienes ${conteo} depósito(s) pendiente(s) por gestionar.`);
+            this.gestionarPendientes('retirosPendientes', retiros, conteo => `Tienes ${conteo} retiro(s) pendiente(s) por gestionar.`);
+          }, err => console.error('Error escuchando transacciones pendientes', err));
+        this.desuscriptores.push(unsub);
+      }catch(err){
+        console.error('No se pudo observar las solicitudes pendientes', err);
+      }
+    }
+
+    iniciarMonitoreoAdministrador(){
+      if(typeof db === 'undefined') return;
+      try{
+        const unsubPremios = db.collection('PremiosSorteos')
+          .where('estado','==','PENDIENTE')
+          .onSnapshot(snapshot => {
+            this.cache.resumenPagos.premios = snapshot.size;
+            this.gestionarPagosPendientes();
+          }, err => console.error('Error escuchando premios pendientes', err));
+        this.desuscriptores.push(unsubPremios);
+      }catch(err){
+        console.error('No se pudieron observar premios pendientes', err);
+      }
+      try{
+        const unsubPagos = db.collection('PagosAdministracion')
+          .where('estado','==','PENDIENTE')
+          .onSnapshot(snapshot => {
+            this.cache.resumenPagos.pagos = snapshot.size;
+            this.gestionarPagosPendientes();
+          }, err => console.error('Error escuchando pagos administrativos pendientes', err));
+        this.desuscriptores.push(unsubPagos);
+      }catch(err){
+        console.error('No se pudieron observar las gestiones de pagos', err);
+      }
+      this.iniciarVerificacionSorteos();
+    }
+
+    iniciarVerificacionSorteos(){
+      if(this.cache.verificadorSorteos){
+        clearInterval(this.cache.verificadorSorteos);
+      }
+      if(typeof initServerTime === 'function'){
+        initServerTime().catch(err => console.error('No se pudo sincronizar la hora del servidor', err));
+      }
+      const revisar = ()=>{
+        if(!this.cache.sorteos.size) return;
+        const ahora = typeof obtenerFechaServidor === 'function' ? obtenerFechaServidor() : new Date();
+        this.cache.sorteos.forEach((data, id) => {
+          const fecha = data.fecha;
+          const hora = data.hora;
+          const cierre = data.horacierre;
+          if(!fecha) return;
+          const momentoCierre = this.combinarFechaHora(fecha, cierre);
+          const momentoInicio = this.combinarFechaHora(fecha, hora);
+          if(momentoCierre && ahora >= momentoCierre && (data.estado === 'Activo' || data.estado === 'Sellado')){
+            this.notificarSellado(id, data);
+          }
+          if(momentoInicio && ahora >= momentoInicio && data.estado !== 'Jugando' && data.estado !== 'Finalizado'){
+            this.notificarJuegoEnVivo(id, data);
+          }
+        });
+      };
+      this.cache.verificadorSorteos = setInterval(revisar, 60000);
+      revisar();
+      this.desuscriptores.push(()=>{
+        clearInterval(this.cache.verificadorSorteos);
+        this.cache.verificadorSorteos = null;
+      });
+    }
+
+    combinarFechaHora(fecha, hora){
+      if(!fecha) return null;
+      const partesFecha = fecha.split('-');
+      if(partesFecha.length < 3) return null;
+      const anio = parseInt(partesFecha[0],10);
+      const mes = parseInt(partesFecha[1],10);
+      const dia = parseInt(partesFecha[2],10);
+      if(!anio || !mes || !dia) return null;
+      let horas = 0;
+      let minutos = 0;
+      if(typeof hora === 'string' && hora.includes(':')){
+        const partes = hora.split(':');
+        horas = parseInt(partes[0],10) || 0;
+        minutos = parseInt(partes[1],10) || 0;
+      }
+      return new Date(anio, mes-1, dia, horas, minutos, 0, 0);
+    }
+
+    puedeNotificar(clave){
+      if(!this.config.global) return false;
+      if(!(clave in this.config.preferencias)) return false;
+      return Boolean(this.config.preferencias[clave]);
+    }
+
+    yaNotificado(clave, id){
+      if(!id) return false;
+      const historial = this.config.historial[clave];
+      if(!historial || !historial.ids) return false;
+      return Boolean(historial.ids[id]);
+    }
+
+    registrarHistorial(clave, id){
+      const historial = this.config.historial[clave];
+      if(!historial) return;
+      if(historial.ids){
+        historial.ids[id] = true;
+      }else if(typeof historial.ultimoEnvio === 'number'){
+        historial.ultimoEnvio = Date.now();
+      }
+      this.programarGuardadoHistorial();
+    }
+
+    verificarIntervalo(clave, esNuevo){
+      const historial = this.config.historial[clave];
+      if(!historial || typeof historial.ultimoEnvio !== 'number') return true;
+      const ahora = Date.now();
+      if(esNuevo){
+        historial.ultimoEnvio = ahora;
+        this.programarGuardadoHistorial();
+        return true;
+      }
+      const ultimo = historial.ultimoEnvio || 0;
+      const intervalo = INTERVALOS_REPETICION[clave] || 600000;
+      if(!ultimo || (ahora - ultimo) >= intervalo){
+        historial.ultimoEnvio = ahora;
+        this.programarGuardadoHistorial();
+        return true;
+      }
+      return false;
+    }
+
+    emitirNotificacion(clave, mensaje, titulo){
+      if(!mensaje) return;
+      const tituloFinal = titulo || 'Bingo Online';
+      let mostrada = false;
+      if(typeof Notification !== 'undefined' && Notification.permission === 'granted'){
+        try{
+          new Notification(tituloFinal, {
+            body: mensaje,
+            icon: 'img/android-chrome-192x192.png',
+            tag: `${clave}-${Date.now()}`
+          });
+          mostrada = true;
+        }catch(err){
+          console.warn('No se pudo mostrar la notificación del navegador', err);
+        }
+      }
+      if(!mostrada){
+        try{ alert(mensaje); }
+        catch(err){ console.warn('No se pudo mostrar alerta de notificación', err); }
+      }
+    }
+
+    notificarRepeticion(clave, mensaje, esNuevo){
+      if(!this.puedeNotificar(clave)) return;
+      if(!this.verificarIntervalo(clave, esNuevo)) return;
+      this.emitirNotificacion(clave, mensaje);
+    }
+
+    configurarTemporizador(clave, mensajeFn){
+      if(this.temporizadores[clave]) return;
+      const intervalo = INTERVALOS_REPETICION[clave] || 600000;
+      this.temporizadores[clave] = setInterval(()=>{
+        if(!this.puedeNotificar(clave)) return;
+        const mensaje = mensajeFn(this.obtenerConteoPendiente(clave));
+        if(!mensaje) return;
+        if(this.verificarIntervalo(clave, false)){
+          this.emitirNotificacion(clave, mensaje);
+        }
+      }, intervalo);
+    }
+
+    detenerTemporizador(clave){
+      if(this.temporizadores[clave]){
+        clearInterval(this.temporizadores[clave]);
+        delete this.temporizadores[clave];
+      }
+    }
+
+    obtenerConteoPendiente(clave){
+      if(clave === 'gestionPagos') return this.cache.pendientes.gestionPagos || 0;
+      const conjunto = this.cache.pendientes[clave];
+      return conjunto ? conjunto.size : 0;
+    }
+
+    gestionarPendientes(clave, nuevos, mensajeFn){
+      const anteriores = this.cache.pendientes[clave] || new Set();
+      const huboNuevo = Array.from(nuevos).some(id => !anteriores.has(id));
+      this.cache.pendientes[clave] = nuevos;
+      const conteo = nuevos.size;
+      if(conteo>0){
+        const mensaje = mensajeFn(conteo);
+        this.notificarRepeticion(clave, mensaje, huboNuevo || !anteriores.size);
+        this.configurarTemporizador(clave, cantidad => mensajeFn(cantidad));
+      }else{
+        this.detenerTemporizador(clave);
+        const historial = this.config.historial[clave];
+        if(historial && typeof historial.ultimoEnvio === 'number'){
+          historial.ultimoEnvio = 0;
+          this.programarGuardadoHistorial();
+        }
+      }
+    }
+
+    gestionarPagosPendientes(){
+      const total = (this.cache.resumenPagos.premios || 0) + (this.cache.resumenPagos.pagos || 0);
+      this.cache.pendientes.gestionPagos = total;
+      if(total>0){
+        const generarMensaje = cantidad => cantidad>0 ? `Existen ${cantidad} gestión(es) de pago pendientes en Centro de Pagos.` : '';
+        const mensaje = generarMensaje(total);
+        const esNuevo = this.config.historial.gestionPagos.ultimoEnvio === 0;
+        this.notificarRepeticion('gestionPagos', mensaje, esNuevo);
+        this.configurarTemporizador('gestionPagos', cantidad => generarMensaje(cantidad));
+      }else{
+        this.detenerTemporizador('gestionPagos');
+        this.config.historial.gestionPagos.ultimoEnvio = 0;
+        this.programarGuardadoHistorial();
+      }
+    }
+
+    notificarSorteoNuevo(id, data){
+      if(!this.puedeNotificar('sorteoNuevo')) return;
+      if(this.yaNotificado('sorteoNuevo', id)) return;
+      const nombre = data.nombre || 'Nuevo sorteo';
+      const mensaje = `Se creó el sorteo "${nombre}".`;
+      this.emitirNotificacion('sorteoNuevo', mensaje, 'Nuevo sorteo disponible');
+      this.registrarHistorial('sorteoNuevo', id);
+    }
+
+    notificarSorteoJugando(id, data){
+      if(!this.puedeNotificar('sorteoJugando')) return;
+      if(this.yaNotificado('sorteoJugando', id)) return;
+      const nombre = data.nombre || 'Un sorteo';
+      const mensaje = `El sorteo "${nombre}" está en vivo.`;
+      this.emitirNotificacion('sorteoJugando', mensaje, 'Sorteo en vivo');
+      this.registrarHistorial('sorteoJugando', id);
+    }
+
+    notificarCambioDeposito(id, data, estado){
+      if(!this.puedeNotificar('estatusDeposito')) return;
+      const clave = `${id}:${estado}`;
+      if(this.yaNotificado('estatusDeposito', clave)) return;
+      const monto = parseFloat(data.Monto || data.MontoSolicitado || 0) || 0;
+      const montoTxt = monto ? monto.toFixed(2) : '';
+      let mensaje = 'Tu solicitud de depósito cambió de estado.';
+      if(estado === 'APROBADO') mensaje = montoTxt ? `Tu depósito de ${montoTxt} fue aprobado.` : 'Tu depósito fue aprobado.';
+      if(estado === 'ANULADO') mensaje = montoTxt ? `Tu depósito de ${montoTxt} fue anulado.` : 'Tu depósito fue anulado.';
+      this.emitirNotificacion('estatusDeposito', mensaje, 'Actualización de depósito');
+      this.registrarHistorial('estatusDeposito', clave);
+    }
+
+    notificarPremio(id, data){
+      if(!this.puedeNotificar('premio')) return;
+      if(this.yaNotificado('premio', id)) return;
+      const monto = parseFloat(data.Monto || 0) || 0;
+      const mensaje = monto ? `Tu premio de ${monto.toFixed(2)} fue acreditado.` : 'Tu premio fue acreditado en tu billetera.';
+      this.emitirNotificacion('premio', mensaje, 'Premio acreditado');
+      this.registrarHistorial('premio', id);
+    }
+
+    notificarSellado(id, data){
+      if(!this.puedeNotificar('selladoSorteo')) return;
+      if(this.yaNotificado('selladoSorteo', id)) return;
+      const nombre = data.nombre || 'Un sorteo';
+      const mensaje = `El sorteo "${nombre}" ya puede ser sellado.`;
+      this.emitirNotificacion('selladoSorteo', mensaje, 'Hora de sellar sorteo');
+      this.registrarHistorial('selladoSorteo', id);
+    }
+
+    notificarJuegoEnVivo(id, data){
+      if(!this.puedeNotificar('juegoEnVivoSorteo')) return;
+      if(this.yaNotificado('juegoEnVivoSorteo', id)) return;
+      const nombre = data.nombre || 'Un sorteo';
+      const mensaje = `El sorteo "${nombre}" puede iniciar.`;
+      this.emitirNotificacion('juegoEnVivoSorteo', mensaje, 'Hora de iniciar sorteo');
+      this.registrarHistorial('juegoEnVivoSorteo', id);
+    }
+  }
+
+  window.notificationCenter = new CentroNotificaciones();
+})();

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -3277,6 +3277,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
   ensureAuth();

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -844,6 +844,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script src="js/estadoSorteos.js"></script>
   <script>

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -276,6 +276,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script type="module">
   import { UPLOAD_ENDPOINT } from './js/config.js';
   ensureAuth('Administrador');

--- a/public/pagoscollab.html
+++ b/public/pagoscollab.html
@@ -438,6 +438,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
     ensureAuth('Colaborador');

--- a/public/parametros.html
+++ b/public/parametros.html
@@ -284,6 +284,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script>
     ensureAuth('Superadmin');
 

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1397,6 +1397,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoeqMV/TJlSKda6FXzoEyYGjTe+vXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-qZvrmS2ekKPF2mSznTQsxqPgnpkI4DNTlrdUmTzrDgektczlKNRRhy5X5AAOnx5S09ydFYWWNSfcEqDTTHgtNA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script>
   ensureAuth('Administrador');
 

--- a/public/pdfsorteo.html
+++ b/public/pdfsorteo.html
@@ -1123,6 +1123,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoeqMV/TJlSKda6FXzoEyYGjTe+vXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-qZvrmS2ekKPF2mSznTQsxqPgnpkI4DNTlrdUmTzrDgektczlKNRRhy5X5AAOnx5S09ydFYWWNSfcEqDTTHgtNA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script>
   ensureAuth('Administrador');
 

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -178,6 +178,128 @@
           cursor:pointer;
           margin-top:10px;
       }
+      .notificaciones-panel{
+          width:100%;
+          margin-top:16px;
+          background:rgba(255,255,255,0.88);
+          border-radius:14px;
+          padding:14px;
+          box-shadow:0 10px 26px rgba(0,0,0,0.18);
+          box-sizing:border-box;
+      }
+      .notificaciones-cabecera{
+          display:flex;
+          align-items:center;
+          justify-content:space-between;
+          gap:12px;
+      }
+      .notificaciones-titulo{
+          font-family:'Bangers',cursive;
+          font-size:1.3rem;
+          color:#0b1b4d;
+          margin:0;
+      }
+      .notificaciones-contenido{
+          margin-top:12px;
+          background:rgba(250,250,250,0.94);
+          border-radius:12px;
+          padding:12px;
+          display:flex;
+          flex-direction:column;
+          gap:14px;
+          box-shadow:inset 0 0 8px rgba(0,0,0,0.08);
+      }
+      .notificaciones-contenido.oculto{
+          display:none;
+      }
+      .notificaciones-descripcion{
+          font-size:0.85rem;
+          color:#333;
+          margin:0;
+          text-align:left;
+      }
+      .notificaciones-lista{
+          display:flex;
+          flex-direction:column;
+          gap:14px;
+      }
+      .notificaciones-grupo{
+          display:flex;
+          flex-direction:column;
+          gap:10px;
+          padding-bottom:6px;
+          border-bottom:1px solid rgba(11,27,77,0.1);
+      }
+      .notificaciones-grupo:last-child{
+          border-bottom:none;
+          padding-bottom:0;
+      }
+      .notificaciones-grupo-titulo{
+          font-weight:600;
+          color:#0b1b4d;
+          margin:0;
+          text-align:left;
+      }
+      .notificacion-item{
+          display:flex;
+          align-items:flex-start;
+          justify-content:space-between;
+          gap:12px;
+      }
+      .notificacion-item h5{
+          margin:0;
+          font-size:1rem;
+          color:#1a237e;
+      }
+      .notificacion-item p{
+          margin:4px 0 0;
+          font-size:0.78rem;
+          color:#444;
+      }
+      .notificacion-info{
+          flex:1;
+          text-align:left;
+      }
+      .switch{
+          position:relative;
+          display:inline-block;
+          width:48px;
+          height:26px;
+      }
+      .switch input{display:none;}
+      .slider{
+          position:absolute;
+          cursor:pointer;
+          inset:0;
+          background:#b0bec5;
+          transition:0.3s;
+          border-radius:26px;
+      }
+      .slider:before{
+          position:absolute;
+          content:"";
+          height:20px;
+          width:20px;
+          left:3px;
+          bottom:3px;
+          background-color:white;
+          transition:0.3s;
+          border-radius:50%;
+          box-shadow:0 2px 6px rgba(0,0,0,0.25);
+      }
+      .switch input:checked + .slider{
+          background:#0a8800;
+      }
+      .switch input:checked + .slider:before{
+          transform:translateX(22px);
+      }
+      .switch input:disabled + .slider{
+          background:#cfd8dc;
+          cursor:not-allowed;
+      }
+      .switch input:disabled + .slider:before{
+          box-shadow:none;
+      }
       #fecha-hora, #derechos { font-size:0.7rem; text-align:center; color:#000; margin:0; }
       #fecha-hora { margin-top:auto; padding-top:12px; }
       #derechos { font-size:0.6rem; padding-bottom:12px; }
@@ -277,6 +399,19 @@
     <div id="perfil-mensaje" class="mensaje-validacion" role="alert" aria-live="polite"></div>
     <button id="guardar-perfil-btn" class="menu-btn" data-modo="guardar">Guardar</button>
     <button id="jugar-carton-btn" class="menu-btn" onclick="window.location.href='jugarcartones.html'">Jugar Cartón</button>
+    <section id="notificaciones-panel" class="notificaciones-panel">
+      <div class="notificaciones-cabecera">
+        <h4 class="notificaciones-titulo">Notificaciones</h4>
+        <label class="switch" aria-label="Activar notificaciones">
+          <input type="checkbox" id="notificaciones-global">
+          <span class="slider"></span>
+        </label>
+      </div>
+      <div id="notificaciones-contenido" class="notificaciones-contenido oculto" aria-hidden="true">
+        <p id="notificaciones-descripcion" class="notificaciones-descripcion">Activa el interruptor para gestionar tus notificaciones.</p>
+        <div id="notificaciones-lista" class="notificaciones-lista"></div>
+      </div>
+    </section>
   </main>
 
   <div id="modal-whatsapp" class="modal-whatsapp" role="dialog" aria-modal="true" aria-labelledby="modal-whatsapp-titulo" aria-hidden="true">
@@ -296,6 +431,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
   initFechaHora('fecha-hora');
@@ -309,6 +445,12 @@
   const whatsappModalMensajeEl=document.getElementById('modal-whatsapp-mensaje');
   const whatsappModalAceptarBtn=document.getElementById('modal-whatsapp-aceptar');
   const mensajeValidacionEl=document.getElementById('perfil-mensaje');
+  const notificacionesPanel=document.getElementById('notificaciones-panel');
+  const notificacionesGlobalInput=document.getElementById('notificaciones-global');
+  const notificacionesContenido=document.getElementById('notificaciones-contenido');
+  const notificacionesDescripcion=document.getElementById('notificaciones-descripcion');
+  const notificacionesLista=document.getElementById('notificaciones-lista');
+  let desuscribirNotificaciones=null;
 
   nombreInput.placeholder='Nombre';
   apellidoInput.placeholder='Apellido';
@@ -321,6 +463,151 @@
   let tieneDatosGuardados=false;
 
   const camposObligatorios=[nombreInput,apellidoInput,aliasInput,celularInput].filter(Boolean);
+
+  if(notificacionesGlobalInput){
+    notificacionesGlobalInput.addEventListener('change',async()=>{
+      if(!window.notificationCenter){
+        notificacionesGlobalInput.checked=false;
+        return;
+      }
+      const activo=notificacionesGlobalInput.checked;
+      notificacionesGlobalInput.disabled=true;
+      try{
+        await window.notificationCenter.actualizarGlobal(activo);
+      }catch(err){
+        console.error('No se pudo actualizar la preferencia global de notificaciones',err);
+        notificacionesGlobalInput.checked=!activo;
+      }finally{
+        notificacionesGlobalInput.disabled=false;
+      }
+    });
+  }
+
+  if(typeof hasWindow==='function' && hasWindow() && typeof window.addEventListener==='function'){
+    window.addEventListener('beforeunload',()=>{
+      if(desuscribirNotificaciones){
+        try{ desuscribirNotificaciones(); }
+        catch(err){ console.error('No se pudo cancelar la suscripción de notificaciones al salir',err); }
+        desuscribirNotificaciones=null;
+      }
+    });
+  }
+
+  function renderizarOpcionesNotificaciones(config,grupos){
+    if(!notificacionesLista) return;
+    notificacionesLista.innerHTML='';
+    if(!Array.isArray(grupos) || !grupos.length){
+      return;
+    }
+    grupos.forEach(grupo=>{
+      if(!grupo || !Array.isArray(grupo.items) || !grupo.items.length) return;
+      const grupoEl=document.createElement('div');
+      grupoEl.className='notificaciones-grupo';
+      if(grupo.etiqueta){
+        const titulo=document.createElement('h5');
+        titulo.className='notificaciones-grupo-titulo';
+        titulo.textContent=grupo.etiqueta;
+        grupoEl.appendChild(titulo);
+      }
+      grupo.items.forEach(item=>{
+        const itemEl=document.createElement('div');
+        itemEl.className='notificacion-item';
+        const infoEl=document.createElement('div');
+        infoEl.className='notificacion-info';
+        const titulo=document.createElement('h5');
+        titulo.textContent=item.titulo;
+        const descripcion=document.createElement('p');
+        descripcion.textContent=item.descripcion||'';
+        infoEl.appendChild(titulo);
+        infoEl.appendChild(descripcion);
+        const control=document.createElement('label');
+        control.className='switch';
+        control.setAttribute('aria-label',item.titulo);
+        const input=document.createElement('input');
+        input.type='checkbox';
+        input.dataset.clave=item.clave;
+        const estadoPreferencia=config && config.preferencias ? config.preferencias[item.clave] : false;
+        input.checked=Boolean(estadoPreferencia);
+        input.disabled=!(config && config.global);
+        input.addEventListener('change',async()=>{
+          if(!window.notificationCenter) return;
+          const valor=input.checked;
+          input.disabled=true;
+          try{
+            await window.notificationCenter.actualizarPreferencia(item.clave,valor);
+          }catch(err){
+            console.error('No se pudo actualizar la preferencia de notificación',err);
+            input.checked=!valor;
+          }finally{
+            input.disabled=false;
+          }
+        });
+        const slider=document.createElement('span');
+        slider.className='slider';
+        control.appendChild(input);
+        control.appendChild(slider);
+        itemEl.appendChild(infoEl);
+        itemEl.appendChild(control);
+        grupoEl.appendChild(itemEl);
+      });
+      notificacionesLista.appendChild(grupoEl);
+    });
+  }
+
+  function actualizarPanelNotificaciones(config,grupos){
+    if(!notificacionesPanel) return;
+    if(!config){
+      notificacionesPanel.style.display='none';
+      return;
+    }
+    if(!Array.isArray(grupos) || !grupos.length){
+      notificacionesPanel.style.display='none';
+      return;
+    }
+    notificacionesPanel.style.display='block';
+    const globalActivo=Boolean(config.global);
+    if(notificacionesGlobalInput){
+      notificacionesGlobalInput.checked=globalActivo;
+    }
+    if(notificacionesContenido){
+      notificacionesContenido.classList.toggle('oculto',!globalActivo);
+      notificacionesContenido.setAttribute('aria-hidden',globalActivo?'false':'true');
+    }
+    if(notificacionesDescripcion){
+      notificacionesDescripcion.textContent=globalActivo?
+        'Configura las notificaciones disponibles para tu perfil.':
+        'Activa el interruptor para gestionar tus notificaciones.';
+    }
+    renderizarOpcionesNotificaciones(config,grupos);
+  }
+
+  async function inicializarNotificacionesPerfil(role){
+    if(!notificacionesPanel) return;
+    if(!window.notificationCenter){
+      notificacionesPanel.style.display='none';
+      return;
+    }
+    notificacionesPanel.style.display='block';
+    const grupos=window.notificationCenter.obtenerGruposUI(role||'Jugador');
+    if(!Array.isArray(grupos) || !grupos.length){
+      notificacionesPanel.style.display='none';
+      return;
+    }
+    try{
+      await window.notificationCenter.cuandoListo();
+    }catch(err){
+      console.error('No se pudo preparar la sección de notificaciones',err);
+    }
+    const configuracion=window.notificationCenter.obtenerConfiguracion();
+    actualizarPanelNotificaciones(configuracion,grupos);
+    if(desuscribirNotificaciones){
+      try{ desuscribirNotificaciones(); }catch(e){ console.error('No se pudo cancelar la suscripción de notificaciones',e); }
+      desuscribirNotificaciones=null;
+    }
+    desuscribirNotificaciones=window.notificationCenter.onChange(cfg=>{
+      actualizarPanelNotificaciones(cfg,grupos);
+    });
+  }
 
   function normalizarAlias(valor){
     return (valor||'').toString().trim().slice(0,20);
@@ -577,10 +864,12 @@
       ensureAuth();
       auth.onAuthStateChanged(async user=>{
         if(user){
+          let datosPerfil=null;
           try{
             const doc=await db.collection('users').doc(user.email).get();
             if(doc.exists){
               const d=doc.data()||{};
+              datosPerfil=d;
               valoresOriginales={
                 name:(d.name||'').toString().trim(),
                 apellido:(d.apellido||'').toString().trim(),
@@ -609,9 +898,18 @@
             console.error('No se pudo cargar la información del perfil',error);
             mostrarMensajeValidacion('No se pudieron cargar los datos del perfil. Intenta nuevamente.');
           }
+          const rolNotificaciones=(datosPerfil && (datosPerfil.role||datosPerfil.rol||datosPerfil.rolinterno))||window.currentRole||'Jugador';
+          inicializarNotificacionesPerfil(rolNotificaciones);
           actualizarEstadoCamposObligatorios();
           evaluarCambios();
-        } else { window.location.href='index.html'; }
+        } else {
+          if(desuscribirNotificaciones){
+            try{ desuscribirNotificaciones(); }
+            catch(err){ console.error('No se pudo limpiar la suscripción de notificaciones',err); }
+            desuscribirNotificaciones=null;
+          }
+          window.location.href='index.html';
+        }
       });
     })
     .catch(error=>{

--- a/public/player.html
+++ b/public/player.html
@@ -663,6 +663,7 @@
   </div>
 
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
 <script>
 (function(){

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -106,6 +106,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
     (async()=>{

--- a/public/sorteosellado.html
+++ b/public/sorteosellado.html
@@ -52,6 +52,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script>
   ensureAuth();
   async function cargar(){

--- a/public/super.html
+++ b/public/super.html
@@ -217,6 +217,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script>
   ensureAuth('Superadmin');
   const mainMenu=document.getElementById('main-menu');

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -170,6 +170,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
     let transRef = null;


### PR DESCRIPTION
## Summary
- crear un centro de notificaciones que maneja permisos, historial y disparo de alertas por rol
- añadir controles en perfil para activar/desactivar notificaciones globales y específicas del usuario
- cargar el módulo en todas las vistas para habilitar recordatorios automáticos sobre sorteos, transacciones y gestiones pendientes

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c4a19c948326b15431e8f91fa6ee)