### PR TITLE
Alinear controles del modo tutorial en billetera

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -320,26 +320,12 @@
     /* Controles del modo tutorial */
     #tutorial-controls {
       position: fixed;
-      left: max(14px, env(safe-area-inset-left));
-      bottom: max(18px, env(safe-area-inset-bottom));
-      right: auto;
-      top: auto;
+      left: 14px;
+      bottom: 18px;
       display: flex;
       align-items: center;
       gap: 12px;
-      flex-wrap: nowrap;
-      width: max-content;
-      z-index: 40000;
-      opacity: 0;
-      pointer-events: none;
-      transition: opacity 0.35s ease;
-      isolation: isolate;
-      transform-origin: left bottom;
-      backface-visibility: hidden;
-    }
-    #tutorial-controls.visible {
-      opacity: 1;
-      pointer-events: auto;
+      z-index: 1300;
     }
     #tutorial-toggle {
       width: 62px;
@@ -367,17 +353,16 @@
       box-shadow: 0 12px 20px rgba(0, 128, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.35);
     }
     #tutorial-toggle:hover { transform: translateY(-1px) scale(1.03); box-shadow: 0 12px 22px rgba(0, 0, 0, 0.4); }
-    #tutorial-toggle:active, #tutorial-toggle:focus-visible { outline: 3px solid orange; outline-offset: 2px; }
     #tutorial-nav { display: none; gap: 8px; align-items: center; transform: translateX(-10px); opacity: 0; }
     #tutorial-toggle.activo + #tutorial-nav,
     #tutorial-nav.activo { display: flex; animation: tutorial-nav-surge 0.42s ease forwards; }
     #tutorial-nav.saliendo { display: flex; animation: tutorial-nav-exit 0.32s ease forwards; }
-    .tutorial-nav-btn { min-width: 38px; height: auto; border: 2px solid transparent; background: transparent; color: #1f1f1f; font-size: 26px; cursor: pointer; box-shadow: none; display: grid; place-items: center; padding: 6px 4px; transition: transform 0.2s ease, color 0.2s ease, border-color 0.2s ease; animation: tutorial-nav-surge 0.42s ease forwards; opacity: 0; border-radius: 12px; }
+    .tutorial-nav-btn { min-width: 38px; height: auto; border: none; background: transparent; color: #1f1f1f; font-size: 26px; cursor: pointer; box-shadow: none; display: grid; place-items: center; padding: 6px 4px; transition: transform 0.2s ease, color 0.2s ease; animation: tutorial-nav-surge 0.42s ease forwards; opacity: 0; }
     #tutorial-nav.saliendo .tutorial-nav-btn { animation: tutorial-nav-exit 0.32s ease forwards; }
     #tutorial-nav.activo .tutorial-nav-btn:nth-child(1) { animation-delay: 0.05s; }
     #tutorial-nav.activo .tutorial-nav-btn:nth-child(2) { animation-delay: 0.12s; }
     .tutorial-nav-btn:hover { transform: scale(1.08); color: #5546c0; }
-    .tutorial-nav-btn:active, .tutorial-nav-btn:focus-visible { transform: scale(0.97); border-color: orange; box-shadow: 0 0 0 2px rgba(255,165,0,0.45); }
+    .tutorial-nav-btn:active { transform: scale(0.95); }
     #tutorial-overlay { position: fixed; inset: 0; pointer-events: none; z-index: 12000; background: rgba(0, 0, 0, 0.65); transition: opacity 0.25s ease; opacity: 0; }
     #tutorial-overlay.sin-mascara{ background: transparent; }
     #tutorial-overlay.activo { opacity: 1; }


### PR DESCRIPTION
### Motivation
- Evitar que los botones del `MODO TUTORIAL` en la ventana `billetera.html` se desplacen y asegurar la misma ubicación y comportamiento que en `player.html` para coherencia de UX.

### Description
- Ajusté los estilos CSS en `public/billetera.html` para que los controles del tutorial usen `position: fixed; left: 14px; bottom: 18px; z-index: 1300;` y la misma disposición que en `player.html`.
- Simplifiqué la visibilidad/interacción del contenedor de controles eliminando la dependencia de `opacity`/`pointer-events` y algunas propiedades que causaban reflow en móviles y safe-area insets.
- Normalicé las reglas de los botones de navegación del tutorial cambiando el `border`/`box-shadow` y las transformaciones para que coincidan con la implementación de `player.html`.
- Los cambios afectan únicamente a la sección de estilos y comportamiento visual del modo tutorial en `public/billetera.html` y no modifican la lógica de pasos del tutorial.

### Testing
- Se realizó una comprobación visual automática sirviendo `public/billetera.html` con `python -m http.server` y cargando la página con Playwright para capturar una captura de pantalla, y la carga/captura se realizó correctamente (smoke test exitoso). 
- No se ejecutaron pruebas unitarias automatizadas adicionales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d64cef00883268327134fe56961b3)