### PR TITLE
Corrige vista de cartones sin ganadores

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -2802,10 +2802,14 @@
           box-shadow: 0 6px 18px rgba(0,0,0,0.16);
           border: 1px solid rgba(0,0,0,0.05);
       }
-      #modal-sin-ganadores-preview .carton-tabla--mini thead,
-      #modal-sin-ganadores-preview .carton-tabla--mini tbody,
+      #modal-sin-ganadores-preview .carton-tabla--mini thead {
+          display: table-header-group;
+      }
+      #modal-sin-ganadores-preview .carton-tabla--mini tbody {
+          display: table-row-group;
+      }
       #modal-sin-ganadores-preview .carton-tabla--mini tr {
-          display: contents;
+          display: table-row;
       }
       #modal-sin-ganadores-preview .carton-tabla--mini th,
       #modal-sin-ganadores-preview .carton-tabla--mini td {
@@ -6246,7 +6250,7 @@
               td.classList.add('celda-cantada');
             }
           }else{
-            span.textContent='—';
+            span.textContent='\u00a0';
           }
           td.appendChild(span);
         }


### PR DESCRIPTION
## Summary
- Mantiene la tabla de los cartones de ejemplo en el modal sin ganadores para que conserve la grilla de 5x5
- Muestra las celdas vacías sin guiones en los cartones miniatura

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f4abc4a8c8326917de6179fd91e17)