### PR TITLE
Alinear panel de ganancias con leyenda en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1783,15 +1783,21 @@
       .panel-botones-formas__mensaje {
           width: 100%;
           min-height: clamp(28px, 3vw, 40px);
-          display: flex;
-          align-items: center;
-          justify-content: center;
+          display: grid;
+          place-items: center;
+          position: relative;
           font-size: clamp(0.62rem, 1.6vw, 0.9rem);
           font-weight: 700;
           letter-spacing: 1px;
           text-transform: uppercase;
           color: #4b0082;
           text-shadow: 0 0 10px rgba(255,255,255,0.95);
+      }
+      .panel-botones-formas__mensaje > * {
+          grid-area: 1 / 1;
+          width: 100%;
+          max-width: min(520px, 100%);
+          justify-self: center;
       }
       .panel-ganancias-totales {
           display: none;
@@ -2104,7 +2110,14 @@
           top: auto;
           left: auto;
           transform: none;
-          margin: 0;
+          margin: 0 auto;
+          width: 100%;
+          max-width: min(520px, 100%);
+          justify-content: center;
+          align-items: center;
+      }
+      .carton-forma-leyenda--panel:not(.visible) {
+          display: none;
       }
       .carton-forma-leyenda.visible {
           opacity: 1;


### PR DESCRIPTION
## Summary
- Centrar y superponer el panel de ganancias totales con la leyenda de la forma en el tablero de juego activo
- Ajustar estilos de la leyenda en panel para usar el mismo ancho que el contenedor de ganancias

## Testing
- No tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69287949081c8326abbc01c5f786f2cc)