### PR TITLE
Actualizar estilos de referidos y año dinámico en footer

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -1689,7 +1689,7 @@
   <div id="mensaje-area">Selecciona un sorteo para administrar su estado.</div>
   <div id="footer">
     <div id="fecha-hora"></div>
-    <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
+    <div id="derechos">Todos los derechos reservados ® Hexaservice <span class="current-year"></span></div>
   </div>
   <div id="sorteos-modal" class="modal" onclick="this.style.display='none'">
     <div class="modal-content" onclick="event.stopPropagation();">

--- a/public/index.html
+++ b/public/index.html
@@ -107,7 +107,7 @@
   </div>
   <div id="login-footer">
     <div id="fecha-hora"></div>
-    <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
+    <div id="derechos">Todos los derechos reservados ® Hexaservice <span class="current-year"></span></div>
   </div>
 
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>

--- a/public/js/timezone.js
+++ b/public/js/timezone.js
@@ -358,3 +358,17 @@ serverTime.serverTimestamp = function () {
   }
   return null;
 };
+
+function actualizarAnioFooter() {
+  const yearEl = document.querySelector('#derechos .current-year');
+  if (!yearEl) return;
+  yearEl.textContent = new Date().getFullYear();
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', actualizarAnioFooter);
+  } else {
+    actualizarAnioFooter();
+  }
+}

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4182,7 +4182,7 @@
 
   <div id="login-footer">
     <div id="fecha-hora"></div>
-    <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
+    <div id="derechos">Todos los derechos reservados ® Hexaservice <span class="current-year"></span></div>
   </div>
 
   <div id="modal-ganadores" class="modal">

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -840,7 +840,7 @@
     <button id="jugar-carton-btn" class="action-btn">JUGAR CARTÓN</button>
   </section>
   <div id="fecha-hora"></div>
-  <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
+  <div id="derechos">Todos los derechos reservados ® Hexaservice <span class="current-year"></span></div>
   <div id="number-modal" class="modal" onclick="this.style.display='none'">
     <div id="number-modal-content" class="modal-content" onclick="event.stopPropagation();">
       <div id="number-modal-title">Elige tu jugada</div>

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -488,7 +488,7 @@
   </div>
 
   <div id="fecha-hora"></div>
-  <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
+  <div id="derechos">Todos los derechos reservados ® Hexaservice <span class="current-year"></span></div>
 
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>

--- a/public/player.html
+++ b/public/player.html
@@ -350,6 +350,9 @@
       .menu-opcion--referidos.referidos-activa .menu-label--referidos {
           animation: pulso-referidos 1.4s ease-in-out infinite;
       }
+      .menu-opcion--referidos.referidos-activa .menu-label--referidos-sub {
+          animation: pulso-referidos 1.4s ease-in-out infinite;
+      }
       .menu-imagen:focus,
       .menu-imagen:hover {
           transform: scale(1.04);
@@ -392,9 +395,10 @@
       }
       .menu-label--referidos-sub {
           font-size: clamp(0.55rem, 1.5vw, 0.75rem);
+          font-family: 'Poppins', sans-serif;
           font-weight: 700;
           color: #ffffff;
-          text-shadow: 0 0 8px rgba(0, 128, 0, 0.85), 0 0 14px rgba(0, 200, 0, 0.9);
+          text-shadow: 0 0 6px rgba(0, 0, 0, 0.85), 0 0 12px rgba(0, 0, 0, 0.75);
           display: block;
           margin-top: -4px;
       }
@@ -873,7 +877,7 @@
   </div>
 
   <div id="fecha-hora"></div>
-  <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
+  <div id="derechos">Todos los derechos reservados ® Hexaservice <span class="current-year"></span></div>
 
   <div id="audio-control-player" class="audio-control audio-control--right">
     <div class="audio-control__volume" hidden aria-hidden="true">

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -160,7 +160,7 @@
   <button id="cancelar" class="action-btn">Cancelar</button>
   <div id="login-footer">
     <div id="fecha-hora"></div>
-    <div id="derechos">Todos los derechos reservados ® Hexaservice 2025</div>
+    <div id="derechos">Todos los derechos reservados ® Hexaservice <span class="current-year"></span></div>
   </div>
 
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>


### PR DESCRIPTION
### Motivation
- Aplicar el nuevo estilo solicitado para la etiqueta bajo "CARTONES GRATIS" usando la fuente Poppins en negrita, color blanco y resplandor negro, y animación de acercar/alejar solo cuando hay campaña activa. 
- Hacer que el año en la última línea del footer se actualice automáticamente en todas las pantallas de la app para evitar revisiones manuales cada año.

### Description
- Cambios CSS en `public/player.html`: la subetiqueta de referidos (`.menu-label--referidos-sub`) ahora usa `font-family: 'Poppins', sans-serif`, `font-weight: 700`, color blanco y `text-shadow` en tonos negros para el resplandor, y se añadió que la animación `pulso-referidos` se aplique a esa subetiqueta solo cuando el contenedor tenga la clase `referidos-activa`.
- Se actualizó la estructura del footer en todas las pantallas reemplazando el año fijo por ` <span class="current-year"></span>` en los archivos `public/index.html`, `public/registrarse.html`, `public/perfil.html`, `public/jugarcartones.html`, `public/juegoactivo.html`, `public/cantarsorteos.html` y `public/player.html`.
- Se añadió la función `actualizarAnioFooter()` en `public/js/timezone.js` que escribe `new Date().getFullYear()` en los elementos `#derechos .current-year` al `DOMContentLoaded` para mantener el año actualizado automáticamente.

### Testing
- Se levantó un servidor estático (`python -m http.server 8000`) y se cargó `player.html` para verificar visualmente los cambios; se ejecutó un script con Playwright para tomar una captura de pantalla de `player.html` (artifact: `artifacts/player-referidos.png`) y la captura se generó correctamente.
- Se verificó por búsqueda que los footers de las pantallas listadas contienen la nueva `span.current-year` y que la función `actualizarAnioFooter` está presente en `public/js/timezone.js`.
- No se ejecutaron pruebas unitarias automatizadas sobre el código; las comprobaciones realizadas (servidor estático + captura) concluyeron con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ef099be483268ab954e1157681de)