### PR TITLE
Ajustes visuales y animaciones en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1609,7 +1609,7 @@
           flex-direction: column;
           align-items: stretch;
           justify-content: flex-start;
-          gap: clamp(1px, 0.35vw, 2px);
+          gap: clamp(0px, 0.3vw, 2px);
           height: 100%;
       }
       #carton-destacado .carton-back-title {
@@ -1629,7 +1629,7 @@
       #carton-destacado .carton-back-formas {
           display: flex;
           flex-direction: column;
-          gap: clamp(4px, 1.6vw, 8px);
+          gap: clamp(3px, 1.2vw, 6px);
           width: 100%;
           align-items: stretch;
       }
@@ -1707,27 +1707,11 @@
           letter-spacing: 0.8px;
           line-height: 1.05;
           color: #ffffff;
-          margin-top: 4px;
+          margin-top: 0;
           display: inline-flex;
           align-items: center;
-          gap: clamp(5px, 1.2vw, 12px);
+          gap: clamp(3px, 0.8vw, 8px);
           text-shadow: 0 0 16px rgba(255,255,255,0.9), 0 0 28px rgba(255,255,255,0.75);
-      }
-      #carton-destacado .carton-back-cartones-valor {
-          font-family: 'Poppins', sans-serif;
-          font-weight: 700;
-          font-size: clamp(0.98rem, 3vw, 1.46rem);
-          color: #ffffff;
-          line-height: 1.05;
-          text-shadow: 0 0 18px rgba(255,255,255,0.95), 0 0 32px rgba(255,255,255,0.75);
-          margin-left: 0;
-          text-align: center;
-          padding: clamp(1px, 0.6vw, 4px) clamp(9px, 1.5vw, 16px);
-          border-radius: 999px;
-          background: linear-gradient(135deg, rgba(255,255,255,0.24), rgba(255,255,255,0.08));
-          border: 1px solid rgba(255,255,255,0.4);
-          box-shadow: 0 6px 16px rgba(255,255,255,0.25);
-          min-width: clamp(52px, 11vw, 88px);
       }
       #panel-botones-formas {
           grid-area: botones;
@@ -2085,8 +2069,15 @@
           letter-spacing: 0.6px;
           text-transform: uppercase;
           border-radius: 999px;
-          padding: clamp(1px, 0.6vw, 3px) clamp(8px, 1.6vw, 12px);
-          white-space: nowrap;
+          padding: clamp(3px, 0.8vw, 6px) clamp(8px, 1.8vw, 14px);
+          white-space: normal;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: clamp(1px, 0.4vw, 3px);
+          text-align: center;
+          min-width: clamp(110px, 34vw, 180px);
+          max-width: clamp(140px, 48vw, 220px);
           opacity: 0;
           transition: opacity 0.3s ease;
           box-shadow: 0 0 10px rgba(255, 215, 0, 0.75);
@@ -2106,6 +2097,21 @@
       }
       .carton-forma-leyenda.visible {
           opacity: 1;
+      }
+      .carton-forma-leyenda__titulo {
+          display: block;
+          color: #000000;
+          font-size: clamp(0.52rem, 2vw, 0.7rem);
+          line-height: 1.05;
+          letter-spacing: 0.7px;
+      }
+      .carton-forma-leyenda__forma {
+          display: block;
+          color: inherit;
+          font-size: clamp(0.48rem, 1.9vw, 0.64rem);
+          line-height: 1.05;
+          word-break: break-word;
+          text-align: center;
       }
       body.simulacion-cartones-activa .carton-visual,
       body.simulacion-cartones-activa .carton-tabla,
@@ -2272,7 +2278,7 @@
           letter-spacing: 1.5px;
       }
       .carton-tabla.ganador thead th .encabezado-letra {
-          animation: zoomPulse 1.6s ease-in-out infinite;
+          animation: none;
       }
       .carton-tabla tbody td {
           font-size: calc(var(--cell-size) * 0.55);
@@ -3354,7 +3360,7 @@
               gap: clamp(2px, 1vw, 6px);
           }
           #carton-destacado .carton-back-formas {
-              gap: clamp(4px, 1.4vw, 10px);
+              gap: clamp(3px, 1vw, 8px);
           }
           #carton-destacado .back-forma-line {
               font-size: clamp(0.74rem, 3.6vw, 0.98rem);
@@ -3370,11 +3376,7 @@
           }
           #carton-destacado .carton-back-cartones-label {
               font-size: clamp(0.86rem, 2.8vw, 1.1rem);
-              gap: clamp(4px, 1.2vw, 10px);
-          }
-          #carton-destacado .carton-back-cartones-valor {
-              font-size: clamp(0.98rem, 3.2vw, 1.4rem);
-              padding: clamp(1px, 0.6vw, 4px) clamp(8px, 1.4vw, 14px);
+              gap: clamp(3px, 0.9vw, 8px);
           }
           #panel-botones-formas {
               --panel-botones-escala: 0.9;
@@ -3571,14 +3573,14 @@
             width: 100%;
         }
         #carton-destacado .carton-back-formas {
-            gap: clamp(6px, 2vw, 12px);
+            gap: clamp(4px, 1.6vw, 10px);
             align-items: stretch;
             width: 100%;
         }
         #carton-destacado .back-forma-line {
             justify-content: flex-start;
             align-items: baseline;
-            gap: clamp(6px, 3vw, 14px);
+            gap: clamp(4px, 2.2vw, 12px);
             font-size: clamp(1rem, 4.4vw, 1.35rem);
             text-align: left;
         }
@@ -3743,18 +3745,18 @@
           }
           #carton-destacado .carton-back-content {
               padding: clamp(12px, 3vw, 24px) clamp(15px, 3.8vw, 26px) clamp(12px, 3vw, 24px) clamp(11px, 3.2vw, 22px);
-              gap: clamp(2px, 0.9vw, 4px);
+              gap: clamp(1px, 0.8vw, 3px);
               align-items: stretch;
           }
           #carton-destacado .carton-back-formas {
-              gap: clamp(6px, 2vw, 12px);
+              gap: clamp(4px, 1.6vw, 10px);
               align-items: stretch;
               width: 100%;
           }
           #carton-destacado .back-forma-line {
               justify-content: flex-start;
               align-items: baseline;
-              gap: clamp(6px, 2.8vw, 14px);
+              gap: clamp(4px, 2vw, 12px);
               text-align: left;
           }
           #carton-destacado .back-forma-line .back-forma-etiqueta,
@@ -4346,6 +4348,8 @@
   let evitarReaplicarFormaDestacada = false;
   let panelFormasLeyendaEl = null;
   let panelGananciasTotalesEl = null;
+  let panelGananciasTotalesSuperiorEl = null;
+  let panelGananciasTotalesInferiorEl = null;
   let panelGananciasTotalesValorEl = null;
   let totalGananciasJugador = 0;
   let ultimoCantoBoton = null;
@@ -5829,6 +5833,8 @@
       panelBotonesFormasEl.innerHTML='';
       panelFormasLeyendaEl=null;
       panelGananciasTotalesEl=null;
+      panelGananciasTotalesSuperiorEl=null;
+      panelGananciasTotalesInferiorEl=null;
       panelGananciasTotalesValorEl=null;
       actualizarAlturaBotonesRetrato();
       return;
@@ -5837,6 +5843,8 @@
     panelSuperiorEl.querySelectorAll('.carton-forma-accion[data-forma-boton="dinamico"]').forEach(boton=>boton.remove());
     panelFormasLeyendaEl=null;
     panelGananciasTotalesEl=null;
+    panelGananciasTotalesSuperiorEl=null;
+    panelGananciasTotalesInferiorEl=null;
     panelGananciasTotalesValorEl=null;
     actualizarAlturaBotonesRetrato();
   }
@@ -5888,7 +5896,19 @@
     if(panelGananciasTotalesValorEl){
       panelGananciasTotalesValorEl.textContent=formatearCreditos(valorMostrar);
     }
+    actualizarEtiquetaGananciasTotales();
     actualizarVisibilidadPanelGanancias();
+  }
+
+  function actualizarEtiquetaGananciasTotales(){
+    if(!panelGananciasTotalesSuperiorEl || !panelGananciasTotalesInferiorEl) return;
+    if(modoSimulacionCartones){
+      panelGananciasTotalesSuperiorEl.textContent='TOTAL';
+      panelGananciasTotalesInferiorEl.textContent='SIMULACION';
+    }else{
+      panelGananciasTotalesSuperiorEl.textContent='GANANCIAS';
+      panelGananciasTotalesInferiorEl.textContent='TOTALES';
+    }
   }
 
   function detenerParpadeoLeyendaSimulacion(){
@@ -5940,9 +5960,9 @@
       const etiqueta=document.createElement('div');
       etiqueta.className='panel-ganancias-totales__etiqueta';
       const textoSuperior=document.createElement('span');
-      textoSuperior.textContent='GANANCIAS';
+      panelGananciasTotalesSuperiorEl=textoSuperior;
       const textoInferior=document.createElement('span');
-      textoInferior.textContent='TOTALES';
+      panelGananciasTotalesInferiorEl=textoInferior;
       etiqueta.appendChild(textoSuperior);
       etiqueta.appendChild(textoInferior);
       const valor=document.createElement('div');
@@ -5952,6 +5972,7 @@
       panelGananciasTotalesEl.appendChild(etiqueta);
       panelGananciasTotalesEl.appendChild(valor);
     }
+    actualizarEtiquetaGananciasTotales();
     if(panelGananciasTotalesEl.parentElement!==panelFormasLeyendaEl){
       if(panelGananciasTotalesEl.parentElement){
         panelGananciasTotalesEl.parentElement.removeChild(panelGananciasTotalesEl);
@@ -6059,6 +6080,20 @@
     etiqueta.classList.toggle('carton-forma-etiqueta--oculta', hayGanadores);
     marquesina.classList.toggle('carton-forma-marquesina--activa', hayGanadores);
     boton.classList.toggle('carton-forma-accion--marquesina-activa', hayGanadores);
+  }
+
+  function controlarMarquesinasDuranteCelebracion(formaActivaIdx=null){
+    const botones=document.querySelectorAll('.carton-forma-accion.carton-forma-accion--marquesina-activa');
+    const indiceObjetivo=Number(formaActivaIdx);
+    const idxValido=Number.isInteger(indiceObjetivo);
+    botones.forEach(boton=>{
+      const contenido=boton.querySelector('.carton-forma-marquesina__contenido');
+      if(!contenido) return;
+      const idxBoton=Number(boton.dataset.formaIdx);
+      const mantenerActivo=idxValido && Number.isInteger(idxBoton) && idxBoton===indiceObjetivo;
+      const playState=formaActivaIdx===null?'' : (mantenerActivo?'running':'paused');
+      contenido.style.animationPlayState=playState;
+    });
   }
 
   function crearBotonGanadoresForma(forma, totalGanadoresAlterno){
@@ -7459,6 +7494,7 @@
     misCartonesLabelEl.textContent = modoSimulacionCartones
       ? 'MIS CARTONES GUARDADOS'
       : 'MIS CARTONES EN EL SORTEO';
+    actualizarEtiquetaGananciasTotales();
   }
 
   function obtenerCartonesJugadorActual(){
@@ -7501,6 +7537,7 @@
       }
     }
     animacionesCartones.delete(cartonId);
+    controlarMarquesinasDuranteCelebracion(null);
   }
 
   function detenerTodasAnimaciones(){
@@ -7646,7 +7683,19 @@
         const leyendaTexto=esPrincipal && etiqueta
           ? (modoSimulacionCartones ? `HUBIESES GANADO CON ${etiqueta}` : `Ganaste con ${etiqueta}`)
           : etiqueta;
-        info.leyenda.textContent=leyendaTexto;
+        if(esPrincipal && etiqueta){
+          info.leyenda.innerHTML='';
+          const titulo=document.createElement('span');
+          titulo.className='carton-forma-leyenda__titulo';
+          titulo.textContent=modoSimulacionCartones?'HUBIESES GANADO CON':'GANASTE CON';
+          const nombre=document.createElement('span');
+          nombre.className='carton-forma-leyenda__forma';
+          nombre.textContent=etiqueta;
+          info.leyenda.appendChild(titulo);
+          info.leyenda.appendChild(nombre);
+        }else{
+          info.leyenda.textContent=leyendaTexto;
+        }
         if(datosForma.color){
           info.leyenda.style.color=ajustarLuminosidad(datosForma.color,-0.5);
           info.leyenda.style.borderColor=ajustarLuminosidad(datosForma.color,-0.2);
@@ -7903,8 +7952,10 @@
       const actual=secuencias[indice];
       const duracion=actual.tipo==='forma'?3000:3000;
       if(actual.tipo==='forma'){
+        controlarMarquesinasDuranteCelebracion(actual?.data?.indice ?? null);
         tablasInfo.forEach(info=>aplicarFormaCarton(info,actual.data));
       }else{
+        controlarMarquesinasDuranteCelebracion(null);
         tablasInfo.forEach(aplicarResumenCarton);
       }
       registro.timer=setTimeout(()=>{
@@ -9016,12 +9067,7 @@
       totalContenedor.appendChild(totalFila);
       const cartonesGratisLabel=document.createElement('span');
       cartonesGratisLabel.className='carton-back-cartones-label';
-      cartonesGratisLabel.textContent='CARTONES GRATIS:';
-      const cartonesGratisValor=document.createElement('span');
-      cartonesGratisValor.className='carton-back-cartones-valor';
-      cartonesGratisValor.textContent=formatearCreditos(resumenGanancias.cartonesGratis || 0);
-      cartonesGratisLabel.appendChild(document.createTextNode(' '));
-      cartonesGratisLabel.appendChild(cartonesGratisValor);
+      cartonesGratisLabel.textContent=`CARTONES GRATIS: ${formatearCreditos(resumenGanancias.cartonesGratis || 0)}`;
       totalContenedor.appendChild(cartonesGratisLabel);
       backContent.appendChild(totalContenedor);
       const backLogo=document.createElement('img');


### PR DESCRIPTION
## Summary
- Reducir espacios y simplificar la visualización de ganancias y cartones gratis en el reverso del cartón destacado
- Adaptar etiquetas de ganancia y mensajes de forma ganadora para modo simulación y mejor legibilidad
- Optimizar animaciones eliminando el pulso de BINGO y pausando marquesinas durante resaltados de formas

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69285d329a7c8326b0c6b03663a7bee4)