### PR TITLE
Ajustar iconos de solicitudes en mensajes de WhatsApp

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -553,7 +553,7 @@
       const formatearEnteroSeguro=valor=>Math.trunc(toNumberSafe(valor,0)).toString();
 
       if(tipo==='deposito'){
-        lineas.push('🪙 *SOLICITUD DEPÓSITO*');
+        lineas.push('🪙 *SOLICITUD DE DEPÓSITO*');
         if(correo) lineas.push(`Correo: ${correo}`);
         if(nombre) lineas.push(`Usuario: ${nombre}`);
         lineas.push(`Banco receptor: ${info?.banco||'N/D'}`);
@@ -561,7 +561,7 @@
         lineas.push(`Referencia: *${info?.referencia||'N/D'}*`);
         if(info?.comentario){ lineas.push(`Comentario: ${info.comentario}`); }
       }else if(tipo==='retiro'){
-        lineas.push('💵 *SOLICITUD RETIRO*');
+        lineas.push('💰 *SOLICITUD DE RETIRO*');
         if(correo) lineas.push(`Correo: ${correo}`);
         if(nombre) lineas.push(`Usuario: ${nombre}`);
         lineas.push(`Banco receptor: ${info?.banco||'N/D'}`);


### PR DESCRIPTION
## Summary
- actualizar el encabezado de la solicitud de depósito para mostrar el ícono de moneda y el texto completo
- ajustar la solicitud de retiro para usar el ícono de bolsa de dinero y la misma redacción de encabezado

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ee48674988326a0a6f2189150a924)