### PR TITLE
Mejorar modal de Referidos: nuevo texto, badge y ajuste responsive

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -318,6 +318,7 @@
           flex-direction: column;
           align-items: center;
           gap: clamp(4px, 1vh, 10px);
+          position: relative;
       }
       .menu-opcion--sorteo .menu-imagen {
           max-width: 115%;
@@ -406,14 +407,37 @@
           font-weight: 700;
           color: #ffffff;
           text-shadow: 0 0 6px rgba(0, 0, 0, 0.85), 0 0 12px rgba(0, 0, 0, 0.75);
-          display: block;
+          display: inline-block;
           margin-top: -4px;
+          position: relative;
+          padding-right: 18px;
       }
       .menu-label--referidos-sub.referidos-datos {
           font-size: clamp(0.85rem, 2.1vw, 1.05rem);
-          text-shadow: 0 0 8px rgba(0, 120, 255, 0.9), 0 0 16px rgba(0, 120, 255, 0.95);
+          text-shadow: 0 0 8px rgba(128, 0, 180, 0.9), 0 0 16px rgba(160, 0, 220, 0.95);
           cursor: pointer;
           animation: pulso-referidos 1.4s ease-in-out infinite;
+      }
+      .referidos-badge {
+          position: absolute;
+          top: -10px;
+          right: -8px;
+          min-width: 18px;
+          height: 18px;
+          padding: 0 4px;
+          border-radius: 999px;
+          background: #e60000;
+          color: #ffffff;
+          font-size: 0.6rem;
+          font-weight: 700;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+          animation: pulso-referidos 1.4s ease-in-out infinite;
+      }
+      .referidos-badge.hidden {
+          display: none;
       }
 
       #carton-screen {
@@ -830,7 +854,7 @@
           display: none;
           align-items: center;
           justify-content: center;
-          padding: 20px;
+          padding: clamp(6px, 2vw, 12px);
           z-index: 2100;
       }
       .modal-referidos.activa {
@@ -841,9 +865,9 @@
           background: #ffffff;
           border-radius: 18px;
           padding: clamp(12px, 2.6vw, 20px);
-          width: min(720px, 98vw);
-          max-width: 96vw;
-          max-height: min(86vh, 720px);
+          width: min(720px, 100%);
+          max-width: 100%;
+          max-height: min(94vh, 760px);
           box-shadow: 0 16px 32px rgba(0, 0, 0, 0.18);
           text-align: center;
           border: 3px solid #ffd700;
@@ -910,15 +934,15 @@
           color: #1f1f1f;
           background: #ffffff;
           border: none;
-          border-radius: 12px;
+          border-radius: 0;
           box-shadow: none;
           margin: 0 auto;
           padding: 0;
-          overflow: hidden;
           flex: 1 1 auto;
           display: block;
           max-height: min(58vh, 480px);
-          overflow: auto;
+          overflow-y: auto;
+          overflow-x: hidden;
       }
       .modal-referidos-tabla thead {
           display: table;
@@ -956,19 +980,19 @@
       }
       .modal-referidos-tabla .col-numero {
           color: #808080;
-          width: 10%;
+          width: 7%;
       }
       .modal-referidos-tabla .col-nombre {
           color: #000000;
-          width: 35%;
+          width: 43%;
       }
       .modal-referidos-tabla .col-fecha {
           color: #0a8a2a;
-          width: 35%;
+          width: 38%;
       }
       .modal-referidos-tabla .col-premio {
           color: #ff8c00;
-          width: 20%;
+          width: 12%;
       }
       .modal-referidos-lista {
           text-align: center;
@@ -1077,7 +1101,10 @@
                 <div class="menu-opcion menu-opcion--referidos">
                   <img id="boton-referidos" class="menu-imagen menu-imagen--referidos" src="img/boton-compartir-200p.png" alt="Compartir código promocional" role="button" tabindex="0" loading="lazy" />
                   <span class="menu-label menu-label--referidos">CARTONES GRATIS</span>
-                  <span class="menu-label menu-label--referidos-sub">AL COMPARTIR BingOnline por WhatsApp</span>
+                  <span class="menu-label menu-label--referidos-sub">
+                    <span class="menu-label--referidos-text">AL COMPARTIR BingOnline por WhatsApp</span>
+                    <span id="referidos-badge" class="referidos-badge hidden" aria-hidden="true">0</span>
+                  </span>
                 </div>
               </td>
               <td>
@@ -1205,6 +1232,8 @@
   const referidosOpcion = document.querySelector('.menu-opcion--referidos');
   const referidosLabel = document.querySelector('.menu-label--referidos');
   const referidosSubLabel = document.querySelector('.menu-label--referidos-sub');
+  const referidosSubTextEl = referidosSubLabel?.querySelector('.menu-label--referidos-text') || null;
+  const referidosBadgeEl = document.getElementById('referidos-badge');
   const tutorialToggle = document.getElementById('tutorial-toggle');
   const tutorialNav = document.getElementById('tutorial-nav');
   const tutorialPrev = document.getElementById('tutorial-prev');
@@ -1534,12 +1563,21 @@
         referidosLabel.textContent = campana ? 'CARTONES GRATIS' : `COMPARTE ${APP_NOMBRE}`;
       }
       if(referidosSubLabel){
-        referidosSubLabel.textContent = campana
+        const textoSub = campana
           ? `AL COMPARTIR ${APP_NOMBRE} por WhatsApp`
           : 'A tus amigos por WhatsApp';
+        if(referidosSubTextEl){
+          referidosSubTextEl.textContent = textoSub;
+        }else{
+          referidosSubLabel.textContent = textoSub;
+        }
         referidosSubLabel.classList.remove('referidos-datos');
         referidosSubLabel.setAttribute('role', 'presentation');
         referidosSubLabel.removeAttribute('tabindex');
+      }
+      if(referidosBadgeEl){
+        referidosBadgeEl.textContent = '0';
+        referidosBadgeEl.classList.add('hidden');
       }
       estadoReferidos.cantidad = 0;
       estadoReferidos.tieneDatos = false;
@@ -1549,10 +1587,18 @@
         estadoReferidos.cantidad = resumen.referidos.length;
         estadoReferidos.tieneDatos = resumen.referidos.length > 0;
         if(referidosSubLabel && estadoReferidos.tieneDatos){
-          referidosSubLabel.textContent = 'DATOS DE TUS REFERIDOS';
+          if(referidosSubTextEl){
+            referidosSubTextEl.textContent = 'Click AQUÍ para ver Referidos';
+          }else{
+            referidosSubLabel.textContent = 'Click AQUÍ para ver Referidos';
+          }
           referidosSubLabel.classList.add('referidos-datos');
           referidosSubLabel.setAttribute('role', 'button');
           referidosSubLabel.setAttribute('tabindex', '0');
+        }
+        if(referidosBadgeEl && estadoReferidos.tieneDatos){
+          referidosBadgeEl.textContent = `${estadoReferidos.cantidad}`;
+          referidosBadgeEl.classList.remove('hidden');
         }
       }
     }catch(error){


### PR DESCRIPTION
### Motivation
- Mejorar la visibilidad y usabilidad del enlace "DATOS DE TUS REFERIDOS" mostrando un texto más claro y un contador visible de referidos, además de ajustar el modal para que se vea correctamente en vista vertical de celular.
- Evitar desplazamiento horizontal y problemas de recorte en la tabla de referidos, así como dar más espacio a las columnas de `Nombre y Apellido` y `Fecha y hora`.

### Description
- Reemplacé la subetiqueta por un texto dinámico que pasa a `Click AQUÍ para ver Referidos` cuando hay datos, y cambié el efecto de resplandor a tonos morados en la clase `.menu-label--referidos-sub.referidos-datos`.
- Añadí un badge circular de notificación (`.referidos-badge`) con fondo rojo y texto blanco que aparece en la esquina superior derecha de la etiqueta y usa la animación `pulso-referidos` ya existente; la lógica de actualización del badge y del texto quedó en `actualizarIndicadorReferidos()` y en el DOM dentro de `public/player.html`.
- Ajusté estilos del modal para reducir márgenes (`padding` con `clamp`), usar `width: min(720px, 100%)`, aumentar `max-height` y asegurar `overflow-y: auto` y `overflow-x: hidden` para evitar scroll horizontal y permitir scroll vertical cuando haya muchos registros.
- Quité el `border-radius` de la tabla (`border-radius: 0`), forcé `overflow-x: hidden`, y redistribuí anchos de columnas a: `N°` 7%, `Nombre y Apellido` 43%, `Fecha y hora` 38%, `Premio` 12%.

### Testing
- Levanté un servidor de pruebas con `python -m http.server 8000` y verifiqué la vista en móvil abriendo `http://127.0.0.1:8000/public/player.html` en Playwright con viewport `430x932` y generé la captura `artifacts/referidos-modal.png`, que se produjo correctamente.
- Verifiqué cambios en git con `git status` y confirmé el commit con `git commit -m "Ajustar modal y aviso de referidos"`, el commit se realizó correctamente.
- No se ejecutaron pruebas unitarias automatizadas adicionales (no aplicaron).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f57edec248326b4db7d44d7e11c3a)