### PR TITLE
Mejoras en referidos y gestión de campañas (móvil y tutorial)

### DIFF
--- a/public/gestionreferidos.html
+++ b/public/gestionreferidos.html
@@ -177,6 +177,9 @@
     .modal-box .detalle-estado { color:crimson; }
     .modal-box .detalle-item { margin-bottom:8px; }
     .modal-box button { margin-top:10px; }
+    .fecha-toggle-header {
+      font-weight: bold;
+    }
   </style>
 </head>
 <body>
@@ -198,12 +201,7 @@
       <tr>
         <th>N°</th>
         <th><input type="text" id="filtro-nombre" placeholder="Nombre de campaña" style="width:100%;box-sizing:border-box;"></th>
-        <th>
-          <div class="fecha-container">
-            <input type="date" id="filtro-fecha" style="width:100%;">
-            <span class="fecha-placeholder">Inicio</span>
-          </div>
-        </th>
+        <th><strong id="fecha-col-header" class="fecha-toggle-header">INICIO</strong></th>
         <th>
           <select id="filtro-estado" style="width:100%;">
             <option value="">Estado</option>
@@ -232,9 +230,11 @@
   <script>
   const datos=[];
   const tbody=document.querySelector('#tabla-campanas tbody');
+  const fechaHeader=document.getElementById('fecha-col-header');
   let mostrarArch=false;
   let cacheCampanas=[];
   let unsubscribeCampanas=null;
+  let mostrarInicio=true;
 
   function actualizarArchivarBtn(){
     const btn=document.getElementById('archivar-btn');
@@ -263,6 +263,27 @@
   function hoySinHora(){
     const ahora = new Date();
     return new Date(ahora.getFullYear(), ahora.getMonth(), ahora.getDate());
+  }
+
+  function esFechaVigente(inicio, fin){
+    const hoy = hoySinHora();
+    const fechaInicio = parseFecha(inicio);
+    const fechaFin = parseFecha(fin);
+    if(!fechaInicio || !fechaFin) return false;
+    return fechaInicio <= hoy && hoy <= fechaFin;
+  }
+
+  async function obtenerCampanaActiva(){
+    const snapshot = await db.collection('campanasReferidos').where('estado','==','ACTIVA').get();
+    let encontrada = null;
+    snapshot.forEach(doc => {
+      if(encontrada) return;
+      const data = doc.data() || {};
+      if(esFechaVigente(data.fechaInicio, data.fechaFin)){
+        encontrada = { id: doc.id, ...data };
+      }
+    });
+    return encontrada;
   }
 
   async function marcarCampanasVencidas(lista){
@@ -318,14 +339,33 @@
     });
   }
 
+  function formatearFecha(valor){
+    if(!valor) return '';
+    if(valor.includes('-')) return valor.split('-').reverse().join('/');
+    return valor;
+  }
+
+  function actualizarFechasTabla(){
+    if(fechaHeader){
+      fechaHeader.textContent = mostrarInicio ? 'INICIO' : 'FIN';
+      fechaHeader.style.color = mostrarInicio ? 'green' : 'red';
+    }
+    document.querySelectorAll('#tabla-campanas tbody .fecha-toggle').forEach(cell=>{
+      const texto = mostrarInicio ? cell.dataset.inicio : cell.dataset.fin;
+      cell.textContent = texto || '';
+      cell.style.color = mostrarInicio ? 'green' : 'red';
+      cell.style.fontWeight = 'bold';
+    });
+  }
+
   function renderTabla(lista){
     tbody.innerHTML='';
     let idx=1;
     lista.forEach(d=>{
-      let fechaInicio=d.fechaInicio||'';
-      if(fechaInicio.includes('-')) fechaInicio=fechaInicio.split('-').reverse().join('/');
+      const fechaInicio=formatearFecha(d.fechaInicio || '');
+      const fechaFin=formatearFecha(d.fechaFin || '');
       const tr=document.createElement('tr');
-      tr.innerHTML=`<td>${idx++}</td><td class="nombre">${d.nombre}</td><td class="fecha">${fechaInicio}</td><td>${d.estado}</td><td style="text-align:center;"><input type="checkbox" data-id="${d.id}" data-estado="${d.estado}"></td>`;
+      tr.innerHTML=`<td>${idx++}</td><td class="nombre">${d.nombre}</td><td class="fecha fecha-toggle" data-inicio="${fechaInicio}" data-fin="${fechaFin}"></td><td>${d.estado}</td><td style="text-align:center;"><input type="checkbox" data-id="${d.id}" data-estado="${d.estado}"></td>`;
       const nombreCell=tr.querySelector('.nombre');
       nombreCell.style.cursor='pointer';
       nombreCell.addEventListener('click',()=>mostrarInfo(d));
@@ -342,29 +382,21 @@
       }
       tbody.appendChild(tr);
     });
+    actualizarFechasTabla();
   }
 
   function filtrar(){
     const nom=document.getElementById('filtro-nombre').value.trim().toLowerCase();
-    const fecha=document.getElementById('filtro-fecha').value;
     const est=document.getElementById('filtro-estado').value;
     let lista=datos.filter(s=>mostrarArch ? s.estado==='ARCHIVADA' : s.estado!=='ARCHIVADA');
     if(nom) lista=lista.filter(s=>(s.nombre||'').toLowerCase().includes(nom));
-    if(fecha) lista=lista.filter(s=>s.fechaInicio===fecha);
     if(est) lista=lista.filter(s=>s.estado===est);
     renderTabla(lista);
   }
 
   document.getElementById('filtro-nombre').addEventListener('input',filtrar);
-  const fechaInput=document.getElementById('filtro-fecha');
-  const fechaPh=document.querySelector('.fecha-placeholder');
-  function toggleFechaPh(){
-    if(fechaInput.value) fechaPh.style.display='none';
-    else fechaPh.style.display='block';
-  }
-  fechaInput.addEventListener('change',()=>{toggleFechaPh();filtrar();});
   document.getElementById('filtro-estado').addEventListener('change',filtrar);
-  toggleFechaPh();
+  actualizarFechasTabla();
 
   document.getElementById('sel-campana').addEventListener('click',()=>{
     const checks=document.querySelectorAll('#tabla-campanas tbody input[type=checkbox]');
@@ -379,7 +411,18 @@
     filtrar();
   });
 
-  document.getElementById('nuevo-btn').addEventListener('click',()=>{
+  document.getElementById('nuevo-btn').addEventListener('click',async ()=>{
+    try{
+      const activa = await obtenerCampanaActiva();
+      if(activa){
+        alert(`No se puede crear una nueva campaña ya que existe activa la campaña ${activa.nombre || ''}`);
+        return;
+      }
+    }catch(err){
+      console.error('No se pudo validar campañas activas', err);
+      alert('No se pudo validar la campaña activa. Intenta nuevamente.');
+      return;
+    }
     localStorage.removeItem('editCampanaId');
     window.location.href='nuevacampana.html';
   });
@@ -441,6 +484,10 @@
 
   document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='admin.html';});
   actualizarArchivarBtn();
+  setInterval(()=>{
+    mostrarInicio = !mostrarInicio;
+    actualizarFechasTabla();
+  }, 5000);
   window.addEventListener('beforeunload',()=>{
     if(unsubscribeCampanas) unsubscribeCampanas();
   });

--- a/public/nuevacampana.html
+++ b/public/nuevacampana.html
@@ -72,25 +72,42 @@
     }
     .row{display:flex;justify-content:center;gap:5px;width:calc(100% - 12px);margin:3px 6px;}
     .row input{flex:1;width:100%;}
+    .row--fechas{align-items:center;}
+    .row--premios{align-items:center;flex-wrap:nowrap;}
     .input-wrapper{display:flex;align-items:center;gap:4px;flex:1;}
     .label-left{font-weight:bold;font-size:0.8rem;margin-right:3px;text-shadow:0 0 3px #fff;}
     .label-right{font-weight:bold;font-size:0.8rem;margin-left:3px;text-shadow:0 0 3px #fff;}
-    .small-label{
-      font-size:0.55rem;
-      font-family:'Poppins', sans-serif;
-      text-transform:uppercase;
-      color:#444;
-      letter-spacing:0.5px;
-      margin-bottom:2px;
-    }
-    .field-block{
+    .label-inicio{color:#0b5d0b;text-shadow:0 0 6px #fff;font-weight:bold;}
+    .label-fin{color:#8b0000;text-shadow:0 0 6px #fff;font-weight:bold;}
+    #fecha-inicio{font-weight:bold;color:#00c853;}
+    #fecha-fin{font-weight:bold;color:#ff1744;}
+    .field-inline{
       display:flex;
-      flex-direction:column;
       align-items:center;
+      gap:4px;
       flex:1;
+      min-width:0;
     }
+    .field-inline input{
+      width:90px;
+      flex:0 0 auto;
+    }
+    .field-label{
+      font-size:0.6rem;
+      line-height:1.1;
+      text-transform:uppercase;
+      font-family:'Poppins', sans-serif;
+      font-weight:bold;
+      text-shadow:0 0 6px #fff;
+      white-space:normal;
+      text-align:right;
+      min-width:78px;
+    }
+    .label-cartones{color:#0047ff;}
+    .label-referidos{color:#ff8c00;}
+    .label-nuevo{color:#1b8f1b;}
     #nombre-campana{font-weight:bold;color:purple;}
-    .toggle-group{display:flex;justify-content:center;gap:5px;margin:8px 0;}
+    .toggle-group{display:flex;justify-content:center;gap:5px;margin:4px 0;}
     .toggle-group button{flex:0 0 auto;width:95px;padding:5px 10px;border-radius:20px;border:1px solid #ccc;font-family:'Bangers',cursive;font-size:1rem;cursor:pointer;background:#808080;color:#fff;text-shadow:1px 1px 2px #333;}
     .toggle-group button.active{filter:brightness(1.2);text-shadow:1px 1px 2px #000;}
     #estado-group button.active[data-value="ACTIVA"]{background:linear-gradient(#00a000,#ffffff);}
@@ -108,11 +125,20 @@
       cursor:pointer;
       margin:5px auto;
     }
+    #guardar-campana-btn.modo-editar{
+      background:#0057ff;
+    }
     @media (max-width:600px){
       body{align-items:stretch;padding:5px 20px;}
       .menu-btn,input,.row,.toggle-group{width:100%;max-width:none;margin-left:0;margin-right:0;}
       .row{flex-direction:column;}
-      .input-wrapper{justify-content:center;}
+      .row--fechas,.row--premios{flex-direction:row;flex-wrap:nowrap;}
+      .row--fechas .input-wrapper{justify-content:center;}
+      .row--fechas input{max-width:140px;font-size:0.85rem;padding:4px;}
+      .row--premios{gap:4px;}
+      .field-inline input{width:78px;font-size:0.85rem;padding:4px;}
+      .field-label{font-size:0.52rem;min-width:70px;}
+      .label-inicio,.label-fin{font-size:0.9rem;}
     }
     @media (orientation:portrait){
       #volver-btn{width:40px;}
@@ -124,29 +150,29 @@
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true"><span class="icon">&#9664;</span><span class="label">Volver</span></button>
   <h2 style="margin-top:0;" id="titulo-campana">NUEVA CAMPAÑA</h2>
   <input id="nombre-campana" maxlength="70" placeholder="Nombre de Campaña">
-  <div class="row">
+  <div class="row row--fechas">
     <div class="input-wrapper">
-      <span class="label-left">INICIO</span>
+      <span class="label-left label-inicio">INICIO</span>
       <input id="fecha-inicio" type="date">
     </div>
     <div class="input-wrapper">
       <input id="fecha-fin" type="date">
-      <span class="label-right">FIN</span>
+      <span class="label-right label-fin">FIN</span>
     </div>
   </div>
-  <div class="row">
-    <div class="field-block">
-      <div class="small-label">Numero de Cartones</div>
+  <div class="row row--premios">
+    <div class="field-inline">
+      <span class="field-label label-cartones">NUMERO<br>DE CARTONES</span>
       <input id="cartones-premio" type="number" inputmode="numeric" min="0" placeholder="Cartones">
     </div>
-    <div class="field-block">
-      <div class="small-label">Numero de Referidos para obtener premio</div>
+    <div class="field-inline">
+      <span class="field-label label-referidos">NUMERO<br>DE REFERIDOS</span>
       <input id="referidos-min" type="number" inputmode="numeric" min="1" placeholder="Referidos">
     </div>
-  </div>
-  <div class="field-block" style="max-width:260px;">
-    <div class="small-label">Cartones gratis nuevo usuario</div>
-    <input id="cartones-nuevo" type="number" inputmode="numeric" min="0" placeholder="Cartones nuevo">
+    <div class="field-inline">
+      <span class="field-label label-nuevo">CARTONES<br>GRATIS NUEVO<br>USUARIO</span>
+      <input id="cartones-nuevo" type="number" inputmode="numeric" min="0" placeholder="Cartones nuevo">
+    </div>
   </div>
   <div id="estado-group" class="toggle-group">
     <button data-value="ACTIVA">ACTIVA</button>
@@ -165,12 +191,55 @@
     const estadoBtns = Array.from(document.querySelectorAll('#estado-group button'));
     let estadoSeleccionado = 'ACTIVA';
     let campanaEditId = null;
+    let snapshotInicial = null;
+    const guardarBtn = document.getElementById('guardar-campana-btn');
 
     function setEstado(valor){
       estadoSeleccionado = valor;
       estadoBtns.forEach(btn => {
         btn.classList.toggle('active', btn.dataset.value === valor);
       });
+      actualizarBotonGuardar();
+    }
+
+    function obtenerEstadoFormulario(){
+      return {
+        nombre: document.getElementById('nombre-campana').value.trim(),
+        fechaInicio: document.getElementById('fecha-inicio').value,
+        fechaFin: document.getElementById('fecha-fin').value,
+        cartonesPremio: document.getElementById('cartones-premio').value,
+        referidosMin: document.getElementById('referidos-min').value,
+        cartonesNuevo: document.getElementById('cartones-nuevo').value,
+        estado: estadoSeleccionado,
+      };
+    }
+
+    function actualizoValor(val){ return val ?? ''; }
+
+    function compararEstados(a, b){
+      if(!a || !b) return false;
+      return (
+        actualizoValor(a.nombre) === actualizoValor(b.nombre) &&
+        actualizoValor(a.fechaInicio) === actualizoValor(b.fechaInicio) &&
+        actualizoValor(a.fechaFin) === actualizoValor(b.fechaFin) &&
+        actualizoValor(a.cartonesPremio) === actualizoValor(b.cartonesPremio) &&
+        actualizoValor(a.referidosMin) === actualizoValor(b.referidosMin) &&
+        actualizoValor(a.cartonesNuevo) === actualizoValor(b.cartonesNuevo) &&
+        actualizoValor(a.estado) === actualizoValor(b.estado)
+      );
+    }
+
+    function actualizarBotonGuardar(){
+      if(!guardarBtn || !campanaEditId || !snapshotInicial) return;
+      const actual = obtenerEstadoFormulario();
+      const sinCambios = compararEstados(actual, snapshotInicial);
+      if(sinCambios){
+        guardarBtn.textContent = 'Guardar';
+        guardarBtn.classList.remove('modo-editar');
+      }else{
+        guardarBtn.textContent = 'EDITAR';
+        guardarBtn.classList.add('modo-editar');
+      }
     }
 
     function parseFecha(valor){
@@ -230,6 +299,8 @@
         document.getElementById('referidos-min').value = data.referidosMin ?? '';
         document.getElementById('cartones-nuevo').value = data.cartonesNuevo ?? '';
         setEstado((data.estado || 'INACTIVA').toUpperCase());
+        snapshotInicial = obtenerEstadoFormulario();
+        actualizarBotonGuardar();
       }catch(err){
         console.error('No se pudo cargar la campaña', err);
         campanaEditId = null;
@@ -240,6 +311,13 @@
       btn.addEventListener('click', () => setEstado(btn.dataset.value));
     });
     setEstado(estadoSeleccionado);
+    ['nombre-campana','fecha-inicio','fecha-fin','cartones-premio','referidos-min','cartones-nuevo'].forEach(id=>{
+      const campo = document.getElementById(id);
+      if(campo){
+        campo.addEventListener('input', actualizarBotonGuardar);
+        campo.addEventListener('change', actualizarBotonGuardar);
+      }
+    });
 
     document.getElementById('guardar-campana-btn').addEventListener('click', async ()=>{
       const nombre = document.getElementById('nombre-campana').value.trim();
@@ -267,13 +345,7 @@
       }
 
       try{
-        if(!campanaEditId){
-          const activa = await obtenerCampanaActiva();
-          if(activa){
-            alert(`No se puede crear una nueva campaña ya que existe activa la campaña ${activa.nombre || ''}`);
-            return;
-          }
-        }else if(estadoFinal === 'ACTIVA'){
+        if(campanaEditId && estadoFinal === 'ACTIVA'){
           const activa = await obtenerCampanaActiva(campanaEditId);
           if(activa){
             alert(`No se puede activar esta campaña ya que existe activa la campaña ${activa.nombre || ''}`);

--- a/public/player.html
+++ b/public/player.html
@@ -335,6 +335,9 @@
       .menu-imagen--jugando {
           animation: pulso-sorteo 1.5s ease-in-out infinite;
       }
+      .menu-imagen--referidos {
+          max-width: 86%;
+      }
       @keyframes pulso-sorteo {
           0%, 100% { transform: scale(1); }
           50% { transform: scale(1.08); }
@@ -820,7 +823,7 @@
               </td>
               <td>
                 <div class="menu-opcion menu-opcion--referidos">
-                  <img id="boton-referidos" class="menu-imagen" src="img/boton-compartir-200p.png" alt="Compartir código promocional" role="button" tabindex="0" loading="lazy" />
+                  <img id="boton-referidos" class="menu-imagen menu-imagen--referidos" src="img/boton-compartir-200p.png" alt="Compartir código promocional" role="button" tabindex="0" loading="lazy" />
                   <span class="menu-label menu-label--referidos">CARTONES GRATIS</span>
                 </div>
               </td>
@@ -945,6 +948,13 @@
       corner: 'bottom-left',
       color: '#b34700',
       label: 'Entra aqui y unete al grupo de Whatsapp',
+    },
+    {
+      elementId: 'boton-referidos',
+      hand: 'img/Mano-abajo.png',
+      corner: 'top-left',
+      color: '#008000',
+      label: 'Comparte con tus conocidos vía WhatsApp y gana Cartones GRATIS',
     },
   ];
   const tutorialState = {
@@ -1117,7 +1127,8 @@
     }catch(err){
       console.error('No se pudo obtener la campaña activa', err);
     }
-    const mensaje = `Epale! estoy jugando a BingOnline, y es un vasilón! 🤩 si entras en este link: https://www.bingo.juega-online.com/registrase.html 👈 y te registras usando mi código ${codigo} te regalarán ${cartonesNuevo} cartones para que juegues GRATIS!`;
+    const registroUrl = `https://www.bingo.juega-online.com/registrarse.html?codigo=${encodeURIComponent(codigo)}`;
+    const mensaje = `Epale! estoy jugando a BingOnline, y es un vasilón! 🤩 si entras en este link: ${registroUrl} 👈 y te registras usando mi código ${codigo} te regalarán ${cartonesNuevo} cartones para que juegues GRATIS!`;
     const enlace = `https://wa.me/?text=${encodeURIComponent(mensaje)}`;
     window.location.href = enlace;
   }

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -365,6 +365,11 @@
       codigoReferidoInputEl.addEventListener('input', e=>{
         e.target.value = (e.target.value || '').toUpperCase();
       });
+      const params = new URLSearchParams(window.location.search);
+      const codigoParam = (params.get('codigo') || '').trim().toUpperCase();
+      if(codigoParam){
+        codigoReferidoInputEl.value = codigoParam;
+      }
     }
     document.getElementById('registrar').addEventListener('click', async ()=>{
       const nombre = document.getElementById('nombre').value.trim();


### PR DESCRIPTION
### Motivation
- Unificar y mejorar la experiencia de la nueva funcionalidad de referidos en la vista jugador y en el flujo de registro para que el código promocional se pueda compartir fácilmente por WhatsApp y precargarse al registrar.
- Optimizar la interfaz y comportamiento de creación/edición de campañas para vista móvil, facilitando la lectura de fechas y la edición explícita por parte del usuario.
- Mover validaciones críticas al punto de creación para evitar bloqueos inesperados durante el guardado.

### Description
- En `public/player.html` se redujo visualmente el botón de "CARTONES GRATIS" añadiendo la clase `.menu-imagen--referidos`, se agregó un paso final al `MODO TUTORIAL` apuntando al botón de referidos con imagen de mano y etiqueta "Comparte con tus conocidos vía WhatsApp y gana Cartones GRATIS", y se cambió el mensaje de WhatsApp para incluir un enlace que pasa el código como parámetro (`registrarse.html?codigo=...`).
- En `public/registrarse.html` se implementó la lectura de `?codigo=` desde la URL y se precarga ese valor en el campo `#codigo-referido` para que el registro reciba automáticamente el código compartido.
- En `public/nuevacampana.html` se reorganizó el layout móvil: etiquetas INICIO/FIN con estilos y resplandor, campos de fecha más pequeños para quedar en la misma línea, los campos `Cartones`, `Referidos` y `Cartones nuevo` pasaron a disposición inline con etiquetas a la izquierda (colores y estilos solicitados), y se añadió la lógica para que el botón `Guardar` cambie a estado visual `EDITAR` (fondo azul) si el formulario fue modificado respecto al valor cargado.
- En `public/gestionreferidos.html` se reemplazó el filtro de fecha por un encabezado de columna alternante que muestra `INICIO` (verde) y `FIN` (rojo) cada 5 segundos, y las celdas de la tabla alternan entre mostrar fecha de inicio/fin en su color correspondiente; además la validación que impide crear una nueva campaña cuando ya existe una activa fue movida del flujo de `Guardar` a la acción del botón `Nuevo`.

### Testing
- Se levantó un servidor local con `python -m http.server 8000` y se generó una captura de la vista móvil de `nuevacampana.html` usando Playwright (`artifacts/nuevacampana-mobile.png`), y la captura se generó correctamente.
- Se inspeccionaron y probó manualmente en entorno local la navegación entre `player.html` → enlace WhatsApp (generación de URL con `?codigo=`) y la precarga en `registrarse.html`, comprobando que el parámetro `codigo` se coloca en `#codigo-referido` cuando está presente en la URL.
- El commit con los cambios se realizó localmente con mensaje `Mejorar referidos y campañas` y fue exitoso.
- No se ejecutaron tests unitarios automáticos adicionales en CI durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69751dbf6a1c8326a1c17012416b2906)