### PR TITLE
Add notification configuration access for admin and collaborator roles

### DIFF
--- a/public/collab.html
+++ b/public/collab.html
@@ -72,13 +72,18 @@
       top: 10px;
       right: 10px;
       display: flex;
-      align-items: center;
+      flex-direction: column;
+      align-items: flex-end;
       font-size: 0.7rem;
+    }
+    #user-line{
+      display:flex;
+      align-items:center;
     }
     #user-data {
       display: flex;
       flex-direction: column;
-      align-items: flex-end;
+      align-items: flex-start;
       margin-right: 5px;
     }
     #user-name, #user-email {
@@ -97,6 +102,25 @@
       font-size: 0.7rem;
       color: #007bff;
       text-decoration: underline;
+    }
+
+    .icon-square {
+      width: 30px;
+      height: 30px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      margin-top: 4px;
+      cursor: pointer;
+    }
+    #config-btn {
+      width: 50px;
+      height: 50px;
+      font-size: 1.8rem;
+      margin-top: 16px;
     }
 
     .back-btn {
@@ -118,12 +142,15 @@
   <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" alt="logo" />
   <h2>Menú Colaborador</h2>
   <div id="session-info">
-    <div id="user-data">
-      <div id="user-name"></div>
-      <div id="user-email"></div>
+    <div id="user-line">
+      <div id="user-data">
+        <div id="user-name"></div>
+        <div id="user-email"></div>
+      </div>
+      <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
     </div>
-    <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
+    <button id="config-btn" class="icon-square" title="Configuraciones">&#9881;</button>
   </div>
   <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
   <div id="main-menu">
@@ -144,6 +171,9 @@
   });
   document.getElementById('ver-pagos-colab-btn').addEventListener('click',()=>{
     window.location.href='pagoscollab.html';
+  });
+  document.getElementById('config-btn').addEventListener('click',()=>{
+    window.location.href='configcollab.html';
   });
   </script>
 </body>

--- a/public/configcollab.html
+++ b/public/configcollab.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="img/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="img/android-chrome-192x192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="img/android-chrome-512x512.png">
+  <link rel="icon" type="image/x-icon" href="img/favicon.ico">
+  <link rel="icon" type="image/x-icon" sizes="16x16" href="img/favicon-16x16.ico">
+  <link rel="icon" type="image/x-icon" sizes="32x32" href="img/favicon-32x32.ico">
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Configuraciones Colaborador</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
+  <style>
+    body {
+      background-color: #ffffff;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      min-height: 100vh;
+      text-align: center;
+      font-family: 'Bangers', cursive;
+      margin: 0;
+      position: relative;
+      overflow-x: hidden;
+    }
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background: url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg') repeat;
+      opacity: 0.08;
+      pointer-events: none;
+      z-index: -1;
+    }
+    #session-info {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      font-size: 0.7rem;
+    }
+    #user-pic {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+    }
+    #logout-link {
+      font-family: Calibri, Arial, sans-serif;
+      margin-left: 5px;
+      font-size: 0.7rem;
+      color: #007bff;
+      text-decoration: underline;
+    }
+    .menu-btn {
+      width: 250px;
+      height: 60px;
+      font-family: 'Bangers', cursive;
+      font-size: 1.4rem;
+      background: rgba(0, 170, 255, 0.8);
+      color: white;
+      border: 4px solid #FFD700;
+      border-radius: 10px;
+      text-shadow: 2px 2px 4px #000;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: transform 0.3s, box-shadow 0.3s, background 0.3s;
+      margin: 5px;
+    }
+    .menu-btn:hover {
+      transform: scale(1.05);
+      box-shadow: 0 0 15px rgba(255, 215, 0, 0.8);
+    }
+    .back-btn {
+      position: fixed;
+      top: 5px;
+      left: 5px;
+      width: 120px;
+      height: 40px;
+      background: orange;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap:5px;
+    }
+    h2 {
+      margin-top: 80px;
+    }
+    .notificaciones-panel {
+      width: min(420px, 90vw);
+      margin-top: 16px;
+      background: rgba(255,255,255,0.88);
+      border-radius: 14px;
+      padding: 16px;
+      box-shadow: 0 10px 26px rgba(0,0,0,0.18);
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+    .notificaciones-fila {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+      width: 100%;
+    }
+    .notificaciones-fila .notificaciones-titulo-texto {
+      margin: 0;
+      flex: 1;
+      text-align: left;
+    }
+    .notificaciones-contenido {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .notificaciones-contenido[aria-hidden="true"] {
+      display: none;
+    }
+    .notificaciones-opcion {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 18px;
+      width: 100%;
+      font-family: Calibri, Arial, sans-serif;
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: #0b1b4d;
+      cursor: pointer;
+    }
+    .notificaciones-opcion-todo {
+      margin-top: 25px;
+    }
+    .notificaciones-fila-titulo {
+      cursor: pointer;
+    }
+    .notificaciones-opcion-titulo {
+      flex: 1;
+      text-align: left;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 4px;
+      margin: 0;
+      padding-right: 12px;
+    }
+    .notificaciones-opcion-titulo small {
+      font-weight: 400;
+      font-size: 0.78rem;
+      color: #444;
+    }
+    .notificaciones-grupo-titulo {
+      margin: 8px 0 0;
+      font-weight: 700;
+      font-size: 0.95rem;
+      text-align: left;
+      font-family: Calibri, Arial, sans-serif;
+    }
+    .notificaciones-grupo-titulo.colaborador {
+      color: #1b5e20;
+    }
+    .notificaciones-grupo-titulo.jugador {
+      color: #FF8C00;
+    }
+    .notificaciones-grupo-titulo.administrador {
+      color: #1565c0;
+    }
+    .notificaciones-titulo-texto {
+      font-family: 'Bangers', cursive;
+      font-size: 1.3rem;
+      color: #0b1b4d;
+      margin: 0;
+      cursor: pointer;
+      padding-right: 12px;
+    }
+    .notificaciones-titulo-texto:focus {
+      outline: 2px solid #0a8800;
+      outline-offset: 2px;
+    }
+    .notificaciones-todo-etiqueta {
+      color: #000000;
+      font-weight: 700;
+    }
+    .notificaciones-panel .switch {
+      position: relative;
+      display: inline-block;
+      width: 48px;
+      height: 26px;
+      cursor: pointer;
+      user-select: none;
+    }
+    .notificaciones-panel .switch input {
+      display: none;
+    }
+    .notificaciones-panel .switch .slider {
+      position: absolute;
+      inset: 0;
+      background: #cccccc;
+      border-radius: 26px;
+      transition: background 0.3s ease;
+    }
+    .notificaciones-panel .switch .slider::before {
+      content: "";
+      position: absolute;
+      width: 22px;
+      height: 22px;
+      left: 2px;
+      top: 2px;
+      background: #ffffff;
+      border-radius: 50%;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.25);
+      transition: transform 0.3s ease;
+    }
+    .notificaciones-panel .switch input:checked + .slider {
+      background: #4caf50;
+    }
+    .notificaciones-panel .switch input:checked + .slider::before {
+      transform: translateX(22px);
+    }
+    .notificaciones-panel .switch input:focus + .slider {
+      outline: 2px solid #0a8800;
+      outline-offset: 2px;
+    }
+  </style>
+</head>
+<body>
+  <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true">&#9664; Volver</button>
+  <div id="session-info">
+    <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
+    <a href="#" id="logout-link">Cerrar sesión</a>
+  </div>
+  <h2>Configuraciones</h2>
+  <section id="notificaciones-panel" class="notificaciones-panel" aria-labelledby="notificaciones-titulo">
+    <div class="notificaciones-fila notificaciones-fila-titulo" data-switch="notificaciones-global">
+      <span id="notificaciones-titulo" class="notificaciones-titulo-texto" data-switch="notificaciones-global">Notificaciones</span>
+      <label class="switch switch-base" aria-labelledby="notificaciones-titulo">
+        <input type="checkbox" id="notificaciones-global">
+        <span class="slider" aria-hidden="true"></span>
+      </label>
+    </div>
+    <div id="notificaciones-contenido" class="notificaciones-contenido" aria-hidden="true">
+      <div class="notificaciones-opcion notificaciones-opcion-todo notificaciones-fila" data-switch="notificaciones-todo" data-base-opcion="true">
+        <span class="notificaciones-opcion-titulo notificaciones-todo-etiqueta">Notificarme de todo</span>
+        <label class="switch switch-base" aria-label="Notificarme de todo" data-base-switch="true">
+          <input type="checkbox" id="notificaciones-todo">
+          <span class="slider" aria-hidden="true"></span>
+        </label>
+      </div>
+    </div>
+  </section>
+
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
+  <script src="js/notificationPanelSetup.js"></script>
+  <script>
+    ensureAuth('Colaborador');
+    const panelNotificacionesColaborador = setupNotificationPanel({ rol: 'Colaborador' });
+  </script>
+</body>
+</html>

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -585,6 +585,144 @@
       #tabla-asignacion col:nth-child(4) { width: calc(18% - 4px); }
       #tabla-asignacion col:nth-child(5) { width: calc(18% - 4px); }
     }
+
+    .notificaciones-panel {
+      width: 100%;
+      margin-top: 16px;
+      background: rgba(255,255,255,0.88);
+      border-radius: 14px;
+      padding: 16px;
+      box-shadow: 0 10px 26px rgba(0,0,0,0.18);
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+    .notificaciones-fila {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+      width: 100%;
+    }
+    .notificaciones-fila .notificaciones-titulo-texto {
+      margin: 0;
+      flex: 1;
+      text-align: left;
+    }
+    .notificaciones-contenido {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .notificaciones-contenido[aria-hidden="true"] {
+      display: none;
+    }
+    .notificaciones-opcion {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 18px;
+      width: 100%;
+      font-family: Calibri, Arial, sans-serif;
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: #0b1b4d;
+      cursor: pointer;
+    }
+    .notificaciones-opcion-todo {
+      margin-top: 25px;
+    }
+    .notificaciones-fila-titulo {
+      cursor: pointer;
+    }
+    .notificaciones-opcion-titulo {
+      flex: 1;
+      text-align: left;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 4px;
+      margin: 0;
+      padding-right: 12px;
+    }
+    .notificaciones-opcion-titulo small {
+      font-weight: 400;
+      font-size: 0.78rem;
+      color: #444;
+    }
+    .notificaciones-grupo-titulo {
+      margin: 8px 0 0;
+      font-weight: 700;
+      font-size: 0.95rem;
+      text-align: left;
+      font-family: Calibri, Arial, sans-serif;
+    }
+    .notificaciones-grupo-titulo.colaborador {
+      color: #1b5e20;
+    }
+    .notificaciones-grupo-titulo.jugador {
+      color: #FF8C00;
+    }
+    .notificaciones-grupo-titulo.administrador {
+      color: #1565c0;
+    }
+    .notificaciones-titulo-texto {
+      font-family: 'Bangers', cursive;
+      font-size: 1.3rem;
+      color: #0b1b4d;
+      margin: 0;
+      cursor: pointer;
+      padding-right: 12px;
+    }
+    .notificaciones-titulo-texto:focus {
+      outline: 2px solid #0a8800;
+      outline-offset: 2px;
+    }
+    .notificaciones-todo-etiqueta {
+      color: #000000;
+      font-weight: 700;
+    }
+    .notificaciones-panel .switch {
+      position: relative;
+      display: inline-block;
+      width: 48px;
+      height: 26px;
+      cursor: pointer;
+      user-select: none;
+    }
+    .notificaciones-panel .switch input {
+      display: none;
+    }
+    .notificaciones-panel .switch .slider {
+      position: absolute;
+      inset: 0;
+      background: #cccccc;
+      border-radius: 26px;
+      transition: background 0.3s ease;
+    }
+    .notificaciones-panel .switch .slider::before {
+      content: "";
+      position: absolute;
+      width: 22px;
+      height: 22px;
+      left: 2px;
+      top: 2px;
+      background: #ffffff;
+      border-radius: 50%;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.25);
+      transition: transform 0.3s ease;
+    }
+    .notificaciones-panel .switch input:checked + .slider {
+      background: #4caf50;
+    }
+    .notificaciones-panel .switch input:checked + .slider::before {
+      transform: translateX(22px);
+    }
+    .notificaciones-panel .switch input:focus + .slider {
+      outline: 2px solid #0a8800;
+      outline-offset: 2px;
+    }
   </style>
 </head>
 <body>
@@ -626,6 +764,24 @@
       <button id="editar-btn" class="icon-btn" title="Editar" style="color:green;">&#9998; Editar</button>
       <button id="borrar-btn" class="icon-btn" title="Borrar" style="color:red;">&#128465; Borrar</button>
     </div>
+    <section id="notificaciones-panel" class="notificaciones-panel" aria-labelledby="notificaciones-titulo">
+      <div class="notificaciones-fila notificaciones-fila-titulo" data-switch="notificaciones-global">
+        <span id="notificaciones-titulo" class="notificaciones-titulo-texto" data-switch="notificaciones-global">Notificaciones</span>
+        <label class="switch switch-base" aria-labelledby="notificaciones-titulo">
+          <input type="checkbox" id="notificaciones-global">
+          <span class="slider" aria-hidden="true"></span>
+        </label>
+      </div>
+      <div id="notificaciones-contenido" class="notificaciones-contenido" aria-hidden="true">
+        <div class="notificaciones-opcion notificaciones-opcion-todo notificaciones-fila" data-switch="notificaciones-todo" data-base-opcion="true">
+          <span class="notificaciones-opcion-titulo notificaciones-todo-etiqueta">Notificarme de todo</span>
+          <label class="switch switch-base" aria-label="Notificarme de todo" data-base-switch="true">
+            <input type="checkbox" id="notificaciones-todo">
+            <span class="slider" aria-hidden="true"></span>
+          </label>
+        </div>
+      </div>
+    </section>
     <table id="bancos-table">
       <thead>
         <tr>
@@ -721,8 +877,10 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
+  <script src="js/notificationPanelSetup.js"></script>
   <script>
     ensureAuth('Administrador');
+    const panelNotificacionesAdministrador = setupNotificationPanel({ rol: 'Administrador' });
     const datos = [];
     const tbody = document.querySelector('#bancos-table tbody');
 

--- a/public/js/notificationPanelSetup.js
+++ b/public/js/notificationPanelSetup.js
@@ -1,0 +1,426 @@
+(function(){
+  if (typeof window === 'undefined') return;
+  if (window.setupNotificationPanel) return;
+
+  function buscarSwitchAsociado(contenedor){
+    if (!contenedor) return null;
+    const identificador = contenedor.dataset ? contenedor.dataset.switch : null;
+    if (identificador){
+      const directo = document.getElementById(identificador);
+      if (directo && directo.type === 'checkbox'){
+        return directo;
+      }
+    }
+    const interno = contenedor.querySelector ? contenedor.querySelector('input[type="checkbox"]') : null;
+    if (interno){
+      return interno;
+    }
+    const siguiente = contenedor.nextElementSibling;
+    if (siguiente && siguiente.matches('label.switch')){
+      const enLabel = siguiente.querySelector('input[type="checkbox"]');
+      if (enLabel){
+        return enLabel;
+      }
+    }
+    return null;
+  }
+
+  function configurarContenedorNotificaciones(contenedor, inputAsociado){
+    if (!contenedor) return;
+    const input = inputAsociado && inputAsociado.type === 'checkbox' ? inputAsociado : buscarSwitchAsociado(contenedor);
+    if (!input) return;
+    if (input.id && (!contenedor.dataset || !contenedor.dataset.switch)){
+      contenedor.dataset.switch = input.id;
+    }
+    if (!contenedor.hasAttribute('tabindex')){
+      contenedor.tabIndex = 0;
+    }
+    if (!contenedor.hasAttribute('role')){
+      contenedor.setAttribute('role', 'button');
+    }
+    if (input.id){
+      contenedor.setAttribute('aria-controls', input.id);
+    }
+    const actualizarAria = ()=>{
+      contenedor.setAttribute('aria-pressed', input.checked ? 'true' : 'false');
+    };
+    actualizarAria();
+    input.addEventListener('change', actualizarAria);
+    contenedor.addEventListener('click', evento=>{
+      const objetivo = evento.target;
+      if (objetivo === input) return;
+      if (objetivo instanceof Element){
+        if (objetivo.closest('label.switch')) return;
+        if (objetivo.closest('input, button, a')) return;
+      }
+      if (input.disabled) return;
+      evento.preventDefault();
+      input.click();
+    });
+    contenedor.addEventListener('keydown', evento=>{
+      if (evento.key === 'Enter' || evento.key === ' '){
+        if (input.disabled) return;
+        evento.preventDefault();
+        input.click();
+      }
+    });
+  }
+
+  function generarIdSwitch(sufijo){
+    const base = String(sufijo || 'opcion').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'opcion';
+    let id = `notificaciones-${base}`;
+    let contador = 0;
+    while (document.getElementById(id)){
+      contador += 1;
+      id = `notificaciones-${base}-${contador}`;
+    }
+    return id;
+  }
+
+  function obtenerClavesNotificacionesDisponibles(grupos){
+    const claves = new Set();
+    if (!Array.isArray(grupos)) return [];
+    grupos.forEach(grupo=>{
+      if (!grupo || !Array.isArray(grupo.items)) return;
+      grupo.items.forEach(item=>{
+        if (item && item.clave){
+          claves.add(item.clave);
+        }
+      });
+    });
+    return Array.from(claves);
+  }
+
+  function estanTodasLasPreferenciasActivas(config, grupos){
+    if (!config || !config.preferencias) return false;
+    if (!config.global) return false;
+    const claves = obtenerClavesNotificacionesDisponibles(grupos);
+    if (!claves.length) return false;
+    return claves.every(clave=>Boolean(config.preferencias[clave]));
+  }
+
+  function obtenerClavesPreferencias(config, grupos){
+    const clavesGrupos = obtenerClavesNotificacionesDisponibles(grupos);
+    if (clavesGrupos.length) return clavesGrupos;
+    if (config && config.preferencias){
+      const clavesConfiguracion = Object.keys(config.preferencias);
+      if (clavesConfiguracion.length) return clavesConfiguracion;
+    }
+    return [];
+  }
+
+  async function actualizarPreferenciasMasivas(valor, config, grupos){
+    if (!window.notificationCenter) return;
+    const claves = obtenerClavesPreferencias(config, grupos);
+    if (!claves.length) return;
+    await Promise.all(claves.map(clave=>window.notificationCenter.actualizarPreferencia(clave, valor)));
+  }
+
+  function limpiarOpcionesNotificaciones(contenedor){
+    if (!contenedor) return;
+    contenedor.querySelectorAll('.notificaciones-opcion[data-clave], .notificaciones-grupo-titulo').forEach(elemento=>{
+      elemento.remove();
+    });
+  }
+
+  function aplicarClaseRol(elemento, etiqueta){
+    if (!elemento || !etiqueta) return;
+    const normalizado = String(etiqueta).trim().toLowerCase();
+    elemento.classList.remove('colaborador', 'jugador', 'administrador');
+    if (normalizado === 'colaborador'){
+      elemento.classList.add('colaborador');
+    }else if (normalizado === 'jugador'){
+      elemento.classList.add('jugador');
+    }else if (normalizado === 'administrador'){
+      elemento.classList.add('administrador');
+    }
+  }
+
+  function renderizarOpcionesNotificaciones(config, grupos, contenedor){
+    if (!contenedor) return;
+    limpiarOpcionesNotificaciones(contenedor);
+    if (!Array.isArray(grupos) || !grupos.length) return;
+    const fragmento = document.createDocumentFragment();
+    const preferencias = config && config.preferencias ? config.preferencias : {};
+    grupos.forEach(grupo=>{
+      if (!grupo || !Array.isArray(grupo.items) || !grupo.items.length) return;
+      if (grupo.etiqueta){
+        const titulo = document.createElement('p');
+        titulo.className = 'notificaciones-grupo-titulo';
+        aplicarClaseRol(titulo, grupo.etiqueta);
+        titulo.textContent = grupo.etiqueta;
+        fragmento.appendChild(titulo);
+      }
+      grupo.items.forEach(item=>{
+        if (!item || !item.clave) return;
+        const fila = document.createElement('div');
+        fila.className = 'notificaciones-opcion notificaciones-fila';
+        fila.dataset.clave = item.clave;
+        const inputId = generarIdSwitch(item.clave);
+        fila.dataset.switch = inputId;
+        const titulo = document.createElement('span');
+        titulo.className = 'notificaciones-opcion-titulo';
+        titulo.textContent = item.titulo || item.clave;
+        if (item.descripcion){
+          const descripcion = document.createElement('small');
+          descripcion.textContent = item.descripcion;
+          titulo.appendChild(descripcion);
+        }
+        fila.appendChild(titulo);
+        const control = document.createElement('label');
+        control.className = 'switch';
+        control.setAttribute('aria-label', item.titulo || item.clave);
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.id = inputId;
+        input.checked = Boolean(preferencias[item.clave]);
+        input.addEventListener('change', async ()=>{
+          if (!window.notificationCenter) return;
+          const valor = input.checked;
+          input.disabled = true;
+          try{
+            await window.notificationCenter.actualizarPreferencia(item.clave, valor);
+          }catch(err){
+            console.error('No se pudo actualizar la preferencia de notificación', err);
+            input.checked = !valor;
+          }finally{
+            if (document.body.contains(input)){
+              input.disabled = false;
+            }
+          }
+        });
+        const slider = document.createElement('span');
+        slider.className = 'slider';
+        control.appendChild(input);
+        control.appendChild(slider);
+        fila.appendChild(control);
+        configurarContenedorNotificaciones(fila, input);
+        fragmento.appendChild(fila);
+      });
+    });
+    contenedor.appendChild(fragmento);
+  }
+
+  window.setupNotificationPanel = function setupNotificationPanel(options = {}){
+    const {
+      rol = 'Jugador',
+      panelSelector = '#notificaciones-panel',
+      globalSelector = '#notificaciones-global',
+      contenidoSelector = '#notificaciones-contenido',
+      todoSelector = '#notificaciones-todo',
+      tituloSelector = '#notificaciones-titulo',
+      encabezadoSelector = '#notificaciones-panel .notificaciones-fila-titulo'
+    } = options;
+
+    const panel = typeof panelSelector === 'string' ? document.querySelector(panelSelector) : panelSelector;
+    const globalInput = typeof globalSelector === 'string' ? document.querySelector(globalSelector) : globalSelector;
+    const contenido = typeof contenidoSelector === 'string' ? document.querySelector(contenidoSelector) : contenidoSelector;
+    const todoInput = typeof todoSelector === 'string' ? document.querySelector(todoSelector) : todoSelector;
+    const titulo = typeof tituloSelector === 'string' ? document.querySelector(tituloSelector) : tituloSelector;
+    const encabezado = typeof encabezadoSelector === 'string' ? document.querySelector(encabezadoSelector) : encabezadoSelector;
+
+    const estado = {
+      panel,
+      cleanup(){
+        if (estado._beforeUnload){
+          window.removeEventListener('beforeunload', estado._beforeUnload);
+          estado._beforeUnload = null;
+        }
+        if (estado._desuscribir){
+          try{ estado._desuscribir(); }
+          catch(err){ console.error('No se pudo cancelar la suscripción de notificaciones', err); }
+          estado._desuscribir = null;
+        }
+      }
+    };
+
+    if (!panel){
+      return estado;
+    }
+
+    let gruposDisponibles = [];
+    let globalInicializado = false;
+
+    if (titulo){
+      titulo.setAttribute('role', 'button');
+      titulo.setAttribute('tabindex', '0');
+      if (contenido){
+        titulo.setAttribute('aria-controls', contenido.id || 'notificaciones-contenido');
+      }
+    }
+
+    function actualizarEstadoPreferencias(){
+      if (!contenido) return;
+      const abierto = !globalInput || globalInput.checked;
+      contenido.setAttribute('aria-hidden', abierto ? 'false' : 'true');
+      if (titulo){
+        titulo.setAttribute('aria-expanded', abierto ? 'true' : 'false');
+      }
+      if (encabezado){
+        encabezado.setAttribute('aria-expanded', abierto ? 'true' : 'false');
+      }
+    }
+
+    function alternarNotificacionesGlobal(){
+      if (!globalInput || globalInput.disabled) return;
+      globalInput.click();
+    }
+
+    function actualizarIndicadoresGlobal(){
+      if (!globalInput) return;
+      const estadoGlobal = globalInput.checked ? 'true' : 'false';
+      if (titulo){
+        titulo.setAttribute('aria-pressed', estadoGlobal);
+        titulo.setAttribute('aria-expanded', estadoGlobal);
+      }
+    }
+
+    if (globalInput){
+      actualizarIndicadoresGlobal();
+      globalInput.addEventListener('change', ()=>{
+        globalInput.dataset.manual = 'true';
+        actualizarIndicadoresGlobal();
+        actualizarEstadoPreferencias();
+      });
+    }
+
+    if (titulo){
+      titulo.addEventListener('click', alternarNotificacionesGlobal);
+      titulo.addEventListener('keydown', evento=>{
+        if (evento.key === 'Enter' || evento.key === ' '){
+          evento.preventDefault();
+          alternarNotificacionesGlobal();
+        }
+      });
+    }
+
+    if (encabezado){
+      configurarContenedorNotificaciones(encabezado, globalInput);
+      if (contenido){
+        encabezado.setAttribute('aria-controls', contenido.id || 'notificaciones-contenido');
+      }
+    }
+
+    if (contenido){
+      const opcionBase = contenido.querySelector('.notificaciones-opcion[data-base-opcion="true"]');
+      const inputBase = opcionBase ? buscarSwitchAsociado(opcionBase) : null;
+      configurarContenedorNotificaciones(opcionBase, inputBase);
+    }
+
+    if (todoInput){
+      todoInput.addEventListener('change', async ()=>{
+        if (!window.notificationCenter){
+          todoInput.checked = false;
+          return;
+        }
+        const activar = todoInput.checked;
+        todoInput.disabled = true;
+        try{
+          const configuracionActual = window.notificationCenter.obtenerConfiguracion();
+          const globalYaActivo = Boolean(configuracionActual && configuracionActual.global);
+          if (activar && !globalYaActivo){
+            const resultado = await window.notificationCenter.actualizarGlobal(true);
+            if (resultado !== 'granted'){
+              todoInput.checked = false;
+              return;
+            }
+            if (globalInput){
+              globalInput.checked = true;
+              globalInput.dataset.manual = 'false';
+            }
+          }
+          const configuracionPosterior = window.notificationCenter.obtenerConfiguracion();
+          await actualizarPreferenciasMasivas(activar, configuracionPosterior, gruposDisponibles);
+        }catch(err){
+          console.error('No se pudo actualizar las preferencias de notificaciones', err);
+          todoInput.checked = !activar;
+        }finally{
+          const configuracionFinal = window.notificationCenter ? window.notificationCenter.obtenerConfiguracion() : null;
+          const clavesDisponibles = obtenerClavesPreferencias(configuracionFinal, gruposDisponibles);
+          const globalHabilitado = Boolean(configuracionFinal && configuracionFinal.global);
+          todoInput.disabled = !clavesDisponibles.length;
+          if (!globalHabilitado && todoInput.checked){
+            todoInput.checked = false;
+          }
+          actualizarEstadoPreferencias();
+        }
+      });
+    }
+
+    actualizarEstadoPreferencias();
+
+    estado._beforeUnload = ()=>{
+      estado.cleanup();
+    };
+    window.addEventListener('beforeunload', estado._beforeUnload);
+
+    async function inicializar(){
+      if (!panel){
+        return;
+      }
+      if (!window.notificationCenter){
+        panel.style.display = 'none';
+        return;
+      }
+      panel.style.display = 'block';
+      gruposDisponibles = window.notificationCenter.obtenerGruposUI(rol || 'Jugador');
+      gruposDisponibles = Array.isArray(gruposDisponibles) ? gruposDisponibles.slice() : [];
+      if (!gruposDisponibles.length){
+        panel.style.display = 'none';
+        return;
+      }
+      try{
+        await window.notificationCenter.cuandoListo();
+      }catch(err){
+        console.error('No se pudo preparar la sección de notificaciones', err);
+      }
+      const configuracion = window.notificationCenter.obtenerConfiguracion();
+      actualizarPanel(configuracion);
+      if (estado._desuscribir){
+        try{ estado._desuscribir(); }
+        catch(e){ console.error('No se pudo cancelar la suscripción de notificaciones', e); }
+      }
+      estado._desuscribir = window.notificationCenter.onChange(cfg=>{
+        actualizarPanel(cfg);
+      });
+    }
+
+    function actualizarPanel(config){
+      if (!panel) return;
+      if (!config){
+        panel.style.display = 'none';
+        return;
+      }
+      if (!Array.isArray(gruposDisponibles) || !gruposDisponibles.length){
+        panel.style.display = 'none';
+        return;
+      }
+      panel.style.display = 'block';
+      const globalActivo = Boolean(config.global);
+      if (globalInput){
+        const fueInicializado = globalInicializado;
+        const esManual = globalInput.dataset.manual === 'true';
+        if (!fueInicializado || !esManual){
+          globalInput.checked = globalActivo;
+          globalInput.dataset.manual = 'false';
+          globalInicializado = true;
+        }else if (!globalActivo && globalInput.checked){
+          globalInput.checked = false;
+          globalInput.dataset.manual = 'false';
+        }
+        actualizarIndicadoresGlobal();
+      }
+      if (todoInput){
+        const clavesDisponibles = obtenerClavesNotificacionesDisponibles(gruposDisponibles);
+        const todasActivas = estanTodasLasPreferenciasActivas(config, gruposDisponibles);
+        todoInput.checked = todasActivas;
+        todoInput.disabled = !clavesDisponibles.length;
+      }
+      renderizarOpcionesNotificaciones(config, gruposDisponibles, contenido);
+      actualizarEstadoPreferencias();
+    }
+
+    estado.ready = inicializar();
+    return estado;
+  };
+})();


### PR DESCRIPTION
## Summary
- add a reusable notification panel setup helper for pages that expose notification preferences
- expose the notification settings panel in the admin configuration view and add a collaborator configuration page
- add a configuration button to the collaborator dashboard to reach the new configuration screen

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127b4ff2d8832693952bba1b56ad17)