### PR TITLE
Mejorar modal y flujo de instalación PWA

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -635,32 +635,32 @@ function ensurePwaModalStyles(){
       display: flex;
       align-items: center;
       justify-content: center;
-      background: rgba(15, 23, 42, 0.2);
+      background: rgba(148, 163, 184, 0.2);
       z-index: 9999;
       padding: 24px;
     }
     .pwa-install-card{
       width: min(360px, 100%);
-      background: #fdf7ff;
+      background: #ffffff;
       border-radius: 18px;
-      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
-      border: 1px solid rgba(148, 163, 184, 0.35);
+      box-shadow: 0 16px 36px rgba(100, 116, 139, 0.18);
+      border: 1px solid rgba(226, 232, 240, 0.9);
       overflow: hidden;
       font-family: "Poppins", "Segoe UI", sans-serif;
       color: #1f2937;
     }
     .pwa-install-header{
-      background: linear-gradient(135deg, #dbeafe, #ede9fe);
+      background: linear-gradient(135deg, #fce7f3, #e0f2fe);
       padding: 16px 20px;
       font-size: 16px;
       font-weight: 600;
-      color: #4c1d95;
+      color: #6b21a8;
     }
     .pwa-install-body{
       padding: 16px 20px 4px;
       font-size: 14px;
       line-height: 1.5;
-      color: #334155;
+      color: #475569;
     }
     .pwa-install-body ul{
       margin: 8px 0 0 18px;
@@ -685,13 +685,13 @@ function ensurePwaModalStyles(){
       transform: scale(0.98);
     }
     .pwa-install-cancel{
-      background: #e2e8f0;
-      color: #475569;
+      background: #f1f5f9;
+      color: #64748b;
     }
     .pwa-install-confirm{
-      background: linear-gradient(135deg, #4ade80, #22c55e);
-      color: #f8fafc;
-      box-shadow: 0 8px 18px rgba(34, 197, 94, 0.35);
+      background: linear-gradient(135deg, #38bdf8, #818cf8);
+      color: #ffffff;
+      box-shadow: 0 10px 20px rgba(59, 130, 246, 0.28);
     }
   `;
   document.head.appendChild(style);
@@ -817,17 +817,37 @@ async function showIosInstallInstructions(){
   });
 }
 
+async function showAndroidInstallInstructions(){
+  await showInstallModal({
+    title: 'Instalación en Android',
+    message: 'Si el navegador no mostró la ventana de instalación, puedes agregar el acceso directo manualmente:',
+    list: [
+      'Abre el menú del navegador (tres puntos).',
+      'Selecciona "Agregar a pantalla principal".',
+      'Confirma el nombre y toca "Agregar".'
+    ],
+    confirmText: 'Entendido',
+    showCancel: false
+  });
+}
+
 async function showAndroidInstallPrompt(){
   if(!deferredInstallPrompt) return;
+  let choicePromise = null;
   const accepted = await showInstallModal({
     title: 'Bingo Online',
     message: '¿Deseas instalar Bingo Online como acceso directo?',
     confirmText: 'Instalar',
     cancelText: 'Cancelar',
     onConfirm: () => {
+      const promptEvent = deferredInstallPrompt;
+      if(!promptEvent) return;
+      deferredInstallPrompt = null;
       try{
-        deferredInstallPrompt.prompt();
+        promptEvent.prompt();
+        choicePromise = promptEvent.userChoice;
       }catch(err){
+        deferredInstallPrompt = promptEvent;
         console.warn('No se pudo lanzar el instalador de la app', err);
       }
     }
@@ -837,7 +857,11 @@ async function showAndroidInstallPrompt(){
     return;
   }
   try{
-    const choice = await deferredInstallPrompt.userChoice;
+    if(!choicePromise){
+      await showAndroidInstallInstructions();
+      return;
+    }
+    const choice = await choicePromise;
     if(choice && choice.outcome !== 'accepted'){
       dismissInstallPrompt();
     }else{
@@ -845,8 +869,8 @@ async function showAndroidInstallPrompt(){
     }
   }catch(err){
     console.warn('No se pudo completar la solicitud de instalación', err);
+    await showAndroidInstallInstructions();
   }
-  deferredInstallPrompt = null;
 }
 
 async function tryPromptPwaInstall(){


### PR DESCRIPTION
### Motivation
- Suavizar la apariencia del modal de instalación para que use colores claros y se integre con el resto de la app. 
- Arreglar el flujo que debe disparar el prompt de instalación del navegador en Android y añadir una guía de respaldo si el navegador no presenta el diálogo. 

### Description
- Cambié la paleta y sombras del modal en `ensurePwaModalStyles()` para usar tonos suaves, fondo blanco y ajustes de `box-shadow` y `border` en `public/js/auth.js`. 
- Añadí la función `showAndroidInstallInstructions()` que muestra instrucciones manuales cuando el navegador no abre el diálogo de instalación. 
- Modifiqué `showAndroidInstallPrompt()` para ejecutar `prompt()` dentro del gesto de usuario y capturar `userChoice` mediante una `choicePromise`, restaurando `deferredInstallPrompt` como fallback si ocurre un error. 
- Mejor manejo de `deferredInstallPrompt` para evitar perder el evento y ofrecer la guía alternativa cuando no sea posible completar la petición de instalación. 

### Testing
- Levanté un servidor estático con `python -m http.server 3000 --directory public` y verifiqué carga de `index.html` y `public/js/auth.js`, lo cual funcionó correctamente. 
- Ejecuté un script de Playwright que inyectó y renderizó el modal y generó la captura `artifacts/pwa-install-modal.png`, y la ejecución completó con éxito.
- No se ejecutaron pruebas unitarias adicionales en este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a71e574988326b1c5f438ab05466d)