### PR TITLE
Ensure ganadores marquee syncs with highlighted form

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -6131,7 +6131,8 @@
   }
 
   function sincronizarMarquesinasConFormaActiva(formaActivaIdx){
-    const idxValido = Number.isInteger(formaActivaIdx) ? formaActivaIdx : null;
+    const indiceNormalizado = Number(formaActivaIdx);
+    const idxValido = Number.isInteger(indiceNormalizado) ? indiceNormalizado : null;
     controlarMarquesinasDuranteCelebracion(idxValido);
   }
 


### PR DESCRIPTION
## Summary
- normalise el índice de forma antes de sincronizar los efectos de marquesina
- asegurar que el botón GANADORES correspondiente se active cuando se resalta la forma en el cartón destacado, manteniendo el movimiento en simulación

## Testing
- no se ejecutaron pruebas (no se indicaron)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69288d220de08326b0035939ffb08903)