### PR TITLE
Ajustar validación de variables requeridas en uploadServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Para almacenar las imágenes de los sorteos se utiliza **Firebase Cloud Storage*
 
 ### Notificaciones por correo
 
-Las notificaciones por correo electrónico se eliminaron del proyecto y ya no es necesario configurar SendGrid ni credenciales asociadas para operar la aplicación.
+Las notificaciones por correo electrónico se eliminaron del proyecto y ya no es necesario configurar SendGrid ni credenciales asociadas para operar la aplicación. En particular, `uploadServer.js` solo valida `GOOGLE_APPLICATION_CREDENTIALS` y `FIREBASE_STORAGE_BUCKET` al iniciar.
 
 Antes de ejecutar los scripts asegúrese de:
 

--- a/__tests__/uploadServer-required-env.test.js
+++ b/__tests__/uploadServer-required-env.test.js
@@ -1,0 +1,57 @@
+jest.mock('firebase-admin', () => ({
+  apps: [],
+  initializeApp: jest.fn()
+}));
+
+describe('uploadServer variables requeridas', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('requiredEnv solo incluye variables realmente obligatorias para arrancar', () => {
+    const { requiredEnv } = require('../uploadServer.js');
+
+    expect(requiredEnv).toEqual(['GOOGLE_APPLICATION_CREDENTIALS', 'FIREBASE_STORAGE_BUCKET']);
+    expect(requiredEnv).not.toContain('SENDGRID_API_KEY');
+  });
+
+  test('getMissingRequiredEnv reporta únicamente variables obligatorias faltantes', () => {
+    const { getMissingRequiredEnv } = require('../uploadServer.js');
+
+    const missing = getMissingRequiredEnv({
+      GOOGLE_APPLICATION_CREDENTIALS: '/tmp/serviceAccountKey.json'
+    });
+
+    expect(missing).toEqual(['FIREBASE_STORAGE_BUCKET']);
+  });
+
+  test('validateRequiredEnv falla solo si falta una variable realmente requerida', () => {
+    const { validateRequiredEnv } = require('../uploadServer.js');
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() =>
+      validateRequiredEnv({
+        GOOGLE_APPLICATION_CREDENTIALS: '/tmp/serviceAccountKey.json'
+      })
+    ).toThrow('process.exit');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Faltan variables de entorno requeridas para uploadServer: FIREBASE_STORAGE_BUCKET'
+    );
+
+    expect(() =>
+      validateRequiredEnv({
+        GOOGLE_APPLICATION_CREDENTIALS: '/tmp/serviceAccountKey.json',
+        FIREBASE_STORAGE_BUCKET: 'demo.appspot.com'
+      })
+    ).not.toThrow();
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+});

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -7,20 +7,28 @@ const rateLimit = require('express-rate-limit');
 const path = require('path');
 const admin = require('firebase-admin');
 
-// Verificar variables de entorno necesarias antes de inicializar Firebase
-const requiredEnv = ['GOOGLE_APPLICATION_CREDENTIALS', 'FIREBASE_STORAGE_BUCKET', 'SENDGRID_API_KEY'];
-for (const name of requiredEnv) {
-  if (!process.env[name]) {
-    console.error(`Falta la variable de entorno ${name}`);
+const requiredEnv = ['GOOGLE_APPLICATION_CREDENTIALS', 'FIREBASE_STORAGE_BUCKET'];
+
+function getMissingRequiredEnv(env = process.env) {
+  return requiredEnv.filter((name) => !env[name]);
+}
+
+function validateRequiredEnv(env = process.env) {
+  const missingRequiredEnv = getMissingRequiredEnv(env);
+  if (missingRequiredEnv.length > 0) {
+    console.error(
+      `Faltan variables de entorno requeridas para uploadServer: ${missingRequiredEnv.join(', ')}`
+    );
     process.exit(1);
   }
 }
 
-// Inicializa Firebase Admin especificando el bucket de Storage
-if (!admin.apps.length) {
-  admin.initializeApp({
-    storageBucket: process.env.FIREBASE_STORAGE_BUCKET
-  });
+function initializeFirebase() {
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      storageBucket: process.env.FIREBASE_STORAGE_BUCKET
+    });
+  }
 }
 
 const app = express();
@@ -204,7 +212,25 @@ app.use((err, req, res, next) => {
   return next(err);
 });
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Servicio de subida escuchando en puerto ${PORT}`);
-});
+function startServer() {
+  validateRequiredEnv();
+  initializeFirebase();
+
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Servicio de subida escuchando en puerto ${PORT}`);
+  });
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = {
+  app,
+  requiredEnv,
+  getMissingRequiredEnv,
+  validateRequiredEnv,
+  initializeFirebase,
+  startServer
+};


### PR DESCRIPTION
### Motivation

- Evitar que `uploadServer.js` exija variables de entorno no utilizadas y dejar claro qué variables son necesarias para arrancar el servicio auxiliar de subida.
- Mejorar los mensajes de error de arranque para indicar únicamente las variables faltantes reales y facilitar testes de smoke/startup.

### Description

- Eliminé `SENDGRID_API_KEY` de `requiredEnv` dejando solo `GOOGLE_APPLICATION_CREDENTIALS` y `FIREBASE_STORAGE_BUCKET` en `uploadServer.js`.
- Añadí las utilidades `getMissingRequiredEnv` y `validateRequiredEnv`, reorganicé la inicialización en `initializeFirebase()` y moví el inicio a `startServer()` para ejecutar la validación solo al correr como entrypoint; además exporté esas funciones para pruebas.
- Añadí la prueba `__tests__/uploadServer-required-env.test.js` que verifica que solo se exigen las variables reales, que `getMissingRequiredEnv` reporta correctamente y que `validateRequiredEnv` falla únicamente cuando falta una variable requerida.
- Actualicé `README.md` (sección Notificaciones por correo) para documentar que `uploadServer.js` valida únicamente las dos variables mencionadas al iniciar.

### Testing

- Ejecuté la nueva prueba individual con `npm test -- --runInBand __tests__/uploadServer-required-env.test.js` y pasó correctamente (tests unitarios del archivo OK, aunque la ejecución aislada mostró el umbral global de coverage de Jest cuando se ejecutó solo ese fichero).
- Ejecuté la suite completa con `npm test -- --runInBand` y todos los tests pasaron: `6` test suites pasadas y `16` tests en total pasados.
- Las modificaciones están cubiertas por la nueva prueba y no introducen fallos en las suites existentes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fe366cb40832690bb12ee409b1dfe)