### PR TITLE
Mejorar guiado visual: máscara radial en billetera y guía con manos en registrarse

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -378,7 +378,7 @@
     #tutorial-nav.activo .tutorial-nav-btn:nth-child(2) { animation-delay: 0.12s; }
     .tutorial-nav-btn:hover { transform: scale(1.08); color: #5546c0; }
     .tutorial-nav-btn:active { transform: scale(0.95); }
-    #tutorial-overlay { position: fixed; inset: 0; pointer-events: none; z-index: 12000; background: rgba(0, 0, 0, 0.65); transition: opacity 0.25s ease; opacity: 0; }
+    #tutorial-overlay { position: fixed; inset: 0; pointer-events: none; z-index: 12000; background: transparent; transition: opacity 0.25s ease, background 0.25s ease; opacity: 0; }
     #tutorial-overlay.sin-mascara{ background: transparent; }
     #tutorial-overlay.activo { opacity: 1; }
     #tutorial-hand { position: fixed; width: 44px; height: auto; display: none; filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.35)); transform-origin: center; z-index: 16000; pointer-events: none; }
@@ -1282,6 +1282,8 @@
       }
     }
 
+    const OPACIDAD_MASCARA_TUTORIAL = 0.52;
+
     function actualizarMascara(rect, extraRect){
       if(!tutorialUI.overlay || !rect) return;
       const padding=14;
@@ -1291,15 +1293,21 @@
         top: Math.max(0, Math.min(rect.top, extraRect?.top ?? rect.top) - padding),
         bottom: Math.min(obtenerAlturaViewport(), Math.max(rect.bottom, extraRect?.bottom ?? rect.bottom) + padding),
       };
+      const centroX=(union.left + union.right) / 2;
+      const centroY=(union.top + union.bottom) / 2;
+      const ancho=union.right - union.left;
+      const alto=union.bottom - union.top;
+      const radio=Math.sqrt((ancho ** 2) + (alto ** 2)) / 2 + 26;
+      const halo=radio + 160;
       tutorialUI.overlay.classList.remove('sin-mascara');
-      tutorialUI.overlay.style.background='rgba(0, 0, 0, 0.6)';
-      tutorialUI.overlay.style.clipPath=`polygon(0 0, 100% 0, 100% 100%, 0 100%, 0 0, 0 0, ${union.left}px 0, ${union.left}px ${union.top}px, ${union.right}px ${union.top}px, ${union.right}px ${union.bottom}px, ${union.left}px ${union.bottom}px, ${union.left}px 0, 0 0)`;
+      tutorialUI.overlay.style.clipPath='none';
+      tutorialUI.overlay.style.background=`radial-gradient(circle at ${centroX}px ${centroY}px, rgba(0, 0, 0, 0) ${radio}px, rgba(0, 0, 0, ${OPACIDAD_MASCARA_TUTORIAL}) ${halo}px)`;
     }
 
     function limpiarMascara(){
       if(!tutorialUI.overlay) return;
       tutorialUI.overlay.style.clipPath='none';
-      tutorialUI.overlay.style.background=tutorialMascaraSuavizada?'transparent':'rgba(0, 0, 0, 0.6)';
+      tutorialUI.overlay.style.background=tutorialMascaraSuavizada?'transparent':`rgba(0, 0, 0, ${OPACIDAD_MASCARA_TUTORIAL})`;
       if(tutorialMascaraSuavizada){ tutorialUI.overlay.classList.add('sin-mascara'); }
     }
 

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -173,12 +173,40 @@
       opacity:1;
       transform:translateX(-50%) translateY(-8px);
     }
+    #registro-hand{
+      position:fixed;
+      width:52px;
+      height:auto;
+      display:none;
+      z-index:14000;
+      pointer-events:none;
+      filter:drop-shadow(0 6px 10px rgba(0, 0, 0, 0.35));
+      transform-origin:center;
+      --registro-hand-shift: 0px;
+    }
+    #registro-hand.registro-hand-pulse{
+      animation:registro-hand-pulse 0.7s ease-in-out infinite;
+    }
+    #registro-hand.registro-hand-sweep{
+      animation:registro-hand-sweep 1.4s ease-in-out infinite;
+    }
+    @keyframes registro-hand-pulse{
+      0%{transform:scale(1);}
+      45%{transform:scale(1.18);}
+      100%{transform:scale(1);}
+    }
+    @keyframes registro-hand-sweep{
+      0%{transform:translateX(0);}
+      50%{transform:translateX(var(--registro-hand-shift));}
+      100%{transform:translateX(0);}
+    }
   </style>
   <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
 <body>
   <img id="logo-bingo" src="img/Logo-BingOnline-nuevo500p.png" />
   <h2>Registro de Jugador</h2>
+  <img id="registro-hand" alt="Guía visual del registro" loading="lazy" />
   <input type="text" id="nombre" placeholder="Nombre">
   <input type="text" id="apellido" placeholder="Apellido">
   <input type="text" id="alias" placeholder="Alias">
@@ -376,6 +404,13 @@
     let registroEnProceso = false;
     const registrarBtn = document.getElementById('registrar');
     const emailLabel = document.getElementById('email');
+    const manoRegistro = document.getElementById('registro-hand');
+    const campoNombre = document.getElementById('nombre');
+    const campoApellido = document.getElementById('apellido');
+    const campoAlias = document.getElementById('alias');
+    const campoCelular = document.getElementById('celular');
+    const botonGoogle = document.getElementById('login-google');
+    const botonApple = document.getElementById('login-apple');
 
     function obtenerDatosFormulario(){
       return {
@@ -631,8 +666,145 @@
         && !!datos.aceptoTerminos
         && !!auth?.currentUser?.email;
       registrarBtn.disabled = !requisitos;
+      actualizarGuiaRegistro();
     }
     initFechaHora('fecha-hora');
+
+    function establecerHabilitado(elemento, habilitado){
+      if(!elemento) return;
+      elemento.disabled = !habilitado;
+      elemento.setAttribute('aria-disabled', (!habilitado).toString());
+    }
+
+    function ocultarManoRegistro(){
+      if(!manoRegistro) return;
+      manoRegistro.style.display='none';
+      manoRegistro.classList.remove('registro-hand-pulse','registro-hand-sweep');
+    }
+
+    function mostrarManoRegistro({src, left, top, clase, shift}){
+      if(!manoRegistro) return;
+      manoRegistro.src = src;
+      manoRegistro.style.left = `${left}px`;
+      manoRegistro.style.top = `${top}px`;
+      manoRegistro.style.setProperty('--registro-hand-shift', `${shift ?? 0}px`);
+      manoRegistro.classList.remove('registro-hand-pulse','registro-hand-sweep');
+      manoRegistro.classList.add(clase);
+      manoRegistro.style.display = 'block';
+    }
+
+    function posicionarManoDerecha(elemento){
+      if(!manoRegistro || !elemento) return null;
+      const rect = elemento.getBoundingClientRect();
+      const manoWidth = manoRegistro.width || 52;
+      const manoHeight = manoRegistro.height || 52;
+      const left = rect.right + 8;
+      const top = rect.top + rect.height / 2 - manoHeight / 2;
+      return { left, top, manoWidth };
+    }
+
+    function posicionarManoProveedores(){
+      if(!manoRegistro || !botonGoogle || !botonApple) return null;
+      const rectGoogle = botonGoogle.getBoundingClientRect();
+      const rectApple = botonApple.getBoundingClientRect();
+      const centroGoogle = rectGoogle.left + rectGoogle.width / 2;
+      const centroApple = rectApple.left + rectApple.width / 2;
+      const baseLeft = Math.min(centroGoogle, centroApple);
+      const shift = Math.max(centroGoogle, centroApple) - baseLeft;
+      const manoWidth = manoRegistro.width || 52;
+      const manoHeight = manoRegistro.height || 52;
+      const left = baseLeft - manoWidth / 2;
+      const top = Math.max(rectGoogle.bottom, rectApple.bottom) + 8;
+      return { left, top, shift };
+    }
+
+    function actualizarBloqueosPaso(paso){
+      const bloqueos = new Set();
+      if(paso === 'nombre'){
+        bloqueos.add('apellido');
+        bloqueos.add('alias');
+        bloqueos.add('celular');
+        bloqueos.add('codigo-pais');
+      }else if(paso === 'apellido'){
+        bloqueos.add('alias');
+        bloqueos.add('celular');
+        bloqueos.add('codigo-pais');
+      }else if(paso === 'alias'){
+        bloqueos.add('celular');
+        bloqueos.add('codigo-pais');
+      }
+      establecerHabilitado(campoNombre, true);
+      establecerHabilitado(campoApellido, !bloqueos.has('apellido'));
+      establecerHabilitado(campoAlias, !bloqueos.has('alias'));
+      establecerHabilitado(campoCelular, !bloqueos.has('celular'));
+      establecerHabilitado(selectCodigoPais, !bloqueos.has('codigo-pais'));
+    }
+
+    function determinarPasoGuia(){
+      const datos = obtenerDatosFormulario();
+      if((datos.nombre || '').length <= 2) return 'nombre';
+      if((datos.apellido || '').length <= 2) return 'apellido';
+      if((datos.alias || '').length <= 2) return 'alias';
+      if((datos.celularLocal || '').length <= 6) return 'celular';
+      if(!auth?.currentUser?.email) return 'proveedor';
+      if(!registrarBtn.disabled) return 'registrar';
+      return 'listo';
+    }
+
+    function actualizarGuiaRegistro(){
+      const paso = determinarPasoGuia();
+      actualizarBloqueosPaso(paso);
+      if(paso === 'nombre'){
+        const pos = posicionarManoDerecha(campoNombre);
+        if(pos){
+          mostrarManoRegistro({ src:'img/Mano-izquierda.png', left:pos.left, top:pos.top, clase:'registro-hand-pulse' });
+          return;
+        }
+      }
+      if(paso === 'apellido'){
+        const pos = posicionarManoDerecha(campoApellido);
+        if(pos){
+          mostrarManoRegistro({ src:'img/Mano-izquierda.png', left:pos.left, top:pos.top, clase:'registro-hand-pulse' });
+          return;
+        }
+      }
+      if(paso === 'alias'){
+        const pos = posicionarManoDerecha(campoAlias);
+        if(pos){
+          mostrarManoRegistro({ src:'img/Mano-izquierda.png', left:pos.left, top:pos.top, clase:'registro-hand-pulse' });
+          return;
+        }
+      }
+      if(paso === 'celular'){
+        const pos = posicionarManoDerecha(campoCelular);
+        if(pos){
+          mostrarManoRegistro({ src:'img/Mano-izquierda.png', left:pos.left, top:pos.top, clase:'registro-hand-pulse' });
+          return;
+        }
+      }
+      if(paso === 'proveedor'){
+        const pos = posicionarManoProveedores();
+        if(pos){
+          mostrarManoRegistro({ src:'img/Mano-arriba.png', left:pos.left, top:pos.top, clase:'registro-hand-sweep', shift: pos.shift });
+          return;
+        }
+      }
+      if(paso === 'registrar'){
+        const pos = posicionarManoDerecha(registrarBtn);
+        if(pos){
+          mostrarManoRegistro({ src:'img/Mano-izquierda.png', left:pos.left, top:pos.top, clase:'registro-hand-pulse' });
+          return;
+        }
+      }
+      ocultarManoRegistro();
+    }
+
+    ['scroll','resize'].forEach(evt=>{
+      window.addEventListener(evt, ()=>{
+        window.requestAnimationFrame(actualizarGuiaRegistro);
+      });
+    });
+    actualizarGuiaRegistro();
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Mejorar la visibilidad de los elementos durante el modo tutorial en `billetera.html` haciendo que la máscara se comporte como en `player.html` (halo transparente alrededor del objetivo) y aclarando ligeramente la opacidad para no oscurecer tanto la ventana.
- Guiar visualmente al usuario en `registrarse.html` fuera de un modo tutorial formal mediante imágenes de mano que indiquen secuencialmente cada campo y habiliten/deshabiliten inputs para facilitar el registro correcto.

### Description
- `public/billetera.html`: Reemplazada la máscara opaca por una aproximación basada en `radial-gradient` centrada en el objetivo y extraída la opacidad a la constante `OPACIDAD_MASCARA_TUTORIAL = 0.52` para una máscara ~12% más clara; se elimina el `clipPath` rígido y se mantiene la visibilidad/animación de la mano y etiqueta del tutorial.
- `public/registrarse.html`: Añadido elemento `<img id="registro-hand">` con estilos y keyframes (`registro-hand-pulse`, `registro-hand-sweep`) y lógica JS para mostrar/ocultar/posicionar la mano; implementadas funciones para bloquear/desbloquear campos (`establecerHabilitado`), calcular pasos de guía (`determinarPasoGuia`) y gestionar la secuencia solicitada (nombre → apellido → alias → celular → proveedores → botón Registrar). La guía se actualiza en `scroll`/`resize` y al cambiar el estado del formulario; se invoca `actualizarGuiaRegistro()` al cargar.
- Archivos cambiados: `public/billetera.html`, `public/registrarse.html`.

### Testing
- Se inició un servidor local con `python -m http.server` en `public/` correctamente para pruebas manuales de UI (servidor levantado con éxito). 
- Intento automatizado de captura con Playwright falló por un error de Chromium en este entorno (el navegador se cerró con SIGSEGV), por lo que no se obtuvo la captura automatizada. 
- Se realizó el commit de los archivos modificados (`git commit`), cambios añadidos y confirmados. No se ejecutaron tests unitarios automatizados adicionales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826e0a0db88326ac1a1f4d957d9231)