### PR TITLE
Ajustar tabla de referidos en modal

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -847,6 +847,7 @@
           box-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
       }
       .modal-referidos {
+          --modal-inline-margen: clamp(6px, 2.4vw, 16px);
           position: fixed;
           top: 0;
           left: 0;
@@ -856,7 +857,7 @@
           display: none;
           align-items: center;
           justify-content: center;
-          padding: clamp(4px, 1.6vw, 10px);
+          padding: var(--modal-inline-margen);
           z-index: 2100;
       }
       .modal-referidos.activa {
@@ -867,7 +868,7 @@
           background: #ffffff;
           border-radius: 18px;
           padding: clamp(10px, 2.2vw, 16px);
-          width: min(720px, 100%);
+          width: min(820px, calc(100% - (2 * var(--modal-inline-margen))));
           max-width: 100%;
           max-height: min(92vh, 760px);
           box-shadow: 0 16px 32px rgba(0, 0, 0, 0.18);
@@ -982,19 +983,23 @@
       }
       .modal-referidos-tabla .col-numero {
           color: #808080;
-          width: 7%;
+          width: 8%;
       }
       .modal-referidos-tabla .col-nombre {
           color: #000000;
-          width: 45%;
+          width: 44%;
       }
       .modal-referidos-tabla .col-fecha {
           color: #0a8a2a;
-          width: 40%;
+          width: 32%;
       }
-      .modal-referidos-tabla .col-premio {
+      .modal-referidos-tabla th.col-premio {
+          width: 16%;
+      }
+      .modal-referidos-tabla tbody .col-premio {
           color: #ff8c00;
-          width: 10px;
+          font-weight: 700;
+          width: 16%;
       }
       .modal-referidos-tabla .icon {
           font-size: 0.85rem;
@@ -1719,7 +1724,8 @@
       fecha.textContent = item.fechaRegistro;
       const premio = document.createElement('td');
       premio.className = 'col-premio';
-      premio.innerHTML = item.cartonesNuevo > 0 ? '<span class="icon check">&#10004;</span>' : '';
+      const cartonesGanados = Number(item.cartonesNuevo || 0) || 0;
+      premio.textContent = `${cartonesGanados}`;
       fila.appendChild(numero);
       fila.appendChild(nombre);
       fila.appendChild(fecha);


### PR DESCRIPTION
### Motivation
- Mejorar presentación de la ventana modal de "Click AQUÍ para ver Referidos" para que no se corte la tabla y muestre correctamente los cartones ganados por cada referido.
- Cumplir requisitos de interfaz: mostrar el símbolo de check solo en el encabezado, mostrar la cantidad de cartones en los registros y resaltar esos valores en naranja.

### Description
- Modifiqué `public/player.html` para añadir la variable CSS `--modal-inline-margen` y usarla en el `padding` del modal para aplicar márgenes simétricos izquierda/derecha y calcular `width: min(820px, calc(100% - (2 * var(--modal-inline-margen))))` en el contenedor `.modal-contenido` para adaptarlo dinámicamente al ancho de pantalla.
- Ajusté los anchos de columnas de la tabla para evitar cortes: `.col-numero` a `8%`, `.col-nombre` a `44%`, `.col-fecha` a `32%`, y la columna de premio/`th.col-premio` y `tbody .col-premio` a `16%`.
- Cambié el estilo de la columna de premio para que los registros muestren la cantidad de cartones en color naranja (`#ff8c00`) y en negrita mediante `.modal-referidos-tabla tbody .col-premio`.
- Actualicé el renderizado en JavaScript para que cada fila ponga el número de `cartonesNuevo` en la celda de premio (`premio.textContent = `${cartonesGanados}``), manteniendo el icono de check únicamente en el `thead` (encabezado).

### Testing
- Levanté un servidor HTTP simple con `python -m http.server` y ejecuté un script de Playwright que abre `public/player.html`, activa el modal, inyecta datos de ejemplo y toma una captura de pantalla, y la ejecución completó correctamente con la imagen generada en `artifacts/modal-referidos.png`.
- Verifiqué cambios en git y realicé un `git commit` del archivo modificado (`public/player.html`) con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7668090083269de5ec26df0ede3c)