### PR TITLE
Mejorar responsividad del panel derecho en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1615,7 +1615,7 @@
       #carton-destacado .carton-back-title {
           margin: 0;
           font-family: 'Bangers', cursive;
-          font-size: clamp(1.1rem, 4.5vw, 1.5rem);
+          font-size: clamp(0.95rem, 4vw, 1.35rem);
           color: #ffffff;
           text-shadow: 0 0 10px rgba(0,0,0,0.85), 0 0 18px rgba(0,0,0,0.6);
           letter-spacing: 1px;
@@ -1635,19 +1635,21 @@
       }
       #carton-destacado .back-forma-line {
           font-family: 'Bangers', cursive;
-          font-size: clamp(0.88rem, 3vw, 1.08rem);
+          font-size: clamp(0.78rem, 2.8vw, 1.05rem);
           display: flex;
           align-items: center;
           justify-content: space-between;
           flex-wrap: wrap;
-          gap: 6px;
+          gap: clamp(4px, 1.8vw, 10px);
           line-height: 1.05;
           width: 100%;
           text-shadow: 0 0 12px rgba(255,255,255,0.85), 0 0 24px rgba(255,255,255,0.7);
+          min-width: 0;
+          word-break: break-word;
       }
       #carton-destacado .back-forma-line .back-forma-valor {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(1rem, 3.4vw, 1.25rem);
+          font-size: clamp(0.92rem, 3vw, 1.18rem);
           font-weight: 700;
       }
       #carton-destacado .back-forma-line .back-forma-etiqueta {
@@ -1684,7 +1686,7 @@
           width: 100%;
       }
       #carton-destacado .carton-back-total-label {
-          font-size: clamp(1.1rem, 3.8vw, 1.4rem);
+          font-size: clamp(1rem, 3.4vw, 1.28rem);
           margin: 0;
           line-height: 1.05;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
@@ -1692,7 +1694,7 @@
       }
       #carton-destacado .carton-back-total-valor {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(1.6rem, 5vw, 2.2rem);
+          font-size: clamp(1.35rem, 4.6vw, 2.05rem);
           margin: 0;
           font-weight: 700;
           line-height: 1.05;
@@ -1701,7 +1703,7 @@
           text-align: left;
       }
       #carton-destacado .carton-back-cartones-label {
-          font-size: clamp(1rem, 3.4vw, 1.3rem);
+          font-size: clamp(0.92rem, 3vw, 1.18rem);
           letter-spacing: 0.8px;
           line-height: 1.05;
           color: #ffffff;
@@ -1714,18 +1716,18 @@
       #carton-destacado .carton-back-cartones-valor {
           font-family: 'Poppins', sans-serif;
           font-weight: 700;
-          font-size: clamp(1.24rem, 3.8vw, 1.7rem);
+          font-size: clamp(1.05rem, 3.4vw, 1.55rem);
           color: #ffffff;
           line-height: 1.05;
           text-shadow: 0 0 18px rgba(255,255,255,0.95), 0 0 32px rgba(255,255,255,0.75);
           margin-left: 0;
           text-align: center;
-          padding: clamp(2px, 0.6vw, 6px) clamp(12px, 1.8vw, 20px);
+          padding: clamp(2px, 0.6vw, 5px) clamp(10px, 1.6vw, 18px);
           border-radius: 999px;
           background: linear-gradient(135deg, rgba(255,255,255,0.24), rgba(255,255,255,0.08));
           border: 1px solid rgba(255,255,255,0.4);
           box-shadow: 0 6px 16px rgba(255,255,255,0.25);
-          min-width: clamp(56px, 12vw, 92px);
+          min-width: clamp(52px, 11vw, 88px);
       }
       #panel-botones-formas {
           grid-area: botones;
@@ -3339,6 +3341,49 @@
       @media (max-width: 480px) {
           #panel-superior {
               row-gap: clamp(8px, 3vw, 14px);
+          }
+      }
+      @media (max-width: 420px) {
+          #panel-columna-derecha {
+              --carton-destacado-max-width: clamp(260px, 86vw, 520px);
+          }
+          #carton-destacado {
+              --destacado-cell-size: clamp(32px, 14vw, 90px);
+          }
+          #carton-destacado .carton-back-content {
+              gap: clamp(2px, 1vw, 6px);
+          }
+          #carton-destacado .carton-back-formas {
+              gap: clamp(4px, 1.4vw, 10px);
+          }
+          #carton-destacado .back-forma-line {
+              font-size: clamp(0.74rem, 3.6vw, 0.98rem);
+          }
+          #carton-destacado .back-forma-line .back-forma-valor {
+              font-size: clamp(0.88rem, 3.2vw, 1.12rem);
+          }
+          #carton-destacado .carton-back-total-label {
+              font-size: clamp(0.92rem, 3.2vw, 1.2rem);
+          }
+          #carton-destacado .carton-back-total-valor {
+              font-size: clamp(1.2rem, 5vw, 1.9rem);
+          }
+          #carton-destacado .carton-back-cartones-label {
+              font-size: clamp(0.86rem, 2.8vw, 1.1rem);
+              gap: clamp(4px, 1.2vw, 10px);
+          }
+          #carton-destacado .carton-back-cartones-valor {
+              font-size: clamp(0.98rem, 3.2vw, 1.4rem);
+              padding: clamp(1px, 0.6vw, 4px) clamp(8px, 1.4vw, 14px);
+          }
+          #panel-botones-formas {
+              --panel-botones-escala: 0.9;
+              --panel-botones-col-min: clamp(120px, 48vw, 200px);
+          }
+          .carton-forma-accion {
+              font-size: clamp(0.58rem, calc(0.78rem * var(--panel-botones-escala-limitada, 1)), 0.95rem);
+              padding: clamp(3px, 0.8vw, 6px) clamp(8px, 1.6vw, 14px);
+              max-width: 100%;
           }
       }
       @media (orientation: portrait) {


### PR DESCRIPTION
## Summary
- Reducir los tamaños mínimos y espacios del reverso del cartón destacado para evitar desbordes en pantallas pequeñas
- Ajustar fuentes y paddings de etiquetas y totales del cartón para adaptarse a más resoluciones
- Escalar botones de ganadores y límites de ancho en móviles de menor anchura

## Testing
- No tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69270acdbbbc83268d167691cb468ee0)