### PR TITLE
Ajustar espaciado del menú en iOS

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -494,16 +494,17 @@
       }
       @supports (-webkit-touch-callout: none) {
           body {
-              padding-top: calc(env(safe-area-inset-top, 0px) + clamp(12px, 3vh, 36px));
+              padding-top: calc(env(safe-area-inset-top, 0px) + clamp(8px, 2vh, 22px));
           }
           #menu-buttons {
               gap: clamp(0px, 0.8vh, 6px);
+              margin-top: clamp(6px, 2vh, 18px);
           }
           #menu-logo {
               margin-bottom: clamp(-2px, 0.4vh, 6px);
           }
           #menu-tabla-wrapper {
-              padding-top: clamp(4px, 0.8vh, 12px);
+              padding-top: clamp(2px, 0.8vh, 10px);
           }
       }
       .modal-whatsapp {


### PR DESCRIPTION
## Summary
- reduce padding superior en iOS para evitar que el menú quede desplazado hacia abajo
- ajusta márgenes y separación del contenedor de botones sin afectar otras plataformas

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2f0dcc588326b8f39975c2d3b0f5)