### PR TITLE
Ajustar validaciones de cartones y corregir comportamiento de scroll en billetera

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -13,6 +13,9 @@
   <title>Billetera</title>
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
   <style>
+    html{
+      scrollbar-gutter: stable;
+    }
     body {
       font-family: Arial, sans-serif;
       background: linear-gradient(rgba(255,255,255,0.7), rgba(255,255,255,0.7)), url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
@@ -20,6 +23,7 @@
       text-align: center;
       padding: 20px;
       margin: 0;
+      overflow-x: hidden;
     }
     .menu-btn {
       width: 250px;

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -921,7 +921,7 @@
       <div class="perfil-pendiente-card" role="document">
           <span class="perfil-pendiente-icono" aria-hidden="true">⚠️</span>
           <h2 id="perfil-pendiente-titulo" class="perfil-pendiente-titulo">DATOS DE PERFIL REQUERIDOS</h2>
-          <p class="perfil-pendiente-mensaje">Para poder realizar jugadas debes primero guardar tus datos de perfil.</p>
+          <p class="perfil-pendiente-mensaje">Para poder jugar debes guardar tu número de celular en tu perfil.</p>
           <button type="button" id="perfil-pendiente-ir" class="perfil-pendiente-boton">Ir PERFIL</button>
       </div>
   </div>
@@ -1018,7 +1018,7 @@
   const premioExtraPlusEl=document.getElementById('premio-extra-plus');
   const premioExtraValorEl=document.getElementById('premio-extra-valor');
   const aliasJugadorInput=document.getElementById('alias-jugador');
-  let perfilDatosCompletos=false;
+  let perfilTieneCelular=false;
   const perfilPendienteModal=document.getElementById('perfil-pendiente-modal');
   const perfilPendienteIrBtn=document.getElementById('perfil-pendiente-ir');
   let datosBancariosCompletos=false;
@@ -1118,11 +1118,16 @@
 
   function datosBancariosEstanCompletos(data){
     if(!data) return false;
-    const campos=['banco','cuenta','cedula','pagomovil','tipoCuenta'];
-    return campos.every(campo=>{
-      const valor=(data[campo]??'').toString().trim();
-      return valor.length>0;
-    });
+    const banco=(data.banco??'').toString().trim();
+    const cedula=(data.cedula??'').toString().trim();
+    const pagomovil=(data.pagomovil??'').toString().trim();
+    if(!banco || !cedula || !pagomovil) return false;
+    const cuenta=(data.cuenta??'').toString().trim();
+    const tipoCuenta=(data.tipoCuenta??'').toString().trim();
+    if((cuenta || tipoCuenta) && (!cuenta || !tipoCuenta)){
+      return false;
+    }
+    return true;
   }
 
   async function cargarDatosBilleteraUsuario(force=false){
@@ -2572,6 +2577,10 @@ function toggleForma(idx){
       }
       return;
     }
+    if(!perfilTieneCelular){
+      mostrarModalPerfilPendiente();
+      return;
+    }
     const billeteraInfo=await cargarDatosBilleteraUsuario(true);
     if(!datosBancariosCompletos){
       mostrarModalDatosBancarios();
@@ -2679,10 +2688,6 @@ function toggleForma(idx){
   }
 
   async function guardarCarton(){
-    if(!perfilDatosCompletos){
-      mostrarModalPerfilPendiente();
-      return;
-    }
     const check=document.getElementById('guardar-check');
     const nombre=document.getElementById('nombre-carton').value.trim();
     if(!check.checked || nombre===''){
@@ -3312,17 +3317,15 @@ document.getElementById('gratis-label').addEventListener('click',()=>{
         if(user){
           const doc=await db.collection('users').doc(user.email).get();
           let aliasMostrado=user.displayName||user.email;
-          perfilDatosCompletos=false;
+          perfilTieneCelular=false;
           if(doc.exists){
             const datosPerfil=doc.data()||{};
-            const nombrePerfil=(datosPerfil.name||'').toString().trim();
-            const apellidoPerfil=(datosPerfil.apellido||'').toString().trim();
             const aliasPerfil=normalizarAliasPerfil(datosPerfil.alias||'');
             const celularPerfil=normalizarCelularPerfil(datosPerfil.celular||datosPerfil.telefono||datosPerfil.Telefono||datosPerfil.whatsapp||'');
             if(aliasPerfil){
               aliasMostrado=aliasPerfil;
             }
-            perfilDatosCompletos=Boolean(nombrePerfil&&apellidoPerfil&&aliasPerfil&&esCelularPerfilValido(celularPerfil));
+            perfilTieneCelular=esCelularPerfilValido(celularPerfil);
           }
           if(aliasJugadorInput){
             aliasJugadorInput.value=aliasMostrado||'';


### PR DESCRIPTION
### Motivation
- Simplificar la validación para guardar/jugar cartones: sólo debe exigirse el número de celular en el perfil al intentar JUGAR CARTÓN, y no bloquear el guardado de cartones guardados por falta de otros campos de perfil.
- Mantener la validación bancaria al jugar cartones pero permitir que los campos de cuenta y tipo de cuenta sean opcionales salvo que el usuario los haya marcado/llenado.
- Evitar saltos/aparición y desaparición de barras de scroll en la vista de escritorio de la página `billetera.html`.

### Description
- Cambiado el texto del modal de perfil pendiente para indicar que se requiere el número de celular (`public/jugarcartones.html`).
- Reemplazada la comprobación global de perfil por una variable booleana `perfilTieneCelular` que se inicializa en el login leyendo sólo el teléfono/celular del documento `users` y se usa para permitir la acción de JUGAR CARTÓN (`public/jugarcartones.html`).
- Eliminada la restricción que impedía guardar cartones personalizados por no tener todos los datos del perfil; ahora `guardarCarton()` no exige campos adicionales (`public/jugarcartones.html`).
- Ajustada la función `datosBancariosEstanCompletos` para requerir `banco`, `cedula` y `pagomovil`, dejando `cuenta` y `tipoCuenta` opcionales salvo que uno de ellos esté informado (entonces ambos deben estar completos) (`public/jugarcartones.html`).
- Estabilizado el comportamiento de scroll en `billetera.html` añadiendo `html { scrollbar-gutter: stable; }` y `body { overflow-x: hidden; }` para evitar cambios bruscos en las barras de desplazamiento en escritorio (`public/billetera.html`).

### Testing
- Levanté un servidor estático simple con `python -m http.server` y tomé una captura de `public/billetera.html` usando Playwright a resolución 1280×720 para validar el comportamiento del scroll, y la captura se generó correctamente (artefacto: `artifacts/billetera-scroll.png`). (Éxito)
- Verifiqué que los archivos modificados sean: `public/jugarcartones.html` y `public/billetera.html` y realicé un commit local con el mensaje "Ajustar validaciones de cartones y billetera". (Éxito)
- No se ejecutaron suites de pruebas automatizadas unitarias adicionales en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978131506148326a1c0bdce5a294541)