### PR TITLE
Corrige superposición de mano del tutorial en billetera

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -471,10 +471,9 @@
 
   <div id="modal-detalle"><div class="contenido"></div></div>
 
-  <div id="tutorial-overlay" aria-hidden="true">
-    <img id="tutorial-hand" alt="Guía visual del tutorial" loading="lazy" />
-    <div id="tutorial-label" role="status"></div>
-  </div>
+  <div id="tutorial-overlay" aria-hidden="true"></div>
+  <img id="tutorial-hand" alt="Guía visual del tutorial" loading="lazy" />
+  <div id="tutorial-label" role="status"></div>
 
   <div id="tutorial-controls" aria-label="Controles del modo tutorial">
     <button id="tutorial-toggle" type="button">MODO<br/>TUTORIAL</button>


### PR DESCRIPTION
## Resumen
- separa la mano y la etiqueta del tutorial del contenedor del overlay para evitar que queden detrás del elemento enfocado
- mantiene los controles y el recorte del overlay sin alterar la lógica existente

## Pruebas
- no se realizaron pruebas automatizadas (cambio de HTML/CSS)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376fb8e93c83269ef61f1784c5ba54)