### PR TITLE
Ajustes visuales del modo tutorial en player

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -513,18 +513,23 @@
       }
 
       #tutorial-toggle {
-          width: 76px;
-          height: 76px;
+          width: 64px;
+          height: 64px;
           border-radius: 50%;
-          border: 3px solid #1f1f1f;
-          background: #7a7a7a;
-          color: #ffffff;
+          border: 2px solid #1f1f1f;
+          background: linear-gradient(140deg, #8d82e2, #5546c0);
+          color: #f5f5f5;
           font-family: 'Poppins', sans-serif;
-          font-weight: 700;
-          font-size: 11px;
-          text-shadow: 1px 1px 2px #000000;
+          font-weight: 800;
+          font-size: 10px;
+          line-height: 1.2;
+          text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.45);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          text-align: center;
           cursor: pointer;
-          box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+          box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
           transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
       }
 
@@ -549,23 +554,23 @@
       }
 
       .tutorial-nav-btn {
-          width: 48px;
-          height: 48px;
-          border-radius: 50%;
-          border: 2px solid #1f1f1f;
-          background: #ffffff;
+          min-width: 38px;
+          height: auto;
+          border: none;
+          background: transparent;
           color: #1f1f1f;
-          font-size: 20px;
+          font-size: 26px;
           cursor: pointer;
-          box-shadow: 0 6px 14px rgba(0, 0, 0, 0.25);
+          box-shadow: none;
           display: grid;
           place-items: center;
-          transition: transform 0.2s ease, box-shadow 0.2s ease;
+          padding: 6px 4px;
+          transition: transform 0.2s ease, color 0.2s ease;
       }
 
       .tutorial-nav-btn:hover {
           transform: scale(1.08);
-          box-shadow: 0 10px 18px rgba(0, 0, 0, 0.25);
+          color: #5546c0;
       }
 
       .tutorial-nav-btn:active {
@@ -581,7 +586,7 @@
 
       #tutorial-hand {
           position: absolute;
-          width: 88px;
+          width: 44px;
           height: auto;
           display: none;
           filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.35));
@@ -590,14 +595,17 @@
       #tutorial-label {
           position: absolute;
           display: none;
-          padding: 4px 8px;
-          background: rgba(255, 255, 255, 0.95);
-          border-radius: 8px;
+          padding: 8px 10px;
+          background: rgba(255, 255, 255, 0.9);
+          border-radius: 6px;
           font-family: 'Poppins', sans-serif;
-          font-size: 11px;
+          font-size: 12px;
           font-weight: 600;
           box-shadow: 0 6px 14px rgba(0, 0, 0, 0.25);
-          white-space: nowrap;
+          white-space: normal;
+          max-width: 240px;
+          text-align: justify;
+          text-justify: inter-word;
           transform: translate(-50%, -100%);
       }
       @supports (-webkit-touch-callout: none) {
@@ -830,7 +838,7 @@
     {
       elementId: 'boton-sorteo',
       hand: 'img/Mano-arri-der.png',
-      corner: 'top-right',
+      corner: 'bottom-left',
       color: '#20004d',
       label: 'Mira el sorteo en vivo al instante.',
     },
@@ -967,7 +975,7 @@
     }
   }
 
-  function calcularPosicionMano(corner, rect, manoWidth = 88, manoHeight = 88){
+  function calcularPosicionMano(corner, rect, manoWidth = 44, manoHeight = 44){
     const base = { x: rect.left, y: rect.top };
     switch(corner){
       case 'bottom-right':
@@ -996,8 +1004,8 @@
     }
 
     const rect = objetivo.getBoundingClientRect();
-    const manoWidth = tutorialHand ? tutorialHand.width || 88 : 88;
-    const manoHeight = tutorialHand ? tutorialHand.height || 88 : 88;
+    const manoWidth = tutorialHand ? tutorialHand.width || 44 : 44;
+    const manoHeight = tutorialHand ? tutorialHand.height || 44 : 44;
     const posicion = calcularPosicionMano(paso.corner, rect, manoWidth, manoHeight);
     if(tutorialHand){
       tutorialHand.src = paso.hand;


### PR DESCRIPTION
## Summary
- Mejoré el botón de activación del tutorial con un formato más compacto y legible.
- Reduje el tamaño de los indicadores de mano y actualicé su posición para el sorteo en vivo.
- Ajusté las etiquetas de ayuda y la navegación del tutorial para un estilo más limpio y legible.

## Testing
- No se realizaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f354f4c6c832681cf26e7df3eb926)