### PR TITLE
Permitir seguir seleccionando celdas durante tutorial en jugarcartones

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -2266,6 +2266,7 @@
       await desplazarVistaSecuenciaInferior();
     }
     if(typeof paso.ejecutar==='function'){
+      limpiarFocoTutorial();
       detenerSeguimientoMano();
       detenerSeguimientoEtiqueta();
       ocultarVisualesTutorial();


### PR DESCRIPTION
### Motivation
- Solucionar el bloqueo de foco en el modo tutorial que impedía reabrir la modal de números y seleccionar más celdas después de mostrar el mensaje de ayuda.

### Description
- Se agregó una llamada a `limpiarFocoTutorial()` antes de ejecutar los pasos personalizados en `ejecutarPasoTutorial(...)` dentro de `public/jugarcartones.html` para liberar el foco y permitir volver a abrir `#number-modal` y elegir números en otras posiciones.

### Testing
- Se revisó el diff de `public/jugarcartones.html` y se validó localmente que el flujo del tutorial ya permite reabrir la modal y seguir seleccionando números, y las comprobaciones automáticas locales terminaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cea0e073c8326a2813600fba9891d)