### PR TITLE
Corregir z-index de controles MODO TUTORIAL en billetera.html

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -325,7 +325,7 @@
       display: flex;
       align-items: center;
       gap: 12px;
-      z-index: 1300;
+      z-index: 17000;
     }
     #tutorial-toggle {
       width: 62px;


### PR DESCRIPTION
### Motivation
- Los botones de control del "MODO TUTORIAL" quedaban debajo de la máscara gris (`#tutorial-overlay`) y no podían ser pulsados en la ventana `public/billetera.html`.

### Description
- Aumenté el `z-index` de `#tutorial-controls` de `1300` a `17000` en `public/billetera.html` para que los controles queden por encima de la máscara y sean interactivos.

### Testing
- Levanté un servidor local (`python -m http.server`) y tomé una captura con Playwright (`artifacts/billetera-tutorial-controls.png`) verificando visualmente que los controles se renderizan por encima de la máscara; la verificación visual fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d66d923cc8326bdc9f4484dea2f0c)