### PR TITLE
Ajusta estilos visuales de notificaciones en perfil

### DIFF
--- a/public/perfil.html
+++ b/public/perfil.html
@@ -256,6 +256,46 @@
           font-size:0.78rem;
           color:#444;
       }
+      .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo{
+          color:#0b6b27;
+      }
+      .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small{
+          color:#0b6b27;
+      }
+      .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small::before{
+          content:"✅ ";
+          font-weight:700;
+      }
+      .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo{
+          color:#b71c1c;
+      }
+      .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small{
+          color:#b71c1c;
+      }
+      .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small::before{
+          content:"✅ ";
+          font-weight:700;
+      }
+      .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo{
+          color:#0a8800;
+      }
+      .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small{
+          color:#0a8800;
+      }
+      .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small::before{
+          content:"🚫 ";
+          font-weight:700;
+      }
+      .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo{
+          color:#d32f2f;
+      }
+      .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small{
+          color:#d32f2f;
+      }
+      .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small::before{
+          content:"🚫 ";
+          font-weight:700;
+      }
       .notificaciones-grupo-titulo{
           margin:8px 0 0;
           font-weight:700;


### PR DESCRIPTION
## Summary
- alinea los estilos de las notificaciones en perfil con la configuración existente
- aplica colores e iconos diferenciados para los mensajes de depósito y retiro

## Testing
- no se ejecutaron pruebas (no aplicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df16ddc50832694346e6a6fe21676)