### PR TITLE
Eliminar animaciones de zoom en botones de ganadores

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1961,10 +1961,11 @@
           min-width: calc(1.8em * var(--panel-botones-escala-limitada, 1));
       }
       .carton-forma-accion.con-ganadores {
-          animation: botonGanadoresResaltar 2.8s ease-in-out infinite;
+          box-shadow: 0 8px 18px rgba(0,0,0,0.22);
+          border-color: var(--forma-color-borde, rgba(0,0,0,0.28));
       }
       .carton-forma-accion.con-ganadores .carton-forma-contador {
-          animation: contadorPulse 0.9s ease-in-out infinite;
+          font-size: calc(1.1em * var(--panel-botones-escala-limitada, 1));
       }
       .carton-forma-accion:hover,
       .carton-forma-accion:focus-visible {


### PR DESCRIPTION
## Summary
- quitar la animación de zoom en los botones de ganadores para mantener su tamaño estable
- aumentar la legibilidad de los contadores de ganadores sin animación de acercar y alejar

## Testing
- no tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b9afd5c08326b6cfd1212c188cff)