### PR TITLE
Ajustar visibilidad de controles del tutorial en billetera

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -324,7 +324,7 @@
       gap: 12px;
       flex-wrap: nowrap;
       width: max-content;
-      z-index: 25000;
+      z-index: 32000;
       opacity: 0;
       pointer-events: none;
       transform: translate3d(0, 10px, 0);
@@ -1264,7 +1264,7 @@
       const objetivoColumnas=['tipo','monto','fecha','estado'];
       let celdasObjetivo=celdas.filter(celda=>objetivoColumnas.includes((celda.textContent||'').trim().toLowerCase()));
       if(!celdasObjetivo.length){
-        celdasObjetivo=celdas.slice(0,4);
+        celdasObjetivo=celdas.slice(1,5);
       }
       const puntos=celdasObjetivo.map(celda=>{
         const rect=celda.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- Eleva el z-index de los controles del modo tutorial para mantenerlos sobre otros elementos.
- Restringe la animación de la mano en la tabla de transacciones a las columnas TIPO, MONTO, Fecha y ESTADO, excluyendo la columna N°.

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b7d9b5acc8326b10513483fed66e8)