### PR TITLE
Ajusta control de marquesinas de formas ganadoras

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -6118,14 +6118,14 @@
       });
       return;
     }
-    const indiceObjetivo=Number(formaActivaIdx);
-    const idxValido=Number.isInteger(indiceObjetivo);
+    const indiceNormalizado=Number(formaActivaIdx);
+    const indiceObjetivo=Number.isInteger(indiceNormalizado)?indiceNormalizado:null;
     botones.forEach(boton=>{
       const contenido=boton.querySelector('.carton-forma-marquesina__contenido');
       if(!contenido) return;
       const idxBoton=Number(boton.dataset.formaIdx);
-      const mantenerActivo=idxValido && Number.isInteger(idxBoton) && idxBoton===indiceObjetivo;
-      const playState=formaActivaIdx===null?'' : (mantenerActivo?'running':'paused');
+      const mantenerActivo=Number.isInteger(idxBoton) && idxBoton===indiceObjetivo;
+      const playState=indiceObjetivo===null?'' : (mantenerActivo?'running':'paused');
       contenido.style.animationPlayState=playState;
     });
   }


### PR DESCRIPTION
## Summary
- Normaliza el índice activo al sincronizar las marquesinas de ganadores
- Mantiene corriendo solo la marquesina de la forma destacada y reanuda las demás cuando no hay foco
- Preserva el comportamiento de simulación para los cartones ganadores

## Testing
- No se ejecutaron pruebas (no se encontraron suites automatizadas aplicables)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692891822d908326b6d4f4f78dba1809)