### PR TITLE
Corrige activación del modal de simulación al ingresar a juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -8887,6 +8887,7 @@
     cartonesSorteo=mapa;
     cartonesRealesCargados=true;
     calcularGanadores();
+    evaluarSolicitudSimulacionInicial();
     actualizarMapaColoresConducto();
     actualizarConductoEsferas([], false);
   }
@@ -8994,6 +8995,7 @@
       cartonesGuardadosJugador=mapa;
       cartonesGuardadosCargados=true;
       calcularGanadores();
+      evaluarSolicitudSimulacionInicial();
     },err=>{
       console.error('Error escuchando cartones guardados',err);
     });


### PR DESCRIPTION
## Resumen
- Disparar la evaluación de la simulación al actualizar los cartones guardados
- Volver a evaluar la solicitud de simulación tras cargar los cartones del sorteo

## Pruebas
- No se agregaron pruebas automatizadas


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209d62c0308326bae213728031a6dd)