### PR TITLE
Corrige visualización del panel de ganancias totales

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1805,7 +1805,7 @@
           box-shadow: 0 6px 18px rgba(0, 0, 0, 0.14);
           max-width: 100%;
           min-width: 0;
-          width: min(100%, 420px);
+          width: min(100%, 520px);
           align-self: center;
           justify-self: center;
           text-align: center;
@@ -1813,7 +1813,7 @@
           margin-inline: auto;
       }
       .panel-ganancias-totales--visible {
-          display: inline-grid;
+          display: grid;
       }
       .panel-ganancias-totales__etiqueta {
           display: flex;
@@ -1841,8 +1841,8 @@
           line-height: 1;
           white-space: nowrap;
           max-width: 100%;
-          overflow: hidden;
-          text-overflow: ellipsis;
+          overflow: visible;
+          text-overflow: clip;
           justify-self: end;
           align-self: center;
           text-align: right;


### PR DESCRIPTION
## Summary
- Ajusta el contenedor de ganancias totales para que se centre como un elemento de cuadrícula
- Amplía el ancho disponible y evita que se trunque el valor mostrado para que se vea completo

## Testing
- No se realizaron pruebas automatizadas


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928751518a483268aeab3be7edc1b75)