### PR TITLE
Agregar soporte de Twitch en transmisión en vivo

### DIFF
--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -1091,8 +1091,8 @@
         <button type="button" id="guardar-links-publicidad-sorteos">Guardar links</button>
       </div>
     </div>
-    <label for="link-live-tiktok">Link de Live Tiktok/Youtube/Facebook</label>
-    <textarea id="link-live-tiktok" placeholder="https://www.tiktok.com/@cuenta/live, https://youtube.com/watch?v=... o https://www.facebook.com/tuPagina/videos/..." spellcheck="false"></textarea>
+    <label for="link-live-tiktok">Link de Live TikTok/YouTube/Facebook/Twitch</label>
+    <textarea id="link-live-tiktok" placeholder="https://www.tiktok.com/@cuenta/live, https://youtube.com/watch?v=..., https://www.facebook.com/tuPagina/videos/... o https://www.twitch.tv/tuCanal" spellcheck="false"></textarea>
     <div class="live-link-actions">
       <button type="button" id="guardar-link-live-tiktok">Guardar</button>
     </div>

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1119,6 +1119,9 @@
       .live-stream-icon--facebook {
           background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><rect width='24' height='24' rx='4' fill='%231877f2'/><path d='M15 7h-2c-.6 0-1 .4-1 1v2h3l-.4 3H12v7H9v-7H7V10h2V8c0-1.7 1.3-3 3-3h3v2z' fill='white'/></svg>");
       }
+      .live-stream-icon--twitch {
+          background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><rect width='24' height='24' rx='4' fill='%239146ff'/><path fill='white' d='M6 5h13l-1.2 8.2-3.4 2.7h-3.1l-1.8 1.8H7v-1.8H4.9V5.9L6 5zm1.4 2.5v6.7h2.1v1.6l1.6-1.6h3.4l2.2-1.7.8-5H7.4zm4.2 1.2h1.4v3.3h-1.4V8.7zm3.3 0h1.4v3.3h-1.4V8.7z'/></svg>");
+      }
       .sr-only {
           position: absolute;
           width: 1px;
@@ -4967,6 +4970,7 @@
     try {
       const url = new URL(valor);
       const host = url.hostname.toLowerCase();
+      const twitchParent = window.location.hostname || 'localhost';
       if(host.includes('youtube.com')){
         const videoId = url.searchParams.get('v');
         if(videoId){
@@ -4998,6 +5002,30 @@
         }
         const href = encodeURIComponent(url.href);
         return `https://www.facebook.com/plugins/video.php?href=${href}&autoplay=true&show_text=false`;
+      }
+      if(host.includes('player.twitch.tv')){
+        if(!url.searchParams.has('parent')){
+          url.searchParams.set('parent', twitchParent);
+        }
+        if(!url.searchParams.has('autoplay')){
+          url.searchParams.set('autoplay','true');
+        }
+        return url.toString();
+      }
+      if(host.includes('clips.twitch.tv')){
+        const clipSlug = url.pathname.split('/').filter(Boolean)[0];
+        if(clipSlug){
+          return `https://clips.twitch.tv/embed?clip=${encodeURIComponent(clipSlug)}&parent=${encodeURIComponent(twitchParent)}&autoplay=true`;
+        }
+      }
+      if(host.includes('twitch.tv')){
+        const segmentos = url.pathname.split('/').filter(Boolean);
+        if(segmentos[0] === 'videos' && segmentos[1]){
+          return `https://player.twitch.tv/?video=${encodeURIComponent(segmentos[1])}&parent=${encodeURIComponent(twitchParent)}&autoplay=true`;
+        }
+        if(segmentos[0]){
+          return `https://player.twitch.tv/?channel=${encodeURIComponent(segmentos[0])}&parent=${encodeURIComponent(twitchParent)}&autoplay=true`;
+        }
       }
       return url.href;
     }catch(err){
@@ -5160,6 +5188,7 @@
       if(host.includes('youtube') || host.includes('youtu.be')) return 'youtube';
       if(host.includes('tiktok')) return 'tiktok';
       if(host.includes('facebook') || host.includes('fb.watch')) return 'facebook';
+      if(host.includes('twitch')) return 'twitch';
       return 'otro';
     }catch(err){
       return 'otro';
@@ -5180,6 +5209,10 @@
       liveStreamToggleBtn.innerHTML = "<span class=\"live-stream-icon live-stream-icon--facebook\" aria-hidden=\"true\"></span><span class=\"sr-only\">Transmisión en Facebook</span>";
       return;
     }
+    if(modo === 'twitch'){
+      liveStreamToggleBtn.innerHTML = "<span class=\"live-stream-icon live-stream-icon--twitch\" aria-hidden=\"true\"></span><span class=\"sr-only\">Transmisión en Twitch</span>";
+      return;
+    }
     liveStreamToggleBtn.textContent = 'LIVE';
   }
 
@@ -5195,7 +5228,7 @@
   function iniciarAlternanciaIconoLive(){
     detenerAlternanciaIconoLive();
     if(!liveStreamTieneTransmision) return;
-    if(liveStreamPlatform !== 'youtube' && liveStreamPlatform !== 'tiktok' && liveStreamPlatform !== 'facebook'){
+    if(liveStreamPlatform !== 'youtube' && liveStreamPlatform !== 'tiktok' && liveStreamPlatform !== 'facebook' && liveStreamPlatform !== 'twitch'){
       establecerContenidoBotonLive();
       return;
     }


### PR DESCRIPTION
### Motivation

- Expandir las opciones de transmisión en vivo para aceptar enlaces de Twitch además de TikTok, YouTube y Facebook.

### Description

- Actualicé la etiqueta y el `placeholder` del campo de configuración en `public/configuraciones.html` para mencionar `Twitch` y sugerir enlaces de canal/video/clip.
- Agregué un icono CSS `live-stream-icon--twitch` en `public/juegoactivo.html` para mostrar la plataforma cuando corresponda.
- Extendí la función `normalizarEnlaceLive` para generar embeds compatibles con `player.twitch.tv`, `clips.twitch.tv` y rutas de `twitch.tv` (canal y video) añadiendo el parámetro `parent` y `autoplay` cuando aplica.
- Añadí detección de plataforma `twitch` en `detectarPlataformaLive` y soporte en `establecerContenidoBotonLive` e inclusión de `twitch` en la alternancia de icono de live.

### Testing

- Levanté un servidor local con `python -m http.server 8000` y verifiqué visualmente la sección de configuraciones cargando `public/configuraciones.html` en un navegador automático; la captura de pantalla se generó correctamente.
- Ejecuté un script de Playwright para abrir la página y tomar una captura (`artifacts/configuraciones-live-link.png`) y la ejecución finalizó sin errores.
- Se agregaron y confirmaron los cambios con un `git commit` exitoso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d2c4aa1e483268e04db82716442ea)