### PR TITLE
Ajustes de publicidad en configuraciones y rotación en juego activo

### DIFF
--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -534,6 +534,7 @@
     .whatsapp-section label[for="link-live-tiktok"] {
       color: #ff7a00;
       text-shadow: none;
+      margin-top: 12px;
     }
     .whatsapp-section label.publicidad-label {
       color: #1d4ed8;
@@ -1056,11 +1057,9 @@
       <p id="publicidad-sorteos-titulo" class="publicidad-titulo">Links de publicidad en Sorteos</p>
       <div class="publicidad-campos">
         <div class="publicidad-campo">
-          <label for="link-publicidad-sorteos" class="publicidad-label">Link publicidad 1</label>
           <input type="text" id="link-publicidad-sorteos" placeholder="https://mis-imagenes.com/publicidad1.jpg" spellcheck="false">
         </div>
         <div class="publicidad-campo">
-          <label for="link-publicidad-sorteos-2" class="publicidad-label">Link publicidad 2</label>
           <input type="text" id="link-publicidad-sorteos-2" placeholder="https://mis-imagenes.com/publicidad2.jpg" spellcheck="false">
         </div>
       </div>

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4338,6 +4338,7 @@
   function iniciarCarruselPublicidadSorteos(){
     detenerCarruselPublicidadSorteos();
     if(publicidadSorteosLinks.length <= 1) return;
+    if(!publicidadSorteosEl?.classList.contains('activo')) return;
     publicidadSorteosIntervalo = setInterval(()=>{
       if(!publicidadSorteosEl?.classList.contains('activo')) return;
       mostrarSiguientePublicidadSorteos();


### PR DESCRIPTION
## Summary
- Retiré las etiquetas de los campos de publicidad y añadí separación con el enlace de live en configuraciones
- Ajusté el carrusel de publicidad en juego activo para que solo se ejecute cuando el contenedor esté visible respetando el intervalo de 6 segundos

## Testing
- No tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c1d5d9208326bcfcdd213a5bdb11)