### PR TITLE
Ajustar contadores de player con segundos

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -264,7 +264,7 @@
           position: static;
           display: none;
           flex-direction: column;
-          gap: 4px;
+          gap: 2px;
           align-items: center;
           pointer-events: none;
           width: 100%;
@@ -274,7 +274,7 @@
       .contador-linea {
           display: inline-flex;
           flex-wrap: wrap;
-          gap: 6px;
+          gap: 4px;
           align-items: center;
           justify-content: center;
           font-family: 'Poppins', sans-serif;
@@ -284,11 +284,11 @@
           background: transparent;
           border-radius: 0;
           box-shadow: none;
+          line-height: 1.2;
       }
 
       .contador-titulo {
-          color: #e6e6e6;
-          border: 3px solid #000;
+          color: #000;
           padding: 2px 8px;
           border-radius: 6px;
           text-transform: uppercase;
@@ -801,7 +801,8 @@
     const dias = Math.floor(totalSegundos / 86400);
     const horas = Math.floor((totalSegundos % 86400) / 3600);
     const minutos = Math.floor((totalSegundos % 3600) / 60);
-    return { dias, horas, minutos };
+    const segundos = totalSegundos % 60;
+    return { dias, horas, minutos, segundos };
   }
 
   function actualizarLineaContador(entrada){
@@ -825,7 +826,7 @@
 
     const tituloSpan = document.createElement('span');
     tituloSpan.className = 'contador-titulo';
-    tituloSpan.textContent = 'Tiempo para:';
+    tituloSpan.textContent = 'Próximo:';
     entrada.elemento.appendChild(tituloSpan);
 
     const nombreSpan = document.createElement('span');
@@ -843,7 +844,7 @@
 
     const tiempoSpan = document.createElement('span');
     tiempoSpan.className = 'contador-tiempo';
-    tiempoSpan.textContent = `${formatearDosDigitos(partes.horas)}:${formatearDosDigitos(partes.minutos)}`;
+    tiempoSpan.textContent = `${formatearDosDigitos(partes.horas)}:${formatearDosDigitos(partes.minutos)}:${formatearDosDigitos(partes.segundos)}`;
     entrada.elemento.appendChild(tiempoSpan);
   }
 


### PR DESCRIPTION
## Summary
- actualicé los contadores de sorteos para mostrar la etiqueta "Próximo" sin borde y con estilo más compacto
- añadí el conteo de segundos al temporizador de los sorteos diarios y especiales

## Testing
- no se ejecutaron pruebas (no solicitado)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224a9687648326bc31ed925f97e55b)