### PR TITLE
Ajusta íconos en mensajes de WhatsApp

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -546,6 +546,11 @@
       return numeroWhatsappDestino;
     }
 
+    const ICONOS_WHATSAPP={
+      solicitudDeposito:'🪙',
+      solicitudRetiro:'💰'
+    };
+
     function construirMensajeWhatsapp(tipo,info){
       const correo=auth.currentUser?.email||'';
       const nombre=obtenerNombreUsuario();
@@ -553,7 +558,7 @@
       const formatearEnteroSeguro=valor=>Math.trunc(toNumberSafe(valor,0)).toString();
 
       if(tipo==='deposito'){
-        lineas.push('🪙 *SOLICITUD DE DEPÓSITO*');
+        lineas.push(`${ICONOS_WHATSAPP.solicitudDeposito} *SOLICITUD DE DEPÓSITO*`);
         if(correo) lineas.push(`Correo: ${correo}`);
         if(nombre) lineas.push(`Usuario: ${nombre}`);
         lineas.push(`Banco receptor: ${info?.banco||'N/D'}`);
@@ -561,7 +566,7 @@
         lineas.push(`Referencia: *${info?.referencia||'N/D'}*`);
         if(info?.comentario){ lineas.push(`Comentario: ${info.comentario}`); }
       }else if(tipo==='retiro'){
-        lineas.push('💰 *SOLICITUD DE RETIRO*');
+        lineas.push(`${ICONOS_WHATSAPP.solicitudRetiro} *SOLICITUD DE RETIRO*`);
         if(correo) lineas.push(`Correo: ${correo}`);
         if(nombre) lineas.push(`Usuario: ${nombre}`);
         lineas.push(`Banco receptor: ${info?.banco||'N/D'}`);

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -619,6 +619,7 @@
       const montoSolicitadoBold=`*${formatearEnteroSeguro(montoSolicitadoNum)}*`;
       const montoTransferido=formatearEnteroSeguro(montoTransferidoNum);
       const lineas=[];
+      const ICONO_WHATSAPP_ANULADO='🚫';
 
       if(estadoFinal==='APROBADO'){
         if(tipo==='deposito'){
@@ -634,10 +635,10 @@
         }
       }else{
         if(tipo==='deposito'){
-          lineas.push('🚫 *DEPÓSITO ANULADO*');
+          lineas.push(`${ICONO_WHATSAPP_ANULADO} *DEPÓSITO ANULADO*`);
           lineas.push(`Tu depósito por ${formatearMonto(montoSolicitadoNum)} Créditos en BingOnline fue anulado.`);
         }else{
-          lineas.push('🚫 *RETIRO ANULADO*');
+          lineas.push(`${ICONO_WHATSAPP_ANULADO} *RETIRO ANULADO*`);
           lineas.push(`Tu retiro por ${formatearMonto(montoSolicitadoNum)} Créditos en BingOnline fue anulado.`);
         }
         if(nota){


### PR DESCRIPTION
## Summary
- agrega constantes para los íconos de solicitud de depósito y retiro en mensajes de WhatsApp
- asegura que las anulaciones usen el ícono de prohibido al inicio del mensaje

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eef1ba5208326a640ff86f88602f6)