### PR TITLE
Forzar selector de cuenta en inicio de sesión Google

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -72,6 +72,7 @@ async function initFirebase(){
     db = firebase.firestore();
     auth = firebase.auth();
     provider = new firebase.auth.GoogleAuthProvider();
+    provider.setCustomParameters({ prompt: 'select_account' });
     await auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL);
     return app;
   })();


### PR DESCRIPTION
### Motivation
- Forzar que Firebase Google Auth muestre el selector de cuentas al iniciar sesión para que en móviles con varias cuentas instaladas se permita elegir con cuál iniciar sesión.

### Description
- Se añadió `provider.setCustomParameters({ prompt: 'select_account' })` en `public/js/auth.js` justo después de crear `new firebase.auth.GoogleAuthProvider()` para forzar el diálogo de selección de cuenta.

### Testing
- No se ejecutaron pruebas automatizadas sobre el cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69753933036083268917119a901ef691)