### PR TITLE
Mantener distribución horizontal en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -3884,11 +3884,10 @@
           #panel-superior {
               column-gap: clamp(6px, 1.6vw, 14px);
               row-gap: clamp(8px, 1.6vw, 14px);
-              grid-template-columns: 1fr;
+              grid-template-columns: minmax(calc(var(--canto-cell-size) * 5 + clamp(6px, 1.4vw, 16px) * 2), clamp(260px, 44vw, 440px)) minmax(var(--panel-columna-derecha-min, clamp(220px, 36vw, 520px)), clamp(300px, 58vw, 560px));
               grid-template-areas:
-                  "cantos"
-                  "carton"
-                  "mensaje";
+                  "cantos carton"
+                  "mensaje carton";
               align-content: start;
               justify-items: stretch;
               padding-inline: clamp(8px, 2vw, 16px);


### PR DESCRIPTION
## Summary
- Ajustar el grid en orientación horizontal para mantener cantos a la izquierda y el cartón destacado a la derecha en pantallas pequeñas.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273dace3388326a21ba2c56bc9ec2f)