### PR TITLE
Fix tutorial controls position on billetera page

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -320,6 +320,7 @@
 
     #tutorial-controls {
       position: fixed;
+      inset: auto auto var(--tutorial-bottom) var(--tutorial-left);
       left: var(--tutorial-left);
       bottom: var(--tutorial-bottom);
       right: auto;
@@ -337,6 +338,7 @@
       isolation: isolate;
       transform-origin: left bottom;
       will-change: transform, opacity;
+      backface-visibility: hidden;
     }
     #tutorial-controls.visible {
       opacity: 1;
@@ -1149,11 +1151,9 @@
 
     if(window.visualViewport){
       window.visualViewport.addEventListener('resize',()=>{actualizarAlturaViewport();actualizarOffsetsTutorial();});
-      window.visualViewport.addEventListener('scroll',()=>{actualizarAlturaViewport();actualizarOffsetsTutorial();});
     }
     window.addEventListener('orientationchange',()=>{actualizarAlturaViewport();actualizarOffsetsTutorial();});
     window.addEventListener('resize',actualizarOffsetsTutorial);
-    window.addEventListener('scroll',actualizarOffsetsTutorial,{passive:true});
 
     function guardarIndiceTutorial(indice){
       if(Number.isInteger(indice)){


### PR DESCRIPTION
## Summary
- keep tutorial control buttons anchored with a fixed inset to avoid scroll shifts
- simplify tutorial offset updates by removing scroll-based recalculation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b72c81c8483269d88019d89a3027c)