### PR TITLE
Permitir simulaciones en sorteos finalizados

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -6465,11 +6465,16 @@
     const guardados=Array.from(cartonesGuardadosJugador.values());
     const datosRealesListos = cartonesRealesCargados || listaReales.length>0;
     const guardadosListos = cartonesGuardadosCargados || guardados.length>0;
-    const activarSimulacion = datosRealesListos
+    const esSorteoFinalizadoSeleccionado = !haySorteoJugando
+      && sorteoManualSeleccionadoId
+      && activeSorteoId===sorteoManualSeleccionadoId
+      && estadoSorteoActual==='finalizado';
+    const activarSimulacion = guardadosListos
       && !listaReales.length
-      && haySorteoJugando
-      && estadoSorteoActual==='jugando'
-      && guardadosListos;
+      && (
+        (datosRealesListos && haySorteoJugando && estadoSorteoActual==='jugando')
+        || esSorteoFinalizadoSeleccionado
+      );
     if(simulacionActivaPrevia!==activarSimulacion){
       formasCelebradasPorCarton.clear();
       if(!activarSimulacion){


### PR DESCRIPTION
## Summary
- habilita el modo de simulación al consultar un sorteo finalizado seleccionado manualmente
- mantiene la visualización de cartones reales sin cambios para sorteos en juego

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fd047836083269277b17101a2dd17)