### PR TITLE
Corrige apertura de modal de simulación

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -9016,7 +9016,6 @@
     const lista=Array.isArray(activos)?activos:[];
     haySorteoJugando=lista.length>0;
     cartonesRealesCargados=false;
-    cartonesGuardadosCargados=false;
     if(haySorteoJugando){
       sorteoManualSeleccionadoId=null;
       reiniciarAlertaFormasSinGanadores();


### PR DESCRIPTION
## Summary
- evita reiniciar la bandera de cartones guardados al cambiar de sorteo para mantener activa la lógica de simulación

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a26e3fdc8326b5df8d88b27d7286)