### PR TITLE
Mejorar modo tutorial en jugarcartones.html (mensajes, animación y scroll)

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -1490,19 +1490,27 @@
       evitarMano=true,
       evitarControles=true
     }=opciones;
+    const mensajePrevio=tutorialLabel.dataset.mensaje ?? '';
+    const necesitaReinicio=tutorialLabel.style.display!=='flex' || mensajePrevio!==mensaje;
     const maxAncho=Math.min(480,viewportWidth*0.9);
     const tamanoFuente=Math.max(16,Math.min(22,maxAncho/18));
     tutorialLabel.style.maxWidth=`${maxAncho}px`;
     tutorialLabel.style.minWidth='200px';
     tutorialLabel.style.fontSize=`${tamanoFuente}px`;
     tutorialLabel.style.padding=`${Math.max(16,tamanoFuente*0.75)}px ${Math.max(20,tamanoFuente*0.95)}px`;
-    tutorialLabel.textContent=mensaje;
-    tutorialLabel.style.display='flex';
-    tutorialLabel.classList.add('adaptado');
-    tutorialLabel.classList.remove('tutorial-label-visible');
-    tutorialLabel.style.visibility='hidden';
-    tutorialLabel.style.left='0px';
-    tutorialLabel.style.top='0px';
+    if(necesitaReinicio){
+      tutorialLabel.textContent=mensaje;
+      tutorialLabel.dataset.mensaje=mensaje;
+      tutorialLabel.style.display='flex';
+      tutorialLabel.classList.add('adaptado');
+      tutorialLabel.classList.remove('tutorial-label-visible');
+      tutorialLabel.style.visibility='hidden';
+      tutorialLabel.style.left='0px';
+      tutorialLabel.style.top='0px';
+    }else{
+      tutorialLabel.textContent=mensaje;
+      tutorialLabel.dataset.mensaje=mensaje;
+    }
     actualizarMascaraTutorial(rect);
 
     const medidas=tutorialLabel.getBoundingClientRect();
@@ -1592,9 +1600,13 @@
     tutorialLabel.style.left=`${left}px`;
     tutorialLabel.style.top=`${top}px`;
     tutorialLabel.style.visibility='visible';
-    requestAnimationFrame(()=>{
+    if(necesitaReinicio){
+      requestAnimationFrame(()=>{
+        tutorialLabel.classList.add('tutorial-label-visible');
+      });
+    }else{
       tutorialLabel.classList.add('tutorial-label-visible');
-    });
+    }
   }
 
   async function pulsarElementoTutorial(elemento){
@@ -1737,7 +1749,7 @@
         }
         const tablero=document.getElementById('bingo-board');
         if(tablero){
-          const opcionesEtiqueta={direccionPreferida:'arriba',forzarDireccion:true,evitarMano:false};
+          const opcionesEtiqueta={direccionPreferida:'arriba',forzarDireccion:true,evitarMano:false,evitarControles:false};
           posicionarEtiquetaTutorial(tablero.getBoundingClientRect(),mensaje,opcionesEtiqueta);
           iniciarSeguimientoEtiqueta(tablero,mensaje,opcionesEtiqueta);
         }
@@ -1760,7 +1772,7 @@
           tutorialHand.classList.remove('tutorial-hand-pulse');
         }
         const tablero=document.getElementById('bingo-board');
-        const opcionesEtiqueta={direccionPreferida:'arriba',forzarDireccion:true,evitarMano:false};
+        const opcionesEtiqueta={direccionPreferida:'arriba',forzarDireccion:true,evitarMano:false,evitarControles:false};
         const headers=[...document.querySelectorAll('.carton th')];
         for(let i=0;i<headers.length;i++){
           const header=headers[i];
@@ -1845,6 +1857,11 @@
     }
   ];
 
+  function necesitaScrollHastaFinal(){
+    const margen=80;
+    return window.scrollY+window.innerHeight < document.documentElement.scrollHeight-margen;
+  }
+
   async function ejecutarPasoTutorial(indice,{manual=false}={}){
     if(!tutorialState.activo || tutorialState.auto.ejecutando) return;
     tutorialState.auto.ejecutando=true;
@@ -1860,6 +1877,10 @@
     if(paso.id==='sorteo' && window.scrollY>0){
       window.scrollTo({top:0,behavior:'smooth'});
       await esperar(400);
+    }
+    if(['guardar-carton','jugar-carton'].includes(paso.id) && necesitaScrollHastaFinal()){
+      window.scrollTo({top:document.documentElement.scrollHeight,behavior:'smooth'});
+      await esperar(500);
     }
     if(typeof paso.ejecutar==='function'){
       detenerSeguimientoMano();


### PR DESCRIPTION
### Motivation
- Corregir por qué no se mostraban correctamente los mensajes del modo tutorial y asegurar que aparezcan visibles sobre el cartón en las secuencias de formas y selección de celdas. 
- Hacer que las etiquetas de ayuda se muestren deslizando desde la izquierda y que el tutorial auto-posicione la vista cuando el paso apunta al botón de guardar/cartón para que queden visibles. 

### Description
- Evité que la etiqueta del tutorial se oculte y pierda su animación al actualizar su texto continuamente, usando `dataset.mensaje` y una lógica que solo reinicia la animación cuando cambia realmente el mensaje o está oculta (archivo modificado: `public/jugarcartones.html`).
- Forcé la posición de las etiquetas para las secuencias del cartón (`recorrido-carton`) y las formas BINGO (`formas-bingo`) para priorizar que el mensaje se muestre arriba del cartón evitando que controles lo solapen (`evitarControles:false`).
- Añadí `necesitaScrollHastaFinal()` y lógica en el ejecutor del paso del tutorial para desplazar la ventana automáticamente al final cuando el paso es `guardar-carton` o `jugar-carton`, asegurando que el control quede visible y señalado.
- Mantengo la animación lateral (desplazamiento desde la izquierda) mediante la reutilización de la clase/transform existente y evitando reinicios innecesarios de la animación al actualizar la etiqueta.

### Testing
- Levanté un servidor local con `python -m http.server 8000` en `public` y abrí `http://127.0.0.1:8000/jugarcartones.html` con Playwright para activar el modo tutorial y validar visualmente; la captura `jugarcartones-tutorial.png` se generó correctamente; acción exitosa. 
- No hay tests automatizados unitarios añadidos; verificación funcional manual automatizada por Playwright (screenshot) completada con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698635d65df08326af9b241db7f2c758)