### PR TITLE
Ocultar prompt automático de activación de audio

### DIFF
--- a/public/js/audioControls.js
+++ b/public/js/audioControls.js
@@ -24,6 +24,7 @@
       storageKeyPrefix = 'bingoAudio',
       defaultVolume = DEFAULT_VOLUME,
       unlockAudioIds = [],
+      mostrarPrompt = false,
     } = config;
 
     const container = document.getElementById(containerId);
@@ -69,6 +70,7 @@
     }
 
     function crearPromptAudio() {
+      if (!mostrarPrompt) return;
       if (promptEl) return;
       promptEl = document.createElement('div');
       promptEl.className = 'audio-control__prompt';
@@ -87,6 +89,7 @@
     }
 
     function mostrarPromptAudio() {
+      if (!mostrarPrompt) return;
       crearPromptAudio();
       if (!promptEl) return;
       promptEl.classList.add('is-visible');


### PR DESCRIPTION
### Motivation
- Evitar que el mensaje automático que solicita la activación del audio se muestre siempre al cargar las ventanas cuando no realiza trabajo útil; dejar control sobre si debe mostrarse.

### Description
- Se añadió el parámetro de configuración `mostrarPrompt` (por defecto `false`) en `initBingoAudioControl` y se protegieron las funciones `crearPromptAudio` y `mostrarPromptAudio` para que no muestren el prompt cuando `mostrarPrompt` sea `false` en `public/js/audioControls.js`.

### Testing
- Se levantó un servidor estático con `python -m http.server 8000 --directory public` y se capturó la página `player.html` mediante un script de Playwright para verificar visualmente que el prompt ya no aparece, y la captura fue generada correctamente (`artifacts/player-audio-prompt-removed.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d7dcc3108326be3e631a707c6b4b)