### PR TITLE
Ajusta estilos de forma y resaltado en juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -2116,6 +2116,7 @@
           width: fit-content;
           max-width: min(100%, 520px);
           min-height: var(--panel-forma-altura);
+          height: var(--panel-forma-altura);
           justify-content: center;
           align-items: center;
           display: inline-flex;
@@ -2422,15 +2423,15 @@
           animation: none;
       }
       .carton-visual--principal.forma-manual-activa .carton-tabla td.celda-forma-activa.celda-forma-solo-borde {
-          border-color: rgba(var(--forma-rgb-borde, var(--forma-rgb, 0, 120, 255)), 0.98);
-          box-shadow: inset 0 0 0 4px rgba(var(--forma-rgb-borde, var(--forma-rgb, 0, 120, 255)), 0.7), 0 0 12px rgba(var(--forma-rgb-borde, var(--forma-rgb, 0, 120, 255)), 0.6);
+          border-color: rgba(var(--forma-rgb-vivo, var(--forma-rgb, 0, 120, 255)), 1);
+          box-shadow: inset 0 0 0 4px rgba(var(--forma-rgb-vivo, var(--forma-rgb, 0, 120, 255)), 0.9), 0 0 14px rgba(var(--forma-rgb-vivo, var(--forma-rgb, 0, 120, 255)), 0.8);
           color: rgba(var(--forma-rgb-vivo, var(--forma-rgb, 0, 120, 255)), 1);
       }
       .carton-visual--principal.forma-manual-activa .carton-tabla td.celda-forma-activa.celda-forma-solo-borde .cell-content {
           color: rgba(var(--forma-rgb-vivo, var(--forma-rgb, 0, 120, 255)), 1);
           -webkit-text-stroke: 2px #000000;
           text-stroke: 2px #000000;
-          text-shadow: 0 0 6px rgba(0, 0, 0, 0.7);
+          text-shadow: 0 0 2px #000000, 0 0 10px rgba(0, 0, 0, 0.85);
       }
       .carton-tabla td.celda-forma-temporal {
           position: relative;


### PR DESCRIPTION
## Summary
- Igualar la altura de la leyenda de formas con el panel de totales para mantener proporciones consistentes
- Intensificar colores vivos y resaltado negro en las celdas activadas al seleccionar letras BINGO en el cartón principal

## Testing
- No tests were run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929ff66890083268db5416fd622807a)