### PR TITLE
Ajusta simulación y prioridad de cartones en sorteos

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -3907,6 +3907,8 @@
   let simulacionActivaPrevia = false;
   let ultimoTextoGanadorSimulado = '';
   let leyendaSimulacionTimer = null;
+  let cartonesRealesCargados = false;
+  let cartonesGuardadosCargados = false;
   let cartonPrincipalInfo = null;
   let resaltadoTemporal = {timer:null, tablas:null, cartonId:null};
   let formaDestacadaSeleccionada = null;
@@ -6461,7 +6463,13 @@
     const listaReales=Array.from(cartonesSorteo.values()).filter(c=>c.userId===(usuarioActual?usuarioActual.uid:null));
     const estadoSorteoActual=(activeSorteo?.estado || activeSorteo?.estadoSorteo || '').toString().toLowerCase();
     const guardados=Array.from(cartonesGuardadosJugador.values());
-    const activarSimulacion=!listaReales.length && haySorteoJugando && estadoSorteoActual==='jugando' && guardados.length>0;
+    const datosRealesListos = cartonesRealesCargados || listaReales.length>0;
+    const guardadosListos = cartonesGuardadosCargados || guardados.length>0;
+    const activarSimulacion = datosRealesListos
+      && !listaReales.length
+      && haySorteoJugando
+      && estadoSorteoActual==='jugando'
+      && guardadosListos;
     if(simulacionActivaPrevia!==activarSimulacion){
       formasCelebradasPorCarton.clear();
       if(!activarSimulacion){
@@ -8554,6 +8562,7 @@
       });
     });
     cartonesSorteo=mapa;
+    cartonesRealesCargados=true;
     calcularGanadores();
     actualizarMapaColoresConducto();
     actualizarConductoEsferas([], false);
@@ -8660,6 +8669,7 @@
         });
       });
       cartonesGuardadosJugador=mapa;
+      cartonesGuardadosCargados=true;
       calcularGanadores();
     },err=>{
       console.error('Error escuchando cartones guardados',err);
@@ -8680,6 +8690,8 @@
   function seleccionarSorteo(activos){
     const lista=Array.isArray(activos)?activos:[];
     haySorteoJugando=lista.length>0;
+    cartonesRealesCargados=false;
+    cartonesGuardadosCargados=false;
     if(haySorteoJugando){
       sorteoManualSeleccionadoId=null;
       reiniciarAlertaFormasSinGanadores();


### PR DESCRIPTION
## Summary
- añade banderas de carga para cartones jugados y guardados
- evita activar la simulación hasta confirmar la ausencia de cartones en juego y prioriza los resultados reales
- reinicia las banderas al cambiar de sorteo para mantener cálculos consistentes en las simulaciones

## Testing
- No tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fcd3106548326a46a98e92fd5a78f)