### PR TITLE
Configurar SendGrid con clave de respaldo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Sigue estos pasos para preparar el envío de correos transaccionales con SendGri
      FIREBASE_STORAGE_BUCKET=bingo-online.appspot.com
      SENDGRID_API_KEY=SG.xxxxxx
      SENDGRID_FROM_EMAIL=notificaciones@tudominio.com
+
+     > **Nota:** El repositorio incluye una clave de SendGrid de respaldo únicamente para facilitar las pruebas locales. Configura siempre tus propias credenciales en las variables de entorno `SENDGRID_API_KEY` y `SENDGRID_FROM_EMAIL` antes de desplegar o ejecutar el script en producción.
      ```
 
    - Recuerda que el archivo `.env` es privado y no debe subirse al repositorio.

--- a/services/email.js
+++ b/services/email.js
@@ -1,14 +1,27 @@
+require('dotenv').config();
 const sgMail = require('@sendgrid/mail');
 
-function ensureApiKey() {
-  if (!process.env.SENDGRID_API_KEY) {
+const FALLBACK_SENDGRID_API_KEY = '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';
+
+function obtenerApiKey() {
+  const apiKey = process.env.SENDGRID_API_KEY || FALLBACK_SENDGRID_API_KEY;
+  if (!apiKey) {
     throw new Error('La variable de entorno SENDGRID_API_KEY es obligatoria para enviar correos.');
   }
+
+  if (!process.env.SENDGRID_API_KEY && apiKey === FALLBACK_SENDGRID_API_KEY) {
+    console.warn(
+      'Usando la clave SendGrid definida en el repositorio porque SENDGRID_API_KEY no está configurada. ' +
+        'Configúrala en el entorno para evitar exponer credenciales en código.'
+    );
+  }
+
+  return apiKey;
 }
 
 function setupSendGrid() {
-  ensureApiKey();
-  sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+  const apiKey = obtenerApiKey();
+  sgMail.setApiKey(apiKey);
 }
 
 /**
@@ -27,7 +40,9 @@ async function enviarCorreo(opciones) {
   const fromAddress = opciones.from || process.env.SENDGRID_FROM_EMAIL;
 
   if (!fromAddress) {
-    throw new Error('Define la variable SENDGRID_FROM_EMAIL o proporciona el campo "from" al enviar un correo.');
+    throw new Error(
+      'Define la variable SENDGRID_FROM_EMAIL con el remitente verificado en SendGrid o proporciona el campo "from" al enviar un correo.'
+    );
   }
 
   const mensaje = {


### PR DESCRIPTION
## Summary
- cargar automáticamente variables de entorno para el módulo de correo
- agregar una clave de respaldo de SendGrid y advertencia cuando se usa
- documentar en el README la necesidad de configurar credenciales propias

## Testing
- not run (not needed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166fb95ebc83269680337ccba80c24)