### PR TITLE
Ajusta estilos de redacción de mensajes en configuraciones

### DIFF
--- a/public/configcollab.html
+++ b/public/configcollab.html
@@ -260,6 +260,46 @@
       font-size: 0.78rem;
       color: #444;
     }
+    .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo {
+      color: #0b6b27;
+    }
+    .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small {
+      color: #0b6b27;
+    }
+    .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small::before {
+      content: "✅ ";
+      font-weight: 700;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo {
+      color: #b71c1c;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small {
+      color: #b71c1c;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small::before {
+      content: "✅ ";
+      font-weight: 700;
+    }
+    .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo {
+      color: #0a8800;
+    }
+    .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small {
+      color: #0a8800;
+    }
+    .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small::before {
+      content: "🚫 ";
+      font-weight: 700;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo {
+      color: #d32f2f;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small {
+      color: #d32f2f;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small::before {
+      content: "🚫 ";
+      font-weight: 700;
+    }
     .notificaciones-grupo-titulo {
       margin: 8px 0 0;
       font-weight: 700;

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -774,6 +774,46 @@
       font-size: 0.78rem;
       color: #444;
     }
+    .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo {
+      color: #0b6b27;
+    }
+    .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small {
+      color: #0b6b27;
+    }
+    .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small::before {
+      content: "✅ ";
+      font-weight: 700;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo {
+      color: #b71c1c;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small {
+      color: #b71c1c;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small::before {
+      content: "✅ ";
+      font-weight: 700;
+    }
+    .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo {
+      color: #0a8800;
+    }
+    .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small {
+      color: #0a8800;
+    }
+    .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small::before {
+      content: "🚫 ";
+      font-weight: 700;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo {
+      color: #d32f2f;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small {
+      color: #d32f2f;
+    }
+    .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small::before {
+      content: "🚫 ";
+      font-weight: 700;
+    }
     .notificaciones-grupo-titulo {
       margin: 8px 0 0;
       font-weight: 700;


### PR DESCRIPTION
## Summary
- resalta con colores específicos los títulos de redacción de mensajes para depósitos y retiros en configuraciones
- añade íconos previos en las descripciones de cada mensaje para reflejar el símbolo usado en WhatsApp

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dee5ab6b08326883ef3e94ab232dc)