### PR TITLE
Ajustar estilos del modal de referidos

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -826,7 +826,7 @@
           left: 0;
           width: 100%;
           height: 100%;
-          background: rgba(0, 0, 0, 0.6);
+          background: rgba(255, 255, 255, 0.72);
           display: none;
           align-items: center;
           justify-content: center;
@@ -838,13 +838,13 @@
       }
       .modal-referidos .modal-contenido {
           position: relative;
-          background: #1a1a1a;
+          background: #ffffff;
           border-radius: 18px;
-          padding: clamp(18px, 4vw, 28px);
-          width: min(420px, 92vw);
-          max-width: 420px;
+          padding: clamp(16px, 3.6vw, 26px);
+          width: min(560px, 96vw);
+          max-width: 96vw;
           max-height: min(86vh, 720px);
-          box-shadow: 0 16px 32px rgba(0, 0, 0, 0.45);
+          box-shadow: 0 16px 32px rgba(0, 0, 0, 0.18);
           text-align: center;
           border: 3px solid #ffd700;
           overflow: hidden;
@@ -852,15 +852,15 @@
       }
       .modal-referidos .modal-contenido h2 {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(1rem, 2.5vw, 1.2rem);
-          color: #ffffff;
+          font-size: clamp(0.95rem, 2.2vw, 1.1rem);
+          color: #1f1f1f;
           margin: 0 0 6px;
-          text-shadow: 1px 1px 0 #000000;
+          text-shadow: none;
       }
       .modal-referidos-fin {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(0.8rem, 2vw, 0.95rem);
-          color: #d3d3d3;
+          font-size: clamp(0.78rem, 2vw, 0.92rem);
+          color: #4a4a4a;
           margin: 0 0 12px;
       }
       .modal-referidos-resumen {
@@ -873,48 +873,52 @@
       }
       .modal-referidos-total {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(0.78rem, 2vw, 0.95rem);
-          color: #ffffff;
+          font-size: clamp(0.78rem, 2vw, 0.92rem);
+          color: #1f1f1f;
       }
       .modal-referidos-nuevo {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(0.78rem, 2vw, 0.95rem);
+          font-size: clamp(0.78rem, 2vw, 0.92rem);
           color: #27c93f;
       }
       .modal-referidos-min {
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(0.78rem, 2vw, 0.95rem);
-          color: #8b5a2b;
+          font-size: clamp(0.78rem, 2vw, 0.92rem);
+          color: #9b6b2d;
       }
       .modal-referidos-tabla-wrapper {
-          max-height: min(52vh, 420px);
+          max-height: min(56vh, 480px);
           overflow: auto;
           border-radius: 12px;
-          background: rgba(255, 255, 255, 0.92);
-          padding: 6px;
-          box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.2);
+          background: #ffffff;
+          padding: clamp(4px, 1.6vw, 8px);
+          box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.12);
       }
       .modal-referidos-tabla {
           width: 100%;
           border-collapse: collapse;
           table-layout: fixed;
           font-family: 'Poppins', sans-serif;
-          font-size: clamp(0.55rem, 1.6vw, 0.7rem);
-          color: #000;
+          font-size: clamp(0.72rem, 2.6vw, 0.95rem);
+          color: #1f1f1f;
+          background: #ffffff;
       }
       .modal-referidos-tabla thead th {
           position: sticky;
           top: 0;
           background: #ffffff;
           font-weight: 700;
-          padding: 4px 2px;
+          padding: clamp(4px, 1.2vw, 6px) clamp(4px, 1.4vw, 8px);
           text-align: center;
           z-index: 1;
+          font-size: clamp(0.68rem, 2.4vw, 0.9rem);
+          border: 1px solid transparent;
       }
       .modal-referidos-tabla td {
-          padding: 4px 2px;
+          padding: clamp(4px, 1.2vw, 8px) clamp(4px, 1.4vw, 10px);
           text-align: center;
           word-break: break-word;
+          border: 1px solid transparent;
       }
       .modal-referidos-tabla .col-numero {
           color: #808080;


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad y responsividad del modal que muestra los datos al presionar `DATOS DE TUS REFERIDOS` para móviles en orientación vertical. 
- Usar un esquema de colores claros (fondo blanco) y mantener líneas de tabla invisibles mientras las celdas y textos se adaptan dinámicamente al ancho.

### Description
- Actualicé estilos en `public/player.html` para `#modal-referidos` y `.modal-referidos .modal-contenido` cambiando el fondo a claro, aumentando el ancho máximo y ajustando `padding`, `box-shadow` y `max-height` para mejor adaptación en móviles. 
- Ajusté tipografías y tamaños dinámicos (`clamp(...)`) para el título (`h2`), resúmenes (`.modal-referidos-total`, `.modal-referidos-nuevo`, `.modal-referidos-min`) y la tabla (`.modal-referidos-tabla`) para que los textos sean legibles y se escalen con la celda. 
- Modifiqué el contenedor de la tabla `.modal-referidos-tabla-wrapper` para usar fondo blanco, padding dinámico y una sombra interna más suave, y aumenté su `max-height` para mejor scroll en pantallas pequeñas. 
- Ajusté `padding` en los encabezados (`thead th`) y celdas (`td`), aumenté la `font-size` de la tabla y añadí `border: 1px solid transparent` a filas y encabezados para mantener “líneas invisibles” pero permitir control de espaciado. 

### Testing
- Se levantó un servidor local con `python -m http.server 8000 --directory /workspace/Bingo-Online` y se ejecutó un script Playwright que abrió `public/player.html`, activó el modal y tomó una captura de pantalla en viewport móvil (390x844), generando `artifacts/referidos-modal.png`, y dicha ejecución fue exitosa. 
- La visualización del modal y la tabla fue verificada mediante la captura generada por Playwright y no se reportaron errores automáticos durante la ejecución del script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eb2eef75483268cfa310e723c4dc5)