### PR TITLE
Ajustar contadores para sorteos activos

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4354,6 +4354,8 @@
     const proximos = { ESPECIAL: null, DIARIO: null };
     const ahora = typeof obtenerEpochActual === 'function' ? obtenerEpochActual() : Date.now();
     lista.forEach(item => {
+      const estado = (item?.estado || '').toString().toLowerCase();
+      if(estado !== 'activo') return;
       const tipo = normalizarTipoSorteo(item?.tipo);
       if(tipo !== 'ESPECIAL' && tipo !== 'DIARIO') return;
       const objetivo = construirFechaObjetivoSorteo(item);
@@ -4712,7 +4714,7 @@
 
     try {
       contadoresFlotantesUnsubscribe = db.collection('sorteos')
-        .where('estado', 'in', ['Activo', 'Sellado'])
+        .where('estado', '==', 'Activo')
         .onSnapshot(snapshot => {
           if(!snapshot){
             limpiarContadoresFlotantes();


### PR DESCRIPTION
## Summary
- limitar la observación de sorteos para los contadores flotantes a los sorteos con estado activo
- seleccionar únicamente el sorteo diario y el especial más cercanos para mostrar como cuenta regresiva
- ocultar los contadores cuando no existan sorteos activos que cumplan las condiciones

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925dfd25a808326855dcccc2515eead)