### PR TITLE
Corregir desbloqueo de audio y actualizar controles de volumen

### DIFF
--- a/public/css/audioControls.css
+++ b/public/css/audioControls.css
@@ -17,16 +17,14 @@
 }
 
 .audio-control__toggle {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
   border: 1px solid rgba(255, 255, 255, 0.18);
-  background: linear-gradient(135deg, rgba(24, 32, 54, 0.9), rgba(10, 16, 26, 0.7));
+  background: transparent;
   color: #fff;
   display: grid;
   place-items: center;
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(8px);
   cursor: pointer;
 }
 
@@ -36,8 +34,8 @@
 }
 
 .audio-control__icon {
-  width: 26px;
-  height: 26px;
+  width: 30px;
+  height: 30px;
   filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.35));
 }
 
@@ -73,6 +71,61 @@
   writing-mode: vertical-rl;
   transform: rotate(180deg);
   accent-color: #4cc9f0;
+}
+
+.audio-control__prompt {
+  margin-top: 10px;
+  background: rgba(10, 14, 24, 0.88);
+  color: #fff;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+  display: none;
+  font-size: 13px;
+  max-width: 220px;
+}
+
+.audio-control__prompt.is-visible {
+  display: block;
+}
+
+.audio-control__prompt p {
+  margin: 0 0 8px 0;
+}
+
+.audio-control__prompt-btn {
+  border: none;
+  background: #4cc9f0;
+  color: #08131f;
+  font-weight: 600;
+  padding: 6px 10px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.audio-control__prompt-btn:focus-visible {
+  outline: 2px solid #ffd700;
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) and (orientation: portrait) {
+  .audio-control {
+    align-items: center;
+  }
+
+  .audio-control__volume {
+    flex-direction: column;
+    padding: 10px 12px;
+  }
+
+  .audio-control__range {
+    width: 130px;
+    height: 8px;
+    writing-mode: horizontal-tb;
+    transform: none;
+    -webkit-appearance: none;
+  }
 }
 
 .sr-only {

--- a/public/js/audioControls.js
+++ b/public/js/audioControls.js
@@ -41,6 +41,8 @@
 
     let hideTimer = null;
     let audioDesbloqueado = false;
+    let promptEl = null;
+    let promptBtn = null;
 
     function actualizarUI() {
       container.classList.toggle('is-muted', estado.muted);
@@ -66,13 +68,48 @@
       }, 5000);
     }
 
-    async function intentarReproducir() {
+    function crearPromptAudio() {
+      if (promptEl) return;
+      promptEl = document.createElement('div');
+      promptEl.className = 'audio-control__prompt';
+      promptEl.setAttribute('role', 'dialog');
+      promptEl.setAttribute('aria-live', 'polite');
+      promptEl.setAttribute('aria-hidden', 'true');
+      promptEl.innerHTML =
+        '<p>Para escuchar la música necesitamos tu interacción.</p>' +
+        '<button type="button" class="audio-control__prompt-btn">Activar audio</button>';
+      promptBtn = promptEl.querySelector('.audio-control__prompt-btn');
+      promptBtn?.addEventListener('click', async () => {
+        await intentarReproducir(true);
+        ocultarPromptAudio();
+      });
+      container.appendChild(promptEl);
+    }
+
+    function mostrarPromptAudio() {
+      crearPromptAudio();
+      if (!promptEl) return;
+      promptEl.classList.add('is-visible');
+      promptEl.removeAttribute('aria-hidden');
+    }
+
+    function ocultarPromptAudio() {
+      if (!promptEl) return;
+      promptEl.classList.remove('is-visible');
+      promptEl.setAttribute('aria-hidden', 'true');
+    }
+
+    async function intentarReproducir(desdePrompt = false) {
       if (estado.muted) return;
       try {
         audioEl.load();
         await audioEl.play();
+        ocultarPromptAudio();
       } catch (err) {
         // Bloqueado por el navegador hasta interacción del usuario.
+        if (!desdePrompt) {
+          mostrarPromptAudio();
+        }
       }
     }
 

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4222,14 +4222,14 @@
     </div>
     <button id="audio-toggle-game" class="audio-control__toggle" type="button" aria-pressed="true" aria-label="Silenciar música de fondo">
       <svg class="audio-control__icon audio-control__icon--on" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M5 9v6h4l5 4V5l-5 4H5z" fill="currentColor" opacity="0.2"></path>
-        <path d="M15 9a4 4 0 0 1 0 6" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"></path>
-        <path d="M17.5 6.5a7 7 0 0 1 0 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.8"></path>
+        <path d="M4 10v4h4l5 4V6l-5 4H4z" fill="currentColor"></path>
+        <path d="M16.5 8.5a4.5 4.5 0 0 1 0 7" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"></path>
+        <path d="M18.8 6a7.5 7.5 0 0 1 0 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.8"></path>
       </svg>
       <svg class="audio-control__icon audio-control__icon--off" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M5 9v6h4l5 4V5l-5 4H5z" fill="currentColor" opacity="0.2"></path>
-        <path d="M19 9l-5 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
-        <path d="M14 9l5 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+        <path d="M4 10v4h4l5 4V6l-5 4H4z" fill="currentColor"></path>
+        <path d="M18.5 8.5l-7 7" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+        <path d="M11.5 8.5l7 7" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
       </svg>
     </button>
   </div>

--- a/public/player.html
+++ b/public/player.html
@@ -853,14 +853,14 @@
     </div>
     <button id="audio-toggle-player" class="audio-control__toggle" type="button" aria-pressed="true" aria-label="Silenciar música de fondo">
       <svg class="audio-control__icon audio-control__icon--on" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M5 9v6h4l5 4V5l-5 4H5z" fill="currentColor" opacity="0.2"></path>
-        <path d="M15 9a4 4 0 0 1 0 6" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"></path>
-        <path d="M17.5 6.5a7 7 0 0 1 0 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.8"></path>
+        <path d="M4 10v4h4l5 4V6l-5 4H4z" fill="currentColor"></path>
+        <path d="M16.5 8.5a4.5 4.5 0 0 1 0 7" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"></path>
+        <path d="M18.8 6a7.5 7.5 0 0 1 0 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.8"></path>
       </svg>
       <svg class="audio-control__icon audio-control__icon--off" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M5 9v6h4l5 4V5l-5 4H5z" fill="currentColor" opacity="0.2"></path>
-        <path d="M19 9l-5 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
-        <path d="M14 9l5 6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+        <path d="M4 10v4h4l5 4V6l-5 4H4z" fill="currentColor"></path>
+        <path d="M18.5 8.5l-7 7" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+        <path d="M11.5 8.5l7 7" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
       </svg>
     </button>
   </div>


### PR DESCRIPTION
### Motivation
- Solucionar por qué el audio no se reproduce cuando los navegadores bloquean la reproducción automática y guiar al usuario para desbloquearlo mediante interacción.  
- Mejorar la apariencia de los iconos de volumen para que no usen fondo circular y sean transparentes.  
- Asegurar que el control de nivel de volumen se muestre vertical en escritorio y cambie a disposición adecuada en móviles en orientación vertical.

### Description
- Añadí un aviso inline para desbloqueo de audio que aparece si la reproducción es bloqueada y ofrece un botón `Activar audio` para forzar la interacción del usuario y reintentar la reproducción, integrado en `initBingoAudioControl` (`public/js/audioControls.js`).
- Implementé funciones `crearPromptAudio`, `mostrarPromptAudio` y `ocultarPromptAudio` y adapté `intentarReproducir` para mostrar/ocultar el prompt según sea necesario.  
- Actualicé estilos en `public/css/audioControls.css` para usar un botón de toggle con fondo transparente y esquinas rectangulares (no circular), añadí estilos para el prompt y añadí una regla responsive que cambia el deslizador vertical a una disposición horizontal en móviles en orientación vertical.  
- Reemplacé los iconos SVG de los toggles en `public/juegoactivo.html` y `public/player.html` por versiones sin fondo circular y más limpias, manteniendo las clases `audio-control__icon--on` / `--off` para estado.
- Conservé la lógica de desbloqueo por interacción (escucha de `pointerdown`, `touchstart`, `keydown`) y la unión con audios adicionales via `unlockAudioIds`, y mantuve las funciones públicas `initBingoAudioControl` y `reproducirSonidoGanador`.

### Testing
- Se inició un servidor local (`python -m http.server 8000`) y se intentó ejecutar un script de Playwright para abrir `player.html`, simular interacciones y tomar una captura; la ejecución automatizada falló debido a un fallo del navegador Chromium en el entorno (SIGSEGV), por lo que la prueba automatizada con Playwright no finalizó correctamente.  
- No se ejecutaron tests unitarios adicionales ni pipelines automatizados en este cambio.  
- Manualmente (inspección del código) se verificó que las nuevas funciones y selectores estén integrados en las páginas `player.html` y `juegoactivo.html` y que las reglas CSS responsive cubran la vista móvil en orientación vertical.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d98dcfac08326a8bd2483f17d584c)