### PR TITLE
Usar audio remoto para música y efectos

### DIFF
--- a/public/css/audioControls.css
+++ b/public/css/audioControls.css
@@ -1,0 +1,77 @@
+.audio-control {
+  position: fixed;
+  bottom: 18px;
+  right: 18px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  font-family: 'Poppins', sans-serif;
+}
+
+.audio-control--left {
+  right: auto;
+  left: 18px;
+  align-items: flex-start;
+}
+
+.audio-control__toggle {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+.audio-control__toggle:focus-visible {
+  outline: 3px solid #ffd700;
+  outline-offset: 2px;
+}
+
+.audio-control__icon {
+  width: 24px;
+  height: 24px;
+}
+
+.audio-control.is-muted .audio-control__icon--on {
+  display: none;
+}
+
+.audio-control:not(.is-muted) .audio-control__icon--off {
+  display: none;
+}
+
+.audio-control__volume {
+  background: rgba(0, 0, 0, 0.75);
+  padding: 8px 10px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+}
+
+.audio-control__volume[hidden] {
+  display: none;
+}
+
+.audio-control__range {
+  width: 120px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/public/js/audioControls.js
+++ b/public/js/audioControls.js
@@ -1,0 +1,136 @@
+(function() {
+  const DEFAULT_VOLUME = 0.22;
+
+  function obtenerEstadoAudio(prefix) {
+    const mutedRaw = localStorage.getItem(`${prefix}:muted`);
+    const volumeRaw = parseFloat(localStorage.getItem(`${prefix}:volume`));
+    const muted = mutedRaw === null ? false : mutedRaw === 'true';
+    const volume = Number.isFinite(volumeRaw) ? Math.min(Math.max(volumeRaw, 0), 1) : DEFAULT_VOLUME;
+    return { muted, volume };
+  }
+
+  function guardarEstadoAudio(prefix, estado) {
+    localStorage.setItem(`${prefix}:muted`, String(estado.muted));
+    localStorage.setItem(`${prefix}:volume`, String(estado.volume));
+  }
+
+  function initBingoAudioControl(config) {
+    if (!config) return;
+    const {
+      containerId,
+      toggleId,
+      volumeId,
+      audioId,
+      storageKeyPrefix = 'bingoAudio',
+      defaultVolume = DEFAULT_VOLUME,
+    } = config;
+
+    const container = document.getElementById(containerId);
+    const toggle = document.getElementById(toggleId);
+    const volumeInput = document.getElementById(volumeId);
+    const audioEl = document.getElementById(audioId);
+    const volumeWrap = container?.querySelector('.audio-control__volume');
+
+    if (!container || !toggle || !volumeInput || !audioEl) return;
+
+    let estado = obtenerEstadoAudio(storageKeyPrefix);
+    if (!Number.isFinite(estado.volume)) {
+      estado.volume = defaultVolume;
+    }
+
+    let hideTimer = null;
+
+    function actualizarUI() {
+      container.classList.toggle('is-muted', estado.muted);
+      toggle.setAttribute('aria-pressed', String(!estado.muted));
+      toggle.setAttribute('title', estado.muted ? 'Activar sonido' : 'Silenciar sonido');
+    }
+
+    function ocultarVolumen() {
+      if (!volumeWrap) return;
+      volumeWrap.hidden = true;
+      volumeWrap.setAttribute('aria-hidden', 'true');
+    }
+
+    function mostrarVolumenTemporal() {
+      if (!volumeWrap) return;
+      volumeWrap.hidden = false;
+      volumeWrap.setAttribute('aria-hidden', 'false');
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+      }
+      hideTimer = setTimeout(() => {
+        ocultarVolumen();
+      }, 5000);
+    }
+
+    async function intentarReproducir() {
+      if (estado.muted) return;
+      try {
+        await audioEl.play();
+      } catch (err) {
+        // Bloqueado por el navegador hasta interacción del usuario.
+      }
+    }
+
+    function aplicarEstadoInicial() {
+      audioEl.volume = estado.volume;
+      audioEl.muted = estado.muted;
+      volumeInput.value = estado.volume.toFixed(2);
+      if (estado.muted) {
+        ocultarVolumen();
+        audioEl.pause();
+      }
+      actualizarUI();
+    }
+
+    toggle.addEventListener('click', async () => {
+      estado.muted = !estado.muted;
+      audioEl.muted = estado.muted;
+      if (estado.muted) {
+        audioEl.pause();
+        ocultarVolumen();
+      } else {
+        await intentarReproducir();
+        mostrarVolumenTemporal();
+      }
+      guardarEstadoAudio(storageKeyPrefix, estado);
+      actualizarUI();
+    });
+
+    volumeInput.addEventListener('input', () => {
+      const value = parseFloat(volumeInput.value);
+      if (!Number.isFinite(value)) return;
+      estado.volume = Math.min(Math.max(value, 0), 1);
+      audioEl.volume = estado.volume;
+      guardarEstadoAudio(storageKeyPrefix, estado);
+    });
+
+    document.addEventListener(
+      'pointerdown',
+      () => {
+        intentarReproducir();
+      },
+      { once: true }
+    );
+
+    aplicarEstadoInicial();
+    if (!estado.muted) {
+      intentarReproducir();
+    }
+
+    window.bingoAudioState = estado;
+  }
+
+  function reproducirSonidoGanador(audioId = 'win-audio', storageKeyPrefix = 'bingoAudio') {
+    const estado = obtenerEstadoAudio(storageKeyPrefix);
+    if (estado.muted) return;
+    const audioEl = document.getElementById(audioId);
+    if (!audioEl) return;
+    audioEl.currentTime = 0;
+    audioEl.play().catch(() => {});
+  }
+
+  window.initBingoAudioControl = initBingoAudioControl;
+  window.reproducirSonidoGanador = reproducirSonidoGanador;
+})();

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -12,6 +12,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Juego Activo</title>
   <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/audioControls.css">
   <style>
       :root {
           --panel-bg: rgba(255, 255, 255, 0.88);
@@ -4214,6 +4215,24 @@
     </div>
   </div>
 
+  <div id="audio-control-game" class="audio-control audio-control--left">
+    <div class="audio-control__volume" hidden aria-hidden="true">
+      <label class="sr-only" for="audio-volume-game">Volumen de música</label>
+      <input id="audio-volume-game" class="audio-control__range" type="range" min="0" max="1" step="0.05" value="0.22">
+    </div>
+    <button id="audio-toggle-game" class="audio-control__toggle" type="button" aria-pressed="true" aria-label="Silenciar música de fondo">
+      <svg class="audio-control__icon audio-control__icon--on" viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="currentColor" d="M14 3.23v17.54a1 1 0 0 1-1.54.84L7.5 18H4a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h3.5l4.96-3.61A1 1 0 0 1 14 3.23Zm4.5 8.77a4.5 4.5 0 0 1-2.2 3.88.75.75 0 1 0 .75 1.3 6 6 0 0 0 0-10.36.75.75 0 1 0-.75 1.3 4.5 4.5 0 0 1 2.2 3.88Z"/>
+      </svg>
+      <svg class="audio-control__icon audio-control__icon--off" viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="currentColor" d="M4 9v6a1 1 0 0 0 1 1h3.5l4.96 3.61A1 1 0 0 0 15 18.77V5.23a1 1 0 0 0-1.54-.84L8.5 8H5a1 1 0 0 0-1 1Zm13.59 3.41 2.7 2.7a1 1 0 0 1-1.42 1.42l-2.7-2.7-2.7 2.7a1 1 0 0 1-1.42-1.42l2.7-2.7-2.7-2.7a1 1 0 0 1 1.42-1.42l2.7 2.7 2.7-2.7a1 1 0 1 1 1.42 1.42Z"/>
+      </svg>
+    </button>
+  </div>
+
+  <audio id="bg-audio-game" preload="none" loop src="https://assets.mixkit.co/music/preview/mixkit-game-level-music-689.mp3"></audio>
+  <audio id="win-audio" preload="metadata" src="https://assets.mixkit.co/sfx/preview/mixkit-winning-chimes-2015.mp3"></audio>
+
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -4221,6 +4240,7 @@
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
+  <script src="js/audioControls.js"></script>
   <script>
   ensureAuth();
   initFechaHora('fecha-hora');
@@ -4237,6 +4257,15 @@
   const sorteoHeaderEl = document.getElementById('sorteo-header');
   const sorteoResumenEl = document.getElementById('sorteo-resumen');
   const sorteoDetallesEl = document.getElementById('sorteo-detalles');
+
+  initBingoAudioControl({
+    containerId: 'audio-control-game',
+    toggleId: 'audio-toggle-game',
+    volumeId: 'audio-volume-game',
+    audioId: 'bg-audio-game',
+    storageKeyPrefix: 'bingoAudio',
+    defaultVolume: 0.22,
+  });
   const sinSorteoContenedorEl = document.getElementById('sin-sorteo-contenedor');
   const seleccionarFinalizadoBtn = document.getElementById('seleccionar-finalizado-btn');
   const sinSorteoMensajeEl = document.getElementById('sin-sorteo-mensaje');
@@ -9012,6 +9041,9 @@
     });
     if(detalles.length){
       mostrarModalCelebracionGanador(detalles, esSimulacion);
+      if(!esSimulacion){
+        reproducirSonidoGanador('win-audio', 'bingoAudio');
+      }
     }
   }
 

--- a/public/player.html
+++ b/public/player.html
@@ -13,6 +13,7 @@
   <title>Bingo Online</title>
   <!-- Fuentes -->
   <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/audioControls.css">
   <style>
      		
       body {
@@ -845,6 +846,23 @@
   <div id="fecha-hora"></div>
   <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
 
+  <div id="audio-control-player" class="audio-control audio-control--right">
+    <div class="audio-control__volume" hidden aria-hidden="true">
+      <label class="sr-only" for="audio-volume-player">Volumen de música</label>
+      <input id="audio-volume-player" class="audio-control__range" type="range" min="0" max="1" step="0.05" value="0.22">
+    </div>
+    <button id="audio-toggle-player" class="audio-control__toggle" type="button" aria-pressed="true" aria-label="Silenciar música de fondo">
+      <svg class="audio-control__icon audio-control__icon--on" viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="currentColor" d="M14 3.23v17.54a1 1 0 0 1-1.54.84L7.5 18H4a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h3.5l4.96-3.61A1 1 0 0 1 14 3.23Zm4.5 8.77a4.5 4.5 0 0 1-2.2 3.88.75.75 0 1 0 .75 1.3 6 6 0 0 0 0-10.36.75.75 0 1 0-.75 1.3 4.5 4.5 0 0 1 2.2 3.88Z"/>
+      </svg>
+      <svg class="audio-control__icon audio-control__icon--off" viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="currentColor" d="M4 9v6a1 1 0 0 0 1 1h3.5l4.96 3.61A1 1 0 0 0 15 18.77V5.23a1 1 0 0 0-1.54-.84L8.5 8H5a1 1 0 0 0-1 1Zm13.59 3.41 2.7 2.7a1 1 0 0 1-1.42 1.42l-2.7-2.7-2.7 2.7a1 1 0 0 1-1.42-1.42l2.7-2.7-2.7-2.7a1 1 0 0 1 1.42-1.42l2.7 2.7 2.7-2.7a1 1 0 1 1 1.42 1.42Z"/>
+      </svg>
+    </button>
+  </div>
+
+  <audio id="bg-audio-player" preload="none" loop src="https://assets.mixkit.co/music/preview/mixkit-game-level-music-689.mp3"></audio>
+
   <!-- Importar el SDK de Firebase (compatibilidad para evitar problemas de CORS al abrir el archivo localmente) -->
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
@@ -861,6 +879,7 @@
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
+  <script src="js/audioControls.js"></script>
 <script>
 (function(){
   const AVATAR_FALLBACK = 'img/avatar-generico.svg';
@@ -1376,6 +1395,15 @@
 
     observarEstadoSorteo();
   }
+
+  initBingoAudioControl({
+    containerId: 'audio-control-player',
+    toggleId: 'audio-toggle-player',
+    volumeId: 'audio-volume-player',
+    audioId: 'bg-audio-player',
+    storageKeyPrefix: 'bingoAudio',
+    defaultVolume: 0.22,
+  });
 
   inicializarVistaJugador();
 })();


### PR DESCRIPTION
### Motivation
- Evitar incluir archivos binarios de audio en el repositorio porque generan incompatibilidades y aumento de tamaño.
- Mantener la reproducción de música de fondo y efectos de ganador sin depender de archivos locales.
- Proveer controles reutilizables de sonido (silenciar/volumen) que persisten entre sesiones mediante `localStorage`.

### Description
- Se eliminaron los archivos locales `public/audio/bingo-fondo.wav` y `public/audio/bingo-ganador.wav` y se reemplazaron los elementos `<audio>` en `public/player.html` y `public/juegoactivo.html` por URLs remotas (`https://assets.mixkit.co/...`) para música y efectos.
- Se añadió el módulo de control de audio `public/js/audioControls.js` que exporta `initBingoAudioControl` y `reproducirSonidoGanador`, y la hoja de estilos `public/css/audioControls.css` para los controles flotantes de UI.
- Se insertaron los componentes de control en `player.html` y `juegoactivo.html`, se inicializan con `initBingoAudioControl({...})` y se invoca `reproducirSonidoGanador('win-audio','bingoAudio')` al mostrar celebraciones de ganador.

### Testing
- No se ejecutaron pruebas automatizadas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d90e77ecc83268dd571e440354a62)