### PR TITLE
Ocultar contenedores flotantes durante sorteos en juego

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4370,7 +4370,8 @@
       return;
     }
     const hayImagenes = publicidadSorteosLinks.length > 0;
-    const puedeMostrar = hayImagenes && publicidadSorteosImagenLista && !contadoresOcultosPorFinalizado;
+    const bloqueadoPorSorteo = contadoresOcultosPorFinalizado || haySorteoJugando;
+    const puedeMostrar = hayImagenes && publicidadSorteosImagenLista && !bloqueadoPorSorteo;
     publicidadSorteosEl.classList.toggle('activo', puedeMostrar);
     publicidadSorteosEl.hidden = !puedeMostrar;
     publicidadSorteosEl.setAttribute('aria-hidden', puedeMostrar ? 'false' : 'true');
@@ -4481,7 +4482,7 @@
   function actualizarVisibilidadContadoresFlotantes(){
     if(!contadoresFlotantesEl) return;
     const hayPublicidadLista = publicidadSorteosLinks.length > 0 && publicidadSorteosImagenLista;
-    const bloqueadoPorSorteo = contadoresOcultosPorFinalizado;
+    const bloqueadoPorSorteo = contadoresOcultosPorFinalizado || haySorteoJugando;
     const contadoresActivos = !bloqueadoPorSorteo && contadoresFlotantesActivos.length > 0;
     const activo = !bloqueadoPorSorteo && (contadoresActivos || hayPublicidadLista);
     contadoresFlotantesEl.classList.toggle('activo', activo);


### PR DESCRIPTION
## Summary
- Evita que los contadores flotantes y la publicidad se muestren cuando hay un sorteo en juego
- Mantiene los contenedores desactivados durante partidas activas para destacar el cartón principal

## Testing
- No se ejecutaron pruebas (no aplicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f2bb01208326901ce194f8ef8320)