### PR TITLE
Evitar notificaciones de sorteos previos para usuarios nuevos

### DIFF
--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -583,7 +583,18 @@
       try{
         const unsubSorteos = db.collection('sorteos').onSnapshot(snapshot => {
           if(!this.inicializaciones.sorteos){
-            snapshot.forEach(doc => this.cache.sorteos.set(doc.id, doc.data() || {}));
+            let historialActualizado = false;
+            snapshot.forEach(doc => {
+              this.cache.sorteos.set(doc.id, doc.data() || {});
+              const historial = this.config.historial.sorteoNuevo;
+              if(historial && historial.ids && !historial.ids[doc.id]){
+                historial.ids[doc.id] = true;
+                historialActualizado = true;
+              }
+            });
+            if(historialActualizado){
+              this.programarGuardadoHistorial();
+            }
             this.inicializaciones.sorteos = true;
             return;
           }


### PR DESCRIPTION
## Summary
- Marca los sorteos existentes en el historial al iniciar la suscripción de notificaciones
- Evita que los usuarios nuevos reciban alertas de sorteos creados antes de su registro

## Testing
- No se ejecutaron pruebas (no se consideraron necesarias para este cambio)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940462f42e48326a1e057195904c250)