### PR TITLE
Ajustes de estilos para enlaces en vivo

### DIFF
--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Configuraciones</title>
-  <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
     body {
       background-color: #ffffff;
@@ -512,6 +512,10 @@
       color: #15803d;
       font-weight: 500;
     }
+    .whatsapp-section label[for="link-live-tiktok"] {
+      color: #ff7a00;
+      text-shadow: 0 0 4px #000, 0 0 10px rgba(0,0,0,0.8);
+    }
     .whatsapp-section textarea {
       width: 100%;
       min-height: 72px;
@@ -522,6 +526,13 @@
       font-family: Calibri, Arial, sans-serif;
       font-size: 0.85rem;
       resize: vertical;
+    }
+    #link-live-tiktok {
+      border-color: #fb923c;
+      box-shadow: 0 0 0 1px rgba(255,146,60,0.25);
+    }
+    #link-live-tiktok:focus {
+      outline: 2px solid rgba(255,146,60,0.55);
     }
     .whatsapp-actions {
       margin-top: 8px;
@@ -551,7 +562,8 @@
       background: linear-gradient(135deg,#ff9a3c,#ff6200);
       color: #fff;
       border: none;
-      font-family: 'Bangers', cursive;
+      font-family: 'Poppins', sans-serif;
+      font-weight: 600;
       font-size: 1rem;
       padding: 8px 18px;
       border-radius: 10px;
@@ -874,7 +886,7 @@
     <div class="whatsapp-actions">
       <button type="button" id="guardar-link-whatsapp">Guardar</button>
     </div>
-    <label for="link-live-tiktok">Link Live Tiktok</label>
+    <label for="link-live-tiktok">Link de Live Tiktok/Youtube</label>
     <textarea id="link-live-tiktok" placeholder="https://www.tiktok.com/@cuenta/live o https://youtube.com/watch?v=..." spellcheck="false"></textarea>
     <div class="live-link-actions">
       <button type="button" id="guardar-link-live-tiktok">Guardar</button>

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -175,7 +175,7 @@
           transition: transform 0.2s ease, box-shadow 0.2s ease;
       }
       .live-stream-toggle.live-activo {
-          animation: livePulse 1.2s ease-in-out infinite;
+          animation: livePulse 0.8s ease-in-out infinite;
           box-shadow: 0 0 18px rgba(255,87,34,0.65);
       }
       @keyframes livePulse {
@@ -183,7 +183,7 @@
               transform: scale(1);
           }
           50% {
-              transform: scale(1.08);
+              transform: scale(1.2);
           }
           100% {
               transform: scale(1);
@@ -330,6 +330,12 @@
       }
       .live-stream-maximize-btn .icon-min {
           display: none;
+      }
+      .live-stream-window.maximizado .live-stream-maximize-btn .icon-max {
+          display: none;
+      }
+      .live-stream-window.maximizado .live-stream-maximize-btn .icon-min {
+          display: inline;
       }
       .live-stream-maximize-btn.activo .icon-max {
           display: none;
@@ -1080,6 +1086,31 @@
           cursor: pointer;
           box-shadow: 0 8px 20px rgba(0,0,0,0.2);
           transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      .live-stream-toggle .live-stream-icon {
+          width: clamp(20px, 6vw, 24px);
+          height: clamp(14px, 4.5vw, 18px);
+          display: inline-block;
+          background-repeat: no-repeat;
+          background-size: contain;
+          filter: drop-shadow(0 0 4px rgba(0,0,0,0.55));
+      }
+      .live-stream-icon--youtube {
+          background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><rect width='24' height='24' rx='4' fill='%23ff0000'/><path d='M10 7l7 5-7 5z' fill='white'/></svg>");
+      }
+      .live-stream-icon--tiktok {
+          background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='%2325F4EE' d='M16 4.5v3.3c1 .8 2.2 1.2 3.5 1.2v2.5c-1.6 0-3-.4-4.3-1.2v5.6c0 3.1-2.5 5.6-5.6 5.6-1.7 0-3.1-.7-4.2-1.8a5.6 5.6 0 0 1 4.2-9.3c.4 0 .9.05 1.3.15v2.6a3 3 0 1 0 2.9 3.1V4.5z'/><path fill='%23FF0050' d='M14.6 7.3a7 7 0 0 1-1.4-.5v5c0 3-2.4 5.4-5.4 5.4-.5 0-.9-.05-1.4-.15 1 1.1 2.4 1.8 4 1.8 3.1 0 5.6-2.5 5.6-5.6V7.3z'/><path fill='white' d='M13.2 5h2.8c.2 1.1 1 2 2.2 2.5v2.3c-1.2-.2-2.2-.7-3-1.5v5.5a4.5 4.5 0 1 1-4.5-4.5c.3 0 .6 0 .9.1V12a2 2 0 1 0 1.6 1.9z'/></svg>");
+      }
+      .sr-only {
+          position: absolute;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          margin: -1px;
+          overflow: hidden;
+          clip: rect(0,0,0,0);
+          white-space: nowrap;
+          border: 0;
       }
       .ultimo-canto-popup .popup-accion:hover {
           transform: translateY(-1px);
@@ -3673,6 +3704,10 @@
   let liveStreamAudioPermisoSolicitado = false;
   let liveStreamAudioHabilitado = false;
   let liveStreamAudioContexto = null;
+  let liveStreamPlatform = 'otro';
+  let liveStreamIconInterval = null;
+  let liveStreamMostrarTexto = true;
+  const LIVE_ICON_INTERVAL_MS = 3000;
 
   let cartonSeleccionadoId = null;
   const animacionesCartones = new Map();
@@ -3961,12 +3996,13 @@
           return;
         }
         const embed = normalizarEnlaceLive(enlace);
+        liveStreamTieneTransmision = !!embed;
+        actualizarPlataformaLive(embed ? enlace : '');
         if(embed){
           mostrarLiveStreamVideo(embed);
         }else{
           mostrarMensajeLive(MENSAJE_LIVE_NO_DISPONIBLE);
         }
-        liveStreamTieneTransmision = !!embed;
         actualizarBotonLiveAnimacion();
       })
       .catch(err=>{
@@ -3982,6 +4018,74 @@
     }else{
       liveStreamToggleBtn.classList.remove('live-activo');
     }
+    actualizarAlternanciaContenidoLive();
+  }
+
+  function detectarPlataformaLive(link){
+    if(typeof link !== 'string') return 'otro';
+    try{
+      const url = new URL(link.trim());
+      const host = url.hostname.toLowerCase();
+      if(host.includes('youtube') || host.includes('youtu.be')) return 'youtube';
+      if(host.includes('tiktok')) return 'tiktok';
+      return 'otro';
+    }catch(err){
+      return 'otro';
+    }
+  }
+
+  function establecerContenidoBotonLive(modo){
+    if(!liveStreamToggleBtn) return;
+    if(modo === 'youtube'){
+      liveStreamToggleBtn.innerHTML = "<span class=\"live-stream-icon live-stream-icon--youtube\" aria-hidden=\"true\"></span><span class=\"sr-only\">Transmisión en YouTube</span>";
+      return;
+    }
+    if(modo === 'tiktok'){
+      liveStreamToggleBtn.innerHTML = "<span class=\"live-stream-icon live-stream-icon--tiktok\" aria-hidden=\"true\"></span><span class=\"sr-only\">Transmisión en TikTok</span>";
+      return;
+    }
+    liveStreamToggleBtn.textContent = 'LIVE';
+  }
+
+  function detenerAlternanciaIconoLive(){
+    if(liveStreamIconInterval){
+      clearInterval(liveStreamIconInterval);
+      liveStreamIconInterval = null;
+    }
+    liveStreamMostrarTexto = true;
+    establecerContenidoBotonLive();
+  }
+
+  function iniciarAlternanciaIconoLive(){
+    detenerAlternanciaIconoLive();
+    if(!liveStreamTieneTransmision) return;
+    if(liveStreamPlatform !== 'youtube' && liveStreamPlatform !== 'tiktok'){
+      establecerContenidoBotonLive();
+      return;
+    }
+    liveStreamMostrarTexto = false;
+    establecerContenidoBotonLive(liveStreamPlatform);
+    liveStreamIconInterval = setInterval(()=>{
+      liveStreamMostrarTexto = !liveStreamMostrarTexto;
+      if(liveStreamMostrarTexto){
+        establecerContenidoBotonLive();
+      }else{
+        establecerContenidoBotonLive(liveStreamPlatform);
+      }
+    }, LIVE_ICON_INTERVAL_MS);
+  }
+
+  function actualizarAlternanciaContenidoLive(){
+    if(liveStreamTieneTransmision){
+      iniciarAlternanciaIconoLive();
+    }else{
+      detenerAlternanciaIconoLive();
+    }
+  }
+
+  function actualizarPlataformaLive(link){
+    liveStreamPlatform = detectarPlataformaLive(link);
+    actualizarAlternanciaContenidoLive();
   }
 
   function calcularAspectRatioDesdeLink(enlace){
@@ -4345,10 +4449,12 @@
     obtenerLinkLiveStream()
       .then(link=>{
         liveStreamTieneTransmision = typeof link === 'string' && !!link.trim();
+        actualizarPlataformaLive(liveStreamTieneTransmision ? link : '');
         actualizarBotonLiveAnimacion();
       })
       .catch(()=>{
         liveStreamTieneTransmision = false;
+        actualizarPlataformaLive('');
         actualizarBotonLiveAnimacion();
       });
   }


### PR DESCRIPTION
## Summary
- actualiza el texto y los estilos del campo de enlace de transmisión, usando borde naranja y tipografía Poppins en el botón Guardar
- acelera y amplía la animación del botón LIVE y alterna ícono/palabra según si el enlace es de YouTube o TikTok
- corrige el icono de minimizar en la ventana de transmisión cuando está maximizada para mostrar el estado correcto

## Testing
- No se ejecutaron pruebas (no tests run)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a7a394cd0832697db6d9ff0c5dca7)