### PR TITLE
Revertir cambios del PR #920 en public/billetera.html

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -330,20 +330,17 @@
     /* Controles del modo tutorial */
     #tutorial-controls {
       position: fixed;
-      left: max(14px, env(safe-area-inset-left));
-      bottom: max(18px, env(safe-area-inset-bottom));
+      left: 14px;
+      bottom: 18px;
       top: auto;
       right: auto;
       display: flex;
       align-items: center;
       gap: 12px;
-      z-index: 20000;
-      transform: none;
-      will-change: auto;
+      z-index: 17000;
+      transform: translate3d(var(--vv-offset-left, 0px), var(--vv-offset-top, 0px), 0);
+      will-change: transform;
       backface-visibility: hidden;
-      contain: layout paint;
-      isolation: isolate;
-      pointer-events: auto;
     }
     #tutorial-toggle {
       width: 62px;


### PR DESCRIPTION
### Motivation
- Restaurar el comportamiento y la posición anteriores de los controles del tutorial en la página de billetera tras una regresión visual introducida por el PR #920.

### Description
- Se revierten los cambios aplicados por el PR #920 en `public/billetera.html`, devolviendo las reglas CSS previas que afectan la posición, z-index y transform del contenedor `#tutorial-controls`.

### Testing
- Se levantó un servidor local con `python -m http.server 8000` y se ejecutó un script automatizado de Playwright que cargó `public/billetera.html` y generó la captura `artifacts/billetera-tutorial-controls.png` con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978cae71e888326890b194b402aa8a9)