### PR TITLE
Agregar premio de segundo lugar, mensajes visuales y campo "C. gratis 2"

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -1895,6 +1895,8 @@
   let evaluandoCantoActual = false;
   const premiosAutomaticosProcesados = new Set();
   const premiosAutomaticosEnCurso = new Set();
+  const premiosSegundoLugarProcesados = new Set();
+  const premiosSegundoLugarEnCurso = new Set();
 
   function manejarAceptarConfirmacionCanto(){
     cerrarConfirmacionCanto(true);
@@ -3111,6 +3113,25 @@
     return null;
   }
 
+  function obtenerCartonesGratisSegundoDesde(datos){
+    if(!datos || typeof datos!=='object') return null;
+    const claves=[
+      'cartonesGratis2','cartonesgratis2','cartones_gratis2',
+      'cartonesGratisSegundo','cartonesGratisSegundoLugar',
+      'premioCartonesGratis2','premioCartonesGratisSegundo',
+      'premioCartonesGratisSegundoLugar'
+    ];
+    for(const clave of claves){
+      if(Object.prototype.hasOwnProperty.call(datos, clave)){
+        const valor=normalizarCartonesGratisValor(datos[clave]);
+        if(valor!==null){
+          return valor;
+        }
+      }
+    }
+    return null;
+  }
+
   function sincronizarFormasBase(formas){
     const lista = Array.isArray(formas) ? formas : [];
     formasBaseResumen = lista
@@ -3119,12 +3140,14 @@
         if(!Number.isFinite(idx)) return null;
         const posicionesNorm = Array.isArray(item.posicionesNormalizadas) ? item.posicionesNormalizadas : [];
         const cartonesGratis = obtenerCartonesGratisDesde(item);
+        const cartonesGratisSegundo = obtenerCartonesGratisSegundoDesde(item);
         return {
           idx,
           nombre: item?.nombre || '',
           porcentaje: Number(item?.porcentaje ?? item?.porcentajePremio ?? 0) || 0,
           premioCreditos: Number(item?.premioCreditos ?? item?.premiocreditos ?? item?.creditos ?? 0) || 0,
           cartonesGratis: cartonesGratis ?? 0,
+          cartonesGratis2: cartonesGratisSegundo ?? 0,
           posicionesNormalizadas: posicionesNorm
             .map(pos=>({ r: Number(pos?.r ?? pos?.row ?? pos?.fila), c: Number(pos?.c ?? pos?.col ?? pos?.columna) }))
             .filter(pos=>Number.isInteger(pos.r) && Number.isInteger(pos.c))
@@ -3169,6 +3192,7 @@
           : [];
         const base = obtenerResumenForma(idx) || {};
         const cartonesGratis = obtenerCartonesGratisDesde(data);
+        const cartonesGratisSegundo = obtenerCartonesGratisSegundoDesde(data);
         mapa.set(idx, {
           ...base,
           id: doc.id,
@@ -3177,6 +3201,7 @@
           porcentaje: Number(data?.porcentaje ?? data?.porcentajePremio ?? base?.porcentaje ?? 0) || 0,
           premioCreditos: Number(data?.premioCreditos ?? data?.premiocreditos ?? data?.creditos ?? base?.premioCreditos ?? 0) || 0,
           cartonesGratis: cartonesGratis ?? base?.cartonesGratis ?? 0,
+          cartonesGratis2: cartonesGratisSegundo ?? base?.cartonesGratis2 ?? 0,
           posicionesNormalizadas: posiciones
         });
       });
@@ -3628,6 +3653,27 @@
       forma?.premioCartonesGratis,
       forma?.premioCartonesgratis,
       forma?.cartones
+    ];
+    for(const candidato of candidatos){
+      const numero = normalizarCartonesGratisValor(candidato);
+      if(numero !== null){
+        return numero;
+      }
+    }
+    return 0;
+  }
+
+  function obtenerCartonesGratisSegundo(forma){
+    if(!forma) return 0;
+    const candidatos = [
+      forma?.cartonesGratis2,
+      forma?.cartonesgratis2,
+      forma?.cartones_gratis2,
+      forma?.cartonesGratisSegundo,
+      forma?.cartonesGratisSegundoLugar,
+      forma?.premioCartonesGratis2,
+      forma?.premioCartonesGratisSegundo,
+      forma?.premioCartonesGratisSegundoLugar
     ];
     for(const candidato of candidatos){
       const numero = normalizarCartonesGratisValor(candidato);
@@ -4278,6 +4324,9 @@
       procesarPremiosAutomaticos({ formas: formasNuevas }).catch(err=>{
         console.warn('No se pudieron procesar premios automáticos', err);
       });
+      procesarPremiosSegundoLugar({ formas: formasNuevas }).catch(err=>{
+        console.warn('No se pudieron procesar premios de segundo lugar', err);
+      });
     }
     if(esPrimerProcesamiento || !nuevos.length) return;
     mostrarModalNuevosGanadores(nuevos);
@@ -4288,6 +4337,43 @@
     const formaSeguro = sanitizarId(`f${formaIdx ?? ''}` || 'forma');
     const cartonSeguro = sanitizarId(cartonId || 'carton');
     return `${sorteoSeguro}__${formaSeguro}__${cartonSeguro}`;
+  }
+
+  function construirIdPremioSegundoLugar(sorteoId, formaIdx, cartonId){
+    const sorteoSeguro = sanitizarId(sorteoId || 'sorteo');
+    const formaSeguro = sanitizarId(`f${formaIdx ?? ''}` || 'forma');
+    const cartonSeguro = sanitizarId(cartonId || 'carton');
+    return `segundo__${sorteoSeguro}__${formaSeguro}__${cartonSeguro}`;
+  }
+
+  function obtenerCartonesSegundoLugar(forma, pasoGanador){
+    const posiciones = obtenerPosicionesForma(forma);
+    if(!posiciones.length || posiciones.length <= 1) return [];
+    const pasoLimite = Number(pasoGanador);
+    if(!Number.isFinite(pasoLimite) || pasoLimite < 0) return [];
+    const resultados = [];
+    cartonesSorteo.forEach(carton=>{
+      let faltantes = 0;
+      let validas = 0;
+      for(const pos of posiciones){
+        const valor = carton.valorPorPos.get(`${pos.r}-${pos.c}`);
+        if(valor === undefined){
+          faltantes = 2;
+          break;
+        }
+        const paso = cantosIndiceMap.get(valor);
+        if(paso === undefined || paso > pasoLimite){
+          faltantes += 1;
+          if(faltantes > 1) break;
+        }else{
+          validas += 1;
+        }
+      }
+      if(faltantes === 1 && validas > 0){
+        resultados.push(carton);
+      }
+    });
+    return resultados;
   }
 
   async function acreditarPremioAutomatico({ carton, forma, totalGanadores }){
@@ -4396,6 +4482,132 @@
     }
   }
 
+  async function acreditarPremioSegundoLugar({ carton, forma }){
+    if(!carton || !forma || !currentSorteoId) return;
+    const cartonReferencia = carton.id || carton.cartonId || carton.carton || carton.userId || carton.usuarioId || '';
+    const premioId = construirIdPremioSegundoLugar(currentSorteoId, forma?.idx, cartonReferencia);
+    if(premiosSegundoLugarProcesados.has(premioId) || premiosSegundoLugarEnCurso.has(premioId)) return;
+    const cartonesGratis = obtenerCartonesGratisSegundo(forma);
+    if(!Number(cartonesGratis) || cartonesGratis <= 0) return;
+    premiosSegundoLugarEnCurso.add(premioId);
+    try {
+      await asegurarDbListo();
+      const identidad = await resolverIdentidadPersona(carton);
+      const email = normalizarEmail(identidad.email);
+      if(!email){
+        return;
+      }
+      const sorteoNombre = (currentSorteoData?.nombre || '').toString();
+      const ahora = getServerNow();
+      const fechaGestion = formatearFechaCorta(ahora);
+      const horaGestion = formatearHoraCorta(ahora);
+      const timestamp = getServerTimestamp();
+      const premioRef = db.collection('PremiosSorteos').doc(premioId);
+      const transaccionRef = db.collection('transacciones').doc(`premio2_${premioId}`);
+      const billeteraRef = db.collection('Billetera').doc(email);
+      await db.runTransaction(async tx => {
+        const premioSnap = await tx.get(premioRef);
+        if(premioSnap.exists){
+          const estadoActual = (premioSnap.data()?.estado || '').toString().trim().toUpperCase();
+          if(estadoActual === 'APROBADO'){
+            return;
+          }
+        }
+        const billeteraSnap = await tx.get(billeteraRef);
+        const datosBilletera = billeteraSnap.exists ? billeteraSnap.data() : {};
+        const nuevosCartones = (Number(datosBilletera.CartonesGratis) || 0) + (Number(cartonesGratis) || 0);
+        const payloadPremio = {
+          sorteoId: currentSorteoId,
+          sorteoNombre,
+          gmail: email,
+          email,
+          alias: identidad.alias || carton.alias || '',
+          aliasJugador: identidad.alias || carton.alias || '',
+          aliasGanador: identidad.alias || carton.alias || '',
+          creditos: 0,
+          creditosGanados: 0,
+          cartonesGratis: Number(cartonesGratis) || 0,
+          cartonesGanados: 0,
+          formasSegundoLugar: [{
+            idx: Number(forma?.idx) || null,
+            nombre: forma?.nombre || '',
+            cartonesGratis: Number(cartonesGratis) || 0
+          }],
+          estado: 'APROBADO',
+          fechaGanado: timestamp,
+          fechaRegistro: timestamp,
+          creadoEn: timestamp,
+          actualizadoEn: timestamp,
+          fechaGestion,
+          horaGestion,
+          gestionadoPor: auth?.currentUser?.email || '',
+          rolGestor: window.currentRole || '',
+          tipoRegistro: 'SEGUNDO_LUGAR_SORTEO',
+          segundoLugar: true,
+          userIds: identidad.userId ? [identidad.userId] : [],
+          cartonId: carton.id || carton.cartonId || '',
+          formaIdx: Number(forma?.idx) || null,
+          generadoDesde: 'cantarsorteos'
+        };
+        if(email){ payloadPremio.idBilletera = email; }
+        tx.set(premioRef, payloadPremio, { merge: true });
+        if(Number(cartonesGratis)){
+          tx.set(billeteraRef, { CartonesGratis: nuevosCartones }, { merge: true });
+        }
+        const transSnap = await tx.get(transaccionRef);
+        if(!transSnap.exists){
+          tx.set(transaccionRef, {
+            tipotrans: 'premio',
+            origen: 'premios_segundo_lugar',
+            Monto: 0,
+            cartonesGratis: Number(cartonesGratis) || 0,
+            estado: 'APROBADO',
+            IDbilletera: email,
+            fechasolicitud: '',
+            horasolicitud: '',
+            fechagestion: fechaGestion,
+            horagestion: horaGestion,
+            usuariogestor: auth?.currentUser?.email || '',
+            rolusuario: window.currentRole || '',
+            referencia: 'PREMIO_SEGUNDO_LUGAR',
+            sorteoId: currentSorteoId,
+            sorteoNombre,
+            rolInterno: '',
+            rolinterno: ''
+          }, { merge: true });
+        }
+      });
+      premiosSegundoLugarProcesados.add(premioId);
+    } catch (err) {
+      console.error('Error acreditando premio segundo lugar', err);
+    } finally {
+      premiosSegundoLugarEnCurso.delete(premioId);
+    }
+  }
+
+  async function procesarPremiosSegundoLugar({ formas } = {}){
+    if(!currentSorteoId || !cartonesGanadoresPorForma || !cartonesGanadoresPorForma.size) return;
+    const indices = formas instanceof Set ? formas : null;
+    const tareas = [];
+    cartonesGanadoresPorForma.forEach((registro, indice)=>{
+      const idxNumero = Number(indice);
+      if(!Number.isFinite(idxNumero)) return;
+      if(indices && !indices.has(idxNumero)) return;
+      const forma = registro?.forma || obtenerResumenForma(idxNumero) || { idx: idxNumero };
+      const cartonesGratisSegundo = obtenerCartonesGratisSegundo(forma);
+      if(!Number(cartonesGratisSegundo) || cartonesGratisSegundo <= 0) return;
+      const pasoGanador = Number(registro?.paso);
+      if(!Number.isFinite(pasoGanador)) return;
+      const segundos = obtenerCartonesSegundoLugar(forma, pasoGanador);
+      segundos.forEach(carton=>{
+        tareas.push(acreditarPremioSegundoLugar({ carton, forma }));
+      });
+    });
+    if(tareas.length){
+      await Promise.all(tareas);
+    }
+  }
+
   async function procesarPremiosAutomaticos({ formas } = {}){
     if(!currentSorteoId || !cartonesGanadoresPorForma || !cartonesGanadoresPorForma.size) return;
     const indices = formas instanceof Set ? formas : null;
@@ -4472,6 +4684,8 @@
     }
     premiosAutomaticosProcesados.clear();
     premiosAutomaticosEnCurso.clear();
+    premiosSegundoLugarProcesados.clear();
+    premiosSegundoLugarEnCurso.clear();
     cerrarModalComplementarios();
     cerrarAvisoSimple();
     cantoCeldas.forEach(celda=>celda.classList.remove('no-jugado'));

--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -82,14 +82,18 @@
     }
     .row{display:flex;justify-content:center;gap:5px;width:calc(100% - 12px);margin:3px 6px;}
     .row input{flex:1;width:100%;}
-    .premio-row{display:grid;grid-template-columns:repeat(4,1fr);align-items:center;width:calc(100% - 12px);gap:5px;font-weight:bold;}
-    .premio-row input{margin:0;text-align:center;font-weight:bold;width:100%;}
+    .premio-row{display:grid;grid-template-columns:1.15fr 0.85fr 1.15fr 0.85fr 1.15fr 0.85fr;align-items:center;width:calc(100% - 12px);gap:5px;font-weight:bold;}
+    .premio-row input{margin:0;text-align:center;font-weight:bold;width:100%;min-width:0;}
     .premio-row span{margin:0;text-align:center;font-weight:bold;}
-    .porcentaje-forma{color:green;}
+    .porcentaje-forma{color:green;border:2px solid #006400;}
     .porcentaje-forma::placeholder,
-    .cartones-forma::placeholder{font-size:0.8rem;}
+    .cartones-forma::placeholder,
+    .cartones-forma-2::placeholder{font-size:0.78rem;}
     .porcentaje-restante{color:#006400;font-size:1.2rem;}
+    .cartones-forma{border:2px solid purple;}
     .cartones-total{color:purple;font-size:1.2rem;}
+    .cartones-forma-2{border:2px solid #ff8c00;}
+    .cartones-total-2{color:#ff8c00;font-size:1.2rem;}
     #nombre-sorteo{font-weight:bold;color:purple;}
     .toggle-group{display:flex;justify-content:center;gap:5px;margin:3px 0;}
     .toggle-group button{flex:0 0 auto;width:95px;padding:5px 10px;border-radius:20px;border:1px solid #ccc;font-family:'Bangers',cursive;font-size:1rem;cursor:pointer;background:#808080;color:#fff;text-shadow:1px 1px 2px #333;}
@@ -202,7 +206,7 @@
     @keyframes pulse{0%{transform:scale(1);}50%{transform:scale(1.1);}100%{transform:scale(1);}}
     @media (orientation:landscape){
       .row,.premio-row,.imagen-wrapper,.toggle-group,.tabs{width:90% !important;margin-left:auto;margin-right:auto;}
-      .premio-row{grid-template-columns:2fr 1fr 2fr 1fr;}
+      .premio-row{grid-template-columns:2fr 1fr 2fr 1fr 2fr 1fr;}
     }
     @media (max-width:600px){
       body{align-items:stretch;padding:5px 20px;}
@@ -382,6 +386,7 @@
         nombre:div.querySelector('.nombre-forma').value.trim(),
         porcentaje:div.querySelector('.porcentaje-forma').value,
         cartones:div.querySelector('.cartones-forma').value,
+        cartones2:div.querySelector('.cartones-forma-2').value,
         imagen:div.querySelector('.imagen-url').value,
         posiciones:[]
       };
@@ -425,6 +430,7 @@
         div.querySelector('.nombre-forma').value=f.nombre||'';
         div.querySelector('.porcentaje-forma').value=f.porcentaje||'';
         div.querySelector('.cartones-forma').value=f.cartones||'';
+        div.querySelector('.cartones-forma-2').value=f.cartones2||'';
         div.querySelector('.imagen-url').value=f.imagen||'';
         if(f.imagen){
           const ver=div.querySelector('.ver-imagen');
@@ -467,9 +473,12 @@
       e.target.value=e.target.value.replace(/[^\d]/g,'');
       saveState();
     });
-    document.querySelectorAll('.tab-content .nombre-forma,.tab-content .porcentaje-forma,.tab-content .cartones-forma,.tab-content .imagen-url').forEach(i=>i.addEventListener('input',e=>{
+    document.querySelectorAll('.tab-content .nombre-forma,.tab-content .porcentaje-forma,.tab-content .cartones-forma,.tab-content .cartones-forma-2,.tab-content .imagen-url').forEach(i=>i.addEventListener('input',e=>{
+      if(e.target.classList.contains('cartones-forma') || e.target.classList.contains('cartones-forma-2')){
+        e.target.value=e.target.value.replace(/[^\d]/g,'');
+      }
       saveState();
-      if(e.target.classList.contains('porcentaje-forma')||e.target.classList.contains('cartones-forma')) actualizarTotales();
+      if(e.target.classList.contains('porcentaje-forma')||e.target.classList.contains('cartones-forma')||e.target.classList.contains('cartones-forma-2')) actualizarTotales();
     }));
   }
 
@@ -492,7 +501,7 @@
     const snap=await db.collection('formas').where('sorteoId','==',sorteoId).get();
     const arr=[];snap.forEach(s=>arr.push(s.data()));
     arr.sort((a,b)=>(a.idx||0)-(b.idx||0));
-    arr.forEach(f=>{data.formas.push({nombre:f.nombre||'',porcentaje:f.porcentaje||'',cartones:f.cartonesGratis||'',imagen:f.premioImagen||'',posiciones:f.posiciones||[]});});
+    arr.forEach(f=>{data.formas.push({nombre:f.nombre||'',porcentaje:f.porcentaje||'',cartones:f.cartonesGratis||'',cartones2:f.cartonesGratis2||'',imagen:f.premioImagen||'',posiciones:f.posiciones||[]});});
     setCookie(cookieKey,JSON.stringify(data));
   }
 
@@ -628,6 +637,9 @@ firebase.auth().onAuthStateChanged(u=>{
     const cartones=Array.from(document.querySelectorAll('.cartones-forma')).map(i=>parseInt(i.value)||0);
     const totalCartones=cartones.reduce((a,b)=>a+b,0);
     document.querySelectorAll('.cartones-total').forEach(span=>{span.textContent=totalCartones;});
+    const cartonesSegundo=Array.from(document.querySelectorAll('.cartones-forma-2')).map(i=>parseInt(i.value)||0);
+    const totalCartonesSegundo=cartonesSegundo.reduce((a,b)=>a+b,0);
+    document.querySelectorAll('.cartones-total-2').forEach(span=>{span.textContent=totalCartonesSegundo;});
   }
 
   function obtenerColorForma(idx){
@@ -875,8 +887,10 @@ firebase.auth().onAuthStateChanged(u=>{
       div.innerHTML=`<div class=\"forma-label\">Forma ${i}</div><div class=\"forma-nombre-row\" data-idx=\"${i}\" style=\"--fx-color:${obtenerColorForma(i)}\"><button type=\"button\" class=\"fx-button\">F${i}</button><input class=\"nombre-forma\" placeholder=\"Nombre de forma\"><button type=\"button\" class=\"guardar-forma-btn\" title=\"Guardar forma\"><span>💾</span></button></div>\
       <div class=\"premio-row\"><input type=\"number\" class=\"porcentaje-forma\" placeholder=\"% Premio\">\
       <span class=\"porcentaje-restante\">100%<\/span>\
-      <input type=\"number\" class=\"cartones-forma\" placeholder=\"Cartones Gratis\">\
-      <span class=\"cartones-total\">0<\/span><\/div>\
+      <input type=\"number\" class=\"cartones-forma\" placeholder=\"C. Gratis\">\
+      <span class=\"cartones-total\">0<\/span>\
+      <input type=\"number\" class=\"cartones-forma-2\" placeholder=\"C. gratis 2\">\
+      <span class=\"cartones-total-2\">0<\/span><\/div>\
       <div class=\"imagen-wrapper\">\
         <button type=\"button\" class=\"ver-foto-btn\"><img src=\"https://img.icons8.com/ios-glyphs/30/image.png\" alt=\"foto\"><\/button>\
         <input type=\"file\" accept=\"image/*\" class=\"imagen-forma\">\
@@ -1092,10 +1106,12 @@ firebase.auth().onAuthStateChanged(u=>{
       const nomInput=div.querySelector('.nombre-forma');
       const porInput=div.querySelector('.porcentaje-forma');
       const cartInput=div.querySelector('.cartones-forma');
+      const cartSegundoInput=div.querySelector('.cartones-forma-2');
       const urlInput=div.querySelector('.imagen-url');
       const nom=nomInput.value.trim();
       const por=parseFloat(porInput.value);
       const cart=parseInt(cartInput.value);
+      const cartSegundo=parseInt(cartSegundoInput.value);
       const img=urlInput.value.trim();
       const pos=[];
       div.querySelectorAll('td.selected').forEach(td=>{
@@ -1103,7 +1119,7 @@ firebase.auth().onAuthStateChanged(u=>{
         if(!(r===2&&c===2)) pos.push({r,c});
       });
         if(!nom){selectTab(i+1);alert(`Asigna un nombre a la forma ${i+1}`);nomInput.focus();return;}
-        if((isNaN(por)||por<=0) && (isNaN(cart)||cart<=0) && !img){
+        if((isNaN(por)||por<=0) && (isNaN(cart)||cart<=0) && (isNaN(cartSegundo)||cartSegundo<=0) && !img){
           selectTab(i+1);
           alert(`Asigna un premio a la forma ${i+1}`);
           porInput.focus();
@@ -1118,6 +1134,7 @@ firebase.auth().onAuthStateChanged(u=>{
       const obj={idx:i+1,nombre:nom,posiciones:pos};
       if(!isNaN(por)&&por>0){obj.porcentaje=por;total+=por;conPorcentaje++;}
       if(!isNaN(cart)&&cart>0){obj.cartonesGratis=cart;}
+      if(!isNaN(cartSegundo)&&cartSegundo>0){obj.cartonesGratis2=cartSegundo;}
       if(img){obj.premioImagen=img;}
       formas.push(obj);
     }

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -2630,6 +2630,55 @@
           gap: 12px;
           box-sizing: border-box;
       }
+      .modal-sin-premio .modal-contenido {
+          max-width: min(520px, calc(100vw - 36px));
+          width: min(520px, calc(100vw - 36px));
+          text-align: center;
+          align-items: center;
+          background: linear-gradient(135deg, #ffd06b, #ff9f43);
+          border: 4px solid #ff7b00;
+          color: #1f1f1f;
+      }
+      .modal-segundo-lugar .modal-contenido {
+          max-width: min(520px, calc(100vw - 36px));
+          width: min(520px, calc(100vw - 36px));
+          text-align: center;
+          align-items: center;
+          background: linear-gradient(135deg, #6d28d9, #ff7a00);
+          border: 4px solid #ffe066;
+          color: #fff;
+      }
+      .modal-premio-extra-titulo {
+          margin: 0;
+          font-family: 'Bangers', cursive;
+          letter-spacing: 1px;
+          font-size: clamp(1.4rem, 4.4vw, 2rem);
+          text-shadow: 0 3px 8px rgba(0,0,0,0.35);
+      }
+      .modal-premio-extra-mensaje {
+          margin: 0;
+          font-size: clamp(0.95rem, 3.4vw, 1.15rem);
+          font-weight: 600;
+          line-height: 1.35;
+      }
+      .modal-premio-extra-accion {
+          border: none;
+          border-radius: 999px;
+          padding: 8px 20px;
+          font-family: 'Bangers', cursive;
+          font-size: 1rem;
+          letter-spacing: 1px;
+          cursor: pointer;
+          background: #1f1f1f;
+          color: #fff;
+          box-shadow: 0 6px 14px rgba(0,0,0,0.25);
+      }
+      .modal-sin-premio .modal-premio-extra-accion {
+          background: #111827;
+      }
+      .modal-segundo-lugar .modal-premio-extra-accion {
+          background: #1f2937;
+      }
       .modal-premio-forma {
           display: none;
           align-items: center;
@@ -4195,6 +4244,24 @@
     </div>
   </div>
 
+  <div id="modal-sin-premio" class="modal modal-sin-premio" role="dialog" aria-modal="true" aria-labelledby="modal-sin-premio-titulo" aria-hidden="true">
+    <div class="modal-contenido" role="document">
+      <button type="button" id="modal-sin-premio-cerrar" class="modal-cerrar" aria-label="Cerrar">✖</button>
+      <h2 id="modal-sin-premio-titulo" class="modal-premio-extra-titulo">¡Gracias por jugar!</h2>
+      <p id="modal-sin-premio-mensaje" class="modal-premio-extra-mensaje"></p>
+      <button type="button" id="modal-sin-premio-aceptar" class="modal-premio-extra-accion">Entendido</button>
+    </div>
+  </div>
+
+  <div id="modal-segundo-lugar" class="modal modal-segundo-lugar" role="dialog" aria-modal="true" aria-labelledby="modal-segundo-lugar-titulo" aria-hidden="true">
+    <div class="modal-contenido" role="document">
+      <button type="button" id="modal-segundo-lugar-cerrar" class="modal-cerrar" aria-label="Cerrar">✖</button>
+      <h2 id="modal-segundo-lugar-titulo" class="modal-premio-extra-titulo">¡Segundo lugar!</h2>
+      <p id="modal-segundo-lugar-mensaje" class="modal-premio-extra-mensaje"></p>
+      <button type="button" id="modal-segundo-lugar-aceptar" class="modal-premio-extra-accion">Entendido</button>
+    </div>
+  </div>
+
   <div id="modal-whatsapp" class="modal modal-whatsapp" role="dialog" aria-modal="true" aria-labelledby="modal-whatsapp-titulo" aria-hidden="true">
     <div class="modal-contenido" role="document">
       <h2 id="modal-whatsapp-titulo">GRUPO DE WHATSAPP NO DISPONIBLE</h2>
@@ -4330,6 +4397,14 @@
   const modalCelebracionAceptarBtn = document.getElementById('modal-celebracion-aceptar');
   const modalCelebracionMensajeEl = document.getElementById('modal-celebracion-mensaje');
   const modalCelebracionTituloEl = document.getElementById('modal-celebracion-titulo');
+  const modalSinPremioEl = document.getElementById('modal-sin-premio');
+  const modalSinPremioMensajeEl = document.getElementById('modal-sin-premio-mensaje');
+  const modalSinPremioCerrarBtn = document.getElementById('modal-sin-premio-cerrar');
+  const modalSinPremioAceptarBtn = document.getElementById('modal-sin-premio-aceptar');
+  const modalSegundoLugarEl = document.getElementById('modal-segundo-lugar');
+  const modalSegundoLugarMensajeEl = document.getElementById('modal-segundo-lugar-mensaje');
+  const modalSegundoLugarCerrarBtn = document.getElementById('modal-segundo-lugar-cerrar');
+  const modalSegundoLugarAceptarBtn = document.getElementById('modal-segundo-lugar-aceptar');
   const whatsappBtnEl = document.getElementById('whatsapp-flotante');
   const whatsappModalEl = document.getElementById('modal-whatsapp');
   const whatsappModalAceptarBtn = document.getElementById('modal-whatsapp-aceptar');
@@ -4398,6 +4473,7 @@
   const LIVE_ICON_INTERVAL_MS = 3000;
   let ventanaEnFoco = document.visibilityState === 'visible' && document.hasFocus();
   let cantosRecientesSinAnimacion = false;
+  let resumenGanadoresPrevio = new Map();
 
   let cartonSeleccionadoId = null;
   const animacionesCartones = new Map();
@@ -4456,6 +4532,10 @@
   let cantoColorMap = new Map();
   let formasSinGanadoresAlertaClave = '';
   let celebracionModalActiva = false;
+  let modalSinPremioActiva = false;
+  let modalSegundoLugarActiva = false;
+  const formasSegundoLugarNotificadas = new Set();
+  const sorteosSinPremioNotificados = new Set();
   let unsubscribeCartonesGuardados = null;
   let contadoresFlotantesIntervalo = null;
   let contadoresFlotantesActivos = [];
@@ -8591,6 +8671,27 @@
     return 0;
   }
 
+  function obtenerCartonesGratisSegundo(forma){
+    if(!forma) return 0;
+    const candidatos=[
+      forma?.cartonesGratis2,
+      forma?.cartonesgratis2,
+      forma?.cartones_gratis2,
+      forma?.cartonesGratisSegundo,
+      forma?.cartonesGratisSegundoLugar,
+      forma?.premioCartonesGratis2,
+      forma?.premioCartonesGratisSegundo,
+      forma?.premioCartonesGratisSegundoLugar
+    ];
+    for(const candidato of candidatos){
+      const numero=normalizarCartonesGratisValor(candidato);
+      if(numero !== null){
+        return numero;
+      }
+    }
+    return 0;
+  }
+
   function obtenerCartonesGratisPorGanador(forma,totalGanadores){
     const totalCartones=obtenerCartonesGratisForma(forma);
     if(totalCartones<=0) return 0;
@@ -9005,6 +9106,136 @@
       modalCelebracionListaEl.innerHTML='';
     }
     detenerConfetiCelebracion();
+  }
+
+  function mostrarModalSinPremio(){
+    if(!modalSinPremioEl || !modalSinPremioMensajeEl) return;
+    modalSinPremioMensajeEl.textContent = '😅 Esta vez no ganaste ningún premio, te invitamos a seguir jugando al Bingo Online y podrás ser un feliz ganador 😊';
+    modalSinPremioEl.classList.add('activa');
+    modalSinPremioEl.setAttribute('aria-hidden','false');
+    modalSinPremioActiva = true;
+    modalSinPremioAceptarBtn?.focus({preventScroll:true});
+  }
+
+  function cerrarModalSinPremio(){
+    if(!modalSinPremioEl) return;
+    modalSinPremioEl.classList.remove('activa');
+    modalSinPremioEl.setAttribute('aria-hidden','true');
+    modalSinPremioActiva = false;
+  }
+
+  function mostrarModalSegundoLugar(mensaje){
+    if(!modalSegundoLugarEl || !modalSegundoLugarMensajeEl) return;
+    modalSegundoLugarMensajeEl.textContent = mensaje;
+    modalSegundoLugarEl.classList.add('activa');
+    modalSegundoLugarEl.setAttribute('aria-hidden','false');
+    modalSegundoLugarActiva = true;
+    modalSegundoLugarAceptarBtn?.focus({preventScroll:true});
+  }
+
+  function cerrarModalSegundoLugar(){
+    if(!modalSegundoLugarEl) return;
+    modalSegundoLugarEl.classList.remove('activa');
+    modalSegundoLugarEl.setAttribute('aria-hidden','true');
+    modalSegundoLugarActiva = false;
+  }
+
+  function obtenerResumenGanadores(map){
+    const resumen = new Map();
+    if(!(map instanceof Map)) return resumen;
+    map.forEach((info, indice)=>{
+      const idxNumero = Number(indice);
+      if(!Number.isFinite(idxNumero)) return;
+      const total = Array.isArray(info?.cartones) ? info.cartones.length : 0;
+      resumen.set(idxNumero, { total, paso: Number(info?.paso) });
+    });
+    return resumen;
+  }
+
+  function obtenerCartonesSegundoLugarPorForma(forma, pasoGanador, cartones){
+    const posiciones = obtenerPosicionesNormalizadas(forma);
+    if(!posiciones.length || posiciones.length <= 1) return [];
+    const pasoLimite = Number(pasoGanador);
+    if(!Number.isFinite(pasoLimite) || pasoLimite < 0) return [];
+    const lista = Array.isArray(cartones) ? cartones : [];
+    const resultado = [];
+    lista.forEach(carton=>{
+      let faltantes = 0;
+      let validas = 0;
+      for(const pos of posiciones){
+        const valor = carton.valorPorPos.get(`${pos.r}-${pos.c}`);
+        if(valor === undefined){
+          faltantes = 2;
+          break;
+        }
+        const paso = cantosIndiceMap.get(valor);
+        if(paso === undefined || paso > pasoLimite){
+          faltantes += 1;
+          if(faltantes > 1) break;
+        }else{
+          validas += 1;
+        }
+      }
+      if(faltantes === 1 && validas > 0){
+        resultado.push(carton);
+      }
+    });
+    return resultado;
+  }
+
+  function evaluarMensajesSegundoLugar(resumenPrevio, resumenActual){
+    if(!usuarioActual || !activeSorteoId) return;
+    const cartonesJugador = obtenerCartonesJugadorActual();
+    if(modoSimulacionCartones) return;
+    const cartonesReales = cartonesJugador.filter(carton=>carton.userId===usuarioActual.uid);
+    if(!cartonesReales.length) return;
+    resumenActual.forEach((infoActual, indice)=>{
+      const totalActual = Number(infoActual?.total || 0);
+      if(totalActual <= 0) return;
+      const previo = Number(resumenPrevio.get(indice)?.total || 0);
+      if(totalActual <= previo) return;
+      const forma = formasActivas.find(f=>Number(f.idx)===Number(indice)) || { idx: indice };
+      const cartonesGratisSegundo = obtenerCartonesGratisSegundo(forma);
+      if(!Number(cartonesGratisSegundo) || cartonesGratisSegundo <= 0) return;
+      const pasoGanador = Number(infoActual?.paso);
+      if(!Number.isFinite(pasoGanador)) return;
+      const claveNotificacion = `${activeSorteoId}__${indice}`;
+      if(formasSegundoLugarNotificadas.has(claveNotificacion)) return;
+      const segundos = obtenerCartonesSegundoLugarPorForma(forma, pasoGanador, cartonesReales);
+      if(!segundos.length) return;
+      const nombreForma = (forma?.nombre || '').toString().trim() || `Forma ${String(indice).padStart(2,'0')}`;
+      const mensaje = `Estuviste a un solo acierto para ganar con la forma ${nombreForma} por eso te ganas en segundo lugar ${cartonesGratisSegundo} cartones !GRATIS! 🤩`;
+      mostrarModalSegundoLugar(mensaje);
+      formasSegundoLugarNotificadas.add(claveNotificacion);
+    });
+  }
+
+  function evaluarMensajeSinPremio(estadoAnterior){
+    if(!activeSorteoId) return;
+    if(estadoAnterior || !todasFormasConGanadores) return;
+    if(!Number.isInteger(indiceUltimoGanador)) return;
+    if(indiceUltimoGanador !== cantosOrdenados.length - 1) return;
+    const clave = `${activeSorteoId}__sin-premio`;
+    if(sorteosSinPremioNotificados.has(clave)) return;
+    const cartonesJugador = obtenerCartonesJugadorActual();
+    if(modoSimulacionCartones) return;
+    if(!cartonesJugador.length) return;
+    const mapaFormasActivo = obtenerFormasPorCartonActivo();
+    const tieneGanancia = cartonesJugador.some(carton=>{
+      const lista = mapaFormasActivo.get(carton.id) || [];
+      return lista.length > 0;
+    });
+    if(tieneGanancia) return;
+    mostrarModalSinPremio();
+    sorteosSinPremioNotificados.add(clave);
+  }
+
+  function reiniciarNotificacionesPremios(){
+    resumenGanadoresPrevio = new Map();
+    formasSegundoLugarNotificadas.clear();
+    sorteosSinPremioNotificados.clear();
+    cerrarModalSegundoLugar();
+    cerrarModalSinPremio();
   }
 
   function gestionarCelebracionesNuevosGanadores(cartones, esSimulacion=false){
@@ -9543,6 +9774,32 @@
       }
     });
   }
+  if(modalSinPremioCerrarBtn){
+    modalSinPremioCerrarBtn.addEventListener('click',cerrarModalSinPremio);
+  }
+  if(modalSinPremioAceptarBtn){
+    modalSinPremioAceptarBtn.addEventListener('click',cerrarModalSinPremio);
+  }
+  if(modalSinPremioEl){
+    modalSinPremioEl.addEventListener('click',evento=>{
+      if(evento.target===modalSinPremioEl){
+        cerrarModalSinPremio();
+      }
+    });
+  }
+  if(modalSegundoLugarCerrarBtn){
+    modalSegundoLugarCerrarBtn.addEventListener('click',cerrarModalSegundoLugar);
+  }
+  if(modalSegundoLugarAceptarBtn){
+    modalSegundoLugarAceptarBtn.addEventListener('click',cerrarModalSegundoLugar);
+  }
+  if(modalSegundoLugarEl){
+    modalSegundoLugarEl.addEventListener('click',evento=>{
+      if(evento.target===modalSegundoLugarEl){
+        cerrarModalSegundoLugar();
+      }
+    });
+  }
 
   if(whatsappBtnEl){
     whatsappBtnEl.addEventListener('click',manejarClickWhatsapp);
@@ -9616,6 +9873,14 @@
     if(evento.key!=='Escape') return;
     if(celebracionModalActiva || modalCelebracionEl?.classList?.contains('activa')){
       cerrarModalCelebracionGanador();
+      return;
+    }
+    if(modalSegundoLugarActiva || modalSegundoLugarEl?.classList?.contains('activa')){
+      cerrarModalSegundoLugar();
+      return;
+    }
+    if(modalSinPremioActiva || modalSinPremioEl?.classList?.contains('activa')){
+      cerrarModalSinPremio();
       return;
     }
     if(complementariosAvisoEl?.classList?.contains('activa')){
@@ -9747,6 +10012,9 @@
     cartonesGanadoresSimuladosPorForma=resultadoSimulado.cartonesGanadoresPorForma || new Map();
     formasPorCartonSimulados=resultadoSimulado.formasPorCarton || new Map();
     evaluarEstadoFormasGanadoras();
+    const resumenActual=obtenerResumenGanadores(cartonesGanadoresPorForma);
+    evaluarMensajesSegundoLugar(resumenGanadoresPrevio, resumenActual);
+    resumenGanadoresPrevio=resumenActual;
     renderFormas();
     renderCartonesJugador();
   }
@@ -10048,6 +10316,11 @@
         data.cartonesGratis ?? data.cartonesgratis ?? data.cartones_gratis ??
         data.premioCartonesGratis ?? data.premioCartonesgratis ?? data.cartones
       ) ?? 0;
+      const cartonesGratisSegundo=normalizarCartonesGratisValor(
+        data.cartonesGratis2 ?? data.cartonesgratis2 ?? data.cartones_gratis2 ??
+        data.cartonesGratisSegundo ?? data.cartonesGratisSegundoLugar ??
+        data.premioCartonesGratis2 ?? data.premioCartonesGratisSegundo ?? data.premioCartonesGratisSegundoLugar
+      ) ?? 0;
       arr.push({
         id:doc.id,
         idx,
@@ -10056,7 +10329,8 @@
         posicionesNormalizadas:normalizadas,
         porcentaje:Number(data.porcentaje ?? data.porcentajePremio ?? data.porcentajepremio ?? 0) || 0,
         premioCreditos:Number(data.premioCreditos ?? data.premiocreditos ?? data.creditos ?? data.premio ?? 0) || 0,
-        cartonesGratis
+        cartonesGratis,
+        cartonesGratis2: cartonesGratisSegundo
       });
     });
     arr.sort((a,b)=>(a.idx||0)-(b.idx||0));
@@ -10145,6 +10419,7 @@
     }else if(!avisoComplementariosMostrado){
       mostrarAvisoComplementarios();
     }
+    evaluarMensajeSinPremio(estadoAnterior);
     evaluarFormasSinGanadores(totalCantos);
   }
 
@@ -10244,6 +10519,7 @@
       activeSorteo=null;
       activeSorteoId=null;
       actualizarHeader();
+      reiniciarNotificacionesPremios();
       reiniciarAlertaFormasSinGanadores();
       if(unsubscribeCantos){unsubscribeCantos();unsubscribeCantos=null;}
       if(unsubscribeFormas){unsubscribeFormas();unsubscribeFormas=null;}
@@ -10270,6 +10546,7 @@
     suscribirSimulacionSorteo(activeSorteoId);
     if(cambio){
       reiniciarAlertaFormasSinGanadores();
+      reiniciarNotificacionesPremios();
       todasFormasConGanadores=false;
       indiceUltimoGanador=null;
       cantosComplementariosActivos=false;

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -82,14 +82,18 @@
     }
     .row{display:flex;justify-content:center;gap:5px;width:calc(100% - 12px);margin:3px 6px;}
     .row input{flex:1;width:100%;}
-    .premio-row{display:grid;grid-template-columns:repeat(4,1fr);align-items:center;width:calc(100% - 12px);gap:5px;font-weight:bold;}
-    .premio-row input{margin:0;text-align:center;font-weight:bold;width:100%;}
+    .premio-row{display:grid;grid-template-columns:1.15fr 0.85fr 1.15fr 0.85fr 1.15fr 0.85fr;align-items:center;width:calc(100% - 12px);gap:5px;font-weight:bold;}
+    .premio-row input{margin:0;text-align:center;font-weight:bold;width:100%;min-width:0;}
     .premio-row span{margin:0;text-align:center;font-weight:bold;}
-    .porcentaje-forma{color:green;}
+    .porcentaje-forma{color:green;border:2px solid #006400;}
     .porcentaje-forma::placeholder,
-    .cartones-forma::placeholder{font-size:0.8rem;}
+    .cartones-forma::placeholder,
+    .cartones-forma-2::placeholder{font-size:0.78rem;}
     .porcentaje-restante{color:#006400;font-size:1.2rem;}
+    .cartones-forma{border:2px solid purple;}
     .cartones-total{color:purple;font-size:1.2rem;}
+    .cartones-forma-2{border:2px solid #ff8c00;}
+    .cartones-total-2{color:#ff8c00;font-size:1.2rem;}
     #nombre-sorteo{font-weight:bold;color:purple;}
     .toggle-group{display:flex;justify-content:center;gap:5px;margin:3px 0;}
     .toggle-group button{flex:0 0 auto;width:95px;padding:5px 10px;border-radius:20px;border:1px solid #ccc;font-family:'Bangers',cursive;font-size:1rem;cursor:pointer;background:#808080;color:#fff;text-shadow:1px 1px 2px #333;}
@@ -377,6 +381,7 @@
         nombre:div.querySelector('.nombre-forma').value.trim(),
         porcentaje:div.querySelector('.porcentaje-forma').value,
         cartones:div.querySelector('.cartones-forma').value,
+        cartones2:div.querySelector('.cartones-forma-2').value,
         imagen:div.querySelector('.imagen-url').value,
         posiciones:[]
       };
@@ -419,6 +424,7 @@
         div.querySelector('.nombre-forma').value=f.nombre||'';
         div.querySelector('.porcentaje-forma').value=f.porcentaje||'';
         div.querySelector('.cartones-forma').value=f.cartones||'';
+        div.querySelector('.cartones-forma-2').value=f.cartones2||'';
         div.querySelector('.imagen-url').value=f.imagen||'';
         if(f.imagen){
           const ver=div.querySelector('.ver-imagen');
@@ -461,9 +467,12 @@
       e.target.value=e.target.value.replace(/[^\d]/g,'');
       saveState();
     });
-    document.querySelectorAll('.tab-content .nombre-forma,.tab-content .porcentaje-forma,.tab-content .cartones-forma,.tab-content .imagen-url').forEach(i=>i.addEventListener('input',e=>{
+    document.querySelectorAll('.tab-content .nombre-forma,.tab-content .porcentaje-forma,.tab-content .cartones-forma,.tab-content .cartones-forma-2,.tab-content .imagen-url').forEach(i=>i.addEventListener('input',e=>{
+      if(e.target.classList.contains('cartones-forma') || e.target.classList.contains('cartones-forma-2')){
+        e.target.value=e.target.value.replace(/[^\d]/g,'');
+      }
       saveState();
-      if(e.target.classList.contains('porcentaje-forma')||e.target.classList.contains('cartones-forma')) actualizarTotales();
+      if(e.target.classList.contains('porcentaje-forma')||e.target.classList.contains('cartones-forma')||e.target.classList.contains('cartones-forma-2')) actualizarTotales();
     }));
   }
 
@@ -604,6 +613,9 @@
     const cartones=Array.from(document.querySelectorAll('.cartones-forma')).map(i=>parseInt(i.value)||0);
     const totalCartones=cartones.reduce((a,b)=>a+b,0);
     document.querySelectorAll('.cartones-total').forEach(span=>{span.textContent=totalCartones;});
+    const cartonesSegundo=Array.from(document.querySelectorAll('.cartones-forma-2')).map(i=>parseInt(i.value)||0);
+    const totalCartonesSegundo=cartonesSegundo.reduce((a,b)=>a+b,0);
+    document.querySelectorAll('.cartones-total-2').forEach(span=>{span.textContent=totalCartonesSegundo;});
   }
 
   function obtenerColorForma(idx){
@@ -851,8 +863,10 @@
       div.innerHTML=`<div class=\"forma-label\">Forma ${i}</div><div class=\"forma-nombre-row\" data-idx=\"${i}\" style=\"--fx-color:${obtenerColorForma(i)}\"><button type=\"button\" class=\"fx-button\">F${i}</button><input class=\"nombre-forma\" placeholder=\"Nombre de forma\"><button type=\"button\" class=\"guardar-forma-btn\" title=\"Guardar forma\"><span>💾</span></button></div>\
       <div class=\"premio-row\"><input type=\"number\" class=\"porcentaje-forma\" placeholder=\"% Premio\">\
       <span class=\"porcentaje-restante\">100%<\/span>\
-      <input type=\"number\" class=\"cartones-forma\" placeholder=\"Cartones Gratis\">\
-      <span class=\"cartones-total\">0<\/span><\/div>\
+      <input type=\"number\" class=\"cartones-forma\" placeholder=\"C. Gratis\">\
+      <span class=\"cartones-total\">0<\/span>\
+      <input type=\"number\" class=\"cartones-forma-2\" placeholder=\"C. gratis 2\">\
+      <span class=\"cartones-total-2\">0<\/span><\/div>\
       <div class=\"imagen-wrapper\">\
         <button type=\"button\" class=\"ver-foto-btn\"><img src=\"https://img.icons8.com/ios-glyphs/30/image.png\" alt=\"foto\"><\/button>\
         <input type=\"file\" accept=\"image/*\" class=\"imagen-forma\">\
@@ -1068,10 +1082,12 @@
       const nomInput=div.querySelector('.nombre-forma');
       const porInput=div.querySelector('.porcentaje-forma');
       const cartInput=div.querySelector('.cartones-forma');
+      const cartSegundoInput=div.querySelector('.cartones-forma-2');
       const urlInput=div.querySelector('.imagen-url');
       const nom=nomInput.value.trim();
       const por=parseFloat(porInput.value);
       const cart=parseInt(cartInput.value);
+      const cartSegundo=parseInt(cartSegundoInput.value);
       const img=urlInput.value.trim();
       const pos=[];
       div.querySelectorAll('td.selected').forEach(td=>{
@@ -1079,7 +1095,7 @@
         if(!(r===2&&c===2)) pos.push({r,c});
       });
         if(!nom){selectTab(i+1);alert(`Asigna un nombre a la forma ${i+1}`);nomInput.focus();return;}
-        if((isNaN(por)||por<=0) && (isNaN(cart)||cart<=0) && !img){
+        if((isNaN(por)||por<=0) && (isNaN(cart)||cart<=0) && (isNaN(cartSegundo)||cartSegundo<=0) && !img){
           selectTab(i+1);
           alert(`Asigna un premio a la forma ${i+1}`);
           porInput.focus();
@@ -1094,6 +1110,7 @@
       const obj={idx:i+1,nombre:nom,posiciones:pos};
       if(!isNaN(por)&&por>0){obj.porcentaje=por;total+=por;conPorcentaje++;}
       if(!isNaN(cart)&&cart>0){obj.cartonesGratis=cart;}
+      if(!isNaN(cartSegundo)&&cartSegundo>0){obj.cartonesGratis2=cartSegundo;}
       if(img){obj.premioImagen=img;}
       formas.push(obj);
     }


### PR DESCRIPTION
### Motivation
- Añadir una recompensa automática para jugadores que estuvieron a un solo acierto (segundo lugar) y mejorar la comunicación visual al final del sorteo para quienes no ganaron.
- Permitir configurar en las formas una segunda cantidad de cartones gratis que se entregará como premio de segundo lugar.
- Ajustar la interfaz de creación/edición de sorteos para mostrar los nuevos campos en la misma línea con estilos diferenciados.

### Description
- Interfaz: en `public/nuevosorteo.html` y `public/editarsorte.html` se añadió el nuevo campo `C. gratis 2` (`.cartones-forma-2`) junto a los campos existentes, se cambió la rejilla `.premio-row` para que los tres inputs y sus etiquetas queden en una sola línea y se aplicaron bordes de color a los inputs (`verde` para `% Premio`, `morado` para `C. Gratis`, `naranja` para `C. gratis 2`), además se añadió validación numérica en los eventos `input` y el cálculo de totales para ambos campos de cartones gratis. (Archivos modificados: `public/nuevosorteo.html`, `public/editarsorte.html`)
- Lógica servidor/cliente (segundo lugar): en `public/cantarsorteos.html` se incorporaron utilidades para leer/normalizar el nuevo valor de segundo lugar desde la metadata de las formas, funciones para detectar cartones que estuvieron a un solo acierto (`obtenerCartonesSegundoLugar`, `obtenerCartonesSegundoLugarPorForma`) y la nueva lógica de acreditación automática en Firestore (`acreditarPremioSegundoLugar`, `procesarPremiosSegundoLugar`), que crea registros en `PremiosSorteos`, actualiza la colección `Billetera` y registra una transacción. También se integró el procesamiento de segundos lugares en el flujo que reacciona a nuevos ganadores. (Archivo modificado: `public/cantarsorteos.html`)
- Mensajes y UX en juego: en `public/juegoactivo.html` se añadieron dos modales y estilos llamativos: uno para notificar a jugadores que no ganaron cuando se canta la última bolita (`modal-sin-premio`) y otro para notificar a ganadores de segundo lugar (`modal-segundo-lugar`); se implementaron las funciones de control (`mostrarModalSinPremio`, `mostrarModalSegundoLugar`, cierre/handlers) y la lógica que decide cuándo mostrarlos (`evaluarMensajeSinPremio`, `evaluarMensajesSegundoLugar`) integradas en el flujo de cálculo de ganadores, con protecciones para evitar notificaciones duplicadas. También se preservó la lógica de celebración normal. (Archivo modificado: `public/juegoactivo.html`)
- Persistencia / compatibilidad: `saveState` / `loadState` en formularios de nuevo/editar sorteo ahora guardan/cargan `cartones2` y el código que construye/actualiza documentos de `formas` incluye el nuevo campo; se agregaron claves de compatibilidad para leer variantes (`cartonesGratis2`, `premioCartonesGratis2`, etc.). (Archivos modificados: `public/nuevosorteo.html`, `public/editarsorte.html`, `public/cantarsorteos.html`, `public/juegoactivo.html`)

### Testing
- Smoke: se ejecutó un commit de los cambios y se verificó el árbol de archivos modificados con `git status` y `git diff --stat`, ambos completaron correctamente; esto confirma que los parches fueron aplicados y versionados (éxito).
- Servidor estático: levanté un servidor HTTP simple (`python -m http.server 8000`) para poder inspeccionar las páginas localmente (éxito del servidor), pero la captura de pantalla automática con Playwright falló por un crash del motor headless en el entorno (error de lanzamiento de Chromium), por lo que no se generó la imagen (falla en Playwright, no en el código fuente).
- Comprobaciones estáticas: se hicieron búsquedas de referencias (`rg`) para asegurar que los nuevos selectores y funciones fueron integrados donde corresponde (éxito).

Nota: No se ejecutaron pruebas unitarias automatizadas sobre la lógica de Firestore (no había tests previos específicos); la implementación intenta seguir las convenciones existentes de la app y mantiene las funciones previas para minimizar riesgos. Si quieres, puedo preparar pasos de prueba manual guiados o agregar pruebas locales para las nuevas funciones antes de crear el PR oficial en GitHub.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978de548dcc8326b09a40f3bfea5039)