### PR TITLE
Ajusta mensaje de WhatsApp para retiros anulados

### DIFF
--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -633,7 +633,11 @@
         if(nota){
           lineas[lineas.length-1]+=` Motivo: ${nota}.`;
         }
-        lineas.push('Revisa los datos de tu solicitud y vuelve a intentarlo.');
+        if(tipo==='retiro'){
+          lineas.push('Se presento un problema. Vuelve a intentarlo');
+        }else{
+          lineas.push('Revisa los datos de tu solicitud y vuelve a intentarlo.');
+        }
       }
 
       return lineas.filter(Boolean).join('\n');


### PR DESCRIPTION
## Summary
- actualizar el mensaje final de WhatsApp para retiros anulados
- mantener el mensaje existente para anulaciones de depósitos

## Testing
- no tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cd1e1912083268056f4add30dc794)