### PR TITLE
Add countdown timers to player menu for upcoming draws

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -235,6 +235,7 @@
           width: 100%;
       }
       #menu-buttons {
+          position: relative;
           margin: clamp(10px, 4vh, 40px) auto 0;
           width: min(95vw, 980px);
           display: flex;
@@ -250,6 +251,65 @@
           text-shadow: 0 0 10px rgba(179, 71, 0, 0.8), 0 0 18px rgba(255, 140, 0, 0.9);
           text-align: center;
           letter-spacing: 1px;
+      }
+
+      #menu-heading {
+          position: relative;
+          display: inline-flex;
+          flex-direction: column;
+          align-items: center;
+      }
+
+      #contadores-sorteos {
+          position: absolute;
+          top: calc(100% + 6px);
+          left: 50%;
+          transform: translateX(-50%);
+          display: none;
+          flex-direction: column;
+          gap: 6px;
+          align-items: center;
+          pointer-events: none;
+          z-index: 1200;
+          width: min(90vw, 520px);
+      }
+
+      .contador-linea {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 6px;
+          align-items: center;
+          justify-content: center;
+          font-family: 'Poppins', sans-serif;
+          font-size: 0.9rem;
+          font-weight: 600;
+          padding: 6px 12px;
+          background: rgba(0, 0, 0, 0.6);
+          border-radius: 12px;
+          box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+      }
+
+      .contador-etiqueta {
+          font-weight: 700;
+          text-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
+      }
+
+      .contador-valor {
+          color: #fff;
+          -webkit-text-stroke: 3px #000;
+          paint-order: stroke fill;
+          text-shadow: 0 0 6px rgba(0, 0, 0, 0.55);
+          font-weight: 700;
+      }
+
+      .contador-especial .contador-etiqueta { color: #ff8c00; }
+      .contador-diario .contador-etiqueta { color: #00aa44; }
+
+      .contador-nombre {
+          font-weight: 700;
+          color: #fff;
+          -webkit-text-stroke: 1px #000;
+          text-shadow: 0 0 6px rgba(0, 0, 0, 0.55);
       }
 
       #menu-tabla-wrapper {
@@ -595,9 +655,12 @@
   <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
 
   <div id="main-menu" class="view">
-    <div id="menu-buttons">
-      <img id="menu-logo" src="img/Logo-BingOnline-nuevo500p.png" alt="Logo de BingOnline" />
-      <h3>Menú Jugador</h3>
+      <div id="menu-buttons">
+        <img id="menu-logo" src="img/Logo-BingOnline-nuevo500p.png" alt="Logo de BingOnline" />
+        <div id="menu-heading">
+          <h3>Menú Jugador</h3>
+          <div id="contadores-sorteos" aria-live="polite"></div>
+        </div>
       <div id="menu-tabla-wrapper">
         <table class="menu-tabla" aria-label="Accesos del menú principal">
           <colgroup>
@@ -674,9 +737,191 @@
   const whatsappModalMensajeEl = document.getElementById('modal-whatsapp-mensaje');
   const whatsappModalAceptarBtn = document.getElementById('modal-whatsapp-aceptar');
   const sorteoImagen = document.getElementById('boton-sorteo');
+  const contenedoresSorteosEl = document.getElementById('contadores-sorteos');
   const whatsappState = { enlace:'', cargado:false };
   let firestoreRef = null;
   let sorteoUnsubscribe = null;
+  let contadoresUnsubscribe = null;
+  let contadoresIntervalo = null;
+  let contadoresActivos = [];
+
+  function limpiarContadores(){
+    if(contadoresIntervalo){
+      clearInterval(contadoresIntervalo);
+      contadoresIntervalo = null;
+    }
+    contadoresActivos = [];
+    if(contenedoresSorteosEl){
+      contenedoresSorteosEl.innerHTML = '';
+      contenedoresSorteosEl.style.display = 'none';
+    }
+  }
+
+  function construirFechaObjetivo(sorteo){
+    if(!sorteo) return null;
+    const { fecha, hora } = sorteo;
+    if(typeof fecha !== 'string' || typeof hora !== 'string') return null;
+    const [anio, mes, dia] = fecha.split('-').map(numero => parseInt(numero, 10));
+    const [horas, minutos] = hora.split(':').map(numero => parseInt(numero, 10));
+    if([anio, mes, dia, horas].some(v => Number.isNaN(v))) return null;
+    const offset = typeof serverTime?.offsetMinutos === 'number' ? serverTime.offsetMinutos : 0;
+    const objetivoUtc = Date.UTC(anio, (mes || 1) - 1, dia || 1, horas || 0, Number.isNaN(minutos) ? 0 : minutos);
+    return objetivoUtc + (offset * 60000);
+  }
+
+  function seleccionarSorteosProximos(lista){
+    const proximos = { ESPECIAL: null, DIARIO: null };
+    const ahora = typeof obtenerEpochActual === 'function' ? obtenerEpochActual() : Date.now();
+    lista.forEach(item => {
+      const tipo = item?.tipo;
+      if(tipo !== 'ESPECIAL' && tipo !== 'DIARIO') return;
+      const objetivo = construirFechaObjetivo(item);
+      if(!objetivo || objetivo <= ahora) return;
+      const actual = proximos[tipo];
+      if(!actual || objetivo < actual.objetivo){
+        proximos[tipo] = { ...item, objetivo };
+      }
+    });
+    return Object.values(proximos).filter(Boolean);
+  }
+
+  function formatearDosDigitos(valor){
+    return String(valor).padStart(2, '0');
+  }
+
+  function construirPartesTiempo(restanteMs){
+    if(restanteMs <= 0) return null;
+    const totalSegundos = Math.floor(restanteMs / 1000);
+    const dias = Math.floor(totalSegundos / 86400);
+    const horas = Math.floor((totalSegundos % 86400) / 3600);
+    const minutos = Math.floor((totalSegundos % 3600) / 60);
+    const partes = [];
+    if(dias > 0){
+      partes.push({ etiqueta: 'Días:', valor: formatearDosDigitos(dias) });
+    }
+    if(horas > 0){
+      partes.push({ etiqueta: 'Horas:', valor: formatearDosDigitos(horas) });
+    }
+    partes.push({ etiqueta: 'Min:', valor: formatearDosDigitos(minutos), sufijo: 'min' });
+    return partes;
+  }
+
+  function actualizarLineaContador(entrada){
+    if(!entrada?.elemento) return;
+    const ahora = typeof obtenerEpochActual === 'function' ? obtenerEpochActual() : Date.now();
+    const restante = entrada.objetivo - ahora;
+    if(restante <= 0){
+      entrada.elemento.remove();
+      entrada.activo = false;
+      return;
+    }
+
+    const partes = construirPartesTiempo(restante);
+    if(!partes){
+      entrada.elemento.remove();
+      entrada.activo = false;
+      return;
+    }
+
+    entrada.elemento.innerHTML = '';
+
+    if(entrada.tipo === 'DIARIO' && entrada.nombre){
+      const nombreSpan = document.createElement('span');
+      nombreSpan.className = 'contador-nombre';
+      nombreSpan.textContent = entrada.nombre;
+      entrada.elemento.appendChild(nombreSpan);
+    }
+
+    partes.forEach(parte => {
+      if(parte.valor === undefined || parte.valor === null) return;
+      const etiquetaSpan = document.createElement('span');
+      etiquetaSpan.className = 'contador-etiqueta';
+      etiquetaSpan.textContent = parte.etiqueta;
+
+      const valorSpan = document.createElement('span');
+      valorSpan.className = 'contador-valor';
+      valorSpan.textContent = parte.valor;
+
+      entrada.elemento.appendChild(etiquetaSpan);
+      entrada.elemento.appendChild(valorSpan);
+
+      if(parte.sufijo){
+        const sufijoSpan = document.createElement('span');
+        sufijoSpan.className = 'contador-etiqueta';
+        sufijoSpan.textContent = parte.sufijo;
+        entrada.elemento.appendChild(sufijoSpan);
+      }
+    });
+  }
+
+  function prepararContadores(sorteos){
+    limpiarContadores();
+    if(!contenedoresSorteosEl) return;
+    if(!Array.isArray(sorteos) || sorteos.length === 0) return;
+
+    contadoresActivos = sorteos.map(sorteo => {
+      const elemento = document.createElement('div');
+      const claseTipo = sorteo.tipo === 'ESPECIAL' ? 'contador-especial' : 'contador-diario';
+      elemento.className = `contador-linea ${claseTipo}`;
+      contenedoresSorteosEl.appendChild(elemento);
+      return { ...sorteo, elemento, activo: true };
+    });
+
+    contenedoresSorteosEl.style.display = 'flex';
+
+    contadoresActivos.forEach(actualizarLineaContador);
+
+    contadoresIntervalo = setInterval(() => {
+      contadoresActivos = contadoresActivos.filter(entrada => {
+        actualizarLineaContador(entrada);
+        return entrada.activo !== false;
+      });
+      if(contadoresActivos.length === 0){
+        limpiarContadores();
+      }
+    }, 1000);
+  }
+
+  async function iniciarContadoresSorteos(){
+    if(!firestoreRef || !contenedoresSorteosEl) return;
+    if(typeof initServerTime === 'function'){
+      try {
+        await initServerTime();
+      } catch (error) {
+        console.error('No se pudo sincronizar la hora del servidor para los contadores', error);
+      }
+    }
+
+    if(contadoresUnsubscribe){
+      contadoresUnsubscribe();
+      contadoresUnsubscribe = null;
+    }
+
+    try {
+      contadoresUnsubscribe = firestoreRef.collection('sorteos')
+        .where('estado', '==', 'Activo')
+        .where('tipo', 'in', ['ESPECIAL', 'DIARIO'])
+        .onSnapshot(snapshot => {
+          if(!snapshot){
+            limpiarContadores();
+            return;
+          }
+          const sorteos = [];
+          snapshot.forEach(doc => sorteos.push({ id: doc.id, ...doc.data() }));
+          const proximos = seleccionarSorteosProximos(sorteos);
+          if(proximos.length > 0){
+            prepararContadores(proximos);
+          } else {
+            limpiarContadores();
+          }
+        }, error => {
+          console.error('Error al observar los sorteos activos para contadores', error);
+          limpiarContadores();
+        });
+    } catch (error) {
+      console.error('No se pudo iniciar la observación de sorteos activos', error);
+    }
+  }
 
   function asignarFotoUsuario(elemento, url){
     if(!elemento) return;
@@ -822,6 +1067,7 @@
       });
     }
 
+    iniciarContadoresSorteos();
     observarEstadoSorteo();
   }
 


### PR DESCRIPTION
## Summary
- add floating countdown badges beneath the player menu title that display the nearest active ESPECIAL and DIARIO draws
- compute countdowns with server time and live Firestore updates, hiding labels as days or hours reach zero

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922390029e4832692f2917cb1603190)