### PR TITLE
Ajustes de tutorial y mejoras de foco en billetera

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -150,6 +150,12 @@
     .tab-buttons button.active { filter:brightness(1.2); position:relative; top:1px; }
     .tab-content { display:none; margin-top:0; border:1px solid #333; border-radius:0 10px 10px 10px; padding:10px; }
     .tab-content.active { display:block; }
+    .tab-content.tab-foco { box-shadow: 0 0 14px rgba(0,0,0,0.25); }
+    .tab-buttons button.tab-animada { animation: pestaña-respira 1s ease-in-out infinite; filter: brightness(1.15); }
+    #depositar.tab-foco { background: rgba(10,136,0,0.08); }
+    #retirar.tab-foco { background: rgba(204,0,0,0.08); }
+    #tabla-bancos:focus-visible { outline: 3px solid rgba(10,136,0,0.6); box-shadow: 0 0 12px rgba(255,255,255,0.85); }
+    #titulo-bancos.resaltado { color: #0a8800; text-shadow: 0 0 10px #fff, 0 0 18px rgba(255,255,255,0.9); }
     input, select, textarea {
       font-size:1rem;
       padding:5px;
@@ -268,10 +274,15 @@
     }
 
     /* Controles del modo tutorial */
+    :root {
+      --tutorial-left: calc(18px + env(safe-area-inset-left, 0px));
+      --tutorial-bottom: calc(18px + env(safe-area-inset-bottom, 0px));
+    }
+
     #tutorial-controls {
       position: fixed;
-      left: 18px;
-      bottom: 18px;
+      left: var(--tutorial-left);
+      bottom: var(--tutorial-bottom);
       right: auto;
       top: auto;
       display: flex;
@@ -332,7 +343,7 @@
     #tutorial-overlay.activo { opacity: 1; }
     #tutorial-hand { position: fixed; width: 44px; height: auto; display: none; filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.35)); transform-origin: center; z-index: 16000; pointer-events: none; }
     .tutorial-hand-pulse { animation: tutorial-hand-pulse 0.65s ease-in-out infinite; }
-    #tutorial-label { position: fixed; left: 50%; display: none; padding: 14px 18px; background: linear-gradient(160deg, rgba(255, 255, 255, 0.98), rgba(237, 241, 255, 0.98)); border: 2px solid rgba(85, 70, 192, 0.45); border-radius: 14px; font-family: 'Poppins', sans-serif; font-size: clamp(16px, 2.4vw, 22px); font-weight: 800; box-shadow: 0 12px 26px rgba(0, 0, 0, 0.3); text-align: center; line-height: 1.35; transform: translate(-50%, -100%); width: fit-content; max-width: min(480px, 90vw); min-width: 200px; z-index: 15000; pointer-events: none; }
+    #tutorial-label { position: fixed; left: 50%; display: none; padding: 14px 18px; background: linear-gradient(160deg, rgba(255, 255, 255, 0.98), rgba(237, 241, 255, 0.98)); border: 2px solid rgba(85, 70, 192, 0.45); border-radius: 14px; font-family: 'Poppins', sans-serif; font-size: clamp(16px, 2.4vw, 22px); font-weight: 800; box-shadow: 0 12px 26px rgba(0, 0, 0, 0.3); text-align: center; line-height: 1.35; transform: translate(-50%, -100%); width: fit-content; max-width: min(480px, 90vw); min-width: 200px; z-index: 15000; pointer-events: none; box-sizing: border-box; max-height: 78vh; overflow: auto; display: flex; align-items: center; justify-content: center; word-break: break-word; }
     #tutorial-label.adaptado { transition: top 0.2s ease, left 0.2s ease; }
     .tutorial-elemento-activo { position: relative; z-index: 13000 !important; filter: none !important; }
     body.tutorial-activo * { pointer-events: none !important; filter: none; }
@@ -349,6 +360,7 @@
     @keyframes tutorial-hand-pulse { 0% { transform: scale(1); } 45% { transform: scale(1.17); } 100% { transform: scale(1); } }
     @keyframes tutorial-nav-surge { 0% { transform: translateX(-12px); opacity: 0; } 100% { transform: translateX(0); opacity: 1; } }
     @keyframes tutorial-nav-exit { 0% { transform: translateX(0); opacity: 1; } 100% { transform: translateX(-16px); opacity: 0; } }
+    @keyframes pestaña-respira { 0% { transform: scale(1); } 50% { transform: scale(1.06); } 100% { transform: scale(1); } }
   </style>
 </head>
 <body>
@@ -409,8 +421,8 @@
       <button id="tab-retirar" data-tab="retirar">RETIROS</button>
     </div>
     <div id="depositar" class="tab-content active">
-      <h3>Bancos habilitados para recargas</h3>
-      <table id="tabla-bancos">
+      <h3 id="titulo-bancos">Bancos habilitados para recargas</h3>
+      <table id="tabla-bancos" tabindex="0">
         <thead>
           <tr><th>Banco</th><th>N° Pago Móvil</th><th>Cédula</th></tr>
         </thead>
@@ -934,6 +946,7 @@
       prev: document.getElementById('tutorial-prev'),
       play: document.getElementById('tutorial-play'),
       next: document.getElementById('tutorial-next'),
+      controles: document.getElementById('tutorial-controls'),
       tabDepositar: document.getElementById('tab-depositar'),
       tabRetirar: document.getElementById('tab-retirar'),
       toggleDatos: document.getElementById('toggle-datos'),
@@ -950,12 +963,23 @@
       datosCargados:false,
       alturaBaseViewport: window.innerHeight,
       viewportAltura: (window.visualViewport?.height)||window.innerHeight,
+      enPausaTemporal:false,
     };
 
     const animacionTabla = { frameId:null, limites:null, posicionX:0, direccion:1, pausaHasta:0, ultimaMarca:0 };
 
     let tutorialControlesListos=false;
     let tutorialScrollPendiente=false;
+
+    function actualizarOffsetsTutorial(){
+      const docStyle=document.documentElement?.style;
+      if(!docStyle){ return; }
+      const margenBase=16;
+      const offsetLeft=Math.max(margenBase, Math.min(28, window.innerWidth*0.02));
+      const offsetBottom=Math.max(margenBase, Math.min(32, (window.visualViewport?.height||window.innerHeight)*0.025));
+      docStyle.setProperty('--tutorial-left', `calc(${offsetLeft}px + env(safe-area-inset-left, 0px))`);
+      docStyle.setProperty('--tutorial-bottom', `calc(${offsetBottom}px + env(safe-area-inset-bottom, 0px))`);
+    }
 
     const TUTORIAL_KEY = 'billeteraTutorialIndice';
 
@@ -1020,10 +1044,12 @@
     }
 
     if(window.visualViewport){
-      window.visualViewport.addEventListener('resize',actualizarAlturaViewport);
-      window.visualViewport.addEventListener('scroll',actualizarAlturaViewport);
+      window.visualViewport.addEventListener('resize',()=>{actualizarAlturaViewport();actualizarOffsetsTutorial();});
+      window.visualViewport.addEventListener('scroll',()=>{actualizarAlturaViewport();actualizarOffsetsTutorial();});
     }
-    window.addEventListener('orientationchange',actualizarAlturaViewport);
+    window.addEventListener('orientationchange',()=>{actualizarAlturaViewport();actualizarOffsetsTutorial();});
+    window.addEventListener('resize',actualizarOffsetsTutorial);
+    window.addEventListener('scroll',actualizarOffsetsTutorial,{passive:true});
 
     function guardarIndiceTutorial(indice){
       if(Number.isInteger(indice)){
@@ -1362,6 +1388,7 @@
     function mostrarControlesTutorial(){
       const controles=document.getElementById('tutorial-controls');
       if(!controles) return;
+      actualizarOffsetsTutorial();
       controles.classList.add('visible');
     }
 
@@ -1420,7 +1447,8 @@
       }
     }
 
-    function desactivarTutorial(){
+    function desactivarTutorial(opciones={}){
+      const omitirGuardado=opciones?.omitirGuardado===true;
       tutorialState.activo=false;
       if(tutorialUI.toggleBtn){ tutorialUI.toggleBtn.classList.remove('activo'); }
       if(tutorialUI.nav){ tutorialUI.nav.setAttribute('aria-hidden','true'); tutorialUI.nav.classList.add('saliendo'); tutorialUI.nav.classList.remove('activo'); }
@@ -1428,19 +1456,42 @@
       window.removeEventListener('resize', enfocarPaso);
       limpiarAuto();
       enfocarPaso();
-      guardarEstadoTutorialFirestore(false);
+      if(!omitirGuardado){ guardarEstadoTutorialFirestore(false); }
+      if(!omitirGuardado){ tutorialState.enPausaTemporal=false; }
     }
 
-    function activarTutorial(){
+    function activarTutorial(opciones={}){
       const pasos=construirPasosTutorial();
       const guardado=obtenerIndiceTutorial();
-      tutorialState.indice=Number.isInteger(guardado)?Math.max(0, Math.min((pasos.length||1)-1, guardado)):0;
+      if(!opciones?.preservarIndice){
+        tutorialState.indice=Number.isInteger(guardado)?Math.max(0, Math.min((pasos.length||1)-1, guardado)):0;
+      }else{
+        tutorialState.indice=Math.max(0, Math.min((pasos.length||1)-1, tutorialState.indice));
+      }
       tutorialState.activo=true;
+      tutorialState.enPausaTemporal=false;
       if(tutorialUI.toggleBtn){ tutorialUI.toggleBtn.classList.add('activo'); }
       if(tutorialUI.nav){ tutorialUI.nav.classList.remove('saliendo'); tutorialUI.nav.classList.add('activo'); tutorialUI.nav.setAttribute('aria-hidden','false'); }
       window.addEventListener('resize', enfocarPaso);
       enfocarPaso();
-      guardarEstadoTutorialFirestore(true);
+      if(!opciones?.omitirGuardado){ guardarEstadoTutorialFirestore(true); }
+    }
+
+    function pausarTutorialTemporal(){
+      const estabaActivo=tutorialState.activo;
+      if(estabaActivo){
+        tutorialState.enPausaTemporal=true;
+        desactivarTutorial({omitirGuardado:true});
+      }
+      let restaurado=false;
+      return function restaurarTutorial(){
+        if(restaurado){ return; }
+        restaurado=true;
+        if(estabaActivo && tutorialState.enPausaTemporal){
+          activarTutorial({omitirGuardado:true, preservarIndice:true});
+        }
+        tutorialState.enPausaTemporal=false;
+      };
     }
 
     function irAlPaso(id){
@@ -1592,11 +1643,13 @@
           `<button id="modal-ok">Aceptar</button>`;
         }
         const modal=document.getElementById('modal-detalle');
+        const restaurarTutorial=pausarTutorialTemporal();
         modal.style.display='flex';
         marcarModalInteractiva(true);
         document.getElementById('modal-ok').addEventListener('click',()=>{
           modal.style.display='none';
           marcarModalInteractiva(false);
+          restaurarTutorial();
         },{once:true});
       }
 
@@ -1619,11 +1672,13 @@
             `<button id='modal-ok'>Aceptar</button>`;
         }
         const modal=document.getElementById('modal-detalle');
+        const restaurarTutorial=pausarTutorialTemporal();
         modal.style.display='flex';
         marcarModalInteractiva(true);
         document.getElementById('modal-ok').addEventListener('click',()=>{
           modal.style.display='none';
           marcarModalInteractiva(false);
+          restaurarTutorial();
         },{once:true});
       }
 
@@ -1775,25 +1830,28 @@
       const montoFinal=monto - (monto*porcentajeRetiro/100) - (monto*porcentajeAdministra/100);
       document.getElementById('monto-retiro-neto').value = montoFinal>0 ? montoFinal.toFixed(2) : '';
       const comentarioRetiro=document.getElementById('comentario-retiro').value.trim();
-      if(await confirm(`¿Confirmas la solicitud de retiro por ${montoFinal.toFixed(2)}?`)){
-        try{
-          const resultado=await ejecutarRetiro(monto,montoFinal, comentarioRetiro);
-          await notificarSolicitudWhatsapp('retiro',{
-            montoSolicitado:monto,
-            montoNeto:montoFinal,
-            comentario:comentarioRetiro,
-            banco:resultado?.billetera?.banco||resultado?.data?.bancoreceptor||'',
-            pagomovil:resultado?.billetera?.pagomovil||'',
-            cuenta:resultado?.billetera?.cuenta||''
-          });
-        }catch(error){
-          if(error?.message==='CREDITOS_INSUFICIENTES'){
-            await refrescarResumenBilletera();
-            alert('El saldo disponible cambió. Inténtalo nuevamente.');
-          }else{
-            alert('No se pudo registrar la solicitud de retiro. Inténtalo nuevamente.');
-          }
+      const restaurarTutorial=pausarTutorialTemporal();
+      const continuar=window.confirm(`¿Confirmas la solicitud de retiro por ${montoFinal.toFixed(2)}?`);
+      if(!continuar){ restaurarTutorial(); return; }
+      try{
+        const resultado=await ejecutarRetiro(monto,montoFinal, comentarioRetiro);
+        await notificarSolicitudWhatsapp('retiro',{
+          montoSolicitado:monto,
+          montoNeto:montoFinal,
+          comentario:comentarioRetiro,
+          banco:resultado?.billetera?.banco||resultado?.data?.bancoreceptor||'',
+          pagomovil:resultado?.billetera?.pagomovil||'',
+          cuenta:resultado?.billetera?.cuenta||''
+        });
+      }catch(error){
+        if(error?.message==='CREDITOS_INSUFICIENTES'){
+          await refrescarResumenBilletera();
+          alert('El saldo disponible cambió. Inténtalo nuevamente.');
+        }else{
+          alert('No se pudo registrar la solicitud de retiro. Inténtalo nuevamente.');
         }
+      }finally{
+        restaurarTutorial();
       }
     });
 
@@ -1808,6 +1866,14 @@
       const datos=document.getElementById('datos-content');
       const toggleT=document.getElementById('toggle-transacciones');
       const transDiv=document.getElementById('transacciones-content');
+      const btnRecargas=document.getElementById('tab-depositar');
+      const btnRetiros=document.getElementById('tab-retirar');
+      const seccionRecargas=document.getElementById('depositar');
+      const seccionRetiros=document.getElementById('retirar');
+      const tablaBancos=document.getElementById('tabla-bancos');
+      const tituloBancos=document.getElementById('titulo-bancos');
+
+      actualizarOffsetsTutorial();
 
       function actualizarVisibilidad(){
         datos.style.display=toggle.checked?'block':'none';
@@ -1815,6 +1881,56 @@
       function visTrans(){
         transDiv.style.display=toggleT.checked?'block':'none';
       }
+
+      function activarEnfasis(tab){
+        if(tab==='recargas'){
+          btnRecargas?.classList.add('tab-animada');
+          seccionRecargas?.classList.add('tab-foco');
+        }else if(tab==='retiros'){
+          btnRetiros?.classList.add('tab-animada');
+          seccionRetiros?.classList.add('tab-foco');
+        }
+      }
+
+      function desactivarEnfasis(tab){
+        if(tab==='recargas'){
+          btnRecargas?.classList.remove('tab-animada');
+          seccionRecargas?.classList.remove('tab-foco');
+        }else if(tab==='retiros'){
+          btnRetiros?.classList.remove('tab-animada');
+          seccionRetiros?.classList.remove('tab-foco');
+        }
+      }
+
+      if(seccionRecargas){
+        seccionRecargas.addEventListener('focusin',()=>activarEnfasis('recargas'));
+        seccionRecargas.addEventListener('focusout',()=>{
+          if(!seccionRecargas.contains(document.activeElement)){
+            desactivarEnfasis('recargas');
+          }
+        });
+      }
+
+      if(seccionRetiros){
+        seccionRetiros.addEventListener('focusin',()=>activarEnfasis('retiros'));
+        seccionRetiros.addEventListener('focusout',()=>{
+          if(!seccionRetiros.contains(document.activeElement)){
+            desactivarEnfasis('retiros');
+          }
+        });
+      }
+
+      if(tablaBancos && tituloBancos){
+        const activarTitulo=()=>tituloBancos.classList.add('resaltado');
+        const desactivarTitulo=()=>tituloBancos.classList.remove('resaltado');
+        tablaBancos.addEventListener('focusin',activarTitulo);
+        tablaBancos.addEventListener('focusout',()=>{
+          if(!tablaBancos.contains(document.activeElement)){
+            desactivarTitulo();
+          }
+        });
+      }
+
       toggle.addEventListener('change',actualizarVisibilidad);
       toggleT.addEventListener('change',visTrans);
       let debeAbrirDatos=false;


### PR DESCRIPTION
## Summary
- Ajusté el anclaje de los controles del modo tutorial y el estilo de los cuadros de ayuda para que se mantengan visibles y centrados.
- Pausé temporalmente el modo tutorial al mostrar confirmaciones o modales interactivos, reanudándolo tras la decisión del usuario.
- Añadí animaciones y resaltados al enfocar elementos de Recargas, Retiros y la tabla de bancos habilitados.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937801e47f08326ab3758c91b7629a1)