### PR TITLE
Solicitar permisos de notificaciones al ingresar

### DIFF
--- a/initUsers.js
+++ b/initUsers.js
@@ -21,6 +21,7 @@ async function createUser(email, role) {
       email,
       alias: email.split('@')[0],
       role,
+      aceptoNotificaciones: 'NO',
     });
     console.log(`Created user ${email} with role ${role}`);
   } else {

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -270,7 +270,7 @@ async function getUserRole(user, options = {}){
     const role = persistentRole || 'Jugador';
     let recordExists = false;
     if(role !== 'Jugador' && (createIfMissing || autoCreateRoles.includes(role))){
-      const baseData = { email: user.email, role };
+      const baseData = { email: user.email, role, aceptoNotificaciones: 'NO' };
       if(user.photoURL){
         baseData.photoURL = user.photoURL;
       }

--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -146,6 +146,8 @@
     document.body.appendChild(overlay);
   }
 
+  const CAMPO_CONSENTIMIENTO = 'aceptoNotificaciones';
+
   class CentroNotificaciones {
     constructor(){
       this.usuario = null;
@@ -155,7 +157,8 @@
         ultimaRespuesta: '',
         preferencias: {},
         historial: historialVacio(),
-        fechaUltimoPrompt: null
+        fechaUltimoPrompt: null,
+        consentimiento: 'NO'
       };
       this.listeners = new Set();
       this.desuscriptores = [];
@@ -227,7 +230,7 @@
         }
         const doc = await db.collection('users').doc(user.email).get();
         const data = doc.exists ? (doc.data() || {}) : {};
-        await this.cargarConfiguracion(data.notificationSettings || {});
+        await this.cargarConfiguracion(data);
         await this.verificarSolicitudInicial();
         this.iniciarMonitoreos();
       }catch(err){
@@ -247,7 +250,8 @@
         ultimaRespuesta: '',
         preferencias: {},
         historial: historialVacio(),
-        fechaUltimoPrompt: null
+        fechaUltimoPrompt: null,
+        consentimiento: 'NO'
       };
       this.cancelarMonitoreos();
       this.rolesActivos.clear();
@@ -282,7 +286,8 @@
       }
     }
 
-    async cargarConfiguracion(raw){
+    async cargarConfiguracion(rawUsuario){
+      const raw = rawUsuario && rawUsuario.notificationSettings ? rawUsuario.notificationSettings : {};
       const claves = clavesPorRol(this.rol);
       const preferencias = {};
       const origenPreferencias = raw.preferencias || {};
@@ -300,7 +305,8 @@
         ultimaRespuesta: raw.ultimaRespuesta || raw.lastChoice || '',
         preferencias,
         historial: historialVacio(),
-        fechaUltimoPrompt: raw.fechaUltimoPrompt || raw.lastPromptAt || null
+        fechaUltimoPrompt: raw.fechaUltimoPrompt || raw.lastPromptAt || null,
+        consentimiento: 'NO'
       };
       const origenHistorial = raw.historial || raw.history || {};
       Object.keys(this.config.historial).forEach(clave => {
@@ -308,6 +314,17 @@
           this.config.historial[clave] = { ...this.config.historial[clave], ...origenHistorial[clave] };
         }
       });
+      const consentimientoRaw = rawUsuario && typeof rawUsuario[CAMPO_CONSENTIMIENTO] === 'string'
+        ? rawUsuario[CAMPO_CONSENTIMIENTO].toUpperCase()
+        : null;
+      if(consentimientoRaw === 'SI'){
+        this.config.consentimiento = 'SI';
+      }else{
+        this.config.consentimiento = 'NO';
+        if(!consentimientoRaw){
+          requiereGuardado = true;
+        }
+      }
       if(requiereGuardado){
         await this.guardarPreferencias();
       }
@@ -315,28 +332,46 @@
 
     async verificarSolicitudInicial(){
       if(!this.usuario) return;
-      if(!hasWindow()) return;
-      if(this.config.global) return;
+      const hayVentana = typeof hasWindow === 'function' ? hasWindow() : (typeof window !== 'undefined');
+      if(!hayVentana) return;
+      if(this.config.global || this.config.consentimiento === 'SI'){
+        if(this.config.global){
+          const resultadoPermiso = await this.solicitarPermisoNavegador();
+          if(resultadoPermiso !== 'granted'){
+            this.config.global = false;
+            this.config.consentimiento = 'NO';
+            if(this.config.ultimaRespuesta !== 'no_mostrar'){
+              this.config.ultimaRespuesta = 'no';
+            }
+            this.establecerPreferenciasIniciales(false);
+            this.config.fechaUltimoPrompt = Date.now();
+            await this.guardarPreferencias();
+            this.notificarCambios();
+          }
+        }
+        return;
+      }
       if(this.config.ultimaRespuesta === 'no_mostrar') return;
       await new Promise(resolve => {
         crearModalPermiso({
           titulo: '¿Deseas recibir notificaciones?',
           mensaje: 'Activa las notificaciones para estar informado en tiempo real.',
           onSi: async ()=>{
-            this.config.global = true;
-            this.config.ultimaRespuesta = 'si';
             this.config.fechaUltimoPrompt = Date.now();
-            this.establecerPreferenciasIniciales(true);
-            await this.guardarPreferencias();
-            await this.solicitarPermisoNavegador();
+            const resultado = await this.actualizarGlobal(true);
+            if(resultado !== 'granted'){
+              this.config.ultimaRespuesta = 'no';
+            }else{
+              this.config.ultimaRespuesta = 'si';
+            }
             resolve();
-            this.notificarCambios();
           },
           onNo: async ()=>{
             this.config.global = false;
             this.config.ultimaRespuesta = 'no';
             this.config.fechaUltimoPrompt = Date.now();
             this.establecerPreferenciasIniciales(false);
+            this.config.consentimiento = 'NO';
             await this.guardarPreferencias();
             resolve();
             this.notificarCambios();
@@ -346,6 +381,7 @@
             this.config.ultimaRespuesta = 'no_mostrar';
             this.config.fechaUltimoPrompt = Date.now();
             this.establecerPreferenciasIniciales(false);
+            this.config.consentimiento = 'NO';
             await this.guardarPreferencias();
             resolve();
             this.notificarCambios();
@@ -361,13 +397,15 @@
     }
 
     async solicitarPermisoNavegador(){
-      if(typeof Notification === 'undefined') return;
+      if(typeof Notification === 'undefined') return 'unsupported';
       try{
-        if(Notification.permission !== 'granted'){
-          await Notification.requestPermission();
-        }
+        if(Notification.permission === 'granted') return 'granted';
+        if(Notification.permission === 'denied') return 'denied';
+        const resultado = await Notification.requestPermission();
+        return resultado;
       }catch(err){
         console.warn('No se pudo solicitar el permiso de notificaciones del navegador', err);
+        return 'error';
       }
     }
 
@@ -381,7 +419,8 @@
           preferencias: this.config.preferencias,
           historial: this.config.historial,
           fechaUltimoPrompt: this.config.fechaUltimoPrompt || Date.now()
-        }
+        },
+        [CAMPO_CONSENTIMIENTO]: this.config.consentimiento === 'SI' ? 'SI' : 'NO'
       };
       try{
         await db.collection('users').doc(this.usuario.email).set(payload, { merge: true });
@@ -410,15 +449,47 @@
     }
 
     async actualizarGlobal(valor){
-      this.config.global = Boolean(valor);
-      if(!this.config.global && this.config.ultimaRespuesta !== 'no_mostrar'){
+      const activar = Boolean(valor);
+      if(activar){
+        const resultado = await this.solicitarPermisoNavegador();
+        if(resultado === 'granted'){
+          this.config.global = true;
+          this.config.consentimiento = 'SI';
+          this.config.ultimaRespuesta = 'si';
+          this.establecerPreferenciasIniciales(true);
+        }else{
+          this.config.global = false;
+          this.config.consentimiento = 'NO';
+          if(this.config.ultimaRespuesta !== 'no_mostrar'){
+            this.config.ultimaRespuesta = 'no';
+          }
+          this.establecerPreferenciasIniciales(false);
+          const puedeAlertar = (typeof hasWindow === 'function' ? hasWindow() : (typeof window !== 'undefined')) && typeof alert === 'function';
+          if(puedeAlertar){
+            if(resultado === 'denied'){
+              alert('No fue posible habilitar las notificaciones porque el permiso fue denegado en el navegador.');
+            }else if(resultado === 'unsupported'){
+              alert('Tu navegador no soporta notificaciones push.');
+            }else if(resultado === 'error'){
+              alert('Ocurrió un problema al solicitar el permiso de notificaciones.');
+            }
+          }
+        }
+        this.config.fechaUltimoPrompt = Date.now();
+        await this.guardarPreferencias();
+        this.notificarCambios();
+        return resultado;
+      }
+      this.config.global = false;
+      this.config.consentimiento = 'NO';
+      if(this.config.ultimaRespuesta !== 'no_mostrar'){
         this.config.ultimaRespuesta = 'no';
       }
+      this.establecerPreferenciasIniciales(false);
+      this.config.fechaUltimoPrompt = Date.now();
       await this.guardarPreferencias();
       this.notificarCambios();
-      if(this.config.global){
-        await this.solicitarPermisoNavegador();
-      }
+      return 'desactivado';
     }
 
     async actualizarPreferencia(clave, valor){

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -451,6 +451,7 @@
   const notificacionesDescripcion=document.getElementById('notificaciones-descripcion');
   const notificacionesLista=document.getElementById('notificaciones-lista');
   let desuscribirNotificaciones=null;
+  let gruposNotificacionesDisponibles=[];
 
   nombreInput.placeholder='Nombre';
   apellidoInput.placeholder='Apellido';
@@ -473,7 +474,12 @@
       const activo=notificacionesGlobalInput.checked;
       notificacionesGlobalInput.disabled=true;
       try{
-        await window.notificationCenter.actualizarGlobal(activo);
+        const resultado=await window.notificationCenter.actualizarGlobal(activo);
+        const configuracion=window.notificationCenter.obtenerConfiguracion();
+        actualizarPanelNotificaciones(configuracion,gruposNotificacionesDisponibles);
+        if(activo && resultado!=='granted'){
+          notificacionesGlobalInput.checked=configuracion.global;
+        }
       }catch(err){
         console.error('No se pudo actualizar la preferencia global de notificaciones',err);
         notificacionesGlobalInput.checked=!activo;
@@ -589,6 +595,7 @@
     }
     notificacionesPanel.style.display='block';
     const grupos=window.notificationCenter.obtenerGruposUI(role||'Jugador');
+    gruposNotificacionesDisponibles=Array.isArray(grupos)?grupos.slice():[];
     if(!Array.isArray(grupos) || !grupos.length){
       notificacionesPanel.style.display='none';
       return;
@@ -599,13 +606,13 @@
       console.error('No se pudo preparar la sección de notificaciones',err);
     }
     const configuracion=window.notificationCenter.obtenerConfiguracion();
-    actualizarPanelNotificaciones(configuracion,grupos);
+    actualizarPanelNotificaciones(configuracion,gruposNotificacionesDisponibles);
     if(desuscribirNotificaciones){
       try{ desuscribirNotificaciones(); }catch(e){ console.error('No se pudo cancelar la suscripción de notificaciones',e); }
       desuscribirNotificaciones=null;
     }
     desuscribirNotificaciones=window.notificationCenter.onChange(cfg=>{
-      actualizarPanelNotificaciones(cfg,grupos);
+      actualizarPanelNotificaciones(cfg,gruposNotificacionesDisponibles);
     });
   }
 

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -172,7 +172,8 @@
         numerocel:celular,
         email:user.email,
         photoURL:user.photoURL,
-        role:'Jugador'
+        role:'Jugador',
+        aceptoNotificaciones:'NO'
       });
       window.location.href='player.html';
     });


### PR DESCRIPTION
## Summary
- Registrar usuarios con el campo `aceptoNotificaciones` en "NO" y actualizarlo automáticamente al sincronizar preferencias.
- Ajustar el centro de notificaciones para solicitar permisos del navegador al iniciar, persistiendo el consentimiento global y forzando la desactivación si el navegador los rechaza.
- Actualizar perfil.html para que el panel de notificaciones muestre los interruptores por rol cuando el switch global se activa o falla la solicitud.

## Testing
- no tests were run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910cd396c948326a4261aac185e5688)