### PR TITLE
Corregir posicion del titulo de proximos sorteos

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1267,6 +1267,7 @@
           left: clamp(4px, 1vw, 10px);
           right: clamp(4px, 1vw, 10px);
           display: none;
+          flex-direction: column;
           align-items: center;
           justify-content: center;
           pointer-events: none;
@@ -1286,6 +1287,7 @@
           text-shadow: 0 0 8px rgba(255, 255, 255, 0.8);
           background: transparent;
           animation: blinkTitulo 1.2s ease-in-out infinite;
+          margin-bottom: clamp(6px, 1.2vw, 10px);
       }
       #contadores-sorteos-flotantes .contadores-flotantes__lista {
           display: flex;


### PR DESCRIPTION
## Summary
- Ajusté el contenedor de contadores de sorteos próximos para apilar el título sobre los contadores.
- Agregué espaciado inferior al encabezado para mantener la separación visual con los contadores.

## Testing
- No se ejecutaron pruebas (no aplica).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692489d09e988326b0191d4dec40880c)