### PR TITLE
Fix tutorial button positioning on wallet page

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -337,7 +337,6 @@
       isolation: isolate;
       transform-origin: left bottom;
       will-change: transform, opacity;
-      inset: auto;
     }
     #tutorial-controls.visible {
       opacity: 1;


### PR DESCRIPTION
## Summary
- keep the tutorial controls fixed to the bottom-left by removing an overriding inset rule

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ac138e2d4832691a54b594f91113e)