### PR TITLE
Corrige rotación de publicidad y contadores en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4485,6 +4485,15 @@
     if(contadoresTituloEl){
       contadoresTituloEl.hidden = !contadoresActivos;
     }
+    if(contadoresFlotantesListaEl){
+      contadoresFlotantesListaEl.hidden = !contadoresActivos;
+      contadoresFlotantesListaEl.setAttribute('aria-hidden', contadoresActivos ? 'false' : 'true');
+    }
+    if(hayPublicidadLista && publicidadSorteosLinks.length > 1){
+      iniciarCarruselPublicidadSorteos();
+    }else if(!hayPublicidadLista){
+      detenerCarruselPublicidadSorteos();
+    }
     actualizarVisibilidadPublicidadSorteos();
   }
 


### PR DESCRIPTION
## Summary
- Reinicia el carrusel de publicidad cuando hay varias imágenes disponibles para que alternen cada 6 segundos
- Oculta la lista de contadores flotantes cuando se seleccionan sorteos finalizados o hay sorteos en juego

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924abed60308326901d339976aa3e88)