### PR TITLE
Corrige iconos duplicados en notificaciones y emojis de WhatsApp

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -561,7 +561,7 @@
         lineas.push(`Referencia: *${info?.referencia||'N/D'}*`);
         if(info?.comentario){ lineas.push(`Comentario: ${info.comentario}`); }
       }else if(tipo==='retiro'){
-        lineas.push('💰 *SOLICITUD RETIRO*');
+        lineas.push('💵 *SOLICITUD RETIRO*');
         if(correo) lineas.push(`Correo: ${correo}`);
         if(nombre) lineas.push(`Usuario: ${nombre}`);
         lineas.push(`Banco receptor: ${info?.banco||'N/D'}`);

--- a/public/configcollab.html
+++ b/public/configcollab.html
@@ -266,19 +266,11 @@
     .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small {
       color: #0b6b27;
     }
-    .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small::before {
-      content: "✅ ";
-      font-weight: 700;
-    }
     .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo {
       color: #b71c1c;
     }
     .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small {
       color: #b71c1c;
-    }
-    .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small::before {
-      content: "✅ ";
-      font-weight: 700;
     }
     .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo {
       color: #0a8800;
@@ -286,19 +278,11 @@
     .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small {
       color: #0a8800;
     }
-    .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small::before {
-      content: "🚫 ";
-      font-weight: 700;
-    }
     .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo {
       color: #d32f2f;
     }
     .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small {
       color: #d32f2f;
-    }
-    .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small::before {
-      content: "🚫 ";
-      font-weight: 700;
     }
     .notificaciones-grupo-titulo {
       margin: 8px 0 0;

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -780,19 +780,11 @@
     .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small {
       color: #0b6b27;
     }
-    .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small::before {
-      content: "✅ ";
-      font-weight: 700;
-    }
     .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo {
       color: #b71c1c;
     }
     .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small {
       color: #b71c1c;
-    }
-    .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small::before {
-      content: "✅ ";
-      font-weight: 700;
     }
     .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo {
       color: #0a8800;
@@ -800,19 +792,11 @@
     .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small {
       color: #0a8800;
     }
-    .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small::before {
-      content: "🚫 ";
-      font-weight: 700;
-    }
     .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo {
       color: #d32f2f;
     }
     .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small {
       color: #d32f2f;
-    }
-    .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small::before {
-      content: "🚫 ";
-      font-weight: 700;
     }
     .notificaciones-grupo-titulo {
       margin: 8px 0 0;

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -262,19 +262,11 @@
       .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small{
           color:#0b6b27;
       }
-      .notificaciones-opcion[data-clave="mensajeDepositoAprobado"] .notificaciones-opcion-titulo small::before{
-          content:"✅ ";
-          font-weight:700;
-      }
       .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo{
           color:#b71c1c;
       }
       .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small{
           color:#b71c1c;
-      }
-      .notificaciones-opcion[data-clave="mensajeRetiroAprobado"] .notificaciones-opcion-titulo small::before{
-          content:"✅ ";
-          font-weight:700;
       }
       .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo{
           color:#0a8800;
@@ -282,19 +274,11 @@
       .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small{
           color:#0a8800;
       }
-      .notificaciones-opcion[data-clave="mensajeDepositoAnulado"] .notificaciones-opcion-titulo small::before{
-          content:"🚫 ";
-          font-weight:700;
-      }
       .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo{
           color:#d32f2f;
       }
       .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small{
           color:#d32f2f;
-      }
-      .notificaciones-opcion[data-clave="mensajeRetiroAnulado"] .notificaciones-opcion-titulo small::before{
-          content:"🚫 ";
-          font-weight:700;
       }
       .notificaciones-grupo-titulo{
           margin:8px 0 0;


### PR DESCRIPTION
## Summary
- elimina los iconos insertados por CSS en las descripciones de notificaciones para evitar duplicados en escritorio
- ajusta los iconos de los mensajes de solicitud de depósito y retiro en WhatsApp para mostrar moneda y billetes

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df9d36d90832680aa38d6a78ea985)