### PR TITLE
Fijar controles del Modo Tutorial en la esquina inferior izquierda (billetera)

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -329,21 +329,17 @@
       gap: 12px;
       flex-wrap: nowrap;
       width: max-content;
-      z-index: 32000;
+      z-index: 40000;
       opacity: 0;
       pointer-events: none;
-      transform: translate3d(0, 10px, 0);
-      transition: opacity 0.35s ease, transform 0.35s ease;
+      transition: opacity 0.35s ease;
       isolation: isolate;
       transform-origin: left bottom;
-      will-change: transform, opacity;
       backface-visibility: hidden;
-      contain: layout paint;
     }
     #tutorial-controls.visible {
       opacity: 1;
       pointer-events: auto;
-      transform: translateY(0);
     }
     #tutorial-toggle {
       width: 62px;


### PR DESCRIPTION
### Motivation
- Evitar que el botón `#tutorial-toggle` y sus controles se desplacen al actualizar, desplazar o cambiar elementos de la página y asegurar que permanezcan visibles por encima de todo, igual que en `player.html`.

### Description
- Modificado `public/billetera.html` para reforzar el comportamiento del contenedor `#tutorial-controls`: se incrementó `z-index` a `40000`, se eliminó la animación/transformación que provocaba desplazamientos (`translate3d`/`translateY`) y se dejó la transición solo sobre `opacity` para impedir que otros cambios de layout muevan los controles.

### Testing
- Levanté un servidor local con `python -m http.server 8000` y ejecuté un script de Playwright que abrió `http://127.0.0.1:8000/billetera.html` y tomó una captura de pantalla; la carga y la captura se completaron correctamente y la imagen quedó en `artifacts/billetera-tutorial-controls.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d620cb5cc832682eda2d9518054ac)