### PR TITLE
Fijar controles del tutorial en vista móvil de billetera

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -330,17 +330,20 @@
     /* Controles del modo tutorial */
     #tutorial-controls {
       position: fixed;
-      left: 14px;
-      bottom: 18px;
+      left: max(14px, env(safe-area-inset-left));
+      bottom: max(18px, env(safe-area-inset-bottom));
       top: auto;
       right: auto;
       display: flex;
       align-items: center;
       gap: 12px;
-      z-index: 17000;
-      transform: translate3d(var(--vv-offset-left, 0px), var(--vv-offset-top, 0px), 0);
-      will-change: transform;
+      z-index: 20000;
+      transform: none;
+      will-change: auto;
       backface-visibility: hidden;
+      contain: layout paint;
+      isolation: isolate;
+      pointer-events: auto;
     }
     #tutorial-toggle {
       width: 62px;


### PR DESCRIPTION
### Motivation
- Asegurar que el botón y controles del modo tutorial permanezcan siempre en la misma posición en vista vertical de celulares, sin verse desplazados por otros elementos o por cargas dinámicas de datos.

### Description
- Actualicé los estilos de `#tutorial-controls` en `public/billetera.html` para usar `left: max(..., env(safe-area-inset-left))` y `bottom: max(..., env(safe-area-inset-bottom))` y así respetar las safe areas en móviles.
- Eliminé la dependencia de `transform: translate3d(...)` y las variables de offset para evitar que el layout mueva los controles, y ajusté `transform`/`will-change` para comportamiento estable.
- Aumenté `z-index` y añadí `contain: layout paint`, `isolation: isolate` y `pointer-events: auto` para aislar visualmente y evitar interferencias con otros elementos.
- Archivo modificado: `public/billetera.html`.

### Testing
- Levanté un servidor estático con `python -m http.server 8000 --directory public` para inspección local y esto se inició correctamente.
- Intenté generar una captura automatizada con Playwright para verificar la UI en viewport móvil, pero la ejecución falló por un error en el entorno (el proceso Chromium se cerró con SIGSEGV), por lo que no fue posible obtener la imagen automáticamente.
- `git commit` del cambio se realizó con éxito; no se ejecutaron tests unitarios automatizados ya que es un ajuste visual de CSS.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c88909b483268f7820dfc2f87c1c)