### PR TITLE
Refuerza autorización en Parámetros (Firebase claims + reautenticación) y elimina `contrasenasu` legacy

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -27,6 +27,19 @@ service cloud.firestore {
       return isSystemRequest() || hasRole(['Superadmin', 'Administrador']);
     }
 
+    function hasStrongRole(roleEsperado) {
+      return isSignedIn()
+        && (
+          request.auth.token.admin == true
+          || request.auth.token.role == roleEsperado
+          || (request.auth.token.roles is list && request.auth.token.roles.hasAny([roleEsperado]))
+        );
+    }
+
+    function isStrongSuperadmin() {
+      return hasStrongRole('Superadmin');
+    }
+
     function isPrivilegedOperator() {
       return isAdmin() || hasRole(['Colaborador']);
     }
@@ -63,7 +76,7 @@ service cloud.firestore {
 
     match /Variablesglobales/{docId} {
       allow read: if isSignedIn();
-      allow write: if isAdmin();
+      allow write: if docId == 'Parametros' ? isStrongSuperadmin() : isAdmin();
     }
 
     match /roles/{docId} {

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -522,6 +522,53 @@ function ensureAuth(roleExpected){
     });
 }
 
+function claimIncluyeRol(claims, role){
+  if(!claims || !role) return false;
+  if(claims.admin === true) return true;
+  if(claims.role === role) return true;
+  if(Array.isArray(claims.roles) && claims.roles.includes(role)) return true;
+  return false;
+}
+
+async function verificarRolFuerte(roleExpected = 'Superadmin', options = {}){
+  const { forceRefresh = true } = options;
+  await initFirebase();
+  const user = auth.currentUser;
+  if(!user){
+    return { ok: false, reason: 'NO_AUTH', claims: null, user: null };
+  }
+  const tokenResult = await user.getIdTokenResult(forceRefresh);
+  const claims = tokenResult?.claims || {};
+  if(claimIncluyeRol(claims, roleExpected)){
+    return { ok: true, reason: null, claims, user };
+  }
+  return { ok: false, reason: 'MISSING_CLAIM', claims, user };
+}
+
+async function reautenticarConPopup(){
+  await initFirebase();
+  const user = auth.currentUser;
+  if(!user){
+    throw new Error('Usuario no autenticado');
+  }
+
+  const providerId = user.providerData?.[0]?.providerId;
+  let providerInstance = null;
+  if(providerId === 'google.com'){
+    providerInstance = new firebase.auth.GoogleAuthProvider();
+    providerInstance.setCustomParameters({ prompt: 'select_account' });
+  }else if(providerId === 'apple.com'){
+    providerInstance = new firebase.auth.OAuthProvider('apple.com');
+    providerInstance.addScope('email');
+    providerInstance.addScope('name');
+  }
+
+  if(!providerInstance || typeof user.reauthenticateWithPopup !== 'function'){
+    throw new Error('Proveedor no soportado para reautenticación con popup');
+  }
+  await user.reauthenticateWithPopup(providerInstance);
+}
+
 let statusWatcher = null;
 function startUserStatusWatcher(){
   if(statusWatcher) return;
@@ -539,4 +586,4 @@ function startUserStatusWatcher(){
   },60000);
 }
 
-if (typeof module !== "undefined") { module.exports = { redirectByRole, ensureAuth, setupSuperadminExit }; }
+if (typeof module !== "undefined") { module.exports = { redirectByRole, ensureAuth, setupSuperadminExit, verificarRolFuerte, reautenticarConPopup }; }

--- a/public/parametros.html
+++ b/public/parametros.html
@@ -136,67 +136,6 @@
       margin-left: 4px;
       font-weight: bold;
     }
-    #password-modal {
-      position: fixed;
-      inset: 0;
-      display: none;
-      align-items: center;
-      justify-content: center;
-      background: rgba(0,0,0,0.55);
-      z-index: 1000;
-      padding: 20px;
-    }
-    #password-modal.visible {
-      display: flex;
-    }
-    #password-modal .modal-box {
-      background: #fff;
-      padding: 20px;
-      border-radius: 12px;
-      max-width: 320px;
-      width: 100%;
-      box-shadow: 0 10px 30px rgba(0,0,0,0.2);
-      font-family: Calibri, Arial, sans-serif;
-      text-align: left;
-    }
-    #password-modal h3 {
-      margin-top: 0;
-      text-align: center;
-      font-family: 'Bangers', cursive;
-      letter-spacing: 1px;
-    }
-    #password-modal input[type="password"] {
-      width: 100%;
-      padding: 8px;
-      border: 1px solid #ccc;
-      border-radius: 6px;
-      box-sizing: border-box;
-      margin-top: 10px;
-    }
-    #password-modal .modal-actions {
-      display: flex;
-      justify-content: flex-end;
-      gap: 10px;
-      margin-top: 15px;
-    }
-    #password-modal button {
-      font-family: Calibri, Arial, sans-serif;
-      padding: 6px 14px;
-      border-radius: 6px;
-      border: none;
-      cursor: pointer;
-      background: rgba(0, 170, 255, 0.8);
-      color: #fff;
-    }
-    #password-modal button#password-cancel {
-      background: #888;
-    }
-    #password-error {
-      display: none;
-      color: #c62828;
-      margin-top: 10px;
-      font-size: 0.85rem;
-    }
   </style>
   <link rel="stylesheet" href="css/desktopFrame.css">
 </head>
@@ -205,18 +144,6 @@
   <div id="session-info" style="display:none;">
     <img id="user-pic" referrerpolicy="no-referrer" crossorigin="anonymous" src="" alt="Usuario" />
     <a href="#" id="logout-link">Cerrar sesión</a>
-  </div>
-  <div id="password-modal" aria-hidden="true">
-    <div class="modal-box" role="dialog" aria-modal="true" aria-labelledby="password-modal-title">
-      <h3 id="password-modal-title">Confirmar acceso</h3>
-      <p>Ingresa la contraseña de Superadmin para continuar.</p>
-      <input type="password" id="password-input" autocomplete="current-password" placeholder="Contraseña" />
-      <div id="password-error" role="alert"></div>
-      <div class="modal-actions">
-        <button type="button" id="password-cancel">Cancelar</button>
-        <button type="button" id="password-submit">Ingresar</button>
-      </div>
-    </div>
   </div>
   <h2 style="margin-top:20px;">Parámetros Globales</h2>
   <div id="parametros-form">
@@ -239,10 +166,6 @@
     <div class="form-row">
       <label for="emailA">Email:</label>
       <input type="text" id="emailA" placeholder="Email" />
-    </div>
-    <div class="form-row">
-      <label for="contrasenasu">Contraseña Superadmin:</label>
-      <input type="password" id="contrasenasu" placeholder="Contraseña Superadmin" autocomplete="off" />
     </div>
     <div class="form-row">
       <label for="nombreAgencia">Nombre Agencia:</label>
@@ -290,6 +213,40 @@
   <script>
     ensureAuth('Superadmin');
 
+    const camposContrasenaLegacy = ['contrasenasu','contrasenaSu','contrasenaSU','Contrasenasu','ContrasenaSu','ContrasenaSU'];
+
+    async function validarAutorizacionFuerteSuperadmin(){
+      const verificacion = await verificarRolFuerte('Superadmin', { forceRefresh: true });
+      if(!verificacion.ok){
+        throw new Error('Sin claims de Superadmin vigentes');
+      }
+      await reautenticarConPopup();
+    }
+
+    async function migrarContrasenaLegacyParametros(){
+      const ref = db.collection('Variablesglobales').doc('Parametros');
+      const doc = await ref.get();
+      if(!doc.exists){
+        return null;
+      }
+
+      const data = doc.data() || {};
+      const cambios = {};
+      let hayCambios = false;
+      for(const campo of camposContrasenaLegacy){
+        if(Object.prototype.hasOwnProperty.call(data, campo)){
+          cambios[campo] = firebase.firestore.FieldValue.delete();
+          hayCambios = true;
+        }
+      }
+
+      if(hayCambios){
+        await ref.set(cambios, { merge: true });
+      }
+      return data;
+    }
+
+
     async function cargarPaises(){
       try{
         const resp = await fetch('https://restcountries.com/v3.1/all?fields=name,translations,timezones');
@@ -313,115 +270,12 @@
       }
     }
 
-    function solicitarPassword(expectedPassword){
-      const modal = document.getElementById('password-modal');
-      const input = document.getElementById('password-input');
-      const cancelarBtn = document.getElementById('password-cancel');
-      const ingresarBtn = document.getElementById('password-submit');
-      const errorEl = document.getElementById('password-error');
-      const esperado = (expectedPassword || '').toString();
-      if(!modal || !input || !cancelarBtn || !ingresarBtn){
-        return Promise.resolve(false);
-      }
-
-      return new Promise(resolve=>{
-        const mostrarError = mensaje => {
-          if(errorEl){
-            errorEl.textContent = mensaje;
-            errorEl.style.display = 'block';
-          }else{
-            alert(mensaje);
-          }
-        };
-
-        const limpiar = ()=>{
-          modal.classList.remove('visible');
-          modal.setAttribute('aria-hidden', 'true');
-          input.value = '';
-          if(errorEl){
-            errorEl.textContent = '';
-            errorEl.style.display = 'none';
-          }
-          ingresarBtn.removeEventListener('click', manejarSubmit);
-          cancelarBtn.removeEventListener('click', manejarCancelar);
-          input.removeEventListener('keydown', manejarKeydown);
-          modal.removeEventListener('click', manejarBackdrop);
-        };
-
-        const manejarSubmit = evento => {
-          evento.preventDefault();
-          const valor = input.value.trim();
-          if(!valor){
-            mostrarError('Ingresa la contraseña.');
-            input.focus();
-            return;
-          }
-          if(valor !== esperado){
-            mostrarError('Contraseña incorrecta.');
-            input.select();
-            return;
-          }
-          limpiar();
-          resolve(true);
-        };
-
-        const manejarCancelar = evento => {
-          evento.preventDefault();
-          limpiar();
-          resolve(false);
-        };
-
-        const manejarKeydown = evento => {
-          if(evento.key === 'Enter'){
-            manejarSubmit(evento);
-          }else if(evento.key === 'Escape'){
-            manejarCancelar(evento);
-          }
-        };
-
-        const manejarBackdrop = evento => {
-          if(evento.target === modal){
-            manejarCancelar(evento);
-          }
-        };
-
-        modal.classList.add('visible');
-        modal.setAttribute('aria-hidden', 'false');
-        if(errorEl){
-          errorEl.textContent = '';
-          errorEl.style.display = 'none';
-        }
-        ingresarBtn.addEventListener('click', manejarSubmit);
-        cancelarBtn.addEventListener('click', manejarCancelar);
-        input.addEventListener('keydown', manejarKeydown);
-        modal.addEventListener('click', manejarBackdrop);
-        setTimeout(()=>input.focus({ preventScroll: true }), 50);
-      });
-    }
-    function obtenerContrasenaSuperadmin(datos){
-      if(!datos || typeof datos !== 'object') return '';
-      const posiblesClaves = ['contrasenasu','contrasenaSu','contrasenaSU','Contrasenasu','ContrasenaSu','ContrasenaSU'];
-      for(const clave of posiblesClaves){
-        const valor = datos[clave];
-        if(typeof valor === 'string'){
-          const limpio = valor.trim();
-          if(limpio){
-            return limpio;
-          }
-        } else if(typeof valor === 'number' && !Number.isNaN(valor)){
-          return valor.toString();
-        }
-      }
-      return '';
-    }
-
     function cargarFormulario(data){
       document.getElementById('aplicacion').value = data.Aplicacion || '';
       document.getElementById('cliente').value = data.Cliente || '';
       document.getElementById('agencia').value = data.Agencia || '';
       document.getElementById('telefonoA').value = data.TelefonoA || '';
       document.getElementById('emailA').value = data.EmailA || '';
-      document.getElementById('contrasenasu').value = obtenerContrasenaSuperadmin(data);
       document.getElementById('nombreAgencia').value = data.NombreAgencia || '';
       document.getElementById('direccion').value = data.Direccion || '';
       if(data.Pais){ document.getElementById('pais').value = data.Pais; }
@@ -445,7 +299,6 @@
         Agencia: document.getElementById('agencia').value.trim(),
         TelefonoA: document.getElementById('telefonoA').value.trim(),
         EmailA: document.getElementById('emailA').value.trim(),
-        contrasenasu: document.getElementById('contrasenasu').value.trim(),
         NombreAgencia: document.getElementById('nombreAgencia').value.trim(),
         Direccion: document.getElementById('direccion').value.trim(),
         Pais: document.getElementById('pais').value.trim(),
@@ -455,7 +308,8 @@
         porcentajeretiro: parseFloat(document.getElementById('porcentajeretiro').value)||0,
         porcentajeadministra: parseFloat(document.getElementById('porcentajeadministra').value)||0
       };
-      await db.collection('Variablesglobales').doc('Parametros').set(data,{merge:true});
+      const limpiezaLegacy = Object.fromEntries(camposContrasenaLegacy.map(campo=>[campo, firebase.firestore.FieldValue.delete()]));
+      await db.collection('Variablesglobales').doc('Parametros').set({ ...data, ...limpiezaLegacy },{merge:true});
       alert('Parámetros guardados');
       toggleEdicion(true);
     });
@@ -473,13 +327,13 @@
       await cargarPaises();
       let datosParametros = null;
       try{
-        const doc = await db.collection('Variablesglobales').doc('Parametros').get();
-        if(!doc.exists){
+        const dataOriginal = await migrarContrasenaLegacyParametros();
+        if(!dataOriginal){
           alert('No se encontraron parámetros configurados.');
           window.location.href='super.html';
           return;
         }
-        datosParametros = doc.data() || {};
+        datosParametros = dataOriginal;
       }catch(error){
         console.error('Error al obtener parámetros', error);
         alert('No fue posible obtener los parámetros.');
@@ -487,10 +341,6 @@
         return;
       }
 
-      const contrasenaEsperada = obtenerContrasenaSuperadmin(datosParametros);
-      if(!contrasenaEsperada){
-        alert('No hay una contraseña configurada para Superadmin. Configúrala en este formulario y guarda los cambios.');
-      }
 
       cargarFormulario(datosParametros);
       document.getElementById('parametros-form').style.display = 'flex';
@@ -504,11 +354,14 @@
           auth.onAuthStateChanged(async usuario=>{
             if(!usuario || parametrosYaInicializados) return;
             try{
+              await validarAutorizacionFuerteSuperadmin();
               await iniciarParametros();
               parametrosYaInicializados=true;
             }catch(err){
               parametrosYaInicializados=false;
               console.error('Fallo al cargar parámetros tras autenticar',err);
+              alert('Tu sesión no cumple la autorización fuerte de Superadmin para acceder a Parámetros.');
+              window.location.href='super.html';
             }
           });
         })

--- a/public/super.html
+++ b/public/super.html
@@ -87,67 +87,6 @@
       cursor: pointer;
     }
 
-    #password-modal {
-      position: fixed;
-      inset: 0;
-      display: none;
-      align-items: center;
-      justify-content: center;
-      background: rgba(0,0,0,0.55);
-      z-index: 1000;
-      padding: 20px;
-      font-family: Calibri, Arial, sans-serif;
-    }
-    #password-modal.visible {
-      display: flex;
-    }
-    #password-modal .modal-box {
-      background: #fff;
-      padding: 20px;
-      border-radius: 12px;
-      max-width: 320px;
-      width: 100%;
-      box-shadow: 0 10px 30px rgba(0,0,0,0.2);
-    }
-    #password-modal h3 {
-      margin-top: 0;
-      text-align: center;
-      font-family: 'Bangers', cursive;
-      letter-spacing: 1px;
-    }
-    #password-modal input[type="password"] {
-      width: 100%;
-      padding: 8px;
-      border: 1px solid #ccc;
-      border-radius: 6px;
-      box-sizing: border-box;
-      margin-top: 10px;
-    }
-    #password-modal .modal-actions {
-      display: flex;
-      justify-content: flex-end;
-      gap: 10px;
-      margin-top: 15px;
-    }
-    #password-modal button {
-      font-family: Calibri, Arial, sans-serif;
-      padding: 6px 14px;
-      border-radius: 6px;
-      border: none;
-      cursor: pointer;
-      background: rgba(0, 170, 255, 0.8);
-      color: #fff;
-    }
-    #password-modal button#password-cancel {
-      background: #888;
-    }
-    #password-error {
-      display: none;
-      color: #c62828;
-      margin-top: 10px;
-      font-size: 0.85rem;
-      text-align: left;
-    }
 
     #user-pic {
       width: 40px;
@@ -194,21 +133,6 @@
     <button id="reportes-btn" class="menu-btn">Reportes Generales</button>
   </div>
 
-  <div id="password-modal" aria-hidden="true">
-    <div class="modal-box" role="dialog" aria-modal="true" aria-labelledby="password-modal-title">
-      <h3 id="password-modal-title">Confirmar acceso</h3>
-      <p>Ingresa la contraseña de Superadmin para continuar.</p>
-      <input type="password" id="password-input" autocomplete="current-password" placeholder="Contraseña" />
-      <div id="password-error" role="alert"></div>
-      <div class="modal-actions">
-        <button type="button" id="password-cancel">Cancelar</button>
-        <button type="button" id="password-submit">Ingresar</button>
-      </div>
-    </div>
-  </div>
-
-
-
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -217,140 +141,23 @@
   <script src="js/notificationCenter.js"></script>
   <script>
   ensureAuth('Superadmin');
-  let contrasenaSuperadminCache=null;
-  let passwordLoadPromise=null;
-  function obtenerContrasenaSuperadmin(datos){
-    if(!datos || typeof datos !== 'object') return '';
-    const posiblesClaves=['contrasenasu','contrasenaSu','contrasenaSU','Contrasenasu','ContrasenaSu','ContrasenaSU'];
-    for(const clave of posiblesClaves){
-      const valor=datos[clave];
-      if(typeof valor==='string'){
-        const limpio=valor.trim();
-        if(limpio){return limpio;}
-      }else if(typeof valor==='number' && !Number.isNaN(valor)){
-        return valor.toString();
-      }
-    }
-    return '';
-  }
-  async function cargarPasswordSuperadmin(){
-    if(contrasenaSuperadminCache!==null) return contrasenaSuperadminCache;
-    if(passwordLoadPromise) return passwordLoadPromise;
-    passwordLoadPromise=(async()=>{
-      await initFirebase();
-      const doc=await db.collection('Variablesglobales').doc('Parametros').get();
-      if(doc.exists){
-        contrasenaSuperadminCache=obtenerContrasenaSuperadmin(doc.data()||{});
-      }else{
-        contrasenaSuperadminCache='';
-      }
-      return contrasenaSuperadminCache;
-    })();
-    try{
-      return await passwordLoadPromise;
-    }catch(error){
-      console.error('No se pudo obtener la contraseña de Superadmin',error);
-      contrasenaSuperadminCache=null;
-      throw error;
-    }finally{
-      passwordLoadPromise=null;
-    }
-  }
-  function solicitarPassword(expectedPassword){
-    const modal=document.getElementById('password-modal');
-    const input=document.getElementById('password-input');
-    const cancelarBtn=document.getElementById('password-cancel');
-    const ingresarBtn=document.getElementById('password-submit');
-    const errorEl=document.getElementById('password-error');
-    const esperado=(expectedPassword||'').toString();
-    if(!modal || !input || !cancelarBtn || !ingresarBtn){
-      return Promise.resolve(false);
-    }
-    return new Promise(resolve=>{
-      const mostrarError=mensaje=>{
-        if(errorEl){
-          errorEl.textContent=mensaje;
-          errorEl.style.display='block';
-        }else{
-          alert(mensaje);
-        }
-      };
-      const limpiar=()=>{
-        modal.classList.remove('visible');
-        modal.setAttribute('aria-hidden','true');
-        input.value='';
-        if(errorEl){
-          errorEl.textContent='';
-          errorEl.style.display='none';
-        }
-        ingresarBtn.removeEventListener('click',manejarSubmit);
-        cancelarBtn.removeEventListener('click',manejarCancelar);
-        input.removeEventListener('keydown',manejarKeydown);
-        modal.removeEventListener('click',manejarBackdrop);
-      };
-      const manejarSubmit=evento=>{
-        evento.preventDefault();
-        const valor=input.value.trim();
-        if(!valor){
-          mostrarError('Ingresa la contraseña.');
-          input.focus();
-          return;
-        }
-        if(valor!==esperado){
-          mostrarError('Contraseña incorrecta.');
-          input.select();
-          return;
-        }
-        limpiar();
-        resolve(true);
-      };
-      const manejarCancelar=evento=>{
-        evento.preventDefault();
-        limpiar();
-        resolve(false);
-      };
-      const manejarKeydown=evento=>{
-        if(evento.key==='Enter'){
-          manejarSubmit(evento);
-        }else if(evento.key==='Escape'){
-          manejarCancelar(evento);
-        }
-      };
-      const manejarBackdrop=evento=>{
-        if(evento.target===modal){
-          manejarCancelar(evento);
-        }
-      };
-      modal.classList.add('visible');
-      modal.setAttribute('aria-hidden','false');
-      if(errorEl){
-        errorEl.textContent='';
-        errorEl.style.display='none';
-      }
-      ingresarBtn.addEventListener('click',manejarSubmit);
-      cancelarBtn.addEventListener('click',manejarCancelar);
-      input.addEventListener('keydown',manejarKeydown);
-      modal.addEventListener('click',manejarBackdrop);
-      setTimeout(()=>input.focus({preventScroll:true}),50);
-    });
-  }
   async function intentarAbrirParametros(){
-    let contrasena;
     try{
-      contrasena=await cargarPasswordSuperadmin();
+      const verificacion = await verificarRolFuerte('Superadmin', { forceRefresh: true });
+      if(!verificacion.ok){
+        alert('No tienes claims de Superadmin vigentes. Vuelve a iniciar sesión o contacta al administrador del sistema.');
+        window.location.href='super.html';
+        return;
+      }
+
+      await reautenticarConPopup();
     }catch(error){
-      alert('No fue posible verificar la contraseña de Superadmin. Intenta nuevamente.');
+      console.error('No fue posible completar la autorización fuerte para Parámetros', error);
+      alert('No fue posible completar la reautenticación de Firebase. Intenta nuevamente.');
       return;
     }
-    if(!contrasena){
-      alert('No hay una contraseña configurada para Superadmin. Configúrala en el formulario de parámetros.');
-      window.location.href='parametros.html';
-      return;
-    }
-    const autorizado=await solicitarPassword(contrasena);
-    if(autorizado){
-      window.location.href='parametros.html';
-    }
+
+    window.location.href='parametros.html';
   }
   document.getElementById("acceder-usuario-btn").addEventListener("click",()=>{window.location.href="accederusuario.html";});
   document.getElementById("gestionar-usuarios-btn").addEventListener("click",()=>{window.location.href="gestionarusuarios.html";});


### PR DESCRIPTION
### Motivation
- Sustituir la verificación local de la contraseña `contrasenasu` por una autorización fuerte basada en claims de Firebase y reautenticación, para evitar almacenamiento/uso de contraseñas en cliente.
- Evitar accesos indebidos a la colección `Variablesglobales/Parametros` y facilitar migración segura de campos legacy.

### Description
- Reemplacé en `public/super.html` el modal/flujo de contraseña local por una verificación de claims (`verificarRolFuerte`) y una reautenticación con popup (`reautenticarConPopup`) antes de abrir `parametros.html`.
- En `public/parametros.html` eliminé el campo visible `contrasenasu` y toda la lógica local de comparación, añadí `migrarContrasenaLegacyParametros()` para detectar y limpiar campos legacy y cambié el guardado para eliminar esos campos con `FieldValue.delete()`.
- En `public/js/auth.js` añadí utilidades para autorización fuerte: `claimIncluyeRol`, `verificarRolFuerte` y `reautenticarConPopup`, y exporté las funciones nuevas para su uso desde las páginas.
- Actualicé `firestore.rules` añadiendo `hasStrongRole` e `isStrongSuperadmin` y endurecí la regla de escritura sobre `Variablesglobales/Parametros` para exigir rol fuerte (claims `admin`/`role`/`roles`) mientras mantengo el comportamiento previo para otros documentos.

### Testing
- Ejecuté validación de sintaxis JS con `node --check` sobre `public/js/auth.js` y los scripts inline extraídos de `public/super.html` y `public/parametros.html`, y pasaron correctamente.
- Busqué referencias legacy con `rg` para confirmar eliminación de comprobaciones/inputs de `contrasenasu` en las vistas afectadas y verifiqué la presencia de las nuevas funciones.
- Intenté una prueba visual con Playwright para servir `public/` y capturar `super.html`, pero el contenedor Chromium falló con `SIGSEGV` (no relacionado con los cambios de código); el resto de las comprobaciones automatizadas fueron exitosas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fbdbb54b0832698e7656440a2b40a)