### PR TITLE
Ajusta espaciado en configuraciones de colaborador

### DIFF
--- a/public/configcollab.html
+++ b/public/configcollab.html
@@ -88,15 +88,16 @@
       gap:5px;
     }
     h2 {
-      margin-top: 80px;
+      margin-top: 70px;
+      margin-bottom: 0;
     }
     main#perfil-contenido {
       width: min(420px, 90vw);
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 10px;
-      margin-top: clamp(30px, 8vh, 90px);
+      gap: 8px;
+      margin-top: 40px;
       font-family: 'Poppins', sans-serif;
     }
     input {font-size:1rem;padding:8px;text-align:center;border-radius:8px;border:1px solid #ccc;width:100%;box-sizing:border-box;display:block;transition:border-color 0.2s ease, box-shadow 0.2s ease;}
@@ -137,7 +138,7 @@
     .mensaje-validacion {
       font-size: 0.8rem;
       color: #b71c1c;
-      min-height: 18px;
+      min-height: 16px;
       text-align: center;
       font-family: 'Poppins', sans-serif;
     }
@@ -161,8 +162,6 @@
       border-radius: 10px;
       text-shadow: 2px 2px 4px #000;
       width: 220px;
-      height: auto;
-      padding: 8px 12px;
       cursor: pointer;
       transition: background 0.3s ease, box-shadow 0.3s ease;
     }


### PR DESCRIPTION
## Summary
- Reduce el espacio entre el título de configuraciones y el formulario para acercar los datos personales
- Ajusta la separación entre el campo de celular y el botón Guardar y alinea el botón con el tamaño usado en perfil

## Testing
- No tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5004c81c83268ecda6d4710a3a4e)