### PR TITLE
Reorganizar switches de notificaciones en perfil

### DIFF
--- a/public/perfil.html
+++ b/public/perfil.html
@@ -186,24 +186,26 @@
           padding:14px;
           box-shadow:0 10px 26px rgba(0,0,0,0.18);
           box-sizing:border-box;
-          display:flex;
-          flex-direction:column;
-          gap:12px;
-      }
-      .notificaciones-encabezado{
-          display:flex;
+          display:grid;
+          grid-template-columns:minmax(0,1fr) auto;
+          column-gap:12px;
+          row-gap:12px;
           align-items:center;
-          justify-content:space-between;
-          gap:12px;
-          text-align:left;
       }
-      .notificaciones-titulo-texto{
-          font-family:'Bangers',cursive;
-          font-size:1.3rem;
-          color:#0b1b4d;
-          margin:0;
-          cursor:pointer;
+      .notificaciones-panel > label.switch{
+          justify-self:end;
       }
+      .notificaciones-panel > .notificaciones-global-descripcion,
+      .notificaciones-panel > .notificaciones-preferencias{
+          grid-column:1 / -1;
+      }
+        .notificaciones-titulo-texto{
+            font-family:'Bangers',cursive;
+            font-size:1.3rem;
+            color:#0b1b4d;
+            margin:0;
+            cursor:pointer;
+        }
       .notificaciones-global-descripcion{
           font-family:Calibri, Arial, sans-serif;
           font-size:0.85rem;
@@ -219,9 +221,14 @@
           outline-offset:2px;
       }
       .notificaciones-preferencias{
-          display:flex;
-          flex-direction:column;
-          gap:12px;
+          display:grid;
+          grid-template-columns:minmax(0,1fr) auto;
+          column-gap:12px;
+          row-gap:12px;
+          align-items:center;
+      }
+      #notificaciones-preferencias > label.switch{
+          justify-self:end;
       }
       .notificaciones-preferencias.deshabilitado .notificaciones-opcion:not(.notificaciones-opcion-todo),
       .notificaciones-preferencias.deshabilitado .notificaciones-grupo-titulo{
@@ -232,39 +239,28 @@
       }
       .notificaciones-opcion{
           display:flex;
-          align-items:center;
-          justify-content:space-between;
-          gap:12px;
+          flex-direction:column;
+          gap:4px;
           padding:10px 12px;
           border-radius:12px;
           background:rgba(250,250,250,0.94);
           box-shadow:inset 0 0 8px rgba(0,0,0,0.08);
           font-family:Calibri, Arial, sans-serif;
-          cursor:pointer;
-      }
-      .notificaciones-opcion-texto{
           font-weight:600;
           color:#0b1b4d;
           font-size:0.95rem;
           text-align:left;
-          flex:1;
-          display:flex;
-          flex-direction:column;
-          gap:4px;
           cursor:pointer;
       }
       .notificaciones-opcion-titulo{
           display:block;
       }
-      .notificaciones-opcion-texto small{
+      .notificaciones-opcion small{
           display:block;
           font-weight:400;
           font-size:0.78rem;
           color:#444;
           margin-top:4px;
-      }
-      .notificaciones-opcion .switch{
-          flex-shrink:0;
       }
       .notificaciones-grupo-titulo{
           margin:2px 4px 0;
@@ -273,6 +269,7 @@
           text-align:left;
           font-family:Calibri, Arial, sans-serif;
           font-size:0.9rem;
+          grid-column:1 / -1;
       }
       .switch{
           position:relative;
@@ -414,24 +411,20 @@
     <button id="guardar-perfil-btn" class="menu-btn" data-modo="guardar">Guardar</button>
     <button id="jugar-carton-btn" class="menu-btn" onclick="window.location.href='jugarcartones.html'">Jugar Cartón</button>
     <section id="notificaciones-panel" class="notificaciones-panel" aria-labelledby="notificaciones-titulo">
-      <div class="notificaciones-encabezado">
-        <span id="notificaciones-titulo" class="notificaciones-titulo-texto">Notificaciones</span>
-        <label class="switch" aria-labelledby="notificaciones-titulo">
-          <input type="checkbox" id="notificaciones-global">
-          <span class="slider"></span>
-        </label>
-      </div>
+      <span id="notificaciones-titulo" class="notificaciones-titulo-texto" data-switch="notificaciones-global">Notificaciones</span>
+      <label class="switch" aria-labelledby="notificaciones-titulo">
+        <input type="checkbox" id="notificaciones-global">
+        <span class="slider"></span>
+      </label>
       <p class="notificaciones-global-descripcion">Activa la recepción general para gestionar tus alertas.</p>
       <div id="notificaciones-preferencias" class="notificaciones-preferencias" aria-disabled="true">
-        <div class="notificaciones-opcion notificaciones-opcion-todo">
-          <div class="notificaciones-opcion-texto">
-            <span class="notificaciones-opcion-titulo">Notificarme de todo</span>
-          </div>
-          <label class="switch" aria-label="Notificarme de todo">
-            <input type="checkbox" id="notificaciones-todo">
-            <span class="slider"></span>
-          </label>
-        </div>
+        <span class="notificaciones-opcion notificaciones-opcion-todo" data-switch="notificaciones-todo">
+          <span class="notificaciones-opcion-titulo">Notificarme de todo</span>
+        </span>
+        <label class="switch" aria-label="Notificarme de todo">
+          <input type="checkbox" id="notificaciones-todo">
+          <span class="slider"></span>
+        </label>
       </div>
     </section>
   </main>
@@ -517,7 +510,11 @@
       }
     });
   }
-  configurarContenedorNotificaciones(notificacionesPreferencias ? notificacionesPreferencias.querySelector('.notificaciones-opcion') : null);
+  if(notificacionesPreferencias){
+    const opcionBase=notificacionesPreferencias.querySelector('.notificaciones-opcion');
+    const inputBase=opcionBase ? buscarSwitchAsociado(opcionBase) : null;
+    configurarContenedorNotificaciones(opcionBase,inputBase);
+  }
   let desuscribirNotificaciones=null;
   let gruposNotificacionesDisponibles=[];
   let notificacionesGlobalInicializado=false;
@@ -540,7 +537,7 @@
       actualizarEstadoPreferencias();
       if(notificacionesPreferencias){
         const habilitado=notificacionesGlobalInput.checked;
-        const dinamicos=notificacionesPreferencias.querySelectorAll('.notificaciones-opcion[data-clave] input[type="checkbox"]');
+        const dinamicos=notificacionesPreferencias.querySelectorAll('label[data-switch-clave] input[type="checkbox"]');
         dinamicos.forEach(input=>{ input.disabled=!habilitado; });
         if(notificacionesTodoInput){
           const clavesDisponibles=notificacionesPreferencias.querySelectorAll('.notificaciones-opcion[data-clave]').length;
@@ -659,15 +656,44 @@
     return id;
   }
 
-  function configurarContenedorNotificaciones(contenedor){
+  function buscarSwitchAsociado(contenedor){
+    if(!contenedor) return null;
+    const identificador=contenedor.dataset ? contenedor.dataset.switch : null;
+    if(identificador){
+      const directo=document.getElementById(identificador);
+      if(directo && directo.type==='checkbox'){
+        return directo;
+      }
+    }
+    const interno=contenedor.querySelector ? contenedor.querySelector('input[type="checkbox"]') : null;
+    if(interno){
+      return interno;
+    }
+    const siguiente=contenedor.nextElementSibling;
+    if(siguiente && siguiente.matches('label.switch')){
+      const enLabel=siguiente.querySelector('input[type="checkbox"]');
+      if(enLabel){
+        return enLabel;
+      }
+    }
+    return null;
+  }
+
+  function configurarContenedorNotificaciones(contenedor,inputAsociado){
     if(!contenedor) return;
-    const input=contenedor.querySelector('input[type="checkbox"]');
+    const input= inputAsociado && inputAsociado.type==='checkbox' ? inputAsociado : buscarSwitchAsociado(contenedor);
     if(!input) return;
+    if(input.id && (!contenedor.dataset || !contenedor.dataset.switch)){
+      contenedor.dataset.switch=input.id;
+    }
     if(!contenedor.hasAttribute('tabindex')){
       contenedor.tabIndex=0;
     }
     if(!contenedor.hasAttribute('role')){
       contenedor.setAttribute('role','button');
+    }
+    if(input.id){
+      contenedor.setAttribute('aria-controls',input.id);
     }
     const actualizarAria=()=>{
       contenedor.setAttribute('aria-pressed',input.checked?'true':'false');
@@ -696,7 +722,7 @@
 
   function limpiarOpcionesNotificaciones(){
     if(!notificacionesPreferencias) return;
-    notificacionesPreferencias.querySelectorAll('.notificaciones-opcion[data-clave], .notificaciones-grupo-titulo').forEach(elemento=>{
+    notificacionesPreferencias.querySelectorAll('.notificaciones-opcion[data-clave], label.switch[data-switch-clave], .notificaciones-grupo-titulo').forEach(elemento=>{
       elemento.remove();
     });
   }
@@ -719,23 +745,23 @@
       }
       grupo.items.forEach(item=>{
         if(!item || !item.clave) return;
-        const opcion=document.createElement('div');
+        const opcion=document.createElement('span');
         opcion.className='notificaciones-opcion';
         opcion.dataset.clave=item.clave;
         const inputId=generarIdSwitch(item.clave);
-        const texto=document.createElement('div');
-        texto.className='notificaciones-opcion-texto';
+        opcion.dataset.switch=inputId;
         const titulo=document.createElement('span');
         titulo.className='notificaciones-opcion-titulo';
         titulo.textContent=item.titulo||item.clave;
-        texto.appendChild(titulo);
+        opcion.appendChild(titulo);
         if(item.descripcion){
           const descripcion=document.createElement('small');
           descripcion.textContent=item.descripcion;
-          texto.appendChild(descripcion);
+          opcion.appendChild(descripcion);
         }
         const control=document.createElement('label');
         control.className='switch';
+        control.dataset.switchClave=item.clave;
         control.setAttribute('aria-label',item.titulo||item.clave);
         control.setAttribute('for',inputId);
         const input=document.createElement('input');
@@ -763,10 +789,9 @@
         slider.className='slider';
         control.appendChild(input);
         control.appendChild(slider);
-        opcion.appendChild(texto);
-        opcion.appendChild(control);
-        configurarContenedorNotificaciones(opcion);
+        configurarContenedorNotificaciones(opcion,input);
         fragmento.appendChild(opcion);
+        fragmento.appendChild(control);
       });
     });
     notificacionesPreferencias.appendChild(fragmento);


### PR DESCRIPTION
## Summary
- reorganize la sección de notificaciones para que los switches y sus etiquetas no estén contenidos en envoltorios anidados
- actualicé los estilos para alinear el diseño con la nueva estructura plana de la cuadrícula
- ajusté la lógica de renderizado y los controladores para enlazar los textos con los interruptores correspondientes

## Testing
- No se realizaron pruebas automatizadas (cambios en HTML/CSS/JS sin suite definida)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f988f43483268303a2aea4f1836a)