### PR TITLE
Endurecer seguridad de uploadServer: validación, límites, CORS y URLs firmadas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.2.1",
         "firebase-admin": "^13.4.0",
+        "helmet": "^8.1.0",
         "multer": "^2.0.2"
       },
       "devDependencies": {
@@ -3343,6 +3345,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -3883,6 +3903,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -4061,6 +4090,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.2.1",
     "firebase-admin": "^13.4.0",
+    "helmet": "^8.1.0",
     "multer": "^2.0.2"
   },
   "devDependencies": {

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -2,6 +2,8 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const multer = require('multer');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
 const path = require('path');
 const admin = require('firebase-admin');
 
@@ -22,10 +24,76 @@ if (!admin.apps.length) {
 }
 
 const app = express();
-app.use(cors());
+
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000,http://127.0.0.1:3000')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+app.use(helmet());
+app.use(
+  rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: Number(process.env.RATE_LIMIT_MAX_REQUESTS || 300),
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Demasiadas solicitudes, intenta más tarde' }
+  })
+);
+app.use(
+  cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error('Origen no permitido por CORS'));
+    }
+  })
+);
 app.use(express.json());
 
-const upload = multer({ storage: multer.memoryStorage() });
+const ALLOWED_FILE_TYPES = {
+  '.png': ['image/png'],
+  '.jpg': ['image/jpeg'],
+  '.jpeg': ['image/jpeg'],
+  '.pdf': ['application/pdf']
+};
+const dangerousNamePattern = /(^\.+$|\.\.|[\\/]|[\x00-\x1F\x7F])/;
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: Number(process.env.MAX_UPLOAD_FILE_SIZE_BYTES || 5 * 1024 * 1024),
+    files: 1
+  },
+  fileFilter(req, file, callback) {
+    const extension = path.extname(file.originalname || '').toLowerCase();
+    const allowedMimeTypes = ALLOWED_FILE_TYPES[extension];
+
+    if (!allowedMimeTypes || !allowedMimeTypes.includes(file.mimetype)) {
+      return callback(new multer.MulterError('LIMIT_UNEXPECTED_FILE', 'file'));
+    }
+
+    if (dangerousNamePattern.test(file.originalname) || path.basename(file.originalname) !== file.originalname) {
+      return callback(new Error('Nombre de archivo inválido'));
+    }
+
+    return callback(null, true);
+  }
+});
+
+function registrarAuditoria({ email, fileType, result, reason }) {
+  console.info(
+    JSON.stringify({
+      event: 'upload_audit',
+      userEmail: email || 'desconocido',
+      timestamp: new Date().toISOString(),
+      fileType: fileType || 'desconocido',
+      result,
+      reason: reason || null
+    })
+  );
+}
 
 async function verificarToken(req, res, next) {
   const authHeader = req.headers.authorization || '';
@@ -80,19 +148,60 @@ app.post('/toggleUser', verificarToken, async (req, res) => {
 });
 
 app.post('/upload', verificarToken, upload.single('file'), async (req, res) => {
-  if (!req.file) return res.status(400).json({ error: 'Archivo requerido' });
+  if (!req.file) {
+    registrarAuditoria({ email: req.user?.email, result: 'rechazado', reason: 'Archivo requerido' });
+    return res.status(400).json({ error: 'Archivo requerido' });
+  }
   try {
     const bucket = admin.storage().bucket();
-    const fileName = `${Date.now()}${path.extname(req.file.originalname)}`;
+    const extension = path.extname(req.file.originalname).toLowerCase();
+    const fileName = `${Date.now()}-${Math.round(Math.random() * 1e9)}${extension}`;
     const file = bucket.file(fileName);
     await file.save(req.file.buffer, { contentType: req.file.mimetype });
-    await file.makePublic();
-    const url = `https://storage.googleapis.com/${bucket.name}/${fileName}`;
-    res.json({ url });
+    const [url] = await file.getSignedUrl({
+      action: 'read',
+      expires: Date.now() + Number(process.env.SIGNED_URL_EXPIRATION_MS || 15 * 60 * 1000)
+    });
+    registrarAuditoria({ email: req.user?.email, fileType: req.file.mimetype, result: 'exitoso' });
+    res.json({ url, expiresInMs: Number(process.env.SIGNED_URL_EXPIRATION_MS || 15 * 60 * 1000) });
   } catch (e) {
     console.error(e);
+    registrarAuditoria({
+      email: req.user?.email,
+      fileType: req.file?.mimetype,
+      result: 'fallido',
+      reason: e.message
+    });
     res.status(500).json({ error: 'Error al subir archivo', message: e.message });
   }
+});
+
+app.use((err, req, res, next) => {
+  if (err instanceof multer.MulterError) {
+    const message = err.code === 'LIMIT_FILE_SIZE' ? 'Archivo excede el tamaño permitido' : 'Archivo no permitido';
+    registrarAuditoria({
+      email: req.user?.email,
+      fileType: req.file?.mimetype,
+      result: 'rechazado',
+      reason: message
+    });
+    return res.status(400).json({ error: message });
+  }
+
+  if (err && err.message === 'Nombre de archivo inválido') {
+    registrarAuditoria({
+      email: req.user?.email,
+      result: 'rechazado',
+      reason: err.message
+    });
+    return res.status(400).json({ error: err.message });
+  }
+
+  if (err && err.message === 'Origen no permitido por CORS') {
+    return res.status(403).json({ error: err.message });
+  }
+
+  return next(err);
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
### Motivation
- Proteger el endpoint de subida frente a archivos maliciosos y abusos limitando tamaño, validando tipo/nombre y evitando exposición pública de los objetos almacenados.
- Añadir controles de superficie (CORS por lista blanca, `helmet`, rate limiting) para reducir riesgos de explotación y abuso.
- Registrar una auditoría mínima de intentos de subida para trazabilidad y detección de incidentes.

### Description
- Se actualizó `uploadServer.js` para configurar `multer` con `limits.fileSize` y `limits.files` y un `fileFilter` que valida extensión y MIME contra una lista blanca (`ALLOWED_FILE_TYPES`) y rechaza nombres peligrosos con patrones de traversal/control chars.
- Se añadieron middlewares de seguridad: `helmet`, rate limiting con `express-rate-limit` y `cors` que permite orígenes solo desde la variable `ALLOWED_ORIGINS`.
- Se reemplazó `file.makePublic()` por la generación de URLs firmadas temporales mediante `file.getSignedUrl(...)` con expiración configurable (`SIGNED_URL_EXPIRATION_MS`).
- Se implementó un registro de auditoría mínimo (`registrarAuditoria`) que emite JSON con `userEmail`, timestamp, tipo de archivo, resultado y motivo, y se añadió manejo centralizado de errores para `multer`, nombres inválidos y CORS.
- Se actualizaron `package.json` y `package-lock.json` para incluir las dependencias `helmet` y `express-rate-limit`.

### Testing
- Se verificó la sintaxis del archivo con `node --check uploadServer.js` y la comprobación final fue satisfactoria (sin errores).
- Se ejecutaron las pruebas unitarias con `npm test -- --runInBand` y la suite existente pasó correctamente (`PASS __tests__/player.test.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fd1d1e4d48326b9397dc2d292b522)