### PR TITLE
Permitir selección de números en el modal durante modo tutorial

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -982,6 +982,10 @@
     body.tutorial-activo.tutorial-focus-lock.tutorial-modal-open .tutorial-modal-abierto *{
       pointer-events:auto !important;
     }
+    body.tutorial-activo.tutorial-focus-lock.tutorial-modal-open #number-modal.tutorial-modal-abierto #number-grid div{
+      pointer-events:auto !important;
+      cursor:pointer;
+    }
     body.tutorial-activo.tutorial-modal-open #tutorial-hand,
     body.tutorial-activo.tutorial-modal-open #tutorial-label{
       display:none !important;


### PR DESCRIPTION
### Motivation
- El modo tutorial estaba bloqueando la interacción sobre las opciones del modal "Selecciona un número" porque una regla global de `tutorial-focus-lock` aplicaba `pointer-events:none` también a los elementos `#number-grid div`.

### Description
- Se añadió una regla CSS específica que restaura `pointer-events:auto` y `cursor:pointer` para `#number-modal.tutorial-modal-abierto #number-grid div` cuando el cuerpo está en `tutorial-activo.tutorial-focus-lock.tutorial-modal-open`.
- Archivo modificado: `public/jugarcartones.html` (sección de estilos inline), sin cambios funcionales al resto del sistema de bloqueo del tutorial.

### Testing
- Prueba automatizada de UI con Playwright que abre `jugarcartones.html`, activa el modo tutorial, abre el modal de número y captura pantalla; la prueba completó correctamente y dejó evidencia visual (screenshot).
- Servidor HTTP local levantado para validar la página (`python3 -m http.server ...`) y búsqueda de selectores con `rg` para comprobar la presencia de la nueva regla; ambas verificaciones fueron exitosas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce76622088326b52e6528623326c3)