### PR TITLE
Fix publicidad carousel and adjust floating counter position

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1263,7 +1263,7 @@
       }
       #contadores-sorteos-flotantes {
           position: absolute;
-          top: calc(clamp(-8px, 1.2vw, 12px) - 40px);
+          top: calc(clamp(-8px, 1.2vw, 12px) - 20px);
           left: clamp(4px, 1vw, 10px);
           right: clamp(4px, 1vw, 10px);
           display: none;
@@ -4427,6 +4427,9 @@
         publicidadSorteosImagenCargando = false;
         aplicarTransicionPublicidadSorteos(urlLimpia);
         actualizarVisibilidadPublicidadSorteos();
+        if(publicidadSorteosLinks.length > 1 && publicidadSorteosEl?.classList.contains('activo')){
+          iniciarCarruselPublicidadSorteos();
+        }
         resolve(true);
       };
       preloader.onerror = ()=>{


### PR DESCRIPTION
## Summary
- Ajuste el carrusel de publicidad para reiniciarse tras cargar las imágenes y asegurar la rotación
- Desplacé hacia abajo los elementos flotantes de próximos sorteos y contadores para mejorar su posición visual

## Testing
- No se realizaron pruebas; se trata de cambios menores en HTML/CSS/JS.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a96f4d4c8326b3787a66eba9b12b)