### PR TITLE
Mejoras visuales para referidos y campos de campañas (móvil)

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -61,6 +61,15 @@
       transform: scale(1.05);
       box-shadow: 0 0 15px rgba(255, 215, 0, 0.8);
     }
+    #gestionar-referidos-btn {
+      background: #0a8800;
+    }
+    #publicar-resultados-btn {
+      background: #6a0dad;
+    }
+    #gestionar-transferencias-btn {
+      background: #ff8c00;
+    }
     #logo-bingo {
       width: 250px;
       max-width: 80vw;

--- a/public/nuevacampana.html
+++ b/public/nuevacampana.html
@@ -81,6 +81,11 @@
     .label-fin{color:#8b0000;text-shadow:0 0 6px #fff;font-weight:bold;}
     #fecha-inicio{font-weight:bold;color:#00c853;}
     #fecha-fin{font-weight:bold;color:#ff1744;}
+    #cartones-premio,
+    #referidos-min,
+    #cartones-nuevo{
+      font-weight:bold;
+    }
     .field-inline{
       display:flex;
       align-items:center;
@@ -136,7 +141,7 @@
       .row--fechas .input-wrapper{justify-content:center;}
       .row--fechas input{max-width:140px;font-size:0.85rem;padding:4px;}
       .row--premios{gap:4px;}
-      .field-inline input{width:78px;font-size:0.85rem;padding:4px;}
+      .field-inline input{width:40px;font-size:0.85rem;padding:4px;}
       .field-label{font-size:0.52rem;min-width:70px;}
       .label-inicio,.label-fin{font-size:0.9rem;}
     }

--- a/public/player.html
+++ b/public/player.html
@@ -336,11 +336,19 @@
           animation: pulso-sorteo 1.5s ease-in-out infinite;
       }
       .menu-imagen--referidos {
-          max-width: 86%;
+          max-width: 40%;
       }
       @keyframes pulso-sorteo {
           0%, 100% { transform: scale(1); }
           50% { transform: scale(1.08); }
+      }
+      @keyframes pulso-referidos {
+          0%, 100% { transform: scale(1); }
+          50% { transform: scale(1.12); }
+      }
+      .menu-opcion--referidos.referidos-activa .menu-imagen--referidos,
+      .menu-opcion--referidos.referidos-activa .menu-label--referidos {
+          animation: pulso-referidos 1.4s ease-in-out infinite;
       }
       .menu-imagen:focus,
       .menu-imagen:hover {
@@ -380,6 +388,7 @@
       }
       .menu-label--referidos {
           text-shadow: 0 0 8px rgba(0, 128, 0, 0.85), 0 0 14px rgba(0, 200, 0, 0.9);
+          display: inline-block;
       }
 
       #carton-screen {
@@ -902,6 +911,7 @@
   const whatsappModalMensajeEl = document.getElementById('modal-whatsapp-mensaje');
   const whatsappModalAceptarBtn = document.getElementById('modal-whatsapp-aceptar');
   const sorteoImagen = document.getElementById('boton-sorteo');
+  const referidosOpcion = document.querySelector('.menu-opcion--referidos');
   const tutorialToggle = document.getElementById('tutorial-toggle');
   const tutorialNav = document.getElementById('tutorial-nav');
   const tutorialPrev = document.getElementById('tutorial-prev');
@@ -1091,6 +1101,17 @@
     });
     if(cambios){ await batch.commit(); }
     return activa;
+  }
+
+  async function actualizarIndicadorReferidos(){
+    if(!firestoreRef || !referidosOpcion) return;
+    try{
+      const campana = await obtenerCampanaActiva();
+      referidosOpcion.classList.toggle('referidos-activa', !!campana);
+    }catch(error){
+      console.error('No se pudo validar la campaña activa de referidos', error);
+      referidosOpcion.classList.remove('referidos-activa');
+    }
   }
 
   async function manejarClickReferidos(){
@@ -1505,6 +1526,7 @@
     }
 
     observarEstadoSorteo();
+    actualizarIndicadorReferidos();
   }
 
   initBingoAudioControl({


### PR DESCRIPTION
### Motivation
- Mejorar la presentación móvil de la nueva funcionalidad de referidos para que el botón y su etiqueta no ocupen tanto espacio y muestren una animación cuando exista una campaña activa.
- Ajustar el formulario de creación/edición de campañas en vista vertical de celular para evitar solapamientos entre etiquetas y campos numéricos.
- Destacar visualmente los botones principales del panel de administración para facilitar la identificación en dispositivos móviles.

### Description
- En `public/player.html` se redujo el tamaño del botón/imagen de "CARTONES GRATIS" cambiando su `max-width` y se añadió una animación (`pulso-referidos`) aplicada tanto a la imagen como a la etiqueta cuando existe una campaña activa; se agregó la función `actualizarIndicadorReferidos()` que consulta la campaña activa y alterna la clase `referidos-activa` en la opción del menú.
- En `public/player.html` también se marcó la etiqueta de referidos como `display:inline-block` para que la animación afecte correctamente la etiqueta.
- En `public/nuevacampana.html` se redujo el ancho de los inputs numéricos en la vista móvil (`@media (max-width:600px)`) para los campos `NUMERO DE CARTONES`, `NUMERO DE REFERIDOS` y `CARTONES GRATIS NUEVO USUARIO`, y se puso en negrita el texto de esos campos con selectores `#cartones-premio`, `#referidos-min`, `#cartones-nuevo`.
- En `public/admin.html` se actualizaron los colores de fondo de los botones solicitados: `Campañas Referidos` a verde (`#0a8800`), `Cantar Sorteo` a morado (`#6a0dad`) y `Gestionar Transferencias` a naranja (`#ff8c00`).

### Testing
- Se levantó un servidor local y se generaron capturas de pantalla de `player.html`, `nuevacampana.html` (vista móvil) y `admin.html` usando Playwright en una viewport de dispositivo móvil, y las capturas se produjeron correctamente (artefactos generados).
- No se ejecutaron pruebas unitarias automatizadas, ya que los cambios son de estilos y ajustes visuales; las verificaciones realizadas fueron visuales mediante las capturas y la revisión del HTML/CSS en las vistas solicitadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975259ff3c08326932a284bf79b7d68)