### PR TITLE
Estabilizar layout móvil en billetera.html

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -15,6 +15,13 @@
   <style>
     html{
       scrollbar-gutter: stable;
+      max-width: 100%;
+      overflow-x: hidden;
+    }
+    *,
+    *::before,
+    *::after{
+      box-sizing: border-box;
     }
     :root{
       --vv-offset-top: 0px;
@@ -28,6 +35,9 @@
       padding: 20px;
       margin: 0;
       overflow-x: hidden;
+      max-width: 100%;
+      min-height: 100svh;
+      overscroll-behavior-x: none;
     }
     .menu-btn {
       width: 250px;
@@ -231,14 +241,12 @@
     #tipo-cuenta.desactivado label{color:#888;}
     #session-info {
       position: fixed;
-      top: 10px;
-      right: 10px;
+      top: max(10px, env(safe-area-inset-top));
+      right: max(10px, env(safe-area-inset-right));
       display: flex;
       align-items: center;
       font-size: 0.7rem;
-      transform: translate3d(var(--vv-offset-left, 0px), var(--vv-offset-top, 0px), 0);
-      will-change: transform;
-      backface-visibility: hidden;
+      transform: none;
     }
     #user-pic {
       width: 40px;
@@ -330,17 +338,15 @@
     /* Controles del modo tutorial */
     #tutorial-controls {
       position: fixed;
-      left: 14px;
-      bottom: 18px;
+      left: max(14px, env(safe-area-inset-left));
+      bottom: max(18px, env(safe-area-inset-bottom));
       top: auto;
       right: auto;
       display: flex;
       align-items: center;
       gap: 12px;
       z-index: 17000;
-      transform: translate3d(var(--vv-offset-left, 0px), var(--vv-offset-top, 0px), 0);
-      will-change: transform;
-      backface-visibility: hidden;
+      transform: none;
     }
     #tutorial-toggle {
       width: 62px;
@@ -389,7 +395,6 @@
       #tutorial-controls{
         left: max(12px, env(safe-area-inset-left));
         bottom: max(16px, env(safe-area-inset-bottom));
-        transform: none;
       }
       #session-info{
         top: max(8px, env(safe-area-inset-top));


### PR DESCRIPTION
### Motivation
- Evitar desplazamientos inesperados y scroll horizontal en vista vertical móvil causados por transformaciones del viewport y desbordes de ancho/alto.

### Description
- Añadí `box-sizing: border-box` global y `max-width:100%`/`overflow-x:hidden` para prevenir overflow horizontal en toda la página.
- Apliqué `min-height: 100svh` y `overscroll-behavior-x: none` en `body` para reducir saltos de altura cuando cambia el viewport en móviles.
- Eliminé las traducciones `translate3d(var(--vv-offset-...), ...)` en elementos fijos y las reemplacé por offsets seguros (`env(safe-area-inset-*)`) y `transform: none` para anclar de forma estable `#session-info` y `#tutorial-controls`.
- Ajusté la media query para dispositivos verticales para que los controles respeten las áreas seguras y no se muevan al abrir/cerrar teclado o al navegar en el tutorial.

### Testing
- Se levantó un servidor local con `python -m http.server` y se realizó una captura visual con Playwright usando `viewport: {"width":390, "height":844}` guardando `artifacts/billetera-mobile.png`, la captura se generó correctamente.
- No se ejecutaron tests unitarios adicionales; los cambios CSS fueron validados con la captura visual en modo móvil.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982837bc7b083268d4af457ee82c1b7)