### PR TITLE
Restringir entradas numéricas en teléfonos y WhatsApp

### DIFF
--- a/public/configcollab.html
+++ b/public/configcollab.html
@@ -351,7 +351,7 @@
     </div>
     <div class="campo-wrap campo-completo celular-row">
       <select id="perfil-codigo-pais" aria-label="Código de país"></select>
-      <input type="tel" id="perfil-celular" placeholder="Número Celular" autocomplete="tel" inputmode="tel" maxlength="20" pattern="[0-9]+" title="Ingresa un número válido" required />
+      <input type="tel" id="perfil-celular" placeholder="Número Celular" autocomplete="tel" inputmode="numeric" maxlength="20" pattern="[0-9]+" title="Ingresa solo números" required />
     </div>
     <div id="perfil-mensaje" class="mensaje-validacion" role="alert" aria-live="polite"></div>
     <button id="guardar-perfil-btn" class="menu-btn" data-modo="guardar">Guardar</button>

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -1358,7 +1358,11 @@
         colPrefijo.appendChild(selectPrefijo);
         const colNumero=document.createElement('td');
         const inputNumero=document.createElement('input');
-        inputNumero.type='text';
+        inputNumero.type='tel';
+        inputNumero.inputMode='numeric';
+        inputNumero.pattern='[0-9]*';
+        inputNumero.title='Solo números';
+        inputNumero.maxLength=20;
         inputNumero.value=(num.local||'').replace(/\D/g,'');
         inputNumero.addEventListener('focus',()=>{ actualizarSeleccion(valorCompuestoNumero(num)); });
         inputNumero.addEventListener('input',()=>{

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -426,7 +426,7 @@
     <div class="campo-wrap campo-completo">
       <div class="celular-row">
         <select id="perfil-codigo-pais" aria-label="Código de país" required></select>
-        <input type="tel" id="perfil-celular" placeholder="Número Celular" autocomplete="tel" inputmode="tel" maxlength="20" pattern="\+?[0-9]+" title="Ingresa un número válido (solo dígitos y un signo + inicial)" required />
+        <input type="tel" id="perfil-celular" placeholder="Número Celular" autocomplete="tel" inputmode="numeric" maxlength="20" pattern="[0-9]+" title="Ingresa solo números" required />
       </div>
     </div>
     <p class="nota-celular"><strong>IMPORTANTE:</strong> Tu número celular no será visible para ningún otro jugador, sin embargo, este número debe ser el mismo que usaras al entrar en los Grupos de WhatsApp, de lo contrario tu acceso al sistema será restringido.</p>

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -120,7 +120,7 @@
   <input type="text" id="alias" placeholder="Alias">
   <div class="celular-row">
     <select id="codigo-pais" aria-label="Código de país" required></select>
-    <input type="tel" id="celular" placeholder="Número Celular" aria-label="Número celular" required>
+    <input type="tel" id="celular" placeholder="Número Celular" aria-label="Número celular" inputmode="numeric" pattern="[0-9]+" title="Ingresa solo números" required>
   </div>
   <p class="nota-registro">Nota: Sólo tu Alias será visible para los otros Jugadores, Tu nombre, Apellido, Número celular o Gmail serán confidenciales.</p>
   <div id="email"></div>


### PR DESCRIPTION
## Summary
- Ajusta los campos editables de la gestión de números de WhatsApp para aceptar únicamente dígitos con configuración de teclado numérico
- Actualiza los formularios de registro y perfil para exigir números de celular en formato exclusivamente numérico

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cd69cae6c8326b8ea503f21e9e151)