### PR TITLE
Ajusta alineación de panel de ganancias totales

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1796,7 +1796,7 @@
       .panel-ganancias-totales {
           display: none;
           align-items: center;
-          justify-content: center;
+          justify-content: space-between;
           gap: clamp(6px, 2vw, 12px);
           padding: clamp(2px, 1vw, 6px) clamp(6px, 2vw, 14px);
           border-radius: 14px;
@@ -1825,7 +1825,9 @@
           color: #000000;
           line-height: 1.05;
           text-transform: uppercase;
-          text-align: center;
+          text-align: left;
+          align-items: flex-start;
+          flex: 1;
       }
       .panel-ganancias-totales__etiqueta span {
           display: block;
@@ -1840,6 +1842,8 @@
           max-width: 100%;
           overflow: hidden;
           text-overflow: ellipsis;
+          margin-left: auto;
+          text-align: right;
       }
       .panel-botones-formas__mensaje .carton-forma-leyenda {
           position: static;


### PR DESCRIPTION
## Summary
- Ajusta la distribución del panel de ganancias totales para que la etiqueta quede a la izquierda y el valor a la derecha
- Mantiene estilos tipográficos originales asegurando presentación en dos líneas para la etiqueta

## Testing
- No se ejecutaron pruebas


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69286fb2e5e083269c0cf15ca14fe48c)