### PR TITLE
Esperar acción explícita del usuario antes de completar el registro

### DIFF
--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -523,26 +523,6 @@
       }
     }
 
-    async function completarRegistroPendiente(user){
-      const datos = cargarRegistroPendiente();
-      if(!datos) return false;
-      try{
-        const doc = await db.collection('users').doc(user.email).get();
-        if(doc.exists){
-          limpiarRegistroPendiente();
-          mostrarToast('Esta cuenta ya esta registrada, se procede con el inicio de sesión');
-          await new Promise(resolve => setTimeout(resolve, 1400));
-          window.location.href='player.html';
-          return true;
-        }
-      }catch(err){
-        console.error('No se pudo validar el estado del registro pendiente', err);
-      }
-      aplicarDatosFormulario(datos);
-      await completarRegistroConDatos(user, datos);
-      return true;
-    }
-
     (async()=>{
       try{
         await initFirebase();
@@ -564,9 +544,10 @@
         }
         emailLabel.textContent = user.email || '';
         actualizarEstadoRegistro();
-        const pendienteProcesado = await completarRegistroPendiente(user);
-        if(pendienteProcesado){
-          return;
+        const datosPendientes = cargarRegistroPendiente();
+        if(datosPendientes){
+          aplicarDatosFormulario(datosPendientes);
+          actualizarEstadoRegistro();
         }
         try{
           const doc = await db.collection('users').doc(user.email).get();


### PR DESCRIPTION
### Motivation
- Evitar que el registro pendiente se envíe automáticamente tras la elección de proveedor (Google/Apple) y asegurar que el usuario acepte términos y presione `Registrarse` antes de crear la cuenta.

### Description
- Se modificó `public/registrarse.html` para eliminar el envío automático de registros pendientes y ya no llamar a la función que completaba el registro tras el login del proveedor.
- Ahora, cuando cambia el estado de autenticación, si existe un `registroPendiente` solo se aplican los datos para precargar el formulario y se actualiza el estado de la UI sin realizar el envío automático.
- Se mantiene la lógica que guarda el formulario en `sessionStorage` al iniciar login con proveedor y la validación que habilita el botón `Registrarse` cuando se cumplen los requisitos.
- Archivo afectado: `public/registrarse.html` (prefill en `auth.onAuthStateChanged`, eliminación de `completarRegistroPendiente`).

### Testing
- No se ejecutaron pruebas automatizadas en este cambio (ninguna corrida).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a57dbd06483268eec22332f79847f)