### PR TITLE
Ajusta panel de ganancias y animaciones en simulación

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1804,6 +1804,11 @@
           box-shadow: 0 6px 18px rgba(0, 0, 0, 0.14);
           max-width: 100%;
           min-width: 0;
+          width: 100%;
+          align-self: center;
+          justify-self: center;
+          flex-wrap: wrap;
+          text-align: center;
           box-sizing: border-box;
       }
       .panel-ganancias-totales--visible {
@@ -6084,6 +6089,14 @@
 
   function controlarMarquesinasDuranteCelebracion(formaActivaIdx=null){
     const botones=document.querySelectorAll('.carton-forma-accion.carton-forma-accion--marquesina-activa');
+    if(modoSimulacionCartones){
+      botones.forEach(boton=>{
+        const contenido=boton.querySelector('.carton-forma-marquesina__contenido');
+        if(!contenido) return;
+        contenido.style.animationPlayState='';
+      });
+      return;
+    }
     const indiceObjetivo=Number(formaActivaIdx);
     const idxValido=Number.isInteger(indiceObjetivo);
     botones.forEach(boton=>{


### PR DESCRIPTION
## Summary
- centra y limita el panel de ganancias totales para evitar desbordes en la columna derecha
- mantiene en movimiento las marquesinas de ganadores cuando se ejecuta la simulación

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928694e51ec83268395e72c04884a94)