### PR TITLE
Ajusta alineación de prefijo y número en config colaborador

### DIFF
--- a/public/configcollab.html
+++ b/public/configcollab.html
@@ -354,9 +354,11 @@
     <div class="campo-wrap campo-completo">
       <input type="text" id="perfil-alias" placeholder="Alias" maxlength="20" autocomplete="nickname" required />
     </div>
-    <div class="campo-wrap campo-completo celular-row">
-      <select id="perfil-codigo-pais" aria-label="Código de país"></select>
-      <input type="tel" id="perfil-celular" placeholder="Número Celular" autocomplete="tel" inputmode="numeric" maxlength="20" pattern="[0-9]+" title="Ingresa solo números" required />
+    <div class="campo-wrap campo-completo">
+      <div class="celular-row">
+        <select id="perfil-codigo-pais" aria-label="Código de país"></select>
+        <input type="tel" id="perfil-celular" placeholder="Número Celular" autocomplete="tel" inputmode="numeric" maxlength="20" pattern="[0-9]+" title="Ingresa solo números" required />
+      </div>
     </div>
     <div id="perfil-mensaje" class="mensaje-validacion" role="alert" aria-live="polite"></div>
     <button id="guardar-perfil-btn" class="menu-btn" data-modo="guardar">Guardar</button>


### PR DESCRIPTION
## Summary
- Reestructura la sección de celular en configcollab para colocar el prefijo y el número en la misma fila, igual que en perfil

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2c287c08832686dcba903dd57d40)