### PR TITLE
Mejorar presentación del modal de Referidos y badge

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -407,10 +407,13 @@
           font-weight: 700;
           color: #ffffff;
           text-shadow: 0 0 6px rgba(0, 0, 0, 0.85), 0 0 12px rgba(0, 0, 0, 0.75);
-          display: inline-block;
+          display: inline-flex;
+          flex-direction: column;
+          align-items: center;
           margin-top: -4px;
           position: relative;
-          padding-bottom: 10px;
+          padding-bottom: 0;
+          gap: 4px;
       }
       .menu-label--referidos-sub.referidos-datos {
           font-size: clamp(0.85rem, 2.1vw, 1.05rem);
@@ -419,9 +422,7 @@
           animation: pulso-referidos 1.4s ease-in-out infinite;
       }
       .referidos-badge {
-          position: absolute;
-          bottom: 0;
-          left: 50%;
+          position: static;
           min-width: 18px;
           height: 18px;
           padding: 0 4px;
@@ -435,7 +436,7 @@
           justify-content: center;
           box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
           animation: pulso-referidos 1.4s ease-in-out infinite;
-          transform: translate(-50%, 30%);
+          transform: none;
       }
       .referidos-badge.hidden {
           display: none;
@@ -958,21 +959,21 @@
           top: 0;
           background: #f0f0f0;
           font-weight: 700;
-          padding: clamp(1px, 0.6vw, 3px) clamp(4px, 1.2vw, 8px);
+          padding: clamp(3px, 0.8vw, 6px) clamp(2px, 0.7vw, 6px);
           text-align: center;
           z-index: 2;
           font-size: clamp(0.68rem, 2.4vw, 0.9rem);
           border: 1px solid #d9d9d9;
           text-shadow: none;
-          line-height: 1.2;
+          line-height: 1.3;
       }
       .modal-referidos-tabla td {
           display: table-cell;
-          padding: clamp(1px, 0.6vw, 3px) clamp(4px, 1.2vw, 8px);
+          padding: clamp(3px, 0.8vw, 6px) clamp(2px, 0.7vw, 6px);
           text-align: center;
           word-break: break-word;
           border: 1px solid #ededed;
-          line-height: 1.2;
+          line-height: 1.3;
       }
       .modal-referidos-tabla tbody tr {
           display: table;
@@ -993,7 +994,7 @@
       }
       .modal-referidos-tabla .col-premio {
           color: #ff8c00;
-          width: 8%;
+          width: calc(8% - 5px);
       }
       .modal-referidos-lista {
           text-align: center;
@@ -1505,7 +1506,7 @@
 
   async function obtenerResumenReferidos(usuarioEmail, campanaActiva){
     if(!firestoreRef || !usuarioEmail){
-      return { referidos: [], totalCartones: 0, cartonesNuevo: 0, referidosMin: 0, totalReferidos: 0, cartonesPremio: 0, campana: null };
+      return { referidos: [], totalCartones: 0, cartonesNuevo: 0, referidosMin: 0, totalReferidos: 0, cartonesPremio: 0, progresoActual: 0, campana: null };
     }
     const referidosSnapshot = await firestoreRef.collection('users').where('referidoPorEmail','==', usuarioEmail).get();
     const referidos = referidosSnapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
@@ -1555,13 +1556,18 @@
     const referidosMin = Number(campanaData?.referidosMin || 0) || 0;
     const cartonesPremio = Number(campanaData?.cartonesPremio || 0) || 0;
     const referidosFiltrados = campanaId ? listado.filter(item => item.campanaId === campanaId) : listado;
+    const totalReferidosCampana = campanaId
+      ? (Number(statsPorCampana[campanaId]?.totalReferidos ?? referidosFiltrados.length) || 0)
+      : referidosFiltrados.length;
+    const progresoActual = referidosMin > 0 ? (totalReferidosCampana % referidosMin) : 0;
     return {
       referidos: referidosFiltrados,
       totalCartones: totalCartonesCampana,
       cartonesNuevo,
       referidosMin,
       cartonesPremio,
-      totalReferidos: referidosFiltrados.length,
+      totalReferidos: totalReferidosCampana,
+      progresoActual,
       campana: campanaData
     };
   }
@@ -1672,7 +1678,8 @@
       referidosModalTotalReferidosEl.textContent = `${resumen.totalReferidos ?? resumen.referidos.length}`;
     }
     if(referidosModalProgresoActualEl){
-      referidosModalProgresoActualEl.textContent = `${resumen.totalReferidos ?? resumen.referidos.length}`;
+      const progresoActual = resumen.progresoActual ?? 0;
+      referidosModalProgresoActualEl.textContent = `${progresoActual}`;
     }
     if(referidosModalCodigoEl){
       referidosModalCodigoEl.textContent = resumen.codigoPromocional || '--';
@@ -1725,7 +1732,7 @@
         renderizarReferidosModal({ ...resumen, codigoPromocional });
       }catch(error){
         console.error('No se pudieron cargar los datos de referidos', error);
-        renderizarReferidosModal({ referidos: [], totalCartones: 0, cartonesNuevo: 0, referidosMin: 0, totalReferidos: 0, cartonesPremio: 0, campana: null, codigoPromocional: '' });
+        renderizarReferidosModal({ referidos: [], totalCartones: 0, cartonesNuevo: 0, referidosMin: 0, totalReferidos: 0, cartonesPremio: 0, progresoActual: 0, campana: null, codigoPromocional: '' });
       }
     }
     referidosModalEl.classList.add('activa');


### PR DESCRIPTION
### Motivation
- Mejorar la presentación y precisión de los datos mostrados en la ventana modal de "Referidos" y reposicionar el globo de notificación para que quede centrado y por debajo de la etiqueta.
- Reducir ligeramente el ancho de la última columna de la tabla y ajustar padding/alto de filas para que las filas (incluida la fila de títulos) no se vean demasiado delgadas.
- Asegurar que el párrafo resumen muestre correctamente el progreso del jugador en la ronda actual y muestre 0 cuando no tiene referidos.

### Description
- Ajuste de estilos en `public/player.html`: la clase `.menu-label--referidos-sub` ahora usa `display: inline-flex`, centra su contenido y elimina padding inferior para colocar el badge debajo; el `.referidos-badge` pasó a `position: static` y se eliminó el `transform` para que quede centrado bajo la etiqueta.
- Ajuste de estilos en `public/player.html`: se incrementó el padding de `thead th` y `td`, se elevó `line-height` para evitar filas demasiado delgadas y se redujo el ancho de la columna `.col-premio` con `width: calc(8% - 5px)` para achicarla ~5px.
- Lógica en `public/player.html` actualizada en `obtenerResumenReferidos`: ahora calcula `totalReferidos` tomando en cuenta las estadísticas en `Referidos` si existen, y añade `progresoActual` (referidos acumulados en la ronda actual mod `referidosMin`).
- Renderizado del modal actualizado en `renderizarReferidosModal` para mostrar `progresoActual` en el elemento `#modal-referidos-progreso-actual` y para aceptar un fallback con `progresoActual: 0` cuando no hay datos.

### Testing
- Prueba visual automatizada local con Playwright: se levantó un servidor local (`python -m http.server 8000`) y se usó Playwright para abrir `player.html`, activar el modal y tomar una captura de pantalla (`artifacts/referidos-modal.png`), la ejecución completó correctamente y generó el artefacto.
- No se ejecutaron tests unitarios adicionales; los cambios se limitaron a `public/player.html` y el test visual validó la posición del badge y la apariencia del modal con datos simulados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f6c32f3d48326a7ae961faab26cfa)