### PR TITLE
Actualizar modal de referidos: filtrar por campaña activa y nuevo diseño móvil

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -837,89 +837,134 @@
           display: flex;
       }
       .modal-referidos .modal-contenido {
-          background: #ffffff;
-          border-radius: 20px;
-          padding: clamp(20px, 4vw, 36px);
-          width: min(720px, 95vw);
-          max-height: min(82vh, 680px);
-          box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+          position: relative;
+          background: #1a1a1a;
+          border-radius: 18px;
+          padding: clamp(18px, 4vw, 28px);
+          width: min(420px, 92vw);
+          max-width: 420px;
+          max-height: min(86vh, 720px);
+          box-shadow: 0 16px 32px rgba(0, 0, 0, 0.45);
           text-align: center;
-          border: 4px solid #ffd700;
-          overflow: auto;
+          border: 3px solid #ffd700;
+          overflow: hidden;
           box-sizing: border-box;
       }
       .modal-referidos .modal-contenido h2 {
-          font-family: 'Bangers', cursive;
-          font-size: clamp(1.6rem, 3.4vw, 2.4rem);
-          color: #0a8a2a;
-          margin-bottom: 6px;
-          text-shadow: 0 0 6px rgba(0, 128, 0, 0.7);
+          font-family: 'Poppins', sans-serif;
+          font-size: clamp(1rem, 2.5vw, 1.2rem);
+          color: #ffffff;
+          margin: 0 0 6px;
+          text-shadow: 1px 1px 0 #000000;
+      }
+      .modal-referidos-fin {
+          font-family: 'Poppins', sans-serif;
+          font-size: clamp(0.8rem, 2vw, 0.95rem);
+          color: #d3d3d3;
+          margin: 0 0 12px;
+      }
+      .modal-referidos-resumen {
+          display: grid;
+          grid-template-columns: repeat(3, minmax(0, 1fr));
+          gap: 6px 8px;
+          align-items: center;
+          justify-items: center;
+          margin-bottom: 12px;
       }
       .modal-referidos-total {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(1rem, 2.3vw, 1.3rem);
-          color: #7b2cbf;
-          margin-bottom: 18px;
+          font-size: clamp(0.78rem, 2vw, 0.95rem);
+          color: #ffffff;
+      }
+      .modal-referidos-nuevo {
+          font-family: 'Poppins', sans-serif;
+          font-size: clamp(0.78rem, 2vw, 0.95rem);
+          color: #27c93f;
+      }
+      .modal-referidos-min {
+          font-family: 'Poppins', sans-serif;
+          font-size: clamp(0.78rem, 2vw, 0.95rem);
+          color: #8b5a2b;
+      }
+      .modal-referidos-tabla-wrapper {
+          max-height: min(52vh, 420px);
+          overflow: auto;
+          border-radius: 12px;
+          background: rgba(255, 255, 255, 0.92);
+          padding: 6px;
+          box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.2);
+      }
+      .modal-referidos-tabla {
+          width: 100%;
+          border-collapse: collapse;
+          table-layout: fixed;
+          font-family: 'Poppins', sans-serif;
+          font-size: clamp(0.55rem, 1.6vw, 0.7rem);
+          color: #000;
+      }
+      .modal-referidos-tabla thead th {
+          position: sticky;
+          top: 0;
+          background: #ffffff;
+          font-weight: 700;
+          padding: 4px 2px;
+          text-align: center;
+          z-index: 1;
+      }
+      .modal-referidos-tabla td {
+          padding: 4px 2px;
+          text-align: center;
+          word-break: break-word;
+      }
+      .modal-referidos-tabla .col-numero {
+          color: #808080;
+          width: 10%;
+      }
+      .modal-referidos-tabla .col-nombre {
+          color: #000000;
+          width: 35%;
+      }
+      .modal-referidos-tabla .col-fecha {
+          color: #0a8a2a;
+          width: 35%;
+      }
+      .modal-referidos-tabla .col-premio {
+          color: #ff8c00;
+          width: 20%;
       }
       .modal-referidos-lista {
-          display: flex;
-          flex-direction: column;
-          gap: 14px;
-          text-align: left;
-      }
-      .referido-item {
-          border-bottom: 2px solid rgba(0, 128, 0, 0.15);
-          padding-bottom: 12px;
-      }
-      .referido-campana {
-          font-family: 'Bangers', cursive;
-          color: #003d7a;
-          font-size: clamp(1.05rem, 2.3vw, 1.35rem);
-          margin-bottom: 6px;
-      }
-      .referido-detalle {
-          display: flex;
-          flex-wrap: wrap;
-          gap: 10px 18px;
-          font-family: 'Poppins', sans-serif;
-          font-size: clamp(0.78rem, 1.8vw, 0.95rem);
-      }
-      .referido-nombre {
-          color: #000;
-          font-weight: 600;
-      }
-      .referido-fecha {
-          color: #0a8a2a;
-          font-weight: 600;
-      }
-      .referido-cartones {
-          color: #ff8c00;
-          font-weight: 600;
+          text-align: center;
       }
       .modal-referidos-vacio {
           font-family: 'Poppins', sans-serif;
-          color: #444;
-          font-size: clamp(0.9rem, 2vw, 1.1rem);
+          color: #333;
+          font-size: clamp(0.8rem, 2vw, 0.95rem);
           text-align: center;
+          padding: 12px 6px;
       }
       #modal-referidos-cerrar {
-          margin-top: 20px;
-          font-family: 'Bangers', cursive;
-          font-size: clamp(1rem, 2.2vw, 1.2rem);
-          background: linear-gradient(135deg, #0a8800, #51c94d);
-          color: #fff;
-          border: 3px solid #ffd700;
-          border-radius: 10px;
-          padding: 10px 24px;
+          position: absolute;
+          top: 10px;
+          right: 10px;
+          width: 32px;
+          height: 32px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: 'Poppins', sans-serif;
+          font-size: 1.1rem;
+          background: #ffffff;
+          color: #000;
+          border: none;
+          border-radius: 50%;
           cursor: pointer;
-          text-transform: uppercase;
-          box-shadow: 0 6px 16px rgba(0, 0, 0, 0.3);
+          box-shadow: 0 4px 10px rgba(0, 0, 0, 0.35);
       }
       #modal-referidos-cerrar:hover,
       #modal-referidos-cerrar:focus {
-          transform: scale(1.03);
+          transform: scale(1.05);
           outline: none;
-          box-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
+          box-shadow: 0 8px 18px rgba(0, 0, 0, 0.4);
       }
   </style>
   <link rel="stylesheet" href="css/desktopFrame.css">
@@ -1071,10 +1116,28 @@
   </div>
   <div id="modal-referidos" class="modal-referidos" role="dialog" aria-modal="true" aria-labelledby="modal-referidos-titulo" aria-hidden="true">
     <div class="modal-contenido">
-      <h2 id="modal-referidos-titulo">MIS REFERIDOS</h2>
-      <p id="modal-referidos-total" class="modal-referidos-total">Cartones gratis que has ganado: 0</p>
-      <div id="modal-referidos-lista" class="modal-referidos-lista"></div>
-      <button type="button" id="modal-referidos-cerrar">Cerrar</button>
+      <button type="button" id="modal-referidos-cerrar" aria-label="Cerrar">✕</button>
+      <h2 id="modal-referidos-titulo">Campaña: --</h2>
+      <p id="modal-referidos-fin" class="modal-referidos-fin">Fin: --/--/----</p>
+      <div class="modal-referidos-resumen">
+        <span id="modal-referidos-total" class="modal-referidos-total">C. Ganados: 0</span>
+        <span id="modal-referidos-nuevo" class="modal-referidos-nuevo">C. Nuevo Jugador: 0</span>
+        <span id="modal-referidos-min" class="modal-referidos-min">Referidos Min: 0</span>
+      </div>
+      <div class="modal-referidos-tabla-wrapper">
+        <table class="modal-referidos-tabla" aria-label="Tabla de referidos">
+          <thead>
+            <tr>
+              <th class="col-numero">N°</th>
+              <th class="col-nombre">Nombre y Apellido</th>
+              <th class="col-fecha">Fecha y hora</th>
+              <th class="col-premio">Premio</th>
+            </tr>
+          </thead>
+          <tbody id="modal-referidos-lista" class="modal-referidos-lista"></tbody>
+        </table>
+      </div>
+      <div id="modal-referidos-vacio" class="modal-referidos-vacio" hidden></div>
     </div>
   </div>
 
@@ -1092,6 +1155,11 @@
   const referidosModalEl = document.getElementById('modal-referidos');
   const referidosModalListaEl = document.getElementById('modal-referidos-lista');
   const referidosModalTotalEl = document.getElementById('modal-referidos-total');
+  const referidosModalTituloEl = document.getElementById('modal-referidos-titulo');
+  const referidosModalFinEl = document.getElementById('modal-referidos-fin');
+  const referidosModalNuevoEl = document.getElementById('modal-referidos-nuevo');
+  const referidosModalMinEl = document.getElementById('modal-referidos-min');
+  const referidosModalVacioEl = document.getElementById('modal-referidos-vacio');
   const referidosModalCerrarBtn = document.getElementById('modal-referidos-cerrar');
   const sorteoImagen = document.getElementById('boton-sorteo');
   const referidosOpcion = document.querySelector('.menu-opcion--referidos');
@@ -1290,7 +1358,21 @@
   function formatearFechaRegistro(valor){
     const fecha = normalizarFechaRegistro(valor);
     if(!fecha) return 'Fecha no disponible';
-    return fecha.toLocaleString('es-ES', { dateStyle: 'medium', timeStyle: 'short' });
+    const dia = String(fecha.getDate()).padStart(2, '0');
+    const mes = String(fecha.getMonth() + 1).padStart(2, '0');
+    const anio = fecha.getFullYear();
+    const hora = String(fecha.getHours()).padStart(2, '0');
+    const minuto = String(fecha.getMinutes()).padStart(2, '0');
+    return `${dia}/${mes}/${anio} ${hora}:${minuto}`;
+  }
+
+  function formatearFechaCorta(valor){
+    const fecha = valor ? parseFecha(valor) : null;
+    if(!fecha || Number.isNaN(fecha.getTime())) return '--/--/----';
+    const dia = String(fecha.getDate()).padStart(2, '0');
+    const mes = String(fecha.getMonth() + 1).padStart(2, '0');
+    const anio = fecha.getFullYear();
+    return `${dia}/${mes}/${anio}`;
   }
 
   function obtenerNombreUsuario(data){
@@ -1317,9 +1399,9 @@
     return mapa;
   }
 
-  async function obtenerResumenReferidos(usuarioEmail){
+  async function obtenerResumenReferidos(usuarioEmail, campanaActiva){
     if(!firestoreRef || !usuarioEmail){
-      return { referidos: [], totalCartones: 0 };
+      return { referidos: [], totalCartones: 0, cartonesNuevo: 0, referidosMin: 0, campana: null };
     }
     const referidosSnapshot = await firestoreRef.collection('users').where('referidoPorEmail','==', usuarioEmail).get();
     const referidos = referidosSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
@@ -1329,6 +1411,10 @@
       ...statsSnapshot.docs.map(doc => doc.id)
     ];
     const campanas = await obtenerCampanasPorIds(campanaIds);
+    const statsPorCampana = {};
+    statsSnapshot.docs.forEach(doc => {
+      statsPorCampana[doc.id] = doc.data() || {};
+    });
     const totalCartones = statsSnapshot.docs.reduce((acc, doc) => {
       const data = doc.data() || {};
       const campana = campanas[doc.id] || {};
@@ -1340,6 +1426,7 @@
       const campana = campanas[item.campanaReferidosId] || {};
       const nombreCampana = (campana.nombre || campana.titulo || 'Campaña sin nombre').toString();
       return {
+        campanaId: item.campanaReferidosId || '',
         campanaNombre: nombreCampana,
         nombre: obtenerNombreUsuario(item),
         fechaRegistro: formatearFechaRegistro(item.fechaRegistro || item.creadoEn || item.createdAt),
@@ -1353,7 +1440,23 @@
       if(!b.fechaOrden) return -1;
       return b.fechaOrden - a.fechaOrden;
     });
-    return { referidos: listado, totalCartones };
+    const campana = campanaActiva || null;
+    const campanaId = campana?.id || '';
+    const campanaData = campanaId ? (campanas[campanaId] || campana || {}) : null;
+    const totalCartonesCampana = campanaId
+      ? (Number(statsPorCampana[campanaId]?.premiosEntregados || 0) || 0)
+        * (Number(campanaData?.cartonesPremio || 0) || 0)
+      : totalCartones;
+    const cartonesNuevo = Number(campanaData?.cartonesNuevo || 0) || 0;
+    const referidosMin = Number(campanaData?.referidosMin || 0) || 0;
+    const referidosFiltrados = campanaId ? listado.filter(item => item.campanaId === campanaId) : listado;
+    return {
+      referidos: referidosFiltrados,
+      totalCartones: totalCartonesCampana,
+      cartonesNuevo,
+      referidosMin,
+      campana: campanaData
+    };
   }
 
   async function obtenerCampanaActiva(){
@@ -1396,11 +1499,13 @@
         referidosSubLabel.setAttribute('role', 'presentation');
         referidosSubLabel.removeAttribute('tabindex');
       }
+      estadoReferidos.cantidad = 0;
+      estadoReferidos.tieneDatos = false;
       const usuario = auth.currentUser;
-      if(usuario?.email){
-        const resumen = await obtenerResumenReferidos(usuario.email);
+      if(usuario?.email && campana){
+        const resumen = await obtenerResumenReferidos(usuario.email, campana);
         estadoReferidos.cantidad = resumen.referidos.length;
-        estadoReferidos.tieneDatos = resumen.referidos.length > 1;
+        estadoReferidos.tieneDatos = resumen.referidos.length > 0;
         if(referidosSubLabel && estadoReferidos.tieneDatos){
           referidosSubLabel.textContent = 'DATOS DE TUS REFERIDOS';
           referidosSubLabel.classList.add('referidos-datos');
@@ -1418,42 +1523,57 @@
     if(referidosModalListaEl){
       referidosModalListaEl.innerHTML = '';
     }
+    if(referidosModalVacioEl){
+      referidosModalVacioEl.hidden = true;
+      referidosModalVacioEl.textContent = '';
+    }
   }
 
   function renderizarReferidosModal(resumen){
     if(!referidosModalListaEl || !referidosModalTotalEl) return;
-    referidosModalTotalEl.textContent = `Cartones gratis que has ganado: ${resumen.totalCartones}`;
+    const campanaNombre = resumen.campana
+      ? (resumen.campana?.nombre || resumen.campana?.titulo || 'Campaña').toString()
+      : '--';
+    if(referidosModalTituloEl){
+      referidosModalTituloEl.textContent = `Campaña: ${campanaNombre}`;
+    }
+    if(referidosModalFinEl){
+      referidosModalFinEl.textContent = `Fin: ${formatearFechaCorta(resumen.campana?.fechaFin)}`;
+    }
+    referidosModalTotalEl.textContent = `C. Ganados: ${resumen.totalCartones}`;
+    if(referidosModalNuevoEl){
+      referidosModalNuevoEl.textContent = `C. Nuevo Jugador: ${resumen.cartonesNuevo}`;
+    }
+    if(referidosModalMinEl){
+      referidosModalMinEl.textContent = `Referidos Min: ${resumen.referidosMin}`;
+    }
     referidosModalListaEl.innerHTML = '';
     if(!resumen.referidos.length){
-      const vacio = document.createElement('div');
-      vacio.className = 'modal-referidos-vacio';
-      vacio.textContent = 'Aún no tienes referidos registrados.';
-      referidosModalListaEl.appendChild(vacio);
+      if(referidosModalVacioEl){
+        referidosModalVacioEl.textContent = 'Aún no tienes referidos registrados.';
+        referidosModalVacioEl.hidden = false;
+      }
       return;
     }
-    resumen.referidos.forEach(item => {
-      const contenedor = document.createElement('div');
-      contenedor.className = 'referido-item';
-      const campana = document.createElement('div');
-      campana.className = 'referido-campana';
-      campana.textContent = item.campanaNombre;
-      const detalle = document.createElement('div');
-      detalle.className = 'referido-detalle';
-      const nombre = document.createElement('span');
-      nombre.className = 'referido-nombre';
+    resumen.referidos.forEach((item, index) => {
+      const fila = document.createElement('tr');
+      const numero = document.createElement('td');
+      numero.className = 'col-numero';
+      numero.textContent = String(index + 1);
+      const nombre = document.createElement('td');
+      nombre.className = 'col-nombre';
       nombre.textContent = item.nombre;
-      const fecha = document.createElement('span');
-      fecha.className = 'referido-fecha';
+      const fecha = document.createElement('td');
+      fecha.className = 'col-fecha';
       fecha.textContent = item.fechaRegistro;
-      const cartones = document.createElement('span');
-      cartones.className = 'referido-cartones';
-      cartones.textContent = `Recibió: ${item.cartonesNuevo} cartones`;
-      detalle.appendChild(nombre);
-      detalle.appendChild(fecha);
-      detalle.appendChild(cartones);
-      contenedor.appendChild(campana);
-      contenedor.appendChild(detalle);
-      referidosModalListaEl.appendChild(contenedor);
+      const premio = document.createElement('td');
+      premio.className = 'col-premio';
+      premio.textContent = `${item.cartonesNuevo}`;
+      fila.appendChild(numero);
+      fila.appendChild(nombre);
+      fila.appendChild(fecha);
+      fila.appendChild(premio);
+      referidosModalListaEl.appendChild(fila);
     });
   }
 
@@ -1463,11 +1583,12 @@
     const usuario = auth.currentUser;
     if(usuario?.email){
       try{
-        const resumen = await obtenerResumenReferidos(usuario.email);
+        const campana = await obtenerCampanaActiva();
+        const resumen = await obtenerResumenReferidos(usuario.email, campana);
         renderizarReferidosModal(resumen);
       }catch(error){
         console.error('No se pudieron cargar los datos de referidos', error);
-        renderizarReferidosModal({ referidos: [], totalCartones: 0 });
+        renderizarReferidosModal({ referidos: [], totalCartones: 0, cartonesNuevo: 0, referidosMin: 0, campana: null });
       }
     }
     referidosModalEl.classList.add('activa');


### PR DESCRIPTION
### Motivation
- Mostrar los datos de referidos únicamente cuando exista una campaña de referidos activa asociada a los referidos del jugador y mejorar la legibilidad y adaptación móvil del modal.
- Simplificar y uniformar la presentación de la información de referidos para que sea más compacta y clara (título de campaña, fecha fin, métricas y tabla). 

### Description
- Se reestructura el HTML del modal en `public/player.html` para reemplazar el título `MIS REFERIDOS` con `Campaña: <nombre>`, agregar `Fin: <FechaFin>`, métricas resumen (`C. Ganados`, `C. Nuevo Jugador`, `Referidos Min`) y una tabla sin bordes visibles con columnas `N°`, `Nombre y Apellido`, `Fecha y hora` y `Premio`.
- Se actualizan estilos CSS del modal para apariencia móvil (fondo oscuro, fuentes `Poppins` reducidas, colores solicitados, botón de cierre en `X` arriba a la derecha y tamaño/centrado tipo vista móvil).
- Se modifica la lógica JS en el mismo archivo para: cambiar `obtenerResumenReferidos` con argumento `campanaActiva`, filtrar referidos por la campaña activa, formatear fechas a `dd/mm/aaaa hh:mm` (`formatearFechaRegistro`) y mostrar/ocultar la opción `DATOS DE TUS REFERIDOS` solo si existe campaña activa con registros.
- Se implementa renderizado de filas de la tabla (autonumerado, nombre, fecha y premio) y manejo del mensaje cuando no hay referidos registrados; archivo modificado: `public/player.html`.

### Testing
- Se levantó un servidor local con `python -m http.server` en `public` y se ejecutó un script de Playwright que abrió `http://127.0.0.1:8000/player.html` con viewport móvil (`width: 430, height: 900`), inyectó datos de ejemplo en el modal y tomó una captura de pantalla `artifacts/player-referidos-modal.png`, prueba exitosa.
- Se realizó commit de los cambios con `git commit` y el commit fue creado correctamente. 
- No se ejecutaron pruebas unitarias automáticas adicionales durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b991089fc83269f26e6fc90dbd2a6)