### PR TITLE
Add admin transfer management and refine notification controls

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -154,6 +154,7 @@
   <div id="main-menu">
     <button id="gestionar-sorteos-btn" class="menu-btn">Gestionar Sorteos</button>
     <button id="publicar-resultados-btn" class="menu-btn">Cantar Sorteo</button>
+    <button id="gestionar-transferencias-btn" class="menu-btn">Gestionar transferencias</button>
   </div>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
@@ -165,6 +166,7 @@
   setupSuperadminExit('#salir-super-btn');
   document.getElementById('gestionar-sorteos-btn').addEventListener('click',()=>{window.location.href='gestionsorteos.html';});
   document.getElementById('publicar-resultados-btn').addEventListener('click',()=>{window.location.href='cantarsorteos.html';});
+  document.getElementById('gestionar-transferencias-btn').addEventListener('click',()=>{window.location.href='transacciones.html';});
   document.getElementById('config-btn').addEventListener('click',()=>{window.location.href='configuraciones.html';});
   </script>
 </body>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -344,6 +344,7 @@ function setupSuperadminExit(buttonSelector = '#salir-super-btn', redirect = 'su
 }
 
 function ensureAuth(roleExpected){
+  const rolesEsperados = Array.isArray(roleExpected) ? roleExpected : (roleExpected ? [roleExpected] : []);
   initFirebase()
     .then(() => {
       auth.onAuthStateChanged(async user => {
@@ -360,7 +361,7 @@ function ensureAuth(roleExpected){
           window.location.href = 'registrarse.html';
           return;
         }
-        if(roleExpected && role !== roleExpected && role !== 'Superadmin'){
+        if(rolesEsperados.length && !rolesEsperados.includes(role) && role !== 'Superadmin'){
           redirectByRole(role);
           return;
         }

--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -16,15 +16,25 @@
       etiqueta: 'Colaborador',
       items: [
         { clave: 'depositosPendientes', titulo: 'Notificación Depósitos Pendientes', descripcion: 'Se repite cada 10 minutos si hay depósitos por gestionar.' },
-        { clave: 'retirosPendientes', titulo: 'Notificación Retiros Pendientes', descripcion: 'Se repite cada 10 minutos si hay retiros por gestionar.' }
+        { clave: 'retirosPendientes', titulo: 'Notificación Retiros Pendientes', descripcion: 'Se repite cada 10 minutos si hay retiros por gestionar.' },
+        { clave: 'mensajeDepositoAprobado', titulo: 'Redacción de mensajes DEPÓSITO APROBADO', descripcion: 'Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Depósito', color: '#0b6b27' },
+        { clave: 'mensajeRetiroAprobado', titulo: 'Redacción de mensajes RETIRO APROBADO', descripcion: 'Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Retiro', color: '#8b0000' },
+        { clave: 'mensajeDepositoAnulado', titulo: 'Redacción de mensajes DEPÓSITO ANULADO', descripcion: 'Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Depósito Anulado', color: '#d32f2f' },
+        { clave: 'mensajeRetiroAnulado', titulo: 'Redacción de mensajes RETIRO ANULADO', descripcion: 'Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Retiro Anulado', color: '#d32f2f' }
       ]
     },
     Administrador: {
       etiqueta: 'Administrador',
       items: [
+        { clave: 'depositosPendientes', titulo: 'Notificación Depósitos Pendientes', descripcion: 'Se repite cada 10 minutos si hay depósitos por gestionar.' },
+        { clave: 'retirosPendientes', titulo: 'Notificación Retiros Pendientes', descripcion: 'Se repite cada 10 minutos si hay retiros por gestionar.' },
         { clave: 'selladoSorteo', titulo: 'Notificación Sellado Sorteo', descripcion: 'Cuando llega la hora de sellado de un sorteo.' },
         { clave: 'juegoEnVivoSorteo', titulo: 'Notificación Juego en vivo Sorteo', descripcion: 'Cuando llega la hora de inicio de un sorteo.' },
-        { clave: 'gestionPagos', titulo: 'Notificación Gestión Pagos', descripcion: 'Recordatorio cada 10 minutos si hay gestiones de pagos pendientes.' }
+        { clave: 'gestionPagos', titulo: 'Notificación Gestión Pagos', descripcion: 'Aviso único si hay gestiones de pagos pendientes.' },
+        { clave: 'mensajeDepositoAprobado', titulo: 'Redacción de mensajes DEPÓSITO APROBADO', descripcion: 'Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Depósito', color: '#0b6b27' },
+        { clave: 'mensajeRetiroAprobado', titulo: 'Redacción de mensajes RETIRO APROBADO', descripcion: 'Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Retiro', color: '#8b0000' },
+        { clave: 'mensajeDepositoAnulado', titulo: 'Redacción de mensajes DEPÓSITO ANULADO', descripcion: 'Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Depósito Anulado', color: '#d32f2f' },
+        { clave: 'mensajeRetiroAnulado', titulo: 'Redacción de mensajes RETIRO ANULADO', descripcion: 'Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Retiro Anulado', color: '#d32f2f' }
       ]
     }
   };
@@ -72,6 +82,7 @@
     }
     if(role === 'Administrador'){
       GRUPOS_NOTIFICACIONES.Administrador.items.forEach(item => claves.add(item.clave));
+      GRUPOS_NOTIFICACIONES.Colaborador.items.forEach(item => claves.add(item.clave));
       GRUPOS_NOTIFICACIONES.Jugador.items.forEach(item => claves.add(item.clave));
       return Array.from(claves);
     }
@@ -512,7 +523,7 @@
         return [GRUPOS_NOTIFICACIONES.Colaborador, GRUPOS_NOTIFICACIONES.Jugador].filter(Boolean);
       }
       if(role === 'Administrador'){
-        return [GRUPOS_NOTIFICACIONES.Administrador, GRUPOS_NOTIFICACIONES.Jugador].filter(Boolean);
+        return [GRUPOS_NOTIFICACIONES.Administrador, GRUPOS_NOTIFICACIONES.Colaborador, GRUPOS_NOTIFICACIONES.Jugador].filter(Boolean);
       }
       return [GRUPOS_NOTIFICACIONES.Jugador];
     }
@@ -521,7 +532,7 @@
       if(!this.usuario) return;
       const roles = new Set();
       roles.add('Jugador');
-      if(this.rol === 'Colaborador' || this.rol === 'Superadmin') roles.add('Colaborador');
+      if(this.rol === 'Colaborador' || this.rol === 'Superadmin' || this.rol === 'Administrador') roles.add('Colaborador');
       if(this.rol === 'Administrador' || this.rol === 'Superadmin') roles.add('Administrador');
       roles.forEach(role => this.iniciarRol(role));
     }
@@ -733,12 +744,12 @@
       const historial = this.config.historial[clave];
       if(!historial || typeof historial.ultimoEnvio !== 'number') return true;
       const ahora = Date.now();
-      if(esNuevo){
+      const ultimo = historial.ultimoEnvio || 0;
+      if(esNuevo && !ultimo){
         historial.ultimoEnvio = ahora;
         this.programarGuardadoHistorial();
         return true;
       }
-      const ultimo = historial.ultimoEnvio || 0;
       const intervalo = INTERVALOS_REPETICION[clave] || 600000;
       if(!ultimo || (ahora - ultimo) >= intervalo){
         historial.ultimoEnvio = ahora;
@@ -824,16 +835,20 @@
     gestionarPagosPendientes(){
       const total = (this.cache.resumenPagos.premios || 0) + (this.cache.resumenPagos.pagos || 0);
       this.cache.pendientes.gestionPagos = total;
+      const historial = this.config.historial.gestionPagos;
       if(total>0){
-        const generarMensaje = cantidad => cantidad>0 ? `Existen ${cantidad} gestión(es) de pago pendientes en Centro de Pagos.` : '';
-        const mensaje = generarMensaje(total);
-        const esNuevo = this.config.historial.gestionPagos.ultimoEnvio === 0;
-        this.notificarRepeticion('gestionPagos', mensaje, esNuevo);
-        this.configurarTemporizador('gestionPagos', cantidad => generarMensaje(cantidad));
+        const mensaje = total>0 ? `Existen ${total} gestión(es) de pago pendientes en Centro de Pagos.` : '';
+        if(historial && historial.ultimoEnvio === 0 && this.puedeNotificar('gestionPagos')){
+          historial.ultimoEnvio = Date.now();
+          this.programarGuardadoHistorial();
+          this.emitirNotificacion('gestionPagos', mensaje);
+        }
       }else{
         this.detenerTemporizador('gestionPagos');
-        this.config.historial.gestionPagos.ultimoEnvio = 0;
-        this.programarGuardadoHistorial();
+        if(historial){
+          historial.ultimoEnvio = 0;
+          this.programarGuardadoHistorial();
+        }
       }
     }
 

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -807,6 +807,9 @@
         const titulo=document.createElement('span');
         titulo.className='notificaciones-opcion-titulo';
         titulo.textContent=item.titulo||item.clave;
+        if(item.color){
+          titulo.style.color=item.color;
+        }
         if(item.descripcion){
           const descripcion=document.createElement('small');
           descripcion.textContent=item.descripcion;

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -177,6 +177,16 @@
     const datosRec = [];
     const datosRet = [];
     let unsubscribeTransacciones = null;
+    const MAPEO_PREFERENCIAS_WHATSAPP={
+      deposito:{
+        APROBADO:'mensajeDepositoAprobado',
+        ANULADO:'mensajeDepositoAnulado'
+      },
+      retiro:{
+        APROBADO:'mensajeRetiroAprobado',
+        ANULADO:'mensajeRetiroAnulado'
+      }
+    };
 
     function volverConFallback(){
       const role=(window.currentRole||'').trim();
@@ -644,6 +654,10 @@
     }
     async function notificarWhatsappTransacciones(lista,estadoFinal,nota){
       for(const transaccion of lista){
+        const permitir=await permitirRedaccionWhatsapp(transaccion,estadoFinal);
+        if(!permitir){
+          continue;
+        }
         const numero=await obtenerNumeroWhatsappDestino(transaccion.IDbilletera);
         if(!numero){
           console.warn('La transacción no tiene número de WhatsApp disponible',transaccion.IDbilletera);
@@ -655,6 +669,23 @@
           window.open(enlace,'_blank');
         }
       }
+    }
+
+    async function permitirRedaccionWhatsapp(transaccion,estadoFinal){
+      const claveEstado=(estadoFinal||'').toUpperCase();
+      const tipo=((transaccion.tipotrans||'').toLowerCase()==='retiro')?'retiro':'deposito';
+      const clavePreferencia=(MAPEO_PREFERENCIAS_WHATSAPP[tipo]||{})[claveEstado];
+      if(!clavePreferencia) return false;
+      if(!window.notificationCenter || typeof window.notificationCenter.cuandoListo!=='function') return false;
+      try{
+        await window.notificationCenter.cuandoListo();
+      }catch(err){
+        console.warn('No se pudo sincronizar preferencias de notificaciones',err);
+        return false;
+      }
+      const config=window.notificationCenter.obtenerConfiguracion();
+      if(!config || !config.global || !config.preferencias) return false;
+      return Boolean(config.preferencias[clavePreferencia]);
     }
 
     async function actualizar(ids,estado,nota,ref,condicion){
@@ -950,13 +981,13 @@
       });
     }
 
-    initFirebase()
-      .then(()=>{
-        ensureAuth('Colaborador');
-        initServerTime();
-        transRef=db.collection('transacciones');
-        iniciarApp();
-      })
+  initFirebase()
+    .then(()=>{
+        ensureAuth(['Colaborador','Administrador']);
+      initServerTime();
+      transRef=db.collection('transacciones');
+      iniciarApp();
+    })
       .catch(err=>{
         console.error('No se pudo iniciar la vista de transacciones',err);
         alert('Error al conectar con los servicios. Intente nuevamente más tarde.');


### PR DESCRIPTION
## Summary
- habilitar a administradores el acceso a gestionar transferencias y ajustes de notificaciones de pendientes
- agregar nuevos switches de redacción de WhatsApp para depósitos y retiros aprobados/anulados con persistencia en Firebase
- ajustar la lógica de notificaciones para mostrar avisos solo una vez o cada 10 minutos según el tipo

## Testing
- no se realizaron pruebas automatizadas (no estaban configuradas)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dbd0af280832686573d063a8f9b60)