### PR TITLE
Ajusta estilos responsivos en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1609,7 +1609,7 @@
           flex-direction: column;
           align-items: stretch;
           justify-content: flex-start;
-          gap: clamp(1px, 0.4vw, 3px);
+          gap: clamp(1px, 0.35vw, 2px);
           height: 100%;
       }
       #carton-destacado .carton-back-title {
@@ -1629,18 +1629,18 @@
       #carton-destacado .carton-back-formas {
           display: flex;
           flex-direction: column;
-          gap: 8px;
+          gap: clamp(4px, 1.6vw, 8px);
           width: 100%;
           align-items: stretch;
       }
       #carton-destacado .back-forma-line {
           font-family: 'Bangers', cursive;
-          font-size: clamp(0.78rem, 2.8vw, 1.05rem);
+          font-size: clamp(0.72rem, 2.4vw, 0.98rem);
           display: flex;
           align-items: center;
           justify-content: space-between;
           flex-wrap: wrap;
-          gap: clamp(4px, 1.8vw, 10px);
+          gap: clamp(3px, 1.4vw, 9px);
           line-height: 1.05;
           width: 100%;
           text-shadow: 0 0 12px rgba(255,255,255,0.85), 0 0 24px rgba(255,255,255,0.7);
@@ -1649,7 +1649,7 @@
       }
       #carton-destacado .back-forma-line .back-forma-valor {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(0.92rem, 3vw, 1.18rem);
+          font-size: clamp(0.86rem, 2.6vw, 1.08rem);
           font-weight: 700;
       }
       #carton-destacado .back-forma-line .back-forma-etiqueta {
@@ -1686,7 +1686,7 @@
           width: 100%;
       }
       #carton-destacado .carton-back-total-label {
-          font-size: clamp(1rem, 3.4vw, 1.28rem);
+          font-size: clamp(0.94rem, 3vw, 1.18rem);
           margin: 0;
           line-height: 1.05;
           text-shadow: 0 0 14px rgba(255,255,255,0.85), 0 0 28px rgba(255,255,255,0.7);
@@ -1694,7 +1694,7 @@
       }
       #carton-destacado .carton-back-total-valor {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(1.35rem, 4.6vw, 2.05rem);
+          font-size: clamp(1.24rem, 4vw, 1.9rem);
           margin: 0;
           font-weight: 700;
           line-height: 1.05;
@@ -1703,26 +1703,26 @@
           text-align: left;
       }
       #carton-destacado .carton-back-cartones-label {
-          font-size: clamp(0.92rem, 3vw, 1.18rem);
+          font-size: clamp(0.88rem, 2.6vw, 1.1rem);
           letter-spacing: 0.8px;
           line-height: 1.05;
           color: #ffffff;
           margin-top: 4px;
           display: inline-flex;
           align-items: center;
-          gap: clamp(6px, 1.4vw, 14px);
+          gap: clamp(5px, 1.2vw, 12px);
           text-shadow: 0 0 16px rgba(255,255,255,0.9), 0 0 28px rgba(255,255,255,0.75);
       }
       #carton-destacado .carton-back-cartones-valor {
           font-family: 'Poppins', sans-serif;
           font-weight: 700;
-          font-size: clamp(1.05rem, 3.4vw, 1.55rem);
+          font-size: clamp(0.98rem, 3vw, 1.46rem);
           color: #ffffff;
           line-height: 1.05;
           text-shadow: 0 0 18px rgba(255,255,255,0.95), 0 0 32px rgba(255,255,255,0.75);
           margin-left: 0;
           text-align: center;
-          padding: clamp(2px, 0.6vw, 5px) clamp(10px, 1.6vw, 18px);
+          padding: clamp(1px, 0.6vw, 4px) clamp(9px, 1.5vw, 16px);
           border-radius: 999px;
           background: linear-gradient(135deg, rgba(255,255,255,0.24), rgba(255,255,255,0.08));
           border: 1px solid rgba(255,255,255,0.4);
@@ -2075,17 +2075,17 @@
       }
       .carton-forma-leyenda {
           position: absolute;
-          top: clamp(6px, 2vw, 16px);
+          top: clamp(4px, 1.6vw, 14px);
           left: 50%;
           transform: translateX(-50%);
           background: rgba(255, 255, 255, 0.92);
           color: #333333;
-          font-size: 0.55rem;
+          font-size: clamp(0.5rem, 2vw, 0.62rem);
           font-weight: 600;
-          letter-spacing: 0.8px;
+          letter-spacing: 0.6px;
           text-transform: uppercase;
           border-radius: 999px;
-          padding: 2px 10px;
+          padding: clamp(1px, 0.6vw, 3px) clamp(8px, 1.6vw, 12px);
           white-space: nowrap;
           opacity: 0;
           transition: opacity 0.3s ease;
@@ -2094,8 +2094,8 @@
           z-index: 2;
       }
       .carton-visual--principal .carton-forma-leyenda {
-          font-size: 0.62rem;
-          padding: 3px 12px;
+          font-size: clamp(0.56rem, 2.2vw, 0.68rem);
+          padding: clamp(2px, 0.8vw, 4px) clamp(10px, 2vw, 14px);
       }
       .carton-forma-leyenda--panel {
           position: static;
@@ -3631,23 +3631,26 @@
       }
       @media (orientation: landscape) {
           main {
-              max-width: min(100%, 1040px);
-              padding-left: clamp(10px, 2.8vw, 22px);
-              padding-right: clamp(10px, 2.8vw, 22px);
+              max-width: min(100%, 940px);
+              padding-left: clamp(8px, 2.2vw, 18px);
+              padding-right: clamp(8px, 2.2vw, 18px);
           }
           #panel-superior {
-              grid-template-columns: minmax(calc(var(--canto-cell-size) * 5 + clamp(6px, 1.6vw, 18px) * 2), clamp(320px, 52vw, 580px)) minmax(var(--panel-columna-derecha-min, clamp(240px, 32vw, 520px)), clamp(340px, 48vw, 640px));
+              width: 100%;
+              max-width: min(100%, 940px);
+              margin-inline: auto;
+              grid-template-columns: minmax(calc(var(--canto-cell-size) * 5 + clamp(6px, 1.4vw, 16px) * 2), clamp(300px, 50vw, 540px)) minmax(var(--panel-columna-derecha-min, clamp(240px, 36vw, 520px)), clamp(320px, 52vw, 560px));
               grid-template-areas:
                   "cantos carton"
                   "mensaje carton";
               align-items: stretch;
               justify-items: stretch;
-              column-gap: clamp(6px, 1.6vw, 18px);
-              row-gap: clamp(6px, 1.2vw, 14px);
+              column-gap: clamp(4px, 1.2vw, 14px);
+              row-gap: clamp(6px, 1.1vw, 12px);
               padding-bottom: 0;
           }
           #panel-columna-derecha {
-              padding-inline: clamp(10px, 2.4vw, 20px);
+              padding-inline: clamp(8px, 2vw, 16px);
               box-sizing: border-box;
           }
           .panel-columna-derecha__destacado {


### PR DESCRIPTION
## Summary
- Reduce tipografías y espaciados en el reverso del cartón destacado para mantenerlo compacto en vista vertical
- Ajusta la leyenda de ganancia de forma con padding y tamaños de fuente responsivos
- Acota márgenes y anchos en orientación horizontal para centrar los elementos como en la vista vertical

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692738082f84832685b3d42eb4f92df2)