### PR TITLE
Ajustar altura de panel de ganancias y realce de formas

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -29,6 +29,7 @@
           --mini-cell-size: clamp(20px, 4.4vw, 28px);
           --canto-cell-size: clamp(28px, 4.8vw, 44px);
           --conducto-borde: clamp(2px, 0.35vw, 3px);
+          --panel-forma-altura: clamp(32px, 7vw, 54px);
       }
       body {
           font-family: 'Poppins', sans-serif;
@@ -1805,6 +1806,7 @@
           justify-content: center;
           gap: clamp(6px, 2vw, 12px);
           padding: clamp(2px, 1vw, 6px) clamp(6px, 2vw, 14px);
+          min-height: var(--panel-forma-altura);
           border-radius: 14px;
           background: rgba(255, 255, 255, 0.96);
           box-shadow: 0 6px 18px rgba(0, 0, 0, 0.14);
@@ -2113,6 +2115,7 @@
           margin: 0 auto;
           width: fit-content;
           max-width: min(100%, 520px);
+          min-height: var(--panel-forma-altura);
           justify-content: center;
           align-items: center;
           display: inline-flex;
@@ -2421,6 +2424,13 @@
       .carton-visual--principal.forma-manual-activa .carton-tabla td.celda-forma-activa.celda-forma-solo-borde {
           border-color: rgba(var(--forma-rgb-borde, var(--forma-rgb, 0, 120, 255)), 0.98);
           box-shadow: inset 0 0 0 4px rgba(var(--forma-rgb-borde, var(--forma-rgb, 0, 120, 255)), 0.7), 0 0 12px rgba(var(--forma-rgb-borde, var(--forma-rgb, 0, 120, 255)), 0.6);
+          color: rgba(var(--forma-rgb-vivo, var(--forma-rgb, 0, 120, 255)), 1);
+      }
+      .carton-visual--principal.forma-manual-activa .carton-tabla td.celda-forma-activa.celda-forma-solo-borde .cell-content {
+          color: rgba(var(--forma-rgb-vivo, var(--forma-rgb, 0, 120, 255)), 1);
+          -webkit-text-stroke: 2px #000000;
+          text-stroke: 2px #000000;
+          text-shadow: 0 0 6px rgba(0, 0, 0, 0.7);
       }
       .carton-tabla td.celda-forma-temporal {
           position: relative;


### PR DESCRIPTION
## Summary
- Ajusta la altura del panel de totales para que coincida visualmente con el aviso de forma ganadora en el panel de formas.
- Mejora el resaltado manual del cartón destacado al aplicar bordes más oscuros y texto con contorno negro en las celdas activas.

## Testing
- No se realizaron pruebas automatizadas; cambios de estilo únicamente.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929ea90ef148326a1cb23d099f31567)