### PR TITLE
Ajustar espaciado del menú en iOS

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -494,17 +494,18 @@
       }
       @supports (-webkit-touch-callout: none) {
           body {
-              padding-top: calc(env(safe-area-inset-top, 0px) + clamp(8px, 2vh, 22px));
+              min-height: 100dvh;
+              padding-top: max(env(safe-area-inset-top, 0px), clamp(12px, 3vh, 36px));
           }
           #menu-buttons {
               gap: clamp(0px, 0.8vh, 6px);
-              margin-top: clamp(6px, 2vh, 18px);
+              margin-top: clamp(2px, 1vh, 12px);
           }
           #menu-logo {
               margin-bottom: clamp(-2px, 0.4vh, 6px);
           }
           #menu-tabla-wrapper {
-              padding-top: clamp(2px, 0.8vh, 10px);
+              padding-top: clamp(0px, 0.6vh, 8px);
           }
       }
       .modal-whatsapp {


### PR DESCRIPTION
## Summary
- mejora el tratamiento del safe area y altura en Safari iOS para alinear el menú del jugador
- ajusta los márgenes superiores del menú para que coincidan con Android y escritorio

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d3359dd648326983093c09259b4b5)