### PR TITLE
Ajusta presentación del panel de ganancias en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1795,8 +1795,9 @@
       }
       .panel-ganancias-totales {
           display: none;
+          grid-template-columns: 1fr auto;
           align-items: center;
-          justify-content: space-between;
+          justify-content: center;
           gap: clamp(6px, 2vw, 12px);
           padding: clamp(2px, 1vw, 6px) clamp(6px, 2vw, 14px);
           border-radius: 14px;
@@ -1804,15 +1805,15 @@
           box-shadow: 0 6px 18px rgba(0, 0, 0, 0.14);
           max-width: 100%;
           min-width: 0;
-          width: 100%;
+          width: min(100%, 420px);
           align-self: center;
           justify-self: center;
-          flex-wrap: wrap;
           text-align: center;
           box-sizing: border-box;
+          margin-inline: auto;
       }
       .panel-ganancias-totales--visible {
-          display: inline-flex;
+          display: inline-grid;
       }
       .panel-ganancias-totales__etiqueta {
           display: flex;
@@ -1825,9 +1826,9 @@
           color: #000000;
           line-height: 1.05;
           text-transform: uppercase;
-          text-align: left;
-          align-items: flex-start;
-          flex: 1;
+          text-align: center;
+          align-self: stretch;
+          justify-self: center;
       }
       .panel-ganancias-totales__etiqueta span {
           display: block;
@@ -1842,7 +1843,8 @@
           max-width: 100%;
           overflow: hidden;
           text-overflow: ellipsis;
-          margin-left: auto;
+          justify-self: end;
+          align-self: center;
           text-align: right;
       }
       .panel-botones-formas__mensaje .carton-forma-leyenda {


### PR DESCRIPTION
## Summary
- reorganiza el contenedor de ganancias totales con una cuadrícula de dos columnas para separar texto y valor
- centra la etiqueta en dos líneas en el lado izquierdo y alinea el valor a la derecha sin alterar su tipografía
- limita el ancho del panel y lo centra dentro de la columna derecha para mejorar la lectura

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69287203aef8832681a770c43e231532)