### PR TITLE
Ajustar vista en PC para player y juego activo

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4086,6 +4086,40 @@
                 font-size: calc(var(--principal-cell-size, var(--cell-size)) * 0.64);
             }
         }
+        @media (min-width: 1024px) {
+            main {
+                max-width: var(--app-desktop-max-width, 520px);
+                margin-inline: auto;
+            }
+            #panel-superior {
+                grid-template-columns: minmax(0, 1fr);
+                grid-template-areas:
+                    "cantos"
+                    "carton"
+                    "mensaje";
+                row-gap: clamp(6px, 2.4vw, 12px);
+                column-gap: 0;
+            }
+            #cantos-panel {
+                height: auto;
+            }
+            #panel-columna-derecha {
+                margin-left: 0;
+            }
+            #carton-destacado {
+                max-width: 100%;
+            }
+            .whatsapp-flotante {
+                right: var(--app-desktop-side-padding, 18px);
+            }
+            .live-stream-toggle {
+                right: var(--app-desktop-side-padding, 18px);
+            }
+            .live-stream-window {
+                right: var(--app-desktop-side-padding, 18px);
+                --live-stream-max-gap: max(12px, var(--app-desktop-side-padding, 16px));
+            }
+        }
   </style>
   <link rel="stylesheet" href="css/desktopFrame.css">
 </head>

--- a/public/player.html
+++ b/public/player.html
@@ -517,6 +517,29 @@
               padding-inline: clamp(40px, 16vw, 160px);
           }
       }
+      @media (min-width: 1024px) {
+          #main-menu,
+          #login-container,
+          #terms-container,
+          #register-container,
+          #carton-screen {
+              width: 100%;
+              max-width: var(--app-desktop-max-width, 520px);
+              margin-inline: auto;
+          }
+          #menu-buttons {
+              width: 100%;
+          }
+          #menu-tabla-wrapper {
+              padding-inline: 0;
+          }
+          #session-info {
+              right: var(--app-desktop-side-padding, 10px);
+          }
+          #tutorial-controls {
+              left: var(--app-desktop-side-padding, 14px);
+          }
+      }
       @media (max-width: 480px) {
           #session-info {
               flex-wrap: wrap;


### PR DESCRIPTION
### Motivation
- Centrar en pantallas de escritorio las vistas que deben verse como si fueran verticales de móvil para `player.html` y `juegoactivo.html`, manteniendo intactas las vistas móviles y la funcionalidad existente.

### Description
- Se añadió un `@media (min-width: 1024px)` en `public/player.html` para limitar el ancho de los contenedores principales (`#main-menu`, `#login-container`, `#terms-container`, `#register-container`, `#carton-screen`) a `--app-desktop-max-width` y centrar con `margin-inline: auto`.
- Se ajustaron en `player.html` el `#menu-buttons`, `#menu-tabla-wrapper` y la posición de elementos fijos como `#session-info` y `#tutorial-controls` para alinearlos al marco centralizado.
- Se añadió un `@media (min-width: 1024px)` en `public/juegoactivo.html` para forzar el layout vertical del panel superior convirtiendo `#panel-superior` en una sola columna (áreas `cantos`, `carton`, `mensaje`) y para adaptar `#carton-destacado` y `#cantos-panel` a una presentación centrada.
- Se alinearon los elementos flotantes (`.whatsapp-flotante`, `.live-stream-toggle`, `.live-stream-window`) usando `var(--app-desktop-side-padding)` para que se ubiquen respecto al marco centrado en desktop.

### Testing
- Levanté un servidor local con `python -m http.server 8000` y verifiqué visualmente ambas páginas abriendo `http://localhost:8000/player.html` y `http://localhost:8000/juegoactivo.html` mediante un script de Playwright que generó capturas (`artifacts/player-desktop.png` y `artifacts/juegoactivo-desktop.png`), las cuales se generaron correctamente.
- No se modificó código funcional ni pruebas unitarias, por lo que no se ejecutaron tests unitarios adicionales y los cambios son únicamente de estilos y maquetado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a601095dc83269744965e8d95292e)