### PR TITLE
Estabilizar controles del tutorial en billetera (móvil, vista vertical)

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -232,6 +232,9 @@
       display: flex;
       align-items: center;
       font-size: 0.7rem;
+      transform: translateZ(0);
+      will-change: transform;
+      backface-visibility: hidden;
     }
     #user-pic {
       width: 40px;
@@ -331,6 +334,9 @@
       align-items: center;
       gap: 12px;
       z-index: 17000;
+      transform: translateZ(0);
+      will-change: transform;
+      backface-visibility: hidden;
     }
     #tutorial-toggle {
       width: 62px;
@@ -375,6 +381,19 @@
     .tutorial-hand-pulse { animation: tutorial-hand-pulse 0.65s ease-in-out infinite; }
     #tutorial-label { position: fixed; left: 50%; display: none; padding: 14px 18px; background: linear-gradient(160deg, rgba(255, 255, 255, 0.98), rgba(237, 241, 255, 0.98)); border: 2px solid rgba(85, 70, 192, 0.45); border-radius: 14px; font-family: 'Poppins', sans-serif; font-size: clamp(16px, 2.4vw, 22px); font-weight: 800; box-shadow: 0 12px 26px rgba(0, 0, 0, 0.3); text-align: center; line-height: 1.35; transform: translate(-50%, -100%); width: fit-content; max-width: min(480px, 90vw); min-width: 200px; z-index: 15000; pointer-events: none; box-sizing: border-box; max-height: 78vh; overflow: auto; align-items: center; justify-content: center; word-break: break-word; }
     #tutorial-label.adaptado { transition: top 0.2s ease, left 0.2s ease; }
+    @media (max-width:480px) and (orientation:portrait){
+      #tutorial-controls{
+        left: max(12px, env(safe-area-inset-left));
+        bottom: max(16px, env(safe-area-inset-bottom));
+      }
+      #session-info{
+        top: max(8px, env(safe-area-inset-top));
+        right: max(8px, env(safe-area-inset-right));
+      }
+      #tutorial-label{
+        max-height: min(70svh, 78vh);
+      }
+    }
     .tutorial-elemento-activo { position: relative; z-index: 13000 !important; filter: none !important; }
     body.tutorial-activo * { pointer-events: none !important; filter: none; }
     body.tutorial-activo #tutorial-controls *,
@@ -1126,6 +1145,9 @@
     let tutorialMascaraSuavizada=false;
 
     function obtenerAlturaViewport(){
+      if(tutorialState.activo && tutorialState.alturaBaseViewport){
+        return tutorialState.alturaBaseViewport;
+      }
       return tutorialState.viewportAltura || window.innerHeight;
     }
 


### PR DESCRIPTION
### Motivation

- Corregir movimientos inesperados de los controles del modo tutorial, la imagen y el enlace de cerrar sesión en la vista vertical de móviles cuando se navega el tutorial (botones forward/back). 
- Evitar saltos de posición por recálculos del viewport y solapamientos con los controles fijos en pantallas pequeñas.

### Description

- Añadí propiedades de composición a los elementos fijos `#tutorial-controls` y `#session-info` (`transform: translateZ(0); will-change: transform; backface-visibility: hidden;`) para mejorar estabilidad visual y reducir repaints/reflows.
- Añadí una media query para móviles en orientación portrait que respeta `safe-area-inset` y limita la altura del `#tutorial-label` para prevenir solapamientos y movimientos en dispositivos con notch o barras de sistema.
- Modifiqué la función `obtenerAlturaViewport()` para que, cuando el tutorial esté activo, use `tutorialState.alturaBaseViewport` como altura de referencia y así evitar cambios bruscos en el cálculo de posiciones al cambiar de paso.

### Testing

- Levanté un servidor local con `python -m http.server 8000` y verifiqué la página `billetera.html` en vista móvil emulada mediante Playwright con `viewport: { width: 390, height: 844 }`, generando la captura `artifacts/billetera-tutorial.png` (éxito). 
- No hay tests unitarios en este cambio porque la modificación es de HTML/CSS/JS de comportamiento visual (verificación manual/automatizada vía captura realizada y sin errores de carga en la página).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69781a3cbbdc8326a65958a3f9cc154a)