### PR TITLE
Animar botones de proveedores en `registrarse.html` y ajustar guía visual

### DIFF
--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -80,6 +80,10 @@
       color:#111827;
       box-shadow:0 2px 6px rgba(0,0,0,0.12);
     }
+    .provider-btn.provider-attention{
+      animation:provider-attention 0.8s ease-in-out infinite;
+      transform-origin:center;
+    }
     .provider-btn svg{
       width:18px;
       height:18px;
@@ -199,6 +203,11 @@
       0%{transform:translateX(0);}
       50%{transform:translateX(var(--registro-hand-shift));}
       100%{transform:translateX(0);}
+    }
+    @keyframes provider-attention{
+      0%{transform:scale(1);}
+      50%{transform:scale(1.08);}
+      100%{transform:scale(1);}
     }
   </style>
   <link rel="stylesheet" href="css/desktopFrame.css">
@@ -690,6 +699,12 @@
       manoRegistro.classList.remove('registro-hand-pulse','registro-hand-sweep');
     }
 
+    function actualizarAnimacionProveedores(activa){
+      if(!botonGoogle || !botonApple) return;
+      botonGoogle.classList.toggle('provider-attention', activa);
+      botonApple.classList.toggle('provider-attention', activa);
+    }
+
     function mostrarManoRegistro({src, left, top, clase, shift}){
       if(!manoRegistro) return;
       manoRegistro.src = src;
@@ -709,21 +724,6 @@
       const left = rect.right + 8;
       const top = rect.top + rect.height / 2 - manoHeight / 2;
       return { left, top, manoWidth };
-    }
-
-    function posicionarManoProveedores(){
-      if(!manoRegistro || !botonGoogle || !botonApple) return null;
-      const rectGoogle = botonGoogle.getBoundingClientRect();
-      const rectApple = botonApple.getBoundingClientRect();
-      const centroGoogle = rectGoogle.left + rectGoogle.width / 2;
-      const centroApple = rectApple.left + rectApple.width / 2;
-      const baseLeft = Math.max(centroGoogle, centroApple);
-      const shift = Math.min(centroGoogle, centroApple) - baseLeft;
-      const manoWidth = manoRegistro.width || 52;
-      const manoHeight = manoRegistro.height || 52;
-      const left = baseLeft - manoWidth / 2;
-      const top = Math.max(rectGoogle.bottom, rectApple.bottom) + 8;
-      return { left, top, shift };
     }
 
     function actualizarBloqueosPaso(paso){
@@ -762,11 +762,13 @@
     function actualizarGuiaRegistro(){
       if(loginEnProceso){
         ocultarManoRegistro();
+        actualizarAnimacionProveedores(false);
         return;
       }
       const paso = determinarPasoGuia();
       actualizarBloqueosPaso(paso);
       if(paso === 'nombre'){
+        actualizarAnimacionProveedores(false);
         const pos = posicionarManoDerecha(campoNombre);
         if(pos){
           mostrarManoRegistro({ src:'img/Mano-izquierda.png', left:pos.left, top:pos.top, clase:'registro-hand-pulse' });
@@ -774,6 +776,7 @@
         }
       }
       if(paso === 'apellido'){
+        actualizarAnimacionProveedores(false);
         const pos = posicionarManoDerecha(campoApellido);
         if(pos){
           mostrarManoRegistro({ src:'img/Mano-izquierda.png', left:pos.left, top:pos.top, clase:'registro-hand-pulse' });
@@ -781,6 +784,7 @@
         }
       }
       if(paso === 'alias'){
+        actualizarAnimacionProveedores(false);
         const pos = posicionarManoDerecha(campoAlias);
         if(pos){
           mostrarManoRegistro({ src:'img/Mano-izquierda.png', left:pos.left, top:pos.top, clase:'registro-hand-pulse' });
@@ -788,6 +792,7 @@
         }
       }
       if(paso === 'celular'){
+        actualizarAnimacionProveedores(false);
         const pos = posicionarManoDerecha(campoCelular);
         if(pos){
           mostrarManoRegistro({ src:'img/Mano-izquierda.png', left:pos.left, top:pos.top, clase:'registro-hand-pulse' });
@@ -795,19 +800,19 @@
         }
       }
       if(paso === 'proveedor'){
-        const pos = posicionarManoProveedores();
-        if(pos){
-          mostrarManoRegistro({ src:'img/Mano-arriba.png', left:pos.left, top:pos.top, clase:'registro-hand-sweep', shift: pos.shift });
-          return;
-        }
+        ocultarManoRegistro();
+        actualizarAnimacionProveedores(true);
+        return;
       }
       if(paso === 'registrar'){
+        actualizarAnimacionProveedores(false);
         const pos = posicionarManoDerecha(registrarBtn);
         if(pos){
           mostrarManoRegistro({ src:'img/Mano-izquierda.png', left:pos.left, top:pos.top, clase:'registro-hand-pulse' });
           return;
         }
       }
+      actualizarAnimacionProveedores(false);
       ocultarManoRegistro();
     }
 


### PR DESCRIPTION
### Motivation
- Corregir la guía visual en la pantalla de registro para que la sugerencia de elegir proveedor (Google/Apple) sea clara cuando el campo de `celular` tenga más de 6 dígitos y no haya sesión activa.  
- Evitar que la mano animada se muestre incorrectamente o que la indicación visual quede inconsistente entre la "mano arriba" y la animación en los botones proveedor.

### Description
- Se añadió la clase CSS `.provider-attention` y la animación `@keyframes provider-attention` para aplicar un pulso/zoom a los botones de Google y Apple.  
- Se añadió la función `actualizarAnimacionProveedores(activa)` que activa/desactiva la clase en `#login-google` y `#login-apple`.  
- Se removió la lógica que posicionaba la mano para la selección de proveedores y se actualizó `actualizarGuiaRegistro()` para ocultar la mano y en su lugar activar la animación de los botones cuando el paso sea `proveedor`, y para detenerla cuando hay un login en proceso u otros pasos.  
- Cambios realizados en el archivo `public/registrarse.html` (CSS + JavaScript) sin alterar otras funcionalidades de registro ni el flujo de guardado/restauración de datos de formulario.

### Testing
- Se intentó ejecutar un script automatizado con Playwright para validar visualmente la página, pero el navegador headless falló al iniciarse (SIGSEGV) y la ejecución terminó en error, por lo que la verificación visual automática no pudo completarse.  
- No se ejecutaron otras pruebas automatizadas adicionales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69827e02defc8326b87f927f39b4c855)