### PR TITLE
Renombrar PQRS a Ayuda, actualizar menú, formulario y icono

### DIFF
--- a/public/ayuda.html
+++ b/public/ayuda.html
@@ -10,7 +10,7 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>PQRS</title>
+  <title>Ayuda</title>
   <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
   <style>
     *, *::before, *::after {
@@ -78,14 +78,14 @@
     }
     .pqrs-card h2 {
       font-family: 'Bangers', cursive;
-      font-size: clamp(2rem, 4vw, 2.8rem);
+      font-size: clamp(1.6rem, 3.2vw, 2.2rem);
       color: #ffffff;
       text-shadow: 0 0 12px rgba(179, 71, 0, 0.8);
       margin: 0;
       letter-spacing: 1px;
       background: linear-gradient(135deg, #1d4ed8, #38bdf8);
-      padding: 12px 20px;
-      border-radius: 16px;
+      padding: 8px 16px;
+      border-radius: 14px;
     }
     .pqrs-subtitle {
       margin: 0;
@@ -101,35 +101,33 @@
       border-radius: 14px;
       padding: 12px 10px;
       font-family: 'Bangers', cursive;
-      font-size: 1.05rem;
+      font-size: 1.25rem;
       text-transform: uppercase;
       cursor: pointer;
       border: 3px solid transparent;
       transition: transform 0.2s ease, box-shadow 0.2s ease;
+      color: #ffffff;
+      text-shadow: 0 2px 6px currentColor;
     }
     .pqrs-type.is-active {
       transform: translateY(-1px) scale(1.02);
       box-shadow: 0 10px 18px rgba(15, 23, 42, 0.2);
     }
     .pqrs-type[data-type="PREGUNTA"] {
-      background: #d9fbe0;
-      border-color: #1b5e20;
-      color: #1b5e20;
+      background: #22c55e;
+      border-color: #15803d;
     }
-    .pqrs-type[data-type="RESPUESTA"] {
-      background: #ffe7c7;
+    .pqrs-type[data-type="INFORMACION"] {
+      background: #f97316;
       border-color: #c2410c;
-      color: #9a3412;
     }
     .pqrs-type[data-type="QUEJA"] {
-      background: #ffd6d6;
+      background: #ef4444;
       border-color: #b91c1c;
-      color: #7f1d1d;
     }
     .pqrs-type[data-type="SUGERENCIA"] {
-      background: #efe2ff;
+      background: #8b5cf6;
       border-color: #6d28d9;
-      color: #4c1d95;
     }
     form {
       display: flex;
@@ -235,12 +233,12 @@
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true">Salir</button>
 
   <main class="pqrs-card">
-    <h2>Centro de PQRS</h2>
-    <p class="pqrs-subtitle">Selecciona el tipo de solicitud para mostrar los campos adecuados.</p>
+    <h2>Centro de Ayuda</h2>
+    <p class="pqrs-subtitle">Seleciona una opción.</p>
 
-    <div class="pqrs-type-buttons" role="radiogroup" aria-label="Tipo de solicitud">
+    <div class="pqrs-type-buttons" role="radiogroup" aria-label="Tipo de ayuda">
       <button type="button" class="pqrs-type" data-type="PREGUNTA" aria-pressed="false">Pregunta</button>
-      <button type="button" class="pqrs-type" data-type="RESPUESTA" aria-pressed="false">Respuesta</button>
+      <button type="button" class="pqrs-type" data-type="INFORMACION" aria-pressed="false">Información</button>
       <button type="button" class="pqrs-type" data-type="QUEJA" aria-pressed="false">Queja</button>
       <button type="button" class="pqrs-type" data-type="SUGERENCIA" aria-pressed="false">Sugerencia</button>
     </div>
@@ -252,28 +250,6 @@
           <div>
             <label for="pqrs-asunto">Asunto</label>
             <input id="pqrs-asunto" type="text" placeholder="Ej. Problema con mi billetera" />
-          </div>
-          <div>
-            <label for="pqrs-urgencia">Nivel de urgencia</label>
-            <select id="pqrs-urgencia">
-              <option value="">Selecciona la urgencia</option>
-              <option value="Baja">Baja</option>
-              <option value="Media">Media</option>
-              <option value="Alta">Alta</option>
-            </select>
-          </div>
-          <div>
-            <label for="pqrs-contacto">Contacto preferido</label>
-            <select id="pqrs-contacto">
-              <option value="">Selecciona una opción</option>
-              <option value="WhatsApp">WhatsApp</option>
-              <option value="Correo">Correo</option>
-              <option value="Llamada">Llamada</option>
-            </select>
-          </div>
-          <div>
-            <label for="pqrs-telefono">Teléfono de contacto</label>
-            <input id="pqrs-telefono" type="tel" placeholder="Opcional si deseas contacto telefónico" />
           </div>
         </div>
         <div style="margin-top:14px;">
@@ -310,26 +286,34 @@
         </div>
       </section>
 
-      <section class="pqrs-section" data-type="RESPUESTA">
-        <p class="section-title">Detalles de la respuesta</p>
+      <section class="pqrs-section" data-type="INFORMACION">
+        <p class="section-title">Solicitud de información</p>
         <div class="form-grid">
           <div>
-            <label for="respuesta-ticket">Número de solicitud previa</label>
-            <input id="respuesta-ticket" type="text" placeholder="Ej. PQRS-000123" />
+            <label for="informacion-tema">Tema principal</label>
+            <select id="informacion-tema">
+              <option value="">Selecciona un tema</option>
+              <option value="Cuenta">Cuenta y perfil</option>
+              <option value="Pagos">Pagos y billetera</option>
+              <option value="Sorteos">Sorteos y premios</option>
+              <option value="Promociones">Promociones</option>
+              <option value="Otros">Otros</option>
+            </select>
           </div>
           <div>
-            <label for="respuesta-estado">Estado actual</label>
-            <select id="respuesta-estado">
-              <option value="">Selecciona un estado</option>
-              <option value="SinRespuesta">Aún no recibo respuesta</option>
-              <option value="Seguimiento">Necesito seguimiento</option>
-              <option value="Actualizacion">Quiero actualizar información</option>
+            <label for="informacion-tipo">Tipo de información</label>
+            <select id="informacion-tipo">
+              <option value="">Selecciona una opción</option>
+              <option value="Proceso">Proceso o pasos</option>
+              <option value="Requisitos">Requisitos</option>
+              <option value="Estado">Estado o seguimiento</option>
+              <option value="Reglas">Reglas y condiciones</option>
             </select>
           </div>
         </div>
         <div style="margin-top:14px;">
-          <label for="respuesta-detalle">Información adicional</label>
-          <textarea id="respuesta-detalle" placeholder="Describe lo que necesitas agregar o aclarar."></textarea>
+          <label for="informacion-detalle">Detalles específicos</label>
+          <textarea id="informacion-detalle" placeholder="Describe lo que necesitas conocer o aclarar."></textarea>
         </div>
       </section>
 
@@ -419,7 +403,7 @@
 
       const requiredByType = {
         PREGUNTA: ['pregunta-tema'],
-        RESPUESTA: ['respuesta-ticket', 'respuesta-estado'],
+        INFORMACION: ['informacion-tema', 'informacion-tipo'],
         QUEJA: ['queja-motivo', 'queja-fecha'],
         SUGERENCIA: ['sugerencia-area']
       };
@@ -458,19 +442,11 @@
 
       const validateForm = () => {
         if (!tipoSeleccionado) {
-          showStatus('Selecciona un tipo de solicitud.', 'error');
+          showStatus('Selecciona una opción de ayuda.', 'error');
           return false;
         }
         if (!getValue('pqrs-asunto')) {
           showStatus('Completa el asunto de la solicitud.', 'error');
-          return false;
-        }
-        if (!getValue('pqrs-urgencia')) {
-          showStatus('Selecciona el nivel de urgencia.', 'error');
-          return false;
-        }
-        if (!getValue('pqrs-contacto')) {
-          showStatus('Selecciona el contacto preferido.', 'error');
           return false;
         }
         if (!getValue('pqrs-descripcion')) {
@@ -497,11 +473,11 @@
               tema: getValue('pregunta-tema'),
               canal: getValue('pregunta-canal')
             };
-          case 'RESPUESTA':
+          case 'INFORMACION':
             return {
-              solicitudRelacionada: getValue('respuesta-ticket'),
-              estadoActual: getValue('respuesta-estado'),
-              detalleExtra: getValue('respuesta-detalle')
+              tema: getValue('informacion-tema'),
+              tipo: getValue('informacion-tipo'),
+              detalleExtra: getValue('informacion-detalle')
             };
           case 'QUEJA':
             return {
@@ -547,9 +523,6 @@
           const payload = {
             tipo: tipoSeleccionado,
             asunto: getValue('pqrs-asunto'),
-            urgencia: getValue('pqrs-urgencia'),
-            contactoPreferido: getValue('pqrs-contacto'),
-            telefonoContacto: getValue('pqrs-telefono'),
             descripcion: getValue('pqrs-descripcion'),
             detalle: getTipoDetalle(),
             estado: 'Pendiente',
@@ -567,9 +540,9 @@
           await docRef.update({ id: docRef.id });
           showStatus('Tu solicitud fue enviada correctamente. Pronto recibirás respuesta.', 'success');
           form.reset();
-          setTipo('PREGUNTA');
+          setTipo('INFORMACION');
         } catch (error) {
-          console.error('Error al guardar la solicitud PQRS', error);
+          console.error('Error al guardar la solicitud de ayuda', error);
           showStatus('No se pudo enviar la solicitud. Intenta nuevamente.', 'error');
         } finally {
           submitBtn.disabled = false;
@@ -578,8 +551,8 @@
 
       initFirebase()
         .then(() => ensureAuth())
-        .catch(error => console.error('No se pudo inicializar Firebase en PQRS', error));
-      setTipo('PREGUNTA');
+        .catch(error => console.error('No se pudo inicializar Firebase en Ayuda', error));
+      setTipo('INFORMACION');
     })();
   </script>
 </body>

--- a/public/img/icono-pqrs.svg
+++ b/public/img/icono-pqrs.svg
@@ -1,17 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
-  <title id="title">Icono PQRS</title>
-  <desc id="desc">Burbuja de chat con signo de atención</desc>
+  <title id="title">Icono Ayuda</title>
+  <desc id="desc">Signo de interrogación con sombra roja</desc>
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#7dd3fc" />
-      <stop offset="1" stop-color="#38bdf8" />
-    </linearGradient>
+    <filter id="red-shadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feDropShadow dx="0" dy="0" stdDeviation="4" flood-color="#ff1a1a" flood-opacity="0.9" />
+    </filter>
   </defs>
-  <rect x="8" y="12" width="96" height="70" rx="18" fill="url(#bg)" stroke="#0f172a" stroke-width="6" />
-  <path d="M36 82 L20 108 L52 88" fill="url(#bg)" stroke="#0f172a" stroke-width="6" stroke-linejoin="round" />
-  <rect x="44" y="28" width="32" height="34" rx="10" fill="#ffffff" opacity="0.9" />
-  <rect x="58" y="34" width="4" height="18" rx="2" fill="#0f172a" />
-  <rect x="58" y="56" width="4" height="4" rx="2" fill="#0f172a" />
-  <path d="M74 38h20" stroke="#0f172a" stroke-width="6" stroke-linecap="round" opacity="0.55" />
-  <path d="M74 54h14" stroke="#0f172a" stroke-width="6" stroke-linecap="round" opacity="0.55" />
+  <circle cx="64" cy="64" r="54" fill="#1d4ed8" opacity="0.18" />
+  <text
+    x="64"
+    y="92"
+    text-anchor="middle"
+    font-size="96"
+    font-family="'Bangers', 'Arial Black', Arial, sans-serif"
+    fill="#ffffff"
+    filter="url(#red-shadow)">?</text>
 </svg>

--- a/public/player.html
+++ b/public/player.html
@@ -397,6 +397,9 @@
       .menu-label--mensajes {
           text-shadow: 0 0 8px rgba(179, 71, 0, 0.85), 0 0 14px rgba(230, 115, 0, 0.9);
       }
+      .menu-label--pqrs {
+          text-shadow: 0 0 8px rgba(0, 0, 0, 0.9), 0 0 14px rgba(0, 0, 0, 0.85);
+      }
       .menu-label--referidos {
           text-shadow: 0 0 8px rgba(0, 128, 0, 0.85), 0 0 14px rgba(0, 200, 0, 0.9);
           display: inline-block;
@@ -1136,8 +1139,8 @@
               <td class="celda-vacia"></td>
               <td>
                 <div class="menu-opcion menu-opcion--pqrs">
-                  <img id="boton-pqrs" class="menu-imagen" src="img/icono-pqrs.svg" alt="Abrir módulo PQRS" role="button" tabindex="0" loading="lazy" />
-                  <span class="menu-label menu-label--pqrs">PQRS</span>
+                  <img id="boton-pqrs" class="menu-imagen" src="img/icono-pqrs.svg" alt="Abrir módulo de ayuda" role="button" tabindex="0" loading="lazy" />
+                  <span class="menu-label menu-label--pqrs">AYUDA</span>
                 </div>
               </td>
             </tr>
@@ -2167,7 +2170,7 @@
     configurarAccionImagen('boton-billetera', ()=>{ window.location.href = 'billetera.html'; });
     configurarAccionImagen('boton-perfil', ()=>{ window.location.href = 'perfil.html'; });
     configurarAccionImagen('boton-mensajes', manejarClickWhatsapp);
-    configurarAccionImagen('boton-pqrs', ()=>{ window.location.href = 'pqrs.html'; });
+    configurarAccionImagen('boton-pqrs', ()=>{ window.location.href = 'ayuda.html'; });
     configurarAccionImagen('boton-referidos', manejarClickReferidos);
     if(referidosSubLabel){
       referidosSubLabel.addEventListener('click', manejarClickDatosReferidos);


### PR DESCRIPTION
### Motivation
- Unificar y simplificar la sección de soporte renombrando la vista de "PQRS" a "Ayuda" y mejorar la usabilidad del formulario. 
- Reducir campos innecesarios y adaptar el flujo para que las respuestas se hagan por el número de WhatsApp del perfil.

### Description
- Renombré la vista `public/pqrs.html` a `public/ayuda.html` y actualicé los textos: título a "Ayuda", encabezado a "Centro de Ayuda" y subtítulo a "Seleciona una opción.".
- Eliminé los campos y validaciones de `Nivel de urgencia`, `Contacto preferido` y `Teléfono de contacto` del formulario y del payload enviado a Firestore.
- Reemplacé la opción `RESPUESTA` por `INFORMACION` (etiqueta "Información") y adapté los campos asociados y la validación requerida para ese tipo.
- Mejoré estilos: reduje tamaño del encabezado y del contenedor azul, aumenté tamaño de fuente de los botones, puse texto blanco con sombra, y añadí sombra negra al label del menú; actualicé el icono `public/img/icono-pqrs.svg` por un signo de interrogación blanco con sombra roja.
- Actualicé el enlace del menú en `public/player.html` y la etiqueta visible a "AYUDA" para que apunte a `ayuda.html`.

### Testing
- Levanté un servidor estático con `python -m http.server --directory public` y verifiqué la página `ayuda.html` con un script de Playwright que tomó una captura (`artifacts/ayuda.png`), y la carga y renderizado fueron correctos (éxito).
- Se ejecutaron comprobaciones automáticas locales de presencia de archivos y rutas tras los cambios (búsqueda y navegación) y no reportaron errores (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c3fb1cc88326adcd6f53d3a08bd1)