### PR TITLE
Ajustar vista de escritorio para simular vista vertical de móvil en Juego Activo y Menú Jugador

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4092,13 +4092,15 @@
                 margin-inline: auto;
             }
             #panel-superior {
-                grid-template-columns: minmax(0, 1fr);
+                grid-template-columns: minmax(calc(var(--canto-cell-size) * 5 + clamp(6px, 2vw, 16px) * 2), 1fr) minmax(var(--panel-columna-derecha-min, clamp(180px, 48vw, 420px)), clamp(240px, 68vw, 520px));
                 grid-template-areas:
-                    "cantos"
-                    "carton"
-                    "mensaje";
-                row-gap: clamp(6px, 2.4vw, 12px);
-                column-gap: 0;
+                    "cantos carton"
+                    "mensaje carton";
+                align-items: stretch;
+                justify-items: stretch;
+                column-gap: clamp(6px, 2vw, 16px);
+                row-gap: clamp(6px, 2vw, 16px);
+                padding-bottom: 0;
             }
             #cantos-panel {
                 height: auto;
@@ -4107,7 +4109,8 @@
                 margin-left: 0;
             }
             #carton-destacado {
-                max-width: 100%;
+                max-width: none;
+                justify-self: stretch;
             }
             .whatsapp-flotante {
                 right: var(--app-desktop-side-padding, 18px);

--- a/public/player.html
+++ b/public/player.html
@@ -528,6 +528,16 @@
               margin-inline: auto;
           }
           #menu-buttons {
+              gap: clamp(0px, 0.6vh, 6px);
+          }
+          #menu-buttons h3 {
+              font-size: clamp(1.3rem, 2vw, 1.7rem);
+              margin: clamp(-10px, -1.6vh, -4px) 0 clamp(2px, 0.4vh, 6px);
+          }
+          #menu-logo {
+              width: clamp(190px, 28vw, 240px);
+          }
+          #menu-buttons {
               width: 100%;
           }
           #menu-tabla-wrapper {


### PR DESCRIPTION
### Motivation
- Mejorar la vista en PCs para que simule la disposición vertical de móvil: tablas de cantos alineadas a la izquierda y cartón / publicidad a la derecha, y compactar el Menú Jugador en escritorios sin romper las vistas móviles actuales.

### Description
- Actualiza `public/juegoactivo.html` en el `@media (min-width: 1024px)` para que `#panel-superior` use un layout de dos columnas (`"cantos carton"` / `"mensaje carton"`), ajuste gaps y alineamientos, y cambie `#carton-destacado` para no limitar su ancho y justificarlo correctamente en escritorio.
- Modifica `public/player.html` en el `@media (min-width: 1024px)` para reducir el ancho de `#menu-logo`, disminuir la fuente del encabezado del menú y ajustar el espaciado de `#menu-buttons` para una apariencia más compacta en escritorio.
- No se tocan las reglas de media queries para móviles/portrait existentes, para evitar romper las vistas verticales en celular.

### Testing
- Levanté un servidor HTTP simple en `public/` y generé capturas de pantalla con Playwright de `juegoactivo.html` y `player.html`; las capturas se guardaron como artefactos y la ejecución completó correctamente.
- Verifiqué que los archivos modificados (`public/juegoactivo.html`, `public/player.html`) fueron añadidos y committeados correctamente en git; el commit se realizó con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a645f4ec48326841ab9c1c8aadd18)