### PR TITLE
Mejorar control de audio: desbloqueo en interacción, volumen vertical y nuevos iconos

### DIFF
--- a/public/css/audioControls.css
+++ b/public/css/audioControls.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 8px;
+  gap: 10px;
   font-family: 'Poppins', sans-serif;
 }
 
@@ -17,15 +17,16 @@
 }
 
 .audio-control__toggle {
-  width: 44px;
-  height: 44px;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
-  border: none;
-  background: rgba(0, 0, 0, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: linear-gradient(135deg, rgba(24, 32, 54, 0.9), rgba(10, 16, 26, 0.7));
   color: #fff;
   display: grid;
   place-items: center;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(8px);
   cursor: pointer;
 }
 
@@ -35,8 +36,9 @@
 }
 
 .audio-control__icon {
-  width: 24px;
-  height: 24px;
+  width: 26px;
+  height: 26px;
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.35));
 }
 
 .audio-control.is-muted .audio-control__icon--on {
@@ -48,13 +50,16 @@
 }
 
 .audio-control__volume {
-  background: rgba(0, 0, 0, 0.75);
-  padding: 8px 10px;
-  border-radius: 10px;
+  background: rgba(16, 20, 32, 0.75);
+  padding: 12px 10px;
+  border-radius: 14px;
   display: flex;
   align-items: center;
   gap: 6px;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(10px);
+  align-self: center;
 }
 
 .audio-control__volume[hidden] {
@@ -62,7 +67,12 @@
 }
 
 .audio-control__range {
-  width: 120px;
+  width: 6px;
+  height: 120px;
+  -webkit-appearance: slider-vertical;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  accent-color: #4cc9f0;
 }
 
 .sr-only {

--- a/public/js/audioControls.js
+++ b/public/js/audioControls.js
@@ -23,6 +23,7 @@
       audioId,
       storageKeyPrefix = 'bingoAudio',
       defaultVolume = DEFAULT_VOLUME,
+      unlockAudioIds = [],
     } = config;
 
     const container = document.getElementById(containerId);
@@ -39,6 +40,7 @@
     }
 
     let hideTimer = null;
+    let audioDesbloqueado = false;
 
     function actualizarUI() {
       container.classList.toggle('is-muted', estado.muted);
@@ -67,10 +69,41 @@
     async function intentarReproducir() {
       if (estado.muted) return;
       try {
+        audioEl.load();
         await audioEl.play();
       } catch (err) {
         // Bloqueado por el navegador hasta interacción del usuario.
       }
+    }
+
+    function desbloquearAudioEnInteraccion() {
+      if (audioDesbloqueado) return;
+      const audios = [audioEl]
+        .concat(
+          unlockAudioIds
+            .map((id) => document.getElementById(id))
+            .filter((el) => el)
+        );
+      audios.forEach((audio) => {
+        const mutedPrevio = audio.muted;
+        audio.muted = true;
+        const intento = audio.play();
+        if (intento && typeof intento.then === 'function') {
+          intento
+            .then(() => {
+              audio.pause();
+              audio.currentTime = 0;
+            })
+            .catch(() => {})
+            .finally(() => {
+              audio.muted = mutedPrevio;
+            });
+        } else {
+          audio.muted = mutedPrevio;
+        }
+      });
+      audioDesbloqueado = true;
+      intentarReproducir();
     }
 
     function aplicarEstadoInicial() {
@@ -106,13 +139,15 @@
       guardarEstadoAudio(storageKeyPrefix, estado);
     });
 
-    document.addEventListener(
-      'pointerdown',
-      () => {
-        intentarReproducir();
-      },
-      { once: true }
-    );
+    ['pointerdown', 'touchstart', 'keydown'].forEach((evento) => {
+      document.addEventListener(
+        evento,
+        () => {
+          desbloquearAudioEnInteraccion();
+        },
+        { once: true }
+      );
+    });
 
     aplicarEstadoInicial();
     if (!estado.muted) {
@@ -128,6 +163,7 @@
     const audioEl = document.getElementById(audioId);
     if (!audioEl) return;
     audioEl.currentTime = 0;
+    audioEl.load();
     audioEl.play().catch(() => {});
   }
 

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4222,10 +4222,14 @@
     </div>
     <button id="audio-toggle-game" class="audio-control__toggle" type="button" aria-pressed="true" aria-label="Silenciar música de fondo">
       <svg class="audio-control__icon audio-control__icon--on" viewBox="0 0 24 24" aria-hidden="true">
-        <path fill="currentColor" d="M14 3.23v17.54a1 1 0 0 1-1.54.84L7.5 18H4a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h3.5l4.96-3.61A1 1 0 0 1 14 3.23Zm4.5 8.77a4.5 4.5 0 0 1-2.2 3.88.75.75 0 1 0 .75 1.3 6 6 0 0 0 0-10.36.75.75 0 1 0-.75 1.3 4.5 4.5 0 0 1 2.2 3.88Z"/>
+        <path d="M5 9v6h4l5 4V5l-5 4H5z" fill="currentColor" opacity="0.2"></path>
+        <path d="M15 9a4 4 0 0 1 0 6" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"></path>
+        <path d="M17.5 6.5a7 7 0 0 1 0 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.8"></path>
       </svg>
       <svg class="audio-control__icon audio-control__icon--off" viewBox="0 0 24 24" aria-hidden="true">
-        <path fill="currentColor" d="M4 9v6a1 1 0 0 0 1 1h3.5l4.96 3.61A1 1 0 0 0 15 18.77V5.23a1 1 0 0 0-1.54-.84L8.5 8H5a1 1 0 0 0-1 1Zm13.59 3.41 2.7 2.7a1 1 0 0 1-1.42 1.42l-2.7-2.7-2.7 2.7a1 1 0 0 1-1.42-1.42l2.7-2.7-2.7-2.7a1 1 0 0 1 1.42-1.42l2.7 2.7 2.7-2.7a1 1 0 1 1 1.42 1.42Z"/>
+        <path d="M5 9v6h4l5 4V5l-5 4H5z" fill="currentColor" opacity="0.2"></path>
+        <path d="M19 9l-5 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+        <path d="M14 9l5 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
       </svg>
     </button>
   </div>
@@ -4265,6 +4269,7 @@
     audioId: 'bg-audio-game',
     storageKeyPrefix: 'bingoAudio',
     defaultVolume: 0.22,
+    unlockAudioIds: ['win-audio'],
   });
   const sinSorteoContenedorEl = document.getElementById('sin-sorteo-contenedor');
   const seleccionarFinalizadoBtn = document.getElementById('seleccionar-finalizado-btn');

--- a/public/player.html
+++ b/public/player.html
@@ -853,10 +853,14 @@
     </div>
     <button id="audio-toggle-player" class="audio-control__toggle" type="button" aria-pressed="true" aria-label="Silenciar música de fondo">
       <svg class="audio-control__icon audio-control__icon--on" viewBox="0 0 24 24" aria-hidden="true">
-        <path fill="currentColor" d="M14 3.23v17.54a1 1 0 0 1-1.54.84L7.5 18H4a1 1 0 0 1-1-1v-6a1 1 0 0 1 1-1h3.5l4.96-3.61A1 1 0 0 1 14 3.23Zm4.5 8.77a4.5 4.5 0 0 1-2.2 3.88.75.75 0 1 0 .75 1.3 6 6 0 0 0 0-10.36.75.75 0 1 0-.75 1.3 4.5 4.5 0 0 1 2.2 3.88Z"/>
+        <path d="M5 9v6h4l5 4V5l-5 4H5z" fill="currentColor" opacity="0.2"></path>
+        <path d="M15 9a4 4 0 0 1 0 6" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"></path>
+        <path d="M17.5 6.5a7 7 0 0 1 0 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.8"></path>
       </svg>
       <svg class="audio-control__icon audio-control__icon--off" viewBox="0 0 24 24" aria-hidden="true">
-        <path fill="currentColor" d="M4 9v6a1 1 0 0 0 1 1h3.5l4.96 3.61A1 1 0 0 0 15 18.77V5.23a1 1 0 0 0-1.54-.84L8.5 8H5a1 1 0 0 0-1 1Zm13.59 3.41 2.7 2.7a1 1 0 0 1-1.42 1.42l-2.7-2.7-2.7 2.7a1 1 0 0 1-1.42-1.42l2.7-2.7-2.7-2.7a1 1 0 0 1 1.42-1.42l2.7 2.7 2.7-2.7a1 1 0 1 1 1.42 1.42Z"/>
+        <path d="M5 9v6h4l5 4V5l-5 4H5z" fill="currentColor" opacity="0.2"></path>
+        <path d="M19 9l-5 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+        <path d="M14 9l5 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
       </svg>
     </button>
   </div>


### PR DESCRIPTION
### Motivation
- Resolver que los sonidos no se reproducían por bloqueo del navegador y mejorar la experiencia visual y de control de volumen para un acabado más profesional.
- Hacer que el control de volumen sea vertical y que el selector aparezca sobre el icono con estilos más pulidos y transparencias.

### Description
- Añadida la opción `unlockAudioIds` a `initBingoAudioControl` y lógica para intentar desbloquear reproducción en la primera interacción del usuario y recargar el audio con `audio.load()` antes de `play()` en `public/js/audioControls.js`.
- Implementado `desbloquearAudioEnInteraccion` que reproduce brevemente (mutado) y pausa los elementos listados para permitir reproducción posterior sin bloqueo del navegador en `public/js/audioControls.js`.
- Mejorados estilos en `public/css/audioControls.css` para un botón más moderno, sombras, transparencias y transformación del control `input[type=range]` a orientación vertical (`writing-mode`, `transform`) con `-webkit-appearance: slider-vertical` y `accent-color` personalizado.
- Reemplazados los SVG de iconos de volumen en `public/juegoactivo.html` y `public/player.html` y registrado `unlockAudioIds: ['win-audio']` en la inicialización del control de audio del juego.

### Testing
- Levanté un servidor estático con `python -m http.server 8000` para probar la interfaz y el script de audio; el servidor se inició correctamente.
- Intenté automatizar una captura con Playwright para validar la UI y la interacción (`click` en `#audio-toggle-player`), pero el lanzamiento del navegador falló con un crash (`TargetClosedError`/SIGSEGV), por lo que no fue posible generar la captura; la prueba automatizada falló.
- No se ejecutaron pruebas unitarias automáticas sobre el código modificado (cambios mayormente de UI/JS/CSS).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d95b1754c8326b0f741dd540202cd)