### PR TITLE
Mejorar flujo de registro: botones Google/Apple, validaciones y manejo de cuenta existente

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,4 +1,4 @@
-let app, auth, db, provider, appName = 'BingOnline';
+let app, auth, db, provider, appleProvider, appName = 'BingOnline';
 const DISABLED_MSG = "Tu cuenta ha sido deshabilitada, Motivado posiblemente a que has incumplido una o más clausulas en nuestros Terminos y condiciones. Contacta con un administrador del sistema si necesitas información.";
 let firebaseInitPromise = null;
 let firebaseConfigLoadPromise = null;
@@ -73,6 +73,9 @@ async function initFirebase(){
     auth = firebase.auth();
     provider = new firebase.auth.GoogleAuthProvider();
     provider.setCustomParameters({ prompt: 'select_account' });
+    appleProvider = new firebase.auth.OAuthProvider('apple.com');
+    appleProvider.addScope('email');
+    appleProvider.addScope('name');
     await auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL);
     return app;
   })();
@@ -293,6 +296,37 @@ async function loginGoogle(){
       } else {
         console.error('Error login Google', e);
         alert('Error al iniciar sesión con Google');
+      }
+    }
+  }
+}
+
+async function loginApple(){
+  try {
+    await initFirebase();
+  } catch(initErr){
+    console.error('No se pudo inicializar Firebase', initErr);
+    alert('Error de inicialización de Firebase');
+    return;
+  }
+  try{
+    await auth.signInWithPopup(appleProvider);
+  }catch(err){
+    if (err.code === 'auth/user-disabled') {
+      alert(DISABLED_MSG);
+      return;
+    }
+    console.warn('Popup login failed, trying redirect', err);
+    try{
+      await auth.signInWithRedirect(appleProvider);
+    }catch(e){
+      if (e.code === 'auth/user-disabled') {
+        alert(DISABLED_MSG);
+      } else if (e.code === 'auth/web-storage-unsupported') {
+        alert('El navegador ha bloqueado las cookies necesarias para continuar. Intenta habilitarlas o abre la aplicación desde un dominio configurado en Firebase.');
+      } else {
+        console.error('Error login Apple', e);
+        alert('Error al iniciar sesión con Apple');
       }
     }
   }

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -58,6 +58,33 @@
       color:#006400;
       font-family:'Poppins',sans-serif;
     }
+    .provider-row{
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap:10px;
+      margin:4px 0 12px;
+    }
+    .provider-btn{
+      border:2px solid #d1d5db;
+      border-radius:10px;
+      background:#fff;
+      padding:6px 12px;
+      display:flex;
+      align-items:center;
+      gap:6px;
+      cursor:pointer;
+      font-family:'Poppins',sans-serif;
+      font-weight:600;
+      font-size:0.85rem;
+      color:#111827;
+      box-shadow:0 2px 6px rgba(0,0,0,0.12);
+    }
+    .provider-btn svg{
+      width:18px;
+      height:18px;
+      display:block;
+    }
     #logo-bingo{width:200px;max-width:80vw;height:auto;margin-bottom:5px;}
     .action-btn{
       font-family:'Bangers',cursive;
@@ -75,7 +102,14 @@
       justify-content:center;
       margin:5px auto;
     }
-    #cancelar{background:linear-gradient(orange,#ffffff);}
+    .action-btn[disabled]{
+      background:linear-gradient(#9ca3af,#e5e7eb);
+      border-color:#9ca3af;
+      color:#f9fafb;
+      cursor:not-allowed;
+      filter:grayscale(1);
+      box-shadow:none;
+    }
     #terms-container{margin:10px;font-size:0.8rem;display:flex;align-items:center;justify-content:center;gap:5px;font-family:'Poppins',sans-serif;}
     #terms-container label{display:flex;align-items:center;gap:4px;font-family:'Poppins',sans-serif;}
     #terms-container a{font-family:'Poppins',sans-serif;}
@@ -153,11 +187,28 @@
   </div>
   <p class="nota-registro">Nota: Sólo tu Alias será visible para los otros Jugadores, Tu nombre, Apellido, Número celular o Gmail serán confidenciales.</p>
   <div id="email"></div>
+  <div class="provider-row" aria-label="Métodos de inicio de sesión">
+    <button id="login-google" class="provider-btn" type="button" aria-label="Continuar con Google">
+      <svg viewBox="0 0 48 48" aria-hidden="true">
+        <path fill="#EA4335" d="M24 9.5c3.33 0 6.26 1.15 8.6 3.05l6.4-6.4C35.1 2.55 29.9 0 24 0 14.6 0 6.5 5.4 2.7 13.3l7.4 5.7C12 13 17.6 9.5 24 9.5z"/>
+        <path fill="#4285F4" d="M46.1 24.5c0-1.6-.14-2.7-.46-3.9H24v7.4h12.8c-.26 2-1.67 5-4.8 7l7.3 5.6c4.3-4 6.8-9.9 6.8-16.1z"/>
+        <path fill="#FBBC05" d="M10.1 28.9c-.4-1.2-.6-2.5-.6-3.9s.2-2.7.6-3.9l-7.4-5.7C.9 18.5 0 21.1 0 24s.9 5.5 2.7 8.6l7.4-5.7z"/>
+        <path fill="#34A853" d="M24 48c6.5 0 12-2.1 16-5.8l-7.3-5.6c-2 1.4-4.7 2.4-8.7 2.4-6.4 0-12-3.5-13.9-8.6l-7.4 5.7C6.5 42.6 14.6 48 24 48z"/>
+      </svg>
+      Google
+    </button>
+    <button id="login-apple" class="provider-btn" type="button" aria-label="Continuar con Apple">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="#111827" d="M16.6 13.4c0 2.3 2 3.1 2 3.1s-1 3-2.6 3c-1.4 0-1.9-1-3.6-1-1.6 0-2.1 1-3.6 1-1.7 0-2.9-3-2.9-3s2.1-.8 2.1-3.1c0-2.1-1.4-3.1-1.4-4.6 0-1.9 1.5-3.1 3-3.1 1.4 0 2.1 1 3.6 1 1.4 0 2.1-1 3.6-1 1.5 0 3 1.2 3 3.1 0 1.5-1.4 2.5-1.4 4.6z"/>
+        <path fill="#111827" d="M14.5 4.4c.6-.7 1-1.7.9-2.7-.9.1-2 .7-2.6 1.4-.6.7-1 1.7-.9 2.7.9.1 2-.6 2.6-1.4z"/>
+      </svg>
+      Apple
+    </button>
+  </div>
   <div class="small-label">CÓDIGO REFERIDO</div>
   <input type="text" id="codigo-referido" placeholder="Opcional" maxlength="12" style="text-transform:uppercase;">
   <div id="terms-container"><input type="checkbox" id="accept-terms"> <label for="accept-terms">Acepto <a href="terminos.html" target="_blank">términos y condiciones</a></label></div>
-  <button id="registrar" class="action-btn">Registrarse</button>
-  <button id="cancelar" class="action-btn">Cancelar</button>
+  <button id="registrar" class="action-btn" disabled>Registrarse</button>
   <div id="login-footer">
     <div id="fecha-hora"></div>
     <div id="derechos">Todos los derechos reservados ® Hexaservice <span class="current-year"></span></div>
@@ -322,6 +373,8 @@
     poblarSelectCodigos(selectCodigoPais);
     const REGISTRO_PENDIENTE_KEY = 'registroPendienteBingoOnline';
     let registroEnProceso = false;
+    const registrarBtn = document.getElementById('registrar');
+    const emailLabel = document.getElementById('email');
 
     function obtenerDatosFormulario(){
       return {
@@ -383,6 +436,10 @@
       if(datos.alias.length>60){ alert('Alias inválido'); document.getElementById('alias').focus(); return null; }
       if(!datos.codigoPais){ alert('Debes elegir un código de país'); selectCodigoPais.focus(); return null; }
       if(!datos.celularLocal){ alert('Debes agregar tu número celular'); document.getElementById('celular').focus(); return null; }
+      if(!auth?.currentUser?.email){
+        alert('Debes seleccionar una cuenta de Google o Apple antes de registrarte.');
+        return null;
+      }
       if(!datos.aceptoTerminos){
         alert('Para poder registrarte debes aceptar nuestros terminos y condiciones');
         return null;
@@ -394,6 +451,14 @@
       if(registroEnProceso) return;
       registroEnProceso = true;
       try{
+        const existente = await db.collection('users').doc(user.email).get();
+        if(existente.exists){
+          mostrarToast('Esta cuenta ya esta registrada, se procede con el inicio de sesión');
+          limpiarRegistroPendiente();
+          await new Promise(resolve => setTimeout(resolve, 1400));
+          window.location.href='player.html';
+          return;
+        }
         const nombre = datos.nombre;
         const apellido = datos.apellido;
         const alias = datos.alias;
@@ -465,6 +530,8 @@
         const doc = await db.collection('users').doc(user.email).get();
         if(doc.exists){
           limpiarRegistroPendiente();
+          mostrarToast('Esta cuenta ya esta registrada, se procede con el inicio de sesión');
+          await new Promise(resolve => setTimeout(resolve, 1400));
           window.location.href='player.html';
           return true;
         }
@@ -491,10 +558,12 @@
       }
       auth.onAuthStateChanged(async user=>{
         if(!user){
-          document.getElementById('email').textContent = 'Inicia sesión con Google para completar el registro.';
+          emailLabel.textContent = 'Selecciona una cuenta de Google o Apple para completar el registro.';
+          actualizarEstadoRegistro();
           return;
         }
-        document.getElementById('email').textContent = user.email || '';
+        emailLabel.textContent = user.email || '';
+        actualizarEstadoRegistro();
         const pendienteProcesado = await completarRegistroPendiente(user);
         if(pendienteProcesado){
           return;
@@ -518,6 +587,7 @@
         }catch(loadErr){
           console.error('No se pudieron cargar datos previos del usuario', loadErr);
         }
+        actualizarEstadoRegistro();
       });
     })();
     function validarTexto(txt,max){
@@ -534,18 +604,51 @@
         codigoReferidoInputEl.value = codigoParam;
       }
     }
+    const camposMonitorear = ['nombre','apellido','alias','celular','accept-terms'];
+    camposMonitorear.forEach(id=>{
+      const el = document.getElementById(id);
+      if(el){
+        const evt = id === 'accept-terms' ? 'change' : 'input';
+        el.addEventListener(evt, actualizarEstadoRegistro);
+      }
+    });
+    if(selectCodigoPais){
+      selectCodigoPais.addEventListener('change', actualizarEstadoRegistro);
+    }
+    async function iniciarLoginConProveedor(tipo){
+      guardarRegistroPendiente(obtenerDatosFormulario());
+      if(auth?.currentUser){
+        await auth.signOut();
+      }
+      if(tipo === 'google'){
+        await loginGoogle();
+        return;
+      }
+      await loginApple();
+    }
+    document.getElementById('login-google').addEventListener('click', ()=>iniciarLoginConProveedor('google'));
+    document.getElementById('login-apple').addEventListener('click', ()=>iniciarLoginConProveedor('apple'));
     document.getElementById('registrar').addEventListener('click', async ()=>{
       const datos = validarFormulario();
       if(!datos) return;
       const user = auth.currentUser;
       if(!user){
-        guardarRegistroPendiente(datos);
-        await loginGoogle();
+        mostrarToast('Selecciona una cuenta de Google o Apple para continuar.');
         return;
       }
       await completarRegistroConDatos(user, datos);
     });
-    document.getElementById('cancelar').addEventListener('click', ()=>{ window.location.href='index.html'; });
+    function actualizarEstadoRegistro(){
+      const datos = obtenerDatosFormulario();
+      const requisitos = !!datos.nombre
+        && !!datos.apellido
+        && !!datos.alias
+        && !!datos.codigoPais
+        && !!datos.celularLocal
+        && !!datos.aceptoTerminos
+        && !!auth?.currentUser?.email;
+      registrarBtn.disabled = !requisitos;
+    }
     initFechaHora('fecha-hora');
   </script>
 </body>


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia de registro mostrando botones de selección de cuenta (Google y Apple), forzar elección de una sola cuenta y mantener las validaciones y la lógica actual de códigos referidos.
- Evitar confusión al eliminar el botón `CANCELAR` y deshabilitar `Registrarse` hasta que todos los requisitos estén completos.
- Detectar cuentas ya registradas y proceder automáticamente al inicio de sesión mostrando un aviso rápido al usuario.

### Description
- Interfaz: agrega una fila de proveedores con botones inline para Google y Apple (`#login-google`, `#login-apple`) y estilos asociados en `public/registrarse.html`.
- Quita el botón `Cancelar` y cambia el botón `Registrarse` para iniciarse deshabilitado (`disabled`) y con estilo en escala de grises cuando no cumple requisitos.
- Validaciones: el formulario ahora verifica además que exista una cuenta autenticada (`auth.currentUser.email`) antes de permitir el registro y muestra mensajes apropiados; el control de habilitado del botón se implementa en la función `actualizarEstadoRegistro`.
- Flujo de autenticación: agrega soporte de Firebase Apple OAuth en `public/js/auth.js` creando `appleProvider` y nueva función `loginApple()` que intenta `signInWithPopup` y cae a `signInWithRedirect` si es necesario.
- Manejo de cuenta existente: antes de crear el documento `users`, se verifica si ya existe la cuenta; en ese caso se muestra un toast con el texto "Esta cuenta ya esta registrada, se procede con el inicio de sesión" y se redirige a `player.html` automáticamente.
- Preserva la lógica existente de códigos promocionales/referidos y la actualización de billeteras y notificaciones ya implementadas.

### Testing
- Levanté un servidor estático local con `python -m http.server 8000` en `public` y cargué `registrarse.html` con Playwright para verificar la interfaz y la presencia de los nuevos botones; la captura de pantalla se generó correctamente (artifacts/registrarse.png), prueba exitosa.
- No se ejecutaron tests unitarios automatizados adicionales; no se detectaron errores en la ejecución manual/visual realizada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a51e42ac883268cb6e9afe93d8881)