### PR TITLE
Agregar sistema de referidos: gestión de campañas, códigos promocionales y compartir

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -153,6 +153,7 @@
   <button id="salir-super-btn" class="menu-btn back-btn" style="display:none;">Salir</button>
   <div id="main-menu">
     <button id="gestionar-sorteos-btn" class="menu-btn">Gestionar Sorteos</button>
+    <button id="gestionar-referidos-btn" class="menu-btn">Campañas Referidos</button>
     <button id="publicar-resultados-btn" class="menu-btn">Cantar Sorteo</button>
     <button id="gestionar-transferencias-btn" class="menu-btn">Gestionar transferencias</button>
   </div>
@@ -166,6 +167,7 @@
   ensureAuth('Administrador');
   setupSuperadminExit('#salir-super-btn');
   document.getElementById('gestionar-sorteos-btn').addEventListener('click',()=>{window.location.href='gestionsorteos.html';});
+  document.getElementById('gestionar-referidos-btn').addEventListener('click',()=>{window.location.href='gestionreferidos.html';});
   document.getElementById('publicar-resultados-btn').addEventListener('click',()=>{window.location.href='cantarsorteos.html';});
   document.getElementById('gestionar-transferencias-btn').addEventListener('click',()=>{window.location.href='transacciones.html';});
   document.getElementById('config-btn').addEventListener('click',()=>{window.location.href='configuraciones.html';});

--- a/public/gestionreferidos.html
+++ b/public/gestionreferidos.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="img/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="img/android-chrome-192x192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="img/android-chrome-512x512.png">
+  <link rel="icon" type="image/x-icon" href="img/favicon.ico">
+  <link rel="icon" type="image/x-icon" sizes="16x16" href="img/favicon-16x16.ico">
+  <link rel="icon" type="image/x-icon" sizes="32x32" href="img/favicon-32x32.ico">
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gestionar Campañas de Referidos</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
+  <style>
+    body {
+      background: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
+                  url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
+      background-repeat: repeat;
+      background-size: auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      min-height: 100vh;
+      text-align: center;
+      font-family: 'Bangers', cursive;
+      padding-top: 20px;
+      margin: 0;
+    }
+    .menu-btn {
+      width: 250px;
+      height: 60px;
+      font-family: 'Bangers', cursive;
+      font-size: 1.4rem;
+      background: rgba(0, 170, 255, 0.8);
+      color: white;
+      border: 4px solid #FFD700;
+      border-radius: 10px;
+      text-shadow: 2px 2px 4px #000;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: transform 0.3s, box-shadow 0.3s, background 0.3s;
+      margin: 5px;
+    }
+    .mini-btn {
+      display:inline-flex;
+      align-items:center;
+      gap:2px;
+      padding:2px 4px;
+      font-size:0.7rem;
+      border:1px solid #ccc;
+      border-radius:4px;
+      background:rgba(255,255,255,0.9);
+      cursor:pointer;
+      margin-right:2px;
+    }
+    .menu-btn:hover {
+      transform: scale(1.05);
+      box-shadow: 0 0 15px rgba(255, 215, 0, 0.8);
+    }
+    .back-btn {
+      position: fixed;
+      top: 5px;
+      left: 5px;
+      width: 120px;
+      height: 40px;
+      background: orange;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap:5px;
+    }
+    #actions {
+      width:95%;
+      display:flex;
+      justify-content:center;
+      margin-top:5px;
+      font-family:Calibri, Arial, sans-serif;
+    }
+
+    #nuevo-btn .icon, #nuevo-btn .txt {
+      color: yellow;
+      text-shadow: 1px 1px 1px #000;
+    }
+
+    #editar-btn .icon, #editar-btn .txt {
+      color: blue;
+      text-shadow: 1px 1px 1px #000;
+    }
+
+    #inactivar-btn .icon, #inactivar-btn .txt {
+      color: red;
+      text-shadow: 1px 1px 1px #000;
+    }
+
+    #archivar-btn .txt {
+      color: brown;
+      text-shadow: 1px 1px 1px #000;
+    }
+    .archivo-activo{background:#654321;color:#fff;}
+
+    .fecha-container { position:relative; }
+    .fecha-placeholder {
+      position:absolute;
+      left:4px;
+      top:2px;
+      pointer-events:none;
+      color:#666;
+      font-size:0.8rem;
+    }
+    #tabla-campanas {
+      width: 95%;
+      max-height: 50vh;
+      overflow-y: auto;
+      font-family: Calibri, Arial, sans-serif;
+      font-size: 0.8rem;
+      border-collapse: collapse;
+      background: rgba(255,255,255,0.6);
+      margin-top: 10px;
+    }
+    #tabla-campanas th, #tabla-campanas td {
+      border: 1px solid #ccc;
+      padding: 4px 6px;
+    }
+    #tabla-campanas tbody td {
+      font-weight: bold;
+    }
+    #tabla-campanas thead th {
+      position: sticky;
+      top: 0;
+      background: rgba(255,255,255,0.8);
+    }
+    #session-info {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      display: flex;
+      align-items: center;
+      font-size: 0.7rem;
+    }
+    #user-pic {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+    }
+    #logout-link {
+      font-family: Calibri, Arial, sans-serif;
+      margin-left: 5px;
+      font-size: 0.7rem;
+      color: #007bff;
+      text-decoration: underline;
+    }
+    .modal {
+      display:none;
+      position:fixed;
+      top:0;
+      left:0;
+      right:0;
+      bottom:0;
+      background:rgba(0,0,0,0.5);
+      align-items:center;
+      justify-content:center;
+    }
+    .modal-box {
+      background:white;
+      padding:20px;
+      border-radius:8px;
+      max-width:320px;
+      text-align:left;
+      font-family: Calibri, Arial, sans-serif;
+    }
+    .modal-box .detalle-nombre { color:orange; font-weight:bold; }
+    .modal-box .detalle-fecha { color:darkgreen; }
+    .modal-box .detalle-cartones { color:purple; }
+    .modal-box .detalle-referidos { color:blue; }
+    .modal-box .detalle-estado { color:crimson; }
+    .modal-box .detalle-item { margin-bottom:8px; }
+    .modal-box button { margin-top:10px; }
+  </style>
+</head>
+<body>
+  <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true">&#9664; Volver</button>
+  <div id="session-info">
+    <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
+    <a href="#" id="logout-link">Cerrar sesión</a>
+  </div>
+  <h2>Gestionar Campañas de Referidos</h2>
+  <div id="actions">
+    <button id="nuevo-btn" class="mini-btn"><span class="icon">&#9728;</span> <span class="txt">Nuevo</span></button>
+    <button id="editar-btn" class="mini-btn"><span class="icon">&#9998;</span> <span class="txt">Editar</span></button>
+    <button id="inactivar-btn" class="mini-btn"><span class="icon">&#128683;</span> <span class="txt">Inactivar</span></button>
+    <button id="archivar-btn" class="mini-btn"><span class="icon">&#128194;</span> <span class="txt">Archivar</span></button>
+    <button id="archivo-btn" class="mini-btn"><span class="icon">&#128230;</span> <span class="txt">Archivo</span></button>
+  </div>
+  <table id="tabla-campanas">
+    <thead>
+      <tr>
+        <th>N°</th>
+        <th><input type="text" id="filtro-nombre" placeholder="Nombre de campaña" style="width:100%;box-sizing:border-box;"></th>
+        <th>
+          <div class="fecha-container">
+            <input type="date" id="filtro-fecha" style="width:100%;">
+            <span class="fecha-placeholder">Inicio</span>
+          </div>
+        </th>
+        <th>
+          <select id="filtro-estado" style="width:100%;">
+            <option value="">Estado</option>
+            <option value="ACTIVA">ACTIVA</option>
+            <option value="INACTIVA">INACTIVA</option>
+            <option value="ARCHIVADA">ARCHIVADA</option>
+          </select>
+        </th>
+        <th style="text-align:center;"><span id="sel-campana" style="cursor:pointer;">&#10004;</span></th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <div id="modal-info" class="modal">
+    <div class="modal-box">
+      <div id="modal-info-content"></div>
+      <button id="modal-info-cerrar">Aceptar</button>
+    </div>
+  </div>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
+  <script src="js/logoSwitcher.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
+  <script>
+  const datos=[];
+  const tbody=document.querySelector('#tabla-campanas tbody');
+  let mostrarArch=false;
+  let cacheCampanas=[];
+  let unsubscribeCampanas=null;
+
+  function actualizarArchivarBtn(){
+    const btn=document.getElementById('archivar-btn');
+    const icon=btn.querySelector('.icon');
+    const txt=btn.querySelector('.txt');
+    if(mostrarArch){
+      txt.textContent='Desarchivar';
+      icon.innerHTML='&#128193;';
+      icon.style.color='blue';
+      txt.style.color='blue';
+    }else{
+      txt.textContent='Archivar';
+      icon.innerHTML='&#128194;';
+      icon.style.color='brown';
+      txt.style.color='brown';
+    }
+  }
+
+  function parseFecha(valor){
+    if(!valor) return null;
+    const base = new Date(`${valor}T00:00:00`);
+    if(Number.isNaN(base.getTime())) return null;
+    return base;
+  }
+
+  function hoySinHora(){
+    const ahora = new Date();
+    return new Date(ahora.getFullYear(), ahora.getMonth(), ahora.getDate());
+  }
+
+  async function marcarCampanasVencidas(lista){
+    const hoy = hoySinHora();
+    const batch = db.batch();
+    let cambios = 0;
+    lista.forEach(item => {
+      const data = item.data || {};
+      if((data.estado || '').toUpperCase() !== 'ACTIVA') return;
+      const fin = parseFecha(data.fechaFin);
+      if(fin && fin < hoy){
+        batch.update(db.collection('campanasReferidos').doc(item.id), { estado:'INACTIVA' });
+        cambios += 1;
+      }
+    });
+    if(cambios){
+      await batch.commit();
+    }
+  }
+
+  function recomponerDatos(){
+    datos.length=0;
+    cacheCampanas.forEach(item=>{
+      const info={id:item.id,...item.data};
+      info.estado=(info.estado||'INACTIVA').toUpperCase();
+      datos.push(info);
+    });
+    datos.sort((a,b)=>{
+      const fa=a.fechaInicio||'';
+      const fb=b.fechaInicio||'';
+      return fa>fb?-1:fa<fb?1:0;
+    });
+    filtrar();
+  }
+
+  function iniciarMonitoreo(){
+    if(unsubscribeCampanas) unsubscribeCampanas();
+
+    unsubscribeCampanas=db.collection('campanasReferidos').onSnapshot(async snapshot=>{
+      cacheCampanas=[];
+      snapshot.forEach(doc=>{
+        cacheCampanas.push({id:doc.id,data:doc.data()});
+      });
+      try{
+        await marcarCampanasVencidas(cacheCampanas);
+      }catch(err){
+        console.error('No se pudo actualizar campañas vencidas', err);
+      }
+      recomponerDatos();
+    },err=>{
+      console.error('Error al escuchar las campañas de referidos',err);
+      alert('No se pudieron cargar las campañas. Intenta nuevamente más tarde.');
+    });
+  }
+
+  function renderTabla(lista){
+    tbody.innerHTML='';
+    let idx=1;
+    lista.forEach(d=>{
+      let fechaInicio=d.fechaInicio||'';
+      if(fechaInicio.includes('-')) fechaInicio=fechaInicio.split('-').reverse().join('/');
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${idx++}</td><td class="nombre">${d.nombre}</td><td class="fecha">${fechaInicio}</td><td>${d.estado}</td><td style="text-align:center;"><input type="checkbox" data-id="${d.id}" data-estado="${d.estado}"></td>`;
+      const nombreCell=tr.querySelector('.nombre');
+      nombreCell.style.cursor='pointer';
+      nombreCell.addEventListener('click',()=>mostrarInfo(d));
+      const fechaCell=tr.querySelector('.fecha');
+      fechaCell.style.cursor='pointer';
+      fechaCell.addEventListener('click',()=>mostrarInfo(d));
+      const color=d.estado==='ACTIVA'?'green':
+                   d.estado==='INACTIVA'?'red':
+                   d.estado==='ARCHIVADA'?'brown':'';
+      if(color){
+        tr.children[1].style.color=color;
+        tr.children[2].style.color=color;
+        tr.children[3].style.color=color;
+      }
+      tbody.appendChild(tr);
+    });
+  }
+
+  function filtrar(){
+    const nom=document.getElementById('filtro-nombre').value.trim().toLowerCase();
+    const fecha=document.getElementById('filtro-fecha').value;
+    const est=document.getElementById('filtro-estado').value;
+    let lista=datos.filter(s=>mostrarArch ? s.estado==='ARCHIVADA' : s.estado!=='ARCHIVADA');
+    if(nom) lista=lista.filter(s=>(s.nombre||'').toLowerCase().includes(nom));
+    if(fecha) lista=lista.filter(s=>s.fechaInicio===fecha);
+    if(est) lista=lista.filter(s=>s.estado===est);
+    renderTabla(lista);
+  }
+
+  document.getElementById('filtro-nombre').addEventListener('input',filtrar);
+  const fechaInput=document.getElementById('filtro-fecha');
+  const fechaPh=document.querySelector('.fecha-placeholder');
+  function toggleFechaPh(){
+    if(fechaInput.value) fechaPh.style.display='none';
+    else fechaPh.style.display='block';
+  }
+  fechaInput.addEventListener('change',()=>{toggleFechaPh();filtrar();});
+  document.getElementById('filtro-estado').addEventListener('change',filtrar);
+  toggleFechaPh();
+
+  document.getElementById('sel-campana').addEventListener('click',()=>{
+    const checks=document.querySelectorAll('#tabla-campanas tbody input[type=checkbox]');
+    const all=Array.from(checks).every(c=>c.checked);
+    checks.forEach(c=>c.checked=!all);
+  });
+
+  document.getElementById('archivo-btn').addEventListener('click',()=>{
+    mostrarArch=!mostrarArch;
+    document.getElementById('archivo-btn').classList.toggle('archivo-activo',mostrarArch);
+    actualizarArchivarBtn();
+    filtrar();
+  });
+
+  document.getElementById('nuevo-btn').addEventListener('click',()=>{
+    localStorage.removeItem('editCampanaId');
+    window.location.href='nuevacampana.html';
+  });
+  document.getElementById('editar-btn').addEventListener('click',()=>{
+    const chks=document.querySelectorAll('#tabla-campanas input[type=checkbox]:checked');
+    if(chks.length===0){alert('Elige al menos una campaña para editarla');return;}
+    const chk=chks[0];
+    localStorage.setItem('editCampanaId',chk.dataset.id);
+    window.location.href='nuevacampana.html';
+  });
+  document.getElementById('inactivar-btn').addEventListener('click',async ()=>{
+    const chks=document.querySelectorAll('#tabla-campanas input[type=checkbox]:checked');
+    if(chks.length===0){alert('Debes seleccionar al menos una campaña para poder inactivarla');return;}
+    const ids=[];
+    chks.forEach(c=>{
+      if(c.dataset.estado==='ARCHIVADA') return;
+      ids.push(c.dataset.id);
+    });
+    if(!ids.length) return;
+    const batch=db.batch();
+    ids.forEach(id=>batch.update(db.collection('campanasReferidos').doc(id),{estado:'INACTIVA'}));
+    await batch.commit();
+  });
+  document.getElementById('archivar-btn').addEventListener('click',async ()=>{
+    const chks=document.querySelectorAll('#tabla-campanas input[type=checkbox]:checked');
+    if(chks.length===0){alert('Debes seleccionar al menos una campaña');return;}
+    const ids=[];
+    chks.forEach(c=>{
+      ids.push(c.dataset.id);
+    });
+    if(!ids.length) return;
+    const batch=db.batch();
+    if(mostrarArch){
+      ids.forEach(id=>batch.update(db.collection('campanasReferidos').doc(id),{estado:'INACTIVA'}));
+    }else{
+      ids.forEach(id=>batch.update(db.collection('campanasReferidos').doc(id),{estado:'ARCHIVADA'}));
+    }
+    await batch.commit();
+  });
+
+  function mostrarInfo(d){
+    const modal=document.getElementById('modal-info');
+    const cont=document.getElementById('modal-info-content');
+    const inicio=d.fechaInicio||'';
+    const fin=d.fechaFin||'';
+    cont.innerHTML=`<div class="detalle-item detalle-nombre">Campaña: ${d.nombre||''}</div>`+
+                   `<div class="detalle-item detalle-fecha">Inicio: ${inicio}</div>`+
+                   `<div class="detalle-item detalle-fecha">Fin: ${fin}</div>`+
+                   `<div class="detalle-item detalle-cartones">Cartones premio: ${d.cartonesPremio||0}</div>`+
+                   `<div class="detalle-item detalle-referidos">Referidos requeridos: ${d.referidosMin||0}</div>`+
+                   `<div class="detalle-item detalle-cartones">Cartones nuevo usuario: ${d.cartonesNuevo||0}</div>`+
+                   `<div class="detalle-item detalle-estado">Estado: ${d.estado||''}</div>`;
+    modal.style.display='flex';
+  }
+
+  document.getElementById('modal-info-cerrar').addEventListener('click',()=>{
+    document.getElementById('modal-info').style.display='none';
+  });
+
+  document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='admin.html';});
+  actualizarArchivarBtn();
+  window.addEventListener('beforeunload',()=>{
+    if(unsubscribeCampanas) unsubscribeCampanas();
+  });
+
+  (async ()=>{
+    try{
+      await initFirebase();
+    }catch(err){
+      console.error('No se pudo inicializar Firebase en gestionreferidos.html',err);
+      alert('No se pudieron cargar las campañas de referidos.');
+      return;
+    }
+    ensureAuth('Administrador');
+    iniciarMonitoreo();
+  })();
+  </script>
+  <script src="js/backNavigation.js"></script>
+</body>
+</html>

--- a/public/nuevacampana.html
+++ b/public/nuevacampana.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <link rel="apple-touch-icon" sizes="180x180" href="img/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="img/android-chrome-192x192.png">
+  <link rel="icon" type="image/x-icon" href="img/favicon.ico">
+  <link rel="icon" type="image/x-icon" sizes="16x16" href="img/favicon-16x16.ico">
+  <link rel="icon" type="image/x-icon" sizes="32x32" href="img/favicon-32x32.ico">
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nueva Campaña</title>
+  <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      background: linear-gradient(rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.7)),
+                  url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
+      background-repeat: repeat;
+      background-size: auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: flex-start;
+      min-height: 100vh;
+      text-align: center;
+      font-family: 'Bangers', cursive;
+      padding-top: 5px;
+      margin: 0;
+    }
+    .menu-btn {
+      width: 250px;
+      height: 60px;
+      font-family: 'Bangers', cursive;
+      font-size: 1.4rem;
+      background: rgba(0, 170, 255, 0.8);
+      color: white;
+      border: 4px solid #FFD700;
+      border-radius: 10px;
+      text-shadow: 2px 2px 4px #000;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: transform 0.3s, box-shadow 0.3s, background 0.3s;
+      margin: 5px;
+    }
+    .menu-btn:hover {
+      transform: scale(1.05);
+      box-shadow: 0 0 15px rgba(255, 215, 0, 0.8);
+    }
+    .back-btn {
+      position: fixed;
+      top: 5px;
+      left: 5px;
+      width: 120px;
+      height: 40px;
+      background: orange;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap:5px;
+    }
+    input {
+      font-size:1rem;
+      padding:5px;
+      text-align:center;
+      border-radius:5px;
+      border:1px solid #ccc;
+      width:250px;
+      display:block;
+      margin:3px auto;
+      color:black;
+      box-sizing:border-box;
+    }
+    .row{display:flex;justify-content:center;gap:5px;width:calc(100% - 12px);margin:3px 6px;}
+    .row input{flex:1;width:100%;}
+    .input-wrapper{display:flex;align-items:center;gap:4px;flex:1;}
+    .label-left{font-weight:bold;font-size:0.8rem;margin-right:3px;text-shadow:0 0 3px #fff;}
+    .label-right{font-weight:bold;font-size:0.8rem;margin-left:3px;text-shadow:0 0 3px #fff;}
+    .small-label{
+      font-size:0.55rem;
+      font-family:'Poppins', sans-serif;
+      text-transform:uppercase;
+      color:#444;
+      letter-spacing:0.5px;
+      margin-bottom:2px;
+    }
+    .field-block{
+      display:flex;
+      flex-direction:column;
+      align-items:center;
+      flex:1;
+    }
+    #nombre-campana{font-weight:bold;color:purple;}
+    .toggle-group{display:flex;justify-content:center;gap:5px;margin:8px 0;}
+    .toggle-group button{flex:0 0 auto;width:95px;padding:5px 10px;border-radius:20px;border:1px solid #ccc;font-family:'Bangers',cursive;font-size:1rem;cursor:pointer;background:#808080;color:#fff;text-shadow:1px 1px 2px #333;}
+    .toggle-group button.active{filter:brightness(1.2);text-shadow:1px 1px 2px #000;}
+    #estado-group button.active[data-value="ACTIVA"]{background:linear-gradient(#00a000,#ffffff);}
+    #estado-group button.active[data-value="INACTIVA"]{background:linear-gradient(#ff0000,#ffffff);}
+    #estado-group button.active[data-value="ARCHIVADA"]{background:linear-gradient(#8b4513,#ffffff);}
+    #guardar-campana-btn{
+      font-family:'Bangers',cursive;
+      font-size:1.2rem;
+      background:#0a8800;
+      color:white;
+      border:3px solid #FFD700;
+      border-radius:8px;
+      text-shadow:2px 2px 4px #000;
+      width:200px;
+      cursor:pointer;
+      margin:5px auto;
+    }
+    @media (max-width:600px){
+      body{align-items:stretch;padding:5px 20px;}
+      .menu-btn,input,.row,.toggle-group{width:100%;max-width:none;margin-left:0;margin-right:0;}
+      .row{flex-direction:column;}
+      .input-wrapper{justify-content:center;}
+    }
+    @media (orientation:portrait){
+      #volver-btn{width:40px;}
+      #volver-btn .label{display:none;}
+    }
+  </style>
+</head>
+<body>
+  <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true"><span class="icon">&#9664;</span><span class="label">Volver</span></button>
+  <h2 style="margin-top:0;" id="titulo-campana">NUEVA CAMPAÑA</h2>
+  <input id="nombre-campana" maxlength="70" placeholder="Nombre de Campaña">
+  <div class="row">
+    <div class="input-wrapper">
+      <span class="label-left">INICIO</span>
+      <input id="fecha-inicio" type="date">
+    </div>
+    <div class="input-wrapper">
+      <input id="fecha-fin" type="date">
+      <span class="label-right">FIN</span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="field-block">
+      <div class="small-label">Numero de Cartones</div>
+      <input id="cartones-premio" type="number" inputmode="numeric" min="0" placeholder="Cartones">
+    </div>
+    <div class="field-block">
+      <div class="small-label">Numero de Referidos para obtener premio</div>
+      <input id="referidos-min" type="number" inputmode="numeric" min="1" placeholder="Referidos">
+    </div>
+  </div>
+  <div class="field-block" style="max-width:260px;">
+    <div class="small-label">Cartones gratis nuevo usuario</div>
+    <input id="cartones-nuevo" type="number" inputmode="numeric" min="0" placeholder="Cartones nuevo">
+  </div>
+  <div id="estado-group" class="toggle-group">
+    <button data-value="ACTIVA">ACTIVA</button>
+    <button data-value="INACTIVA">INACTIVA</button>
+    <button data-value="ARCHIVADA">ARCHIVADA</button>
+  </div>
+  <button id="guardar-campana-btn">Guardar</button>
+
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
+  <script src="js/logoSwitcher.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/notificationCenter.js"></script>
+  <script>
+    const estadoBtns = Array.from(document.querySelectorAll('#estado-group button'));
+    let estadoSeleccionado = 'ACTIVA';
+    let campanaEditId = null;
+
+    function setEstado(valor){
+      estadoSeleccionado = valor;
+      estadoBtns.forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.value === valor);
+      });
+    }
+
+    function parseFecha(valor){
+      if(!valor) return null;
+      const base = new Date(`${valor}T00:00:00`);
+      if(Number.isNaN(base.getTime())) return null;
+      return base;
+    }
+
+    function hoySinHora(){
+      const ahora = new Date();
+      return new Date(ahora.getFullYear(), ahora.getMonth(), ahora.getDate());
+    }
+
+    function esFechaVigente(inicio, fin){
+      const hoy = hoySinHora();
+      const fechaInicio = parseFecha(inicio);
+      const fechaFin = parseFecha(fin);
+      if(!fechaInicio || !fechaFin) return false;
+      return fechaInicio <= hoy && hoy <= fechaFin;
+    }
+
+    async function obtenerCampanaActiva(excluirId){
+      const snapshot = await db.collection('campanasReferidos').where('estado','==','ACTIVA').get();
+      let encontrada = null;
+      snapshot.forEach(doc => {
+        if(encontrada) return;
+        if(excluirId && doc.id === excluirId) return;
+        const data = doc.data() || {};
+        if(esFechaVigente(data.fechaInicio, data.fechaFin)){
+          encontrada = { id: doc.id, ...data };
+        }
+      });
+      return encontrada;
+    }
+
+    function toNumero(valor){
+      const num = parseInt(valor, 10);
+      return Number.isFinite(num) ? num : NaN;
+    }
+
+    async function cargarCampana(){
+      campanaEditId = localStorage.getItem('editCampanaId');
+      if(!campanaEditId) return;
+      try{
+        const doc = await db.collection('campanasReferidos').doc(campanaEditId).get();
+        if(!doc.exists){
+          campanaEditId = null;
+          return;
+        }
+        const data = doc.data() || {};
+        document.getElementById('titulo-campana').textContent = 'EDITAR CAMPAÑA';
+        document.getElementById('nombre-campana').value = data.nombre || '';
+        document.getElementById('fecha-inicio').value = data.fechaInicio || '';
+        document.getElementById('fecha-fin').value = data.fechaFin || '';
+        document.getElementById('cartones-premio').value = data.cartonesPremio ?? '';
+        document.getElementById('referidos-min').value = data.referidosMin ?? '';
+        document.getElementById('cartones-nuevo').value = data.cartonesNuevo ?? '';
+        setEstado((data.estado || 'INACTIVA').toUpperCase());
+      }catch(err){
+        console.error('No se pudo cargar la campaña', err);
+        campanaEditId = null;
+      }
+    }
+
+    estadoBtns.forEach(btn => {
+      btn.addEventListener('click', () => setEstado(btn.dataset.value));
+    });
+    setEstado(estadoSeleccionado);
+
+    document.getElementById('guardar-campana-btn').addEventListener('click', async ()=>{
+      const nombre = document.getElementById('nombre-campana').value.trim();
+      const fechaInicio = document.getElementById('fecha-inicio').value;
+      const fechaFin = document.getElementById('fecha-fin').value;
+      const cartonesPremio = toNumero(document.getElementById('cartones-premio').value);
+      const referidosMin = toNumero(document.getElementById('referidos-min').value);
+      const cartonesNuevo = toNumero(document.getElementById('cartones-nuevo').value);
+
+      if(!nombre){ alert('Debes colocar el nombre de la campaña'); return; }
+      if(!fechaInicio){ alert('Debes seleccionar la fecha de inicio'); return; }
+      if(!fechaFin){ alert('Debes seleccionar la fecha de fin'); return; }
+      const inicioDate = parseFecha(fechaInicio);
+      const finDate = parseFecha(fechaFin);
+      if(!inicioDate || !finDate){ alert('Las fechas no son válidas'); return; }
+      if(finDate < inicioDate){ alert('La fecha fin debe ser mayor o igual a la fecha inicio'); return; }
+      if(!Number.isFinite(cartonesPremio) || cartonesPremio < 0){ alert('El número de cartones debe ser válido'); return; }
+      if(!Number.isFinite(referidosMin) || referidosMin < 1){ alert('El número de referidos debe ser válido'); return; }
+      if(!Number.isFinite(cartonesNuevo) || cartonesNuevo < 0){ alert('El número de cartones para el nuevo usuario debe ser válido'); return; }
+
+      let estadoFinal = estadoSeleccionado;
+      const hoy = hoySinHora();
+      if(estadoFinal === 'ACTIVA' && finDate < hoy){
+        estadoFinal = 'INACTIVA';
+      }
+
+      try{
+        if(!campanaEditId){
+          const activa = await obtenerCampanaActiva();
+          if(activa){
+            alert(`No se puede crear una nueva campaña ya que existe activa la campaña ${activa.nombre || ''}`);
+            return;
+          }
+        }else if(estadoFinal === 'ACTIVA'){
+          const activa = await obtenerCampanaActiva(campanaEditId);
+          if(activa){
+            alert(`No se puede activar esta campaña ya que existe activa la campaña ${activa.nombre || ''}`);
+            return;
+          }
+        }
+      }catch(err){
+        console.error('No se pudo validar campañas activas', err);
+        alert('No se pudo validar la campaña activa. Intenta nuevamente.');
+        return;
+      }
+
+      const payload = {
+        nombre,
+        fechaInicio,
+        fechaFin,
+        cartonesPremio,
+        referidosMin,
+        cartonesNuevo,
+        estado: estadoFinal,
+        actualizadoEn: new Date().toISOString()
+      };
+
+      try{
+        if(campanaEditId){
+          await db.collection('campanasReferidos').doc(campanaEditId).set(payload, { merge:true });
+        }else{
+          payload.creadoEn = new Date().toISOString();
+          await db.collection('campanasReferidos').add(payload);
+        }
+        localStorage.removeItem('editCampanaId');
+        window.location.href='gestionreferidos.html';
+      }catch(err){
+        console.error('No se pudo guardar la campaña', err);
+        alert('No se pudo guardar la campaña. Intenta nuevamente.');
+      }
+    });
+
+    document.getElementById('volver-btn').addEventListener('click', ()=>{
+      localStorage.removeItem('editCampanaId');
+      window.location.href='gestionreferidos.html';
+    });
+
+    (async ()=>{
+      try{
+        await initFirebase();
+      }catch(err){
+        console.error('No se pudo inicializar Firebase en nuevacampana.html', err);
+        alert('No se pudo preparar la campaña.');
+        return;
+      }
+      ensureAuth('Administrador');
+      cargarCampana();
+    })();
+  </script>
+  <script src="js/backNavigation.js"></script>
+</body>
+</html>

--- a/public/player.html
+++ b/public/player.html
@@ -375,6 +375,9 @@
       .menu-label--mensajes {
           text-shadow: 0 0 8px rgba(179, 71, 0, 0.85), 0 0 14px rgba(230, 115, 0, 0.9);
       }
+      .menu-label--referidos {
+          text-shadow: 0 0 8px rgba(0, 128, 0, 0.85), 0 0 14px rgba(0, 200, 0, 0.9);
+      }
 
       #carton-screen {
           position: relative;
@@ -815,7 +818,12 @@
                   <span class="menu-label menu-label--perfil">PERFIL</span>
                 </div>
               </td>
-              <td class="celda-vacia" aria-hidden="true"></td>
+              <td>
+                <div class="menu-opcion menu-opcion--referidos">
+                  <img id="boton-referidos" class="menu-imagen" src="img/boton-compartir-200p.png" alt="Compartir código promocional" role="button" tabindex="0" loading="lazy" />
+                  <span class="menu-label menu-label--referidos">CARTONES GRATIS</span>
+                </div>
+              </td>
               <td>
                 <div class="menu-opcion menu-opcion--mensajes">
                   <img id="boton-mensajes" class="menu-imagen" src="img/boton-mensajes300p.png" alt="Abrir el grupo de WhatsApp" role="button" tabindex="0" loading="lazy" />
@@ -1025,6 +1033,93 @@
       return `https://${enlace}`;
     }
     return `https://${enlace}`;
+  }
+
+  function generarCodigoPromocional(email, telefono){
+    const local = (email || '').split('@')[0] || '';
+    const letras = local.replace(/[^a-zA-Z]/g,'');
+    let prefijo = letras.slice(0,2).toUpperCase();
+    if(prefijo.length < 2){
+      prefijo = (local.replace(/[^a-zA-Z0-9]/g,'').slice(0,2) || '').toUpperCase();
+    }
+    const digitos = (telefono || '').toString().replace(/\D/g,'');
+    const sufijo = digitos.slice(-4);
+    return `${prefijo}${sufijo}`.trim();
+  }
+
+  function parseFecha(valor){
+    if(!valor) return null;
+    const base = new Date(`${valor}T00:00:00`);
+    if(Number.isNaN(base.getTime())) return null;
+    return base;
+  }
+
+  function hoySinHora(){
+    const ahora = new Date();
+    return new Date(ahora.getFullYear(), ahora.getMonth(), ahora.getDate());
+  }
+
+  async function obtenerCampanaActiva(){
+    if(!firestoreRef) return null;
+    const snapshot = await firestoreRef.collection('campanasReferidos').where('estado','==','ACTIVA').get();
+    const hoy = hoySinHora();
+    let activa = null;
+    const batch = firestoreRef.batch();
+    let cambios = 0;
+    snapshot.forEach(doc => {
+      const data = doc.data() || {};
+      const fin = parseFecha(data.fechaFin);
+      if(fin && fin < hoy){
+        batch.update(firestoreRef.collection('campanasReferidos').doc(doc.id), { estado:'INACTIVA' });
+        cambios += 1;
+        return;
+      }
+      const inicio = parseFecha(data.fechaInicio);
+      if(inicio && fin && inicio <= hoy && hoy <= fin && !activa){
+        activa = { id: doc.id, ...data };
+      }
+    });
+    if(cambios){ await batch.commit(); }
+    return activa;
+  }
+
+  async function manejarClickReferidos(){
+    if(!firestoreRef){
+      alert('No se pudo preparar el código promocional.');
+      return;
+    }
+    const usuario = auth.currentUser;
+    if(!usuario){
+      alert('Debes iniciar sesión para compartir tu código.');
+      return;
+    }
+    let telefono = '';
+    let codigo = '';
+    try{
+      const doc = await firestoreRef.collection('users').doc(usuario.email).get();
+      const data = doc.exists ? (doc.data() || {}) : {};
+      telefono = data.celular || data.numerocel || '';
+      codigo = data.codigoPromocional || generarCodigoPromocional(usuario.email, telefono);
+      if(!data.codigoPromocional && codigo){
+        await firestoreRef.collection('users').doc(usuario.email).set({ codigoPromocional: codigo }, { merge:true });
+      }
+    }catch(err){
+      console.error('No se pudo generar el código promocional', err);
+    }
+    if(!codigo){
+      alert('No se pudo generar tu código promocional. Completa tus datos en el perfil.');
+      return;
+    }
+    let cartonesNuevo = 0;
+    try{
+      const campana = await obtenerCampanaActiva();
+      cartonesNuevo = Number(campana?.cartonesNuevo || 0) || 0;
+    }catch(err){
+      console.error('No se pudo obtener la campaña activa', err);
+    }
+    const mensaje = `Epale! estoy jugando a BingOnline, y es un vasilón! 🤩 si entras en este link: https://www.bingo.juega-online.com/registrase.html 👈 y te registras usando mi código ${codigo} te regalarán ${cartonesNuevo} cartones para que juegues GRATIS!`;
+    const enlace = `https://wa.me/?text=${encodeURIComponent(mensaje)}`;
+    window.location.href = enlace;
   }
 
   async function obtenerLinkWhatsapp(){
@@ -1385,6 +1480,7 @@
     configurarAccionImagen('boton-billetera', ()=>{ window.location.href = 'billetera.html'; });
     configurarAccionImagen('boton-perfil', ()=>{ window.location.href = 'perfil.html'; });
     configurarAccionImagen('boton-mensajes', manejarClickWhatsapp);
+    configurarAccionImagen('boton-referidos', manejarClickReferidos);
 
     if(whatsappModalAceptarBtn){
       whatsappModalAceptarBtn.addEventListener('click', cerrarModalWhatsapp);

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -110,6 +110,35 @@
       width:100%;
       margin:5px 0;
     }
+    .small-label{
+      font-size:0.55rem;
+      font-family:'Poppins',sans-serif;
+      text-transform:uppercase;
+      color:#444;
+      letter-spacing:0.5px;
+      margin-top:6px;
+    }
+    .toast{
+      position:fixed;
+      left:50%;
+      bottom:80px;
+      transform:translateX(-50%);
+      background:rgba(0,128,0,0.92);
+      color:#fff;
+      padding:10px 16px;
+      border-radius:12px;
+      font-size:0.9rem;
+      font-family:'Poppins',sans-serif;
+      box-shadow:0 6px 18px rgba(0,0,0,0.35);
+      opacity:0;
+      pointer-events:none;
+      transition:opacity 0.3s ease, transform 0.3s ease;
+      z-index:12000;
+    }
+    .toast.mostrar{
+      opacity:1;
+      transform:translateX(-50%) translateY(-8px);
+    }
   </style>
 </head>
 <body>
@@ -124,6 +153,8 @@
   </div>
   <p class="nota-registro">Nota: Sólo tu Alias será visible para los otros Jugadores, Tu nombre, Apellido, Número celular o Gmail serán confidenciales.</p>
   <div id="email"></div>
+  <div class="small-label">CÓDIGO REFERIDO</div>
+  <input type="text" id="codigo-referido" placeholder="Opcional" maxlength="12" style="text-transform:uppercase;">
   <div id="terms-container"><input type="checkbox" id="accept-terms"> <label for="accept-terms">Acepto <a href="terminos.html" target="_blank">términos y condiciones</a></label></div>
   <button id="registrar" class="action-btn">Registrarse</button>
   <button id="cancelar" class="action-btn">Cancelar</button>
@@ -183,6 +214,110 @@
       return (prefijo||'')+local;
     }
 
+    function generarCodigoPromocional(email, telefono){
+      const local = (email || '').split('@')[0] || '';
+      const letras = local.replace(/[^a-zA-Z]/g,'');
+      let prefijo = letras.slice(0,2).toUpperCase();
+      if(prefijo.length < 2){
+        prefijo = (local.replace(/[^a-zA-Z0-9]/g,'').slice(0,2) || '').toUpperCase();
+      }
+      const digitos = (telefono || '').toString().replace(/\D/g,'');
+      const sufijo = digitos.slice(-4);
+      return `${prefijo}${sufijo}`.trim();
+    }
+
+    function parseFecha(valor){
+      if(!valor) return null;
+      const base = new Date(`${valor}T00:00:00`);
+      if(Number.isNaN(base.getTime())) return null;
+      return base;
+    }
+
+    function hoySinHora(){
+      const ahora = new Date();
+      return new Date(ahora.getFullYear(), ahora.getMonth(), ahora.getDate());
+    }
+
+    function mostrarToast(texto){
+      let toast = document.getElementById('toast-referral');
+      if(!toast){
+        toast = document.createElement('div');
+        toast.id = 'toast-referral';
+        toast.className = 'toast';
+        document.body.appendChild(toast);
+      }
+      toast.textContent = texto;
+      toast.classList.add('mostrar');
+      setTimeout(()=>toast.classList.remove('mostrar'), 3500);
+    }
+
+    async function obtenerCampanaActiva(){
+      const snapshot = await db.collection('campanasReferidos').where('estado','==','ACTIVA').get();
+      const hoy = hoySinHora();
+      let activa = null;
+      const batch = db.batch();
+      let cambios = 0;
+      snapshot.forEach(doc => {
+        const data = doc.data() || {};
+        const fin = parseFecha(data.fechaFin);
+        if(fin && fin < hoy){
+          batch.update(db.collection('campanasReferidos').doc(doc.id), { estado:'INACTIVA' });
+          cambios += 1;
+          return;
+        }
+        const inicio = parseFecha(data.fechaInicio);
+        if(inicio && fin && inicio <= hoy && hoy <= fin && !activa){
+          activa = { id: doc.id, ...data };
+        }
+      });
+      if(cambios){ await batch.commit(); }
+      return activa;
+    }
+
+    async function buscarUsuarioPorCodigo(codigo){
+      const snapshot = await db.collection('users').where('codigoPromocional','==',codigo).limit(1).get();
+      if(snapshot.empty) return null;
+      const doc = snapshot.docs[0];
+      return { id: doc.id, ...doc.data() };
+    }
+
+    async function actualizarBilletera(email, cartonesAgregar){
+      if(!cartonesAgregar || cartonesAgregar <= 0) return;
+      const ref = db.collection('Billetera').doc(email);
+      await db.runTransaction(async tx => {
+        const doc = await tx.get(ref);
+        const data = doc.exists ? doc.data() || {} : {};
+        const actuales = Number(data.CartonesGratis ?? data.cartonesGratis ?? 0) || 0;
+        const nuevos = actuales + cartonesAgregar;
+        tx.set(ref, { CartonesGratis: nuevos }, { merge:true });
+      });
+    }
+
+    async function registrarReferido({campana, nuevoEmail, referidoEmail}){
+      if(!campana || !referidoEmail || !nuevoEmail) return { premioReferidor: 0 };
+      const ref = db.collection('Referidos').doc(referidoEmail).collection('campanas').doc(campana.id);
+      let premioReferidor = 0;
+      await db.runTransaction(async tx => {
+        const doc = await tx.get(ref);
+        const data = doc.exists ? doc.data() || {} : {};
+        const total = Number(data.totalReferidos || 0) + 1;
+        const premiosEntregados = Number(data.premiosEntregados || 0);
+        const meta = Number(campana.referidosMin || 0);
+        const premiosNuevoTotal = meta > 0 ? Math.floor(total / meta) : 0;
+        const premiosPorDar = Math.max(premiosNuevoTotal - premiosEntregados, 0);
+        if(premiosPorDar > 0){
+          premioReferidor = premiosPorDar * (Number(campana.cartonesPremio || 0));
+        }
+        tx.set(ref, {
+          totalReferidos: total,
+          premiosEntregados: premiosEntregados + premiosPorDar,
+          ultimoReferido: nuevoEmail,
+          actualizadoEn: new Date().toISOString()
+        }, { merge:true });
+      });
+      return { premioReferidor };
+    }
+
     const selectCodigoPais=document.getElementById('codigo-pais');
     poblarSelectCodigos(selectCodigoPais);
 
@@ -225,6 +360,12 @@
     function validarTexto(txt,max){
       return txt && txt.length<=max && /^[A-Za-zÁÉÍÓÚáéíóúñÑ\s]+$/.test(txt);
     }
+    const codigoReferidoInputEl = document.getElementById('codigo-referido');
+    if(codigoReferidoInputEl){
+      codigoReferidoInputEl.addEventListener('input', e=>{
+        e.target.value = (e.target.value || '').toUpperCase();
+      });
+    }
     document.getElementById('registrar').addEventListener('click', async ()=>{
       const nombre = document.getElementById('nombre').value.trim();
       if(!nombre){ alert('Debes llenar el campo nombre'); document.getElementById('nombre').focus(); return; }
@@ -249,6 +390,22 @@
         return;
       }
       const numeroCompleto=obtenerNumeroCompleto();
+      const codigoPromocional = generarCodigoPromocional(user.email, numeroCompleto);
+      const codigoReferido = (codigoReferidoInputEl?.value || '').trim().toUpperCase();
+      let campanaActiva = null;
+      let usuarioReferidor = null;
+      if(codigoReferido){
+        usuarioReferidor = await buscarUsuarioPorCodigo(codigoReferido);
+        if(!usuarioReferidor){
+          alert('Este código promocional no existe, coloca uno válido o deja en blanco');
+          return;
+        }
+        if(usuarioReferidor.email === user.email || usuarioReferidor.id === user.email){
+          alert('No puedes usar tu propio código promocional.');
+          return;
+        }
+        campanaActiva = await obtenerCampanaActiva();
+      }
       await db.collection('users').doc(user.email).set({
         name:nombre,
         apellido:apellido,
@@ -258,8 +415,32 @@
         email:user.email,
         photoURL:user.photoURL,
         role:'Jugador',
-        aceptoNotificaciones:'NO'
+        aceptoNotificaciones:'NO',
+        codigoPromocional,
+        codigoReferidoUsado: codigoReferido || '',
+        referidoPorEmail: usuarioReferidor ? (usuarioReferidor.email || usuarioReferidor.id || '') : '',
+        campanaReferidosId: campanaActiva ? campanaActiva.id : ''
       });
+      let delayRedirect = 0;
+      if(codigoReferido && usuarioReferidor && campanaActiva){
+        const cartonesNuevo = Number(campanaActiva.cartonesNuevo || 0) || 0;
+        if(cartonesNuevo > 0){
+          await actualizarBilletera(user.email, cartonesNuevo);
+          mostrarToast(`¡Código exitoso! ganaste ${cartonesNuevo} cartones GRATIS`);
+          delayRedirect = 1400;
+        }
+        const { premioReferidor } = await registrarReferido({
+          campana: campanaActiva,
+          nuevoEmail: user.email,
+          referidoEmail: usuarioReferidor.email || usuarioReferidor.id
+        });
+        if(premioReferidor > 0){
+          await actualizarBilletera(usuarioReferidor.email || usuarioReferidor.id, premioReferidor);
+        }
+      }
+      if(delayRedirect){
+        await new Promise(resolve => setTimeout(resolve, delayRedirect));
+      }
       window.location.href='player.html';
     });
     document.getElementById('cancelar').addEventListener('click', ()=>{ window.location.href='index.html'; });


### PR DESCRIPTION
### Motivation
- Añadir un sistema de referidos para que los jugadores compartan un código promocional y reciban cartones gratis según campañas configurables desde el panel de administración.
- Integrar la lógica en el registro y UI del jugador para aplicar premios al nuevo usuario y al referidor respetando reglas de campaña (una activa por rango de fechas).

### Description
- Se añadió el botón "Campañas Referidos" en `public/admin.html` y se crearon las vistas `public/gestionreferidos.html` y `public/nuevacampana.html` para listar, crear y editar campañas con estados (ACTIVA, INACTIVA, ARCHIVADA), filtros y acciones (Nuevo, Editar, Inactivar, Archivar, Archivo). 
- Al guardar una campaña se valida que no exista otra campaña ACTIVA y vigente que solape; al expirar `fechaFin` una campaña ACTIVA pasa a INACTIVA automáticamente (monitoreo y marcación por lote).
- En `public/nuevacampana.html` se implementaron los campos solicitados (Nombre, fechas INICIO/FIN, Cartones premio, Referidos requeridos, Cartones gratis para nuevo usuario) y botones de estado inicial (ACTIVA/INACTIVA/ARCHIVADA) con validaciones de fechas y números.
- En `public/registrarse.html` se añadió el campo "CÓDIGO REFERIDO" y funciones para: generar el `codigoPromocional` (2 primeras letras del correo en mayúscula + 4 últimos dígitos del teléfono), validar código ingresado, buscar campaña ACTIVA vigente, acreditar cartones gratis al nuevo usuario y acumular contabilización de referidos para otorgar premios al referidor usando transacciones Firestore; se muestra un toast de éxito y mensajes de error cuando el código no existe.
- En `public/player.html` se añadió el botón "CARTONES GRATIS" (imagen `img/boton-compartir-200p.png`) que genera/almacena el código promocional del usuario y abre WhatsApp con la redacción solicitada incluyendo el `codigo` y la cantidad de `cartonesNuevo` de la campaña activa.
- Se implementaron utilidades compartidas en los archivos HTML: generación de código promocional, funciones para obtener la campaña activa, actualizar billetera (`CartonesGratis`) y registrar referidos con reglas de entrega (un referidor puede recibir premios multiplicados si supera múltiplos de la meta de referidos).

### Testing
- Se inició un servidor estático local con `python -m http.server` sobre `public/` para pruebas manuales de interfaz y el servidor fue levantado correctamente (sucedido). 
- Se intentó ejecutar una captura automática con Playwright para validar la nueva UI del `player.html`, pero la ejecución del navegador falló en este entorno (Playwright/Chromium target closed / SIGSEGV); por tanto la captura automática no se pudo generar (fallido).
- Se realizó el commit con los cambios y los archivos nuevos fueron añadidos y registrados en el repositorio (operación Git realizada con éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69750ddc3a048326a475d8db5f9a90c3)