### PR TITLE
Ajusta estilos del perfil de colaborador

### DIFF
--- a/public/configcollab.html
+++ b/public/configcollab.html
@@ -149,6 +149,9 @@
       border-color: #d50000 !important;
       box-shadow: 0 0 6px rgba(213,0,0,0.35);
     }
+    #perfil-nombre, #perfil-apellido, #perfil-alias {font-weight:bold;}
+    #perfil-nombre, #perfil-apellido {color:#00008B;}
+    #perfil-alias {color:#FF8C00;}
     #guardar-perfil-btn {
       font-family: 'Bangers', cursive;
       font-size: 1.2rem;
@@ -158,6 +161,8 @@
       border-radius: 10px;
       text-shadow: 2px 2px 4px #000;
       width: 220px;
+      height: auto;
+      padding: 8px 12px;
       cursor: pointer;
       transition: background 0.3s ease, box-shadow 0.3s ease;
     }
@@ -312,7 +317,6 @@
   </div>
   <h2>Configuraciones</h2>
   <main id="perfil-contenido">
-    <h3 id="perfil-titulo">Perfil del Colaborador</h3>
     <h4 id="perfil-subtitulo">Tus Datos Personales</h4>
     <div class="nombre-apellido-row">
       <div class="campo-wrap">


### PR DESCRIPTION
## Summary
- elimina el encabezado redundante del perfil en la página de configuraciones del colaborador
- alinea los colores de los campos con los usados en la página de perfil
- ajusta el tamaño del botón Guardar para que coincida con el perfil

## Testing
- No se ejecutaron pruebas (no aplicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4c8340808326b6cb0ef657d781ce)