### PR TITLE
Fix notification preferences rendering on profile page

### DIFF
--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -184,10 +184,15 @@
       this.resetReady();
     }
 
-    resetReady(){
-      this.readyPromise = new Promise(resolve => {
-        this.readyResolver = resolve;
-      });
+    resetReady(pendiente = false){
+      if(pendiente){
+        this.readyPromise = new Promise(resolve => {
+          this.readyResolver = resolve;
+        });
+      }else{
+        this.readyPromise = Promise.resolve();
+        this.readyResolver = ()=>{};
+      }
     }
 
     cuandoListo(){
@@ -221,7 +226,7 @@
       const mismo = this.usuario && this.usuario.email === user.email && this.rol === role;
       if(mismo) return this.cuandoListo();
       this.desvincularUsuario();
-      this.resetReady();
+      this.resetReady(true);
       this.usuario = user;
       this.rol = role;
       try{


### PR DESCRIPTION
## Summary
- ensure the notification center readiness promise resolves when no user is linked yet
- only create a pending readiness promise while vinculating a user so the profile UI can render the notification preferences immediately

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911ede466ac8326b90510c230f8870c)