### PR TITLE
Ajustar márgenes de escritorio con hoja de estilo compartida

### DIFF
--- a/public/accederusuario.html
+++ b/public/accederusuario.html
@@ -114,6 +114,7 @@
       height: 40px;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" alt="logo" />

--- a/public/admin.html
+++ b/public/admin.html
@@ -144,6 +144,7 @@
     }
     #salir-super-btn { background: red; border:4px solid orange; }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" alt="logo" />

--- a/public/billetera.html
+++ b/public/billetera.html
@@ -418,6 +418,7 @@
     @keyframes tutorial-nav-exit { 0% { transform: translateX(0); opacity: 1; } 100% { transform: translateX(-16px); opacity: 0; } }
     @keyframes pestaña-respira { 0% { transform: scale(1); } 50% { transform: scale(1.06); } 100% { transform: scale(1); } }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <div id="session-info" style="display:none;">

--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -1503,6 +1503,7 @@
     }
     #footer #derechos { font-size: 0.6rem; }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="salir-btn" class="menu-btn"><span class="tri">&#9664;</span><span class="label">Salir</span></button>

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -505,6 +505,7 @@
     }
     @media (orientation: landscape) { table { font-size: 0.9rem; } }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true"><span class="icon">&#9664;</span><span class="label">Volver</span></button>

--- a/public/collab.html
+++ b/public/collab.html
@@ -137,6 +137,7 @@
     }
     #salir-super-btn { background: red; border:4px solid orange; }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" alt="logo" />

--- a/public/configcollab.html
+++ b/public/configcollab.html
@@ -357,6 +357,7 @@
       outline-offset: 2px;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true">&#9664; Volver</button>

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -947,6 +947,7 @@
       outline-offset: 2px;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true">&#9664; Volver</button>

--- a/public/css/desktopFrame.css
+++ b/public/css/desktopFrame.css
@@ -1,0 +1,15 @@
+:root {
+  --app-desktop-max-width: 520px;
+}
+
+@media (min-width: 1024px) {
+  body {
+    --app-desktop-side-padding: max(16px, calc((100vw - var(--app-desktop-max-width)) / 2));
+    padding-inline: var(--app-desktop-side-padding);
+    box-sizing: border-box;
+  }
+
+  .back-btn {
+    left: max(8px, calc((100vw - var(--app-desktop-max-width)) / 2 + 8px));
+  }
+}

--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -230,6 +230,7 @@
       margin:5px auto;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true"><span class="icon">&#9664;</span><span class="label">Volver</span></button>

--- a/public/gestionarusuarios.html
+++ b/public/gestionarusuarios.html
@@ -178,6 +178,7 @@
     input:checked + .slider{background-color:#4caf50;}
     input:checked + .slider:before{transform:translateX(18px);}
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <h2>Gestionar Usuarios</h2>

--- a/public/gestionreferidos.html
+++ b/public/gestionreferidos.html
@@ -181,6 +181,7 @@
       font-weight: bold;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true">&#9664; Volver</button>

--- a/public/gestionsorteos.html
+++ b/public/gestionsorteos.html
@@ -177,6 +177,7 @@
     .modal-box .forma-detalle { margin-bottom:8px; }
     .modal-box button { margin-top:10px; }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true">&#9664; Volver</button>

--- a/public/index.html
+++ b/public/index.html
@@ -98,6 +98,7 @@
       font-family: 'Poppins', sans-serif;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <div id="login-container">

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4087,6 +4087,7 @@
             }
         }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" aria-label="Volver" data-compact-back="true">&#9664;</button>

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -768,6 +768,7 @@
       .datos-sorteo,#alias-section,.carton-box{max-width:560px;width:100%;}
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true"><span class="tri">&#9664;</span><span class="label">Volver</span></button>

--- a/public/nuevacampana.html
+++ b/public/nuevacampana.html
@@ -150,6 +150,7 @@
       #volver-btn .label{display:none;}
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true"><span class="icon">&#9664;</span><span class="label">Volver</span></button>

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -230,6 +230,7 @@
       margin:5px auto;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true"><span class="icon">&#9664;</span><span class="label">Volver</span></button>

--- a/public/pagoscollab.html
+++ b/public/pagoscollab.html
@@ -385,6 +385,7 @@
       .menu-btn.back-btn > * { display: none; }
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true">&#9664; Volver</button>

--- a/public/parametros.html
+++ b/public/parametros.html
@@ -198,6 +198,7 @@
       font-size: 0.85rem;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true">&#9664; Volver</button>

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1315,6 +1315,7 @@
       font-size: 1.25em;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <div id="loading-overlay">

--- a/public/pdfsorteo.html
+++ b/public/pdfsorteo.html
@@ -1049,6 +1049,7 @@
       font-size: 1.25em;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <div id="loading-overlay">

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -425,6 +425,7 @@
           }
       }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <div id="session-info" style="display:none;">

--- a/public/player.html
+++ b/public/player.html
@@ -775,6 +775,7 @@
           box-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
       }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <div id="terms-container" style="display:none;">

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -174,6 +174,7 @@
       transform:translateX(-50%) translateY(-8px);
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" />

--- a/public/reportes.html
+++ b/public/reportes.html
@@ -212,6 +212,7 @@
       .data-card { font-size: 0.88rem; }
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-super" class="menu-btn back-btn" data-compact-back="true">&#9664; Volver</button>

--- a/public/sorteosellado.html
+++ b/public/sorteosellado.html
@@ -43,6 +43,7 @@
     .mini-carton-wrapper.gratis .mini-carton th{background:radial-gradient(circle,#ffffff,#ffffff 60%,#0000ff);}
     @media (orientation:landscape){#cartones-container{justify-content:flex-start;}}
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <h1 id="titulo"></h1>

--- a/public/super.html
+++ b/public/super.html
@@ -175,6 +175,7 @@
       gap:5px;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" alt="logo" />

--- a/public/terminos.html
+++ b/public/terminos.html
@@ -39,6 +39,7 @@
       gap:5px;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
 <button id="volver-btn" class="back-btn" data-compact-back="true">&#9664; Volver</button>

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -77,6 +77,7 @@
       border-right:8px solid transparent;
     }
   </style>
+  <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true"><span class="icon">&#9664;</span><span class="label">Volver</span></button>


### PR DESCRIPTION
### Motivation
- Centrar y limitar el ancho visual de la app cuando se ve en navegadores de PC para simular la vista vertical de un móvil de buena resolución y que los elementos se vean más centrados y ajustados.
- Mantener intactas las vistas móviles y la funcionalidad actual evitando cambios en estilos para pantallas pequeñas.

### Description
- Se agregó la hoja de estilos `public/css/desktopFrame.css` que define `--app-desktop-max-width` y aplica `padding-inline` en pantallas grandes mediante `@media (min-width: 1024px)` para centrar el contenido y mantener el box-sizing adecuado.
- La hoja ajusta también la posición del botón `.back-btn` en escritorio para que respete el margen centralizado.
- Se vinculó la nueva hoja de estilo en las páginas públicas relevantes (aprox. 29 archivos en `public/*.html`) insertando `<link rel="stylesheet" href="css/desktopFrame.css">` dentro de cada `</head>` para aplicar el ajuste en todas las vistas de escritorio.

### Testing
- Se inició un servidor HTTP local con `python -m http.server 8000` en `public/` para servir las páginas y verificar que el archivo CSS era accesible, lo que funcionó correctamente.
- Se intentó generar una captura de pantalla con Playwright para validación visual, pero el navegador headless falló al iniciarse en el entorno y la prueba de captura falló.
- No se ejecutaron pruebas unitarias automáticas; los cambios están limitados a una hoja CSS y la inclusión en HTML, y la regla de medios está restringida a pantallas >=1024px para no afectar la vista móvil.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a5c4903088326bef80ca4a1c447ac)