### PR TITLE
Evitar notificaciones de sorteos finalizados

### DIFF
--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -608,6 +608,10 @@
             const anterior = this.cache.sorteos.get(id);
             this.cache.sorteos.set(id, data);
             if(cambio.type === 'added'){
+              if((data.estado || '').toUpperCase() === 'FINALIZADO'){
+                this.registrarHistorial('sorteoNuevo', id);
+                return;
+              }
               this.notificarSorteoNuevo(id, data);
             }
             if(cambio.type === 'modified'){
@@ -889,6 +893,11 @@
     }
 
     notificarSorteoNuevo(id, data){
+      const estadoActual = (data.estado || '').toUpperCase();
+      if(estadoActual === 'FINALIZADO'){
+        this.registrarHistorial('sorteoNuevo', id);
+        return;
+      }
       if(!this.puedeNotificar('sorteoNuevo')) return;
       if(this.yaNotificado('sorteoNuevo', id)) return;
       const nombre = data.nombre || 'Nuevo sorteo';


### PR DESCRIPTION
## Summary
- evita que los sorteos con estado Finalizado generen notificaciones de creación durante la sincronización inicial
aumentando el registro del historial en esos casos
- aplica la misma exclusión en la rutina de notificación de sorteos nuevos para evitar avisos residuales

## Testing
- no se ejecutaron pruebas; no solicitado


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69404d0e528083269a30411852d0a359)