### PR TITLE
Estabilizar posicionamiento de controles del tutorial en vista móvil (billetera.html)

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -16,6 +16,10 @@
     html{
       scrollbar-gutter: stable;
     }
+    :root{
+      --vv-offset-top: 0px;
+      --vv-offset-left: 0px;
+    }
     body {
       font-family: Arial, sans-serif;
       background: linear-gradient(rgba(255,255,255,0.7), rgba(255,255,255,0.7)), url('https://img.freepik.com/vectores-premium/padrao-sem-costura-com-simbolos-de-dolar-e-porcentagem_637741-777.jpg');
@@ -232,7 +236,7 @@
       display: flex;
       align-items: center;
       font-size: 0.7rem;
-      transform: translateZ(0);
+      transform: translate3d(var(--vv-offset-left, 0px), var(--vv-offset-top, 0px), 0);
       will-change: transform;
       backface-visibility: hidden;
     }
@@ -334,7 +338,7 @@
       align-items: center;
       gap: 12px;
       z-index: 17000;
-      transform: translateZ(0);
+      transform: translate3d(var(--vv-offset-left, 0px), var(--vv-offset-top, 0px), 0);
       will-change: transform;
       backface-visibility: hidden;
     }
@@ -1061,6 +1065,26 @@
       viewportAltura: (window.visualViewport?.height)||window.innerHeight,
       enPausaTemporal:false,
     };
+
+    function sincronizarViewportVisual(){
+      if(!document.documentElement) return;
+      if(!window.visualViewport){
+        document.documentElement.style.setProperty('--vv-offset-top', '0px');
+        document.documentElement.style.setProperty('--vv-offset-left', '0px');
+        return;
+      }
+      const { offsetTop, offsetLeft } = window.visualViewport;
+      document.documentElement.style.setProperty('--vv-offset-top', `${offsetTop || 0}px`);
+      document.documentElement.style.setProperty('--vv-offset-left', `${offsetLeft || 0}px`);
+    }
+
+    sincronizarViewportVisual();
+    if(window.visualViewport){
+      window.visualViewport.addEventListener('resize', sincronizarViewportVisual);
+      window.visualViewport.addEventListener('scroll', sincronizarViewportVisual);
+    }
+    window.addEventListener('resize', sincronizarViewportVisual);
+    window.addEventListener('scroll', sincronizarViewportVisual, { passive: true });
 
     const animacionTabla = { frameId:null, puntos:[], posicionX:0, direccion:1, pausaHasta:0, ultimaMarca:0, indiceObjetivo:0, y:0 };
 


### PR DESCRIPTION
### Motivation
- Corregir el desplazamiento y salto de posición de los controles del modo tutorial, la imagen de cuenta y el link de cerrar sesión en `billetera.html` cuando cambia el viewport en móviles (p. ej. al activar el teclado o navegar entre pasos del tutorial). 
- La causa principal es que los elementos `position: fixed` se ven afectados por desplazamientos del `visualViewport` en navegadores móviles, provocando que los controles parezcan moverse.

### Description
- Añadí variables CSS `--vv-offset-top` y `--vv-offset-left` en `:root` y apliqué `transform: translate3d(...)` a `#tutorial-controls` y `#session-info` para que respeten offsets del `visualViewport` y no salten de posición. 
- Implementé la función `sincronizarViewportVisual()` que lee `window.visualViewport.offsetTop/offsetLeft` y actualiza las variables CSS, y registré listeners en `visualViewport` y `window` para mantenerlas sincronizadas. 
- Mantengo la lógica existente del tutorial sin cambios funcionales; la solución es puramente de posicionamiento visual y no altera la secuencia de pasos del tutorial.

### Testing
- Levanté un servidor estático con `python -m http.server 8000 --directory public` y verifiqué la página `billetera.html` en un viewport móvil emulado; la verificación consistió en tomar una captura con Playwright a `375x667` y se generó `artifacts/billetera-tutorial-controls.png` correctamente. 
- No se añadieron pruebas automatizadas unitarias porque los cambios son de UI/estilos, y la validación fue visual y manual vía captura; la comprobación de ejecución del script de Playwright finalizó con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69781ef4bc488326b3cda650254354c5)