### PR TITLE
Ajustar presentación y formato del modal de referidos

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -871,11 +871,11 @@
           flex-wrap: wrap;
       }
       .modal-referidos-inicio {
-          color: #8b1d1d;
+          color: #0e6b2b;
           font-weight: 600;
       }
       .modal-referidos-fin-valor {
-          color: #0e6b2b;
+          color: #8b1d1d;
           font-weight: 600;
       }
       .modal-referidos-resumen {
@@ -909,7 +909,11 @@
           font-size: clamp(0.72rem, 2.6vw, 0.95rem);
           color: #1f1f1f;
           background: #ffffff;
+          border: none;
           border-radius: 12px;
+          box-shadow: none;
+          margin: 0 auto;
+          padding: 0;
           overflow: hidden;
           flex: 1 1 auto;
           display: block;
@@ -1397,9 +1401,11 @@
     const dia = String(fecha.getDate()).padStart(2, '0');
     const mes = String(fecha.getMonth() + 1).padStart(2, '0');
     const anio = fecha.getFullYear();
-    const hora = String(fecha.getHours()).padStart(2, '0');
+    const horas = fecha.getHours();
+    const hora = String(horas % 12 || 12).padStart(2, '0');
     const minuto = String(fecha.getMinutes()).padStart(2, '0');
-    return `${dia}/${mes}/${anio} ${hora}:${minuto}`;
+    const periodo = horas >= 12 ? 'pm' : 'am';
+    return `${dia}/${mes}/${anio} ${hora}:${minuto} ${periodo}`;
   }
 
   function formatearFechaCorta(valor){


### PR DESCRIPTION
### Motivation
- Mejorar la presentación del modal mostrado al pulsar la etiqueta `DATOS DE TUS REFERIDOS` para que la tabla quede centrada y sin borde verde heredado. 
- Mostrar la hora en formato de 12 horas con `am/pm` en lugar de 24 horas para mayor legibilidad. 
- Invertir los colores de las etiquetas `Inicio: dd/mm/aaaa` y `Fin: dd/mm/aaaa` para cumplir el requerimiento visual.

### Description
- Se modificó `public/player.html` para invertir los colores de los elementos `.modal-referidos-inicio` y `.modal-referidos-fin-valor` (ahora `Inicio` en verde oscuro y `Fin` en rojo oscuro). 
- Se eliminaron el borde y la sombra alrededor de la tabla de referidos ajustando `.modal-referidos-tabla` (se quitó `border`/`box-shadow`, se añadió `margin: 0 auto` y se dejó la tabla centrada). 
- Se actualizó la función `formatearFechaRegistro` para convertir la hora a formato de 12 horas con sufijo `am`/`pm` y conservar el formato `dd/mm/aaaa hh:mm am/pm`.

### Testing
- Se levantó un servidor estático con `python -m http.server 8000` y se cargó `http://127.0.0.1:8000/public/player.html` automáticamente con un script de Playwright que inyectó datos de ejemplo en el modal. 
- El script de Playwright tomó una captura `artifacts/modal-referidos.png` del modal activo para validar visualmente que la tabla está centrada y sin borde, que los colores de `Inicio`/`Fin` están invertidos y que la hora aparece con `am/pm`, y la ejecución fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5151eae88326b25f2417d44080f7)