### PR TITLE
Oculta contadores flotantes en sorteos finalizados

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1327,6 +1327,7 @@
           font-weight: 700;
           color: #f5f5f5;
           text-shadow: 0 0 10px rgba(0, 0, 0, 0.92), 0 0 16px rgba(0, 0, 0, 0.85);
+          margin-right: clamp(6px, 1.2vw, 12px);
       }
       .panel-columna-derecha__destacado > #carton-destacado,
       .panel-columna-derecha__destacado > .sin-cartones-activos {
@@ -4159,6 +4160,7 @@
   let contadoresFlotantesIntervalo = null;
   let contadoresFlotantesActivos = [];
   let contadoresFlotantesUnsubscribe = null;
+  let contadoresOcultosPorFinalizado = false;
 
   function mostrarModalWhatsapp(mensaje){
     if(!whatsappModalEl) return;
@@ -4228,7 +4230,7 @@
 
   function actualizarVisibilidadContadoresFlotantes(){
     if(!contadoresFlotantesEl) return;
-    const activo = !haySorteoJugando && contadoresFlotantesActivos.length > 0;
+    const activo = !haySorteoJugando && !contadoresOcultosPorFinalizado && contadoresFlotantesActivos.length > 0;
     contadoresFlotantesEl.classList.toggle('activo', activo);
     contadoresFlotantesEl.hidden = !activo;
   }
@@ -9427,6 +9429,9 @@
   function seleccionarSorteo(activos){
     const lista=Array.isArray(activos)?activos:[];
     haySorteoJugando=lista.length>0;
+    if(haySorteoJugando || !sorteoManualSeleccionadoId){
+      contadoresOcultosPorFinalizado=false;
+    }
     actualizarVisibilidadContadoresFlotantes();
     cartonesRealesCargados=false;
     if(haySorteoJugando){
@@ -9627,6 +9632,7 @@
         return;
       }
       sorteoManualSeleccionadoId=info.id;
+      contadoresOcultosPorFinalizado=true;
       haySorteoJugando=false;
       actualizarVisibilidadContadoresFlotantes();
       actualizarSinSorteoUI();


### PR DESCRIPTION
## Summary
- Oculta los contadores regresivos flotantes al abrir sorteos finalizados, sean simulados o reales, para evitar superposiciones
- Ajusta el espaciado entre el texto de días y el bloque de horas en los contadores flotantes

## Testing
- No se ejecutaron pruebas automatizadas


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bb23d0b88326bbe34191815ebaed)