### PR TITLE
Corregir layout de miniaturas de cartones en pdfresultados para vista de escritorio

### DIFF
--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -559,7 +559,7 @@
     }
     #cartones-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(clamp(150px, 20vw, 200px), 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(clamp(170px, 17vw, 210px), 1fr));
       gap: clamp(6px, 1.8vw, 14px);
       justify-items: center;
       align-items: flex-start;
@@ -588,25 +588,25 @@
     }
     @media (orientation: landscape) and (min-width: 1024px) {
       #cartones-grid {
-        grid-template-columns: repeat(6, minmax(0, 1fr));
-        gap: clamp(6px, 1vw, 12px);
+        grid-template-columns: repeat(auto-fit, minmax(clamp(175px, 15vw, 220px), 1fr));
+        gap: clamp(8px, 0.95vw, 14px);
       }
       .pdf-carton {
         max-width: none;
       }
       .pdf-carton-table {
-        --cell-size: clamp(22px, 2.6vw, 28px);
+        --cell-size: clamp(22px, 1.85vw, 27px);
       }
     }
     body.forzar-orientacion-landscape #cartones-grid {
-      grid-template-columns: repeat(6, minmax(0, 1fr));
-      gap: clamp(6px, 1vw, 12px);
+      grid-template-columns: repeat(auto-fit, minmax(clamp(175px, 15vw, 220px), 1fr));
+      gap: clamp(8px, 0.95vw, 14px);
     }
     body.forzar-orientacion-landscape .pdf-carton {
       max-width: none;
     }
     body.forzar-orientacion-landscape .pdf-carton-table {
-      --cell-size: clamp(22px, 2.6vw, 28px);
+      --cell-size: clamp(22px, 1.85vw, 27px);
     }
     @media (min-width: 1500px) {
       #pdf-wrapper {
@@ -614,11 +614,11 @@
         padding-right: clamp(16px, 2vw, 32px);
       }
       #cartones-grid {
-        grid-template-columns: repeat(6, minmax(0, 1fr));
-        gap: clamp(6px, 0.8vw, 12px);
+        grid-template-columns: repeat(auto-fit, minmax(clamp(175px, 13vw, 230px), 1fr));
+        gap: clamp(8px, 0.7vw, 12px);
       }
       .pdf-carton-table {
-        --cell-size: clamp(20px, 2.1vw, 26px);
+        --cell-size: clamp(21px, 1.4vw, 26px);
       }
     }
     @media (max-width: 900px) {


### PR DESCRIPTION
### Motivation
- Evitar que las miniaturas de los cartones se monten entre sí en vista PC al aprovechar mejor el ancho disponible y mantener legibilidad sin alterar la generación de PDF.

### Description
- Cambié la regla de `#cartones-grid` en `public/pdfresultados.html` para usar `repeat(auto-fit, minmax(...))` en lugar de forzar `repeat(6, ...)`, permitiendo columnas dinámicas según el ancho del contenedor. 
- Apliqué el mismo enfoque responsive a las variantes de escritorio y a `body.forzar-orientacion-landscape` para prevenir solapamientos en pantallas grandes o contenedores angostos. 
- Ajusté los valores de `--cell-size` en los breakpoints de escritorio para mantener proporciones apropiadas y evitar desbordes en las miniaturas. 
- Los cambios están en `public/pdfresultados.html` y se mantuvo intacto el layout específico de `body.pdf-captura` usado para la generación de PDFs.

### Testing
- Ejecuté `npm test -- --runInBand` y todas las suites automatizadas pasaron (6 suites, 16 tests) con éxito. 
- Ejecuté `npm test -- --runInBand __tests__/player.test.js` y la prueba pasó, aunque al ejecutar solo esa suite primero apareció una advertencia de umbral de cobertura (esto no afectó el resultado final). 
- Validación visual: levanté un servidor local con `python3 -m http.server 4173`, inyecté cartones demo con un script de Playwright y generé una captura (`artifacts/pdfresultados-cartones-demo.png`) para verificar la distribución de miniaturas en escritorio; la navegación a la URL externa falló por `ERR_NAME_NOT_RESOLVED` pero la verificación local fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69907149d4508326be17f2c94c6418b4)