### PR TITLE
Refina lógica de simulación en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -8573,7 +8573,7 @@
     const tieneGuardados=cartonesGuardadosJugador.size>0;
     if(modalSimulacionAvisoEl){
       modalSimulacionAvisoEl.textContent=tieneGuardados
-        ? 'Usaremos tus cartones guardados para simular tu participación sin afectar el sorteo real.'
+        ? 'Usaremos tus cartones GUARDADOS para simular que juegas en el sorteo real, sin embargo no ganarás ningún premio.'
         : 'Necesitas tener cartones guardados para poder simular tu participación.';
     }
     if(modalSimulacionJugarBtn){
@@ -8714,7 +8714,7 @@
     if(!haySorteoJugando || estadoSorteoActual!=='jugando' || !sorteoId){
       return;
     }
-    if(!cartonesGuardadosJugador.size){
+    if(!cartonesGuardadosJugador.size || !cartonesGuardadosCargados || !cartonesRealesCargados){
       return;
     }
     if(simulacionSorteoActiva || simulacionCancelada.has(sorteoId) || simulacionModalMostrada.has(sorteoId)){


### PR DESCRIPTION
## Summary
- Actualiza el mensaje del modal de simulación para aclarar el uso de cartones guardados y que no otorga premios
- Evita mostrar la invitación a simular hasta cargar cartones reales y guardados, y solo si el jugador no tiene cartones participando

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209a007bac83269b9e35ef181ac425)