### PR TITLE
Ajustar miniaturas de cartones sin ganadores en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -2788,28 +2788,35 @@
           border-radius: 10px;
       }
       #modal-sin-ganadores-preview .carton-visual--mini {
-          padding: 8px;
-          background: linear-gradient(160deg, rgba(255,255,255,0.95), rgba(243,247,255,0.92));
-          border-radius: 14px;
-          border: 1px solid rgba(0,0,0,0.06);
+          padding: clamp(6px, 1.4vw, 10px);
+          background: #ffffff;
+          border-radius: 12px;
+          border: 1px solid rgba(0,0,0,0.08);
+          box-shadow: 0 6px 14px rgba(0,0,0,0.14);
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 100%;
+          max-width: clamp(150px, 32vw, 220px);
       }
       #modal-sin-ganadores-preview .carton-tabla--mini {
-          width: 100%;
-          max-width: clamp(150px, 34vw, 220px);
-          background: linear-gradient(160deg, rgba(255,255,255,0.95), rgba(243,247,255,0.95));
+          border-collapse: separate;
+          border-spacing: 0;
+          background: linear-gradient(160deg, rgba(255,255,255,0.95), var(--forma-color-super-suave, #f3f7ff));
           border-radius: 10px;
           overflow: hidden;
-          box-shadow: 0 6px 18px rgba(0,0,0,0.16);
-          border: 1px solid rgba(0,0,0,0.05);
+          width: 100%;
+          max-width: clamp(150px, 30vw, 220px);
+          box-shadow: 0 6px 14px rgba(0,0,0,0.16);
+          display: grid;
+          grid-template-columns: repeat(5, 1fr);
+          grid-auto-rows: 1fr;
+          aspect-ratio: 5 / 6;
       }
-      #modal-sin-ganadores-preview .carton-tabla--mini thead {
-          display: table-header-group;
-      }
-      #modal-sin-ganadores-preview .carton-tabla--mini tbody {
-          display: table-row-group;
-      }
+      #modal-sin-ganadores-preview .carton-tabla--mini thead,
+      #modal-sin-ganadores-preview .carton-tabla--mini tbody,
       #modal-sin-ganadores-preview .carton-tabla--mini tr {
-          display: table-row;
+          display: contents;
       }
       #modal-sin-ganadores-preview .carton-tabla--mini th,
       #modal-sin-ganadores-preview .carton-tabla--mini td {
@@ -2821,18 +2828,17 @@
           justify-content: center;
           aspect-ratio: 1 / 1;
           position: relative;
-          font-size: clamp(0.52rem, 2.4vw, 0.82rem);
+          font-size: clamp(0.45rem, 1.95vmin, 0.82rem);
+          min-width: 0;
       }
       #modal-sin-ganadores-preview .carton-tabla--mini th {
-          font-size: clamp(0.68rem, 2.8vw, 1.05rem);
-          background: linear-gradient(135deg, rgba(var(--forma-rgb, 11, 83, 148), 1), rgba(var(--forma-rgb, 11, 83, 148), 0.9));
+          font-size: clamp(0.66rem, 2.6vmin, 1.05rem);
+          background: linear-gradient(135deg, var(--forma-color-intenso, #0b5394), var(--forma-color, #0b5394));
           color: #ffffff;
           text-shadow: 0 1px 2px rgba(0,0,0,0.6);
       }
       #modal-sin-ganadores-preview .carton-tabla--mini td.celda-forma-estrella {
-          background: linear-gradient(145deg,
-              rgba(var(--forma-rgb, 0, 120, 255), 0.25),
-              rgba(255,255,255,0.95));
+          background: linear-gradient(145deg, var(--forma-color-suave, #6fa8dc), rgba(255,255,255,0.9));
       }
       #modal-sin-ganadores-preview .carton-tabla--mini td.celda-forma-estrella .cell-content {
           opacity: 0.5;
@@ -2843,8 +2849,8 @@
           display: inline-flex;
           align-items: center;
           justify-content: center;
-          color: rgb(var(--forma-rgb, 0, 120, 255));
-          font-size: clamp(0.9rem, 3.4vw, 1.3rem);
+          color: var(--forma-color-intenso, #0b5394);
+          font-size: clamp(0.72rem, 3vmin, 1.2rem);
           text-shadow: 0 0 6px rgba(0,0,0,0.15);
       }
       #modal-sin-ganadores-preview .carton-tabla--mini td.free {


### PR DESCRIPTION
## Summary
- actualiza los estilos de las miniaturas en el modal de formas sin ganadores para igualar la vista de pdfsorteo
- usa un layout en rejilla y sombreados similares para resaltar mejor cada cartón previsualizado

## Testing
- No tests were run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f536ffd3483268c9cbf4b84baa9bd)