### PR TITLE
Corregir simulación y etiquetas de cartones guardados

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -6522,15 +6522,15 @@
       numeroSpan.className='carton-mini-numero';
       const numeroCarton=obtenerNumeroCarton(carton);
       const aliasCarton=(carton.alias || carton.nombre || '').toString().trim();
-      const mostrarAliasSimulacion = modoSimulacionCartones && aliasCarton.length>0;
-      numeroSpan.textContent=mostrarAliasSimulacion
-        ? aliasCarton
+      const etiquetaSimulada = aliasCarton || (numeroCarton==='--'?'Cartón guardado':`#${numeroCarton}`);
+      numeroSpan.textContent=modoSimulacionCartones
+        ? etiquetaSimulada
         : numeroCarton==='--'?'--':`#${numeroCarton}`;
       const tipoSpan=document.createElement('div');
       const tipoCartonTexto=tipoCarton==='gratis'?'GRATIS':'PAGADO';
       tipoSpan.className=`carton-mini-tipo carton-mini-tipo--${tipoCarton}`;
       tipoSpan.textContent = modoSimulacionCartones
-        ? (numeroCarton==='--'?'--':`#${numeroCarton}`)
+        ? etiquetaSimulada
         : `Tipo: ${tipoCartonTexto}`;
       infoMini.appendChild(numeroSpan);
       infoMini.appendChild(tipoSpan);
@@ -7912,6 +7912,9 @@
 
   function gestionarCelebracionesNuevosGanadores(cartones, esSimulacion=false){
     if(!Array.isArray(cartones) || !cartones.length){
+      return;
+    }
+    if(esSimulacion && !cartonesRealesCargados){
       return;
     }
     const idsActuales=new Set(cartones.map(carton=>carton?.id).filter(Boolean));


### PR DESCRIPTION
## Summary
- Evita mostrar celebraciones simuladas hasta que los cartones reales del sorteo estén cargados
- Muestra el nombre asignado a los cartones guardados en las etiquetas cuando se visualizan en modo simulación

## Testing
- No se ejecutaron pruebas (no disponible)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922072cc31c83268780099a32e00960)