### PR TITLE
Fijar controles del tutorial a safe-area y preservar color de pestañas RECARGAS/RETIROS

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -190,7 +190,7 @@
     .tab-content { display:none; margin-top:0; border:1px solid #333; border-radius:0 10px 10px 10px; padding:10px; }
     .tab-content.active { display:block; }
     .tab-content.tab-foco { box-shadow: 0 0 14px rgba(0,0,0,0.25); }
-    .tab-buttons button.tab-animada { animation: pestaña-respira 1s ease-in-out infinite; filter: brightness(1.15); }
+    .tab-buttons button.tab-animada { animation: pestaña-respira 1s ease-in-out infinite; filter: none; }
     #depositar.tab-foco { background: rgba(10,136,0,0.08); }
     #retirar.tab-foco { background: rgba(204,0,0,0.08); }
     #tabla-bancos:focus-visible { outline: 3px solid rgba(10,136,0,0.6); box-shadow: 0 0 12px rgba(255,255,255,0.85); }
@@ -320,8 +320,8 @@
     /* Controles del modo tutorial */
     #tutorial-controls {
       position: fixed;
-      left: 14px;
-      bottom: 18px;
+      left: max(14px, env(safe-area-inset-left));
+      bottom: max(18px, env(safe-area-inset-bottom));
       right: auto;
       top: auto;
       display: flex;


### PR DESCRIPTION
### Motivation
- Evitar que el botón y los controles de `MODO TUTORIAL` se desplacen o queden fuera de la vista en dispositivos con `safe-area`, y asegurar que las pestañas `RECARGAS`/`RETIROS` mantengan su color original mientras se reproduce la animación del tutorial.

### Description
- Actualizado `public/billetera.html` para fijar los controles con `#tutorial-controls { left: max(14px, env(safe-area-inset-left)); bottom: max(18px, env(safe-area-inset-bottom)); }` para respetar safe-area.
- Cambiado `.tab-buttons button.tab-animada` para usar `filter: none;` en lugar de `filter: brightness(1.15);` para que las pestañas `RECARGAS`/`RETIROS` no cambien de color durante la animación.

### Testing
- Se ejecutó una verificación visual automatizada usando Playwright que cargó `public/billetera.html` y generó una captura de pantalla; la carga y la captura finalizaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d5ecb9e108326ac3be72d707ea6f3)