### PR TITLE
Ajustar presentación de cartones mini sin ganadores

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -2781,11 +2781,12 @@
       #modal-sin-ganadores-preview {
           display: flex;
           justify-content: center;
-          margin-top: 10px;
+          margin-top: 0;
       }
       #modal-sin-ganadores-preview .carton-visual {
           box-shadow: 0 6px 14px rgba(0,0,0,0.2);
           border-radius: 10px;
+          margin: 0 !important;
       }
       #modal-sin-ganadores-preview .carton-visual--mini {
           padding: clamp(6px, 1.4vw, 10px);
@@ -2798,6 +2799,12 @@
           justify-content: center;
           width: 100%;
           max-width: clamp(150px, 32vw, 220px);
+          margin: 0 !important;
+      }
+      #modal-sin-ganadores-preview .carton-box,
+      #modal-sin-ganadores-preview .carton-wrapper,
+      #modal-sin-ganadores-preview .carton-tabla--mini {
+          margin: 0 !important;
       }
       #modal-sin-ganadores-preview .carton-tabla--mini {
           border-collapse: separate;
@@ -2830,6 +2837,11 @@
           position: relative;
           font-size: clamp(0.45rem, 1.95vmin, 0.82rem);
           min-width: 0;
+          margin: 0;
+          text-align: center;
+      }
+      #modal-sin-ganadores-preview .carton-tabla--mini th .encabezado-letra {
+          margin: 0;
       }
       #modal-sin-ganadores-preview .carton-tabla--mini th {
           font-size: clamp(0.66rem, 2.6vmin, 1.05rem);
@@ -2842,6 +2854,9 @@
       }
       #modal-sin-ganadores-preview .carton-tabla--mini td.celda-forma-estrella .cell-content {
           opacity: 0.5;
+          align-items: center;
+          justify-content: center;
+          margin: 0;
       }
       #modal-sin-ganadores-preview .carton-tabla--mini td.celda-forma-estrella .forma-estrella {
           position: absolute;
@@ -2852,6 +2867,7 @@
           color: var(--forma-color-intenso, #0b5394);
           font-size: clamp(0.72rem, 3vmin, 1.2rem);
           text-shadow: 0 0 6px rgba(0,0,0,0.15);
+          margin: 0;
       }
       #modal-sin-ganadores-preview .carton-tabla--mini td.free {
           background: linear-gradient(135deg, #ffb347, #ff7b00);
@@ -2861,6 +2877,9 @@
           color: inherit;
           font-weight: 700;
           text-shadow: 0 0 6px rgba(0,0,0,0.25);
+          align-items: center;
+          justify-content: center;
+          margin: 0;
       }
       @keyframes zoomPulse {
           0% { transform: scale(1); }


### PR DESCRIPTION
## Summary
- eliminar márgenes en la vista previa de cartones mini cuando no hay ganadores
- centrar contenido y estrellas en las celdas de la tabla mini del modal

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5699329883269451ed0ba3ed8fcd)