### PR TITLE
Mejora visual: mano del tutorial y reinicio de scroll en modales

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -1212,7 +1212,14 @@
     seguimiento:null,
     posicionMano:null
   };
-  const HAND_OFFSET={x:4,y:-12};
+  const HAND_OFFSET={x:4,y:-20};
+
+  function asegurarManoVisible(){
+    if(!tutorialHand || !tutorialState.posicionMano) return;
+    if(tutorialHand.style.display!=='block'){
+      aplicarPosicionMano(tutorialState.posicionMano,{transicion:false});
+    }
+  }
 
   function actualizarSorteoHint(){
     if(!sorteoHintHand) return;
@@ -1278,6 +1285,7 @@
 
   function iniciarSeguimientoMano(elemento,opciones){
     if(!tutorialHand || !elemento) return;
+    asegurarManoVisible();
     detenerSeguimientoMano();
     tutorialState.seguimiento={elemento,opciones,rafId:null};
     actualizarPosicionManoSeguimiento({transicion:true});
@@ -1295,6 +1303,7 @@
 
   async function moverManoAElemento(elemento,opciones={}){
     if(!tutorialHand || !elemento) return;
+    asegurarManoVisible();
     const {track=true}=opciones;
     if(track){
       iniciarSeguimientoMano(elemento,opciones);
@@ -2514,6 +2523,7 @@ function toggleForma(idx){
       grid.appendChild(div);
     }
     document.getElementById('number-modal').style.display='flex';
+    reiniciarScrollModal(grid);
   }
 
   function selectNumber(num){
@@ -2832,6 +2842,7 @@ function toggleForma(idx){
       list.appendChild(div);
     });
     document.getElementById('sorteos-modal').style.display='flex';
+    reiniciarScrollModal(list);
   }
 
   async function cargarSorteosActivos(){


### PR DESCRIPTION
### Motivation
- Evitar que la imagen de la "Mano-arriba" salte a la esquina o quede desalineada entre transiciones y simular mejor el dedo apuntando al elemento (subir la mano ~8px).
- Asegurar que las ventanas modales siempre muestren su contenido desde arriba al abrirse para que la simulación empiece desde la parte superior.

### Description
- Ajusta el offset vertical de la mano en `public/jugarcartones.html` cambiando `HAND_OFFSET.y` de `-12` a `-20` para elevar la mano ~8px sobre los elementos objetivo. 
- Añade la función `asegurarManoVisible()` y la invoca antes de iniciar seguimiento o mover la mano (`iniciarSeguimientoMano` y `moverManoAElemento`) para mantener la mano visible en la última posición y evitar que desaparezca o salte al iniciar un movimiento.
- Llama a `reiniciarScrollModal(...)` al abrir el modal de selección de números y al abrir el modal de sorteos para forzar que el scroll comience desde arriba y la animación/simulación empiece correctamente desde la posición superior.

### Testing
- Se levantó un servidor HTTP local y se cargó `public/jugarcartones.html` con Playwright para verificar visualmente los cambios; la captura de pantalla se generó correctamente (éxito).
- No se ejecutaron pruebas unitarias automáticas adicionales; los cambios fueron validados con la carga de la página en el navegador (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983e2f4062483268c17aef051bd4ad6)