### PR TITLE
Ajustar alineación de paneles en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1801,7 +1801,6 @@
       }
       .panel-ganancias-totales {
           display: none;
-          grid-template-columns: 1fr auto;
           align-items: center;
           justify-content: center;
           gap: clamp(6px, 2vw, 12px);
@@ -1809,17 +1808,18 @@
           border-radius: 14px;
           background: rgba(255, 255, 255, 0.96);
           box-shadow: 0 6px 18px rgba(0, 0, 0, 0.14);
-          max-width: 100%;
           min-width: 0;
-          width: min(100%, 520px);
+          width: fit-content;
+          max-width: min(100%, 560px);
           align-self: center;
           justify-self: center;
           text-align: center;
           box-sizing: border-box;
           margin-inline: auto;
+          inline-size: fit-content;
       }
       .panel-ganancias-totales--visible {
-          display: grid;
+          display: inline-flex;
       }
       .panel-ganancias-totales__etiqueta {
           display: flex;
@@ -1849,9 +1849,8 @@
           max-width: 100%;
           overflow: visible;
           text-overflow: clip;
-          justify-self: end;
           align-self: center;
-          text-align: right;
+          text-align: center;
       }
       .panel-botones-formas__mensaje .carton-forma-leyenda {
           position: static;
@@ -2093,8 +2092,9 @@
           align-items: center;
           gap: clamp(1px, 0.4vw, 3px);
           text-align: center;
-          min-width: clamp(110px, 34vw, 180px);
-          max-width: clamp(140px, 48vw, 220px);
+          width: fit-content;
+          min-width: auto;
+          max-width: min(90vw, 320px);
           opacity: 0;
           transition: opacity 0.3s ease;
           box-shadow: 0 0 10px rgba(255, 215, 0, 0.75);
@@ -2111,10 +2111,12 @@
           left: auto;
           transform: none;
           margin: 0 auto;
-          width: 100%;
-          max-width: min(520px, 100%);
+          width: fit-content;
+          max-width: min(100%, 520px);
           justify-content: center;
           align-items: center;
+          display: inline-flex;
+          flex-direction: column;
       }
       .carton-forma-leyenda--panel:not(.visible) {
           display: none;


### PR DESCRIPTION
## Summary
- Centrar y dimensionar dinámicamente el contenedor de ganancias totales para que se ajuste al contenido
- Ajustar la leyenda de formas ganadoras para que su ancho se adapte al texto y se mantenga centrada

## Testing
- No automated tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692886321ee883268493afad8b51a5b8)