### PR TITLE
Mejora iconos de transmisión en vivo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -328,6 +328,18 @@
           transform: scale(1.05);
           background: rgba(0,0,0,0.65);
       }
+      .live-stream-maximize-btn .icon {
+          width: 18px;
+          height: 18px;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+      }
+      .live-stream-maximize-btn .icon svg {
+          width: 100%;
+          height: 100%;
+          fill: currentColor;
+      }
       .live-stream-maximize-btn .icon-min {
           display: none;
       }
@@ -335,13 +347,13 @@
           display: none;
       }
       .live-stream-window.maximizado .live-stream-maximize-btn .icon-min {
-          display: inline;
+          display: inline-flex;
       }
       .live-stream-maximize-btn.activo .icon-max {
           display: none;
       }
       .live-stream-maximize-btn.activo .icon-min {
-          display: inline;
+          display: inline-flex;
       }
       .live-stream-vacio {
           flex: 1;
@@ -1090,9 +1102,11 @@
       .live-stream-toggle .live-stream-icon {
           width: clamp(20px, 6vw, 24px);
           height: clamp(14px, 4.5vw, 18px);
-          display: inline-block;
+          display: block;
           background-repeat: no-repeat;
           background-size: contain;
+          background-position: center;
+          margin: 0 auto;
           filter: drop-shadow(0 0 4px rgba(0,0,0,0.55));
       }
       .live-stream-icon--youtube {
@@ -3454,8 +3468,16 @@
         <button id="live-stream-accept" type="button" class="live-stream-control">Aceptar</button>
       </div>
       <button id="live-stream-maximize" type="button" class="live-stream-maximize-btn live-stream-control" aria-label="Maximizar video">
-        <span class="icon-max" aria-hidden="true">⛶</span>
-        <span class="icon-min" aria-hidden="true">🗗</span>
+        <span class="icon icon-max" aria-hidden="true">
+          <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+            <path d="M4 4h7v2H6v5H4V4zm10 0h6v6h-2V6h-4V4zm6 10v6h-6v-2h4v-4h2zm-10 6H4v-6h2v4h4v2z" />
+          </svg>
+        </span>
+        <span class="icon icon-min" aria-hidden="true">
+          <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+            <path d="M5 7h14a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1zm1 2v8h12V9H6zm2-5h8v2H8V4z" />
+          </svg>
+        </span>
       </button>
     </div>
     <div class="live-stream-resize-handle live-stream-resize-handle--left live-stream-control" data-live-resize="left" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- centra los iconos de plataforma en el botón LIVE para YouTube y TikTok
- reemplaza los símbolos de maximizar/minimizar por SVG reconocibles y ajusta estilos de alineación

## Testing
- no tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a7db984148326bb272c187eeb4a8f)