### PR TITLE
Ajusta etiquetas de ayuda del tutorial en player

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -609,22 +609,25 @@
       #tutorial-label {
           position: absolute;
           display: none;
-          inline-size: 210px;
-          aspect-ratio: 1 / 1;
-          padding: 12px;
+          padding: 8px 12px;
           background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(237, 241, 255, 0.96));
           border: 2px solid rgba(85, 70, 192, 0.35);
           border-radius: 12px;
           font-family: 'Poppins', sans-serif;
-          font-size: 13px;
+          font-size: 12px;
           font-weight: 700;
           box-shadow: 0 10px 20px rgba(0, 0, 0, 0.28);
           display: flex;
           align-items: center;
           justify-content: center;
           text-align: center;
-          line-height: 1.35;
+          line-height: 1.25;
           transform: translate(-50%, -100%);
+          width: fit-content;
+          max-width: min(240px, 78vw);
+          min-width: 120px;
+          word-break: break-word;
+          hyphens: auto;
       }
 
       @keyframes tutorial-nav-surge {
@@ -1045,10 +1048,20 @@
     if(tutorialLabel){
       tutorialLabel.textContent = paso.label;
       tutorialLabel.style.color = paso.color;
-      const labelTop = Math.max(10, rect.top - 12);
-      tutorialLabel.style.left = `${rect.left + rect.width / 2}px`;
-      tutorialLabel.style.top = `${labelTop}px`;
       tutorialLabel.style.display = 'block';
+      tutorialLabel.style.visibility = 'hidden';
+      const labelRect = tutorialLabel.getBoundingClientRect();
+      const margen = 12;
+      const mitadAncho = labelRect.width / 2;
+      const centroDeseado = rect.left + rect.width / 2;
+      const centroLimitado = Math.min(
+        window.innerWidth - margen - mitadAncho,
+        Math.max(margen + mitadAncho, centroDeseado)
+      );
+      const labelTop = Math.max(labelRect.height + margen, rect.top - 12);
+      tutorialLabel.style.left = `${centroLimitado}px`;
+      tutorialLabel.style.top = `${labelTop}px`;
+      tutorialLabel.style.visibility = 'visible';
     }
     if(tutorialOverlay){
       tutorialOverlay.setAttribute('aria-hidden', 'false');


### PR DESCRIPTION
## Summary
- compacta el cuadro de mensajes del modo tutorial para que se adapte al texto sin desbordes
- limita el posicionamiento de las etiquetas del tutorial para mantenerlas dentro de la pantalla

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4867f1308326b34f45bc1f930ef6)