### PR TITLE
Corrige acreditación inmediata de premios y visualización en sorteos finalizados

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -605,6 +605,8 @@
     let creditosTotales=0, creditosTransito=0, creditosDisponibles=0;
     let numeroWhatsappDestino='';
     let numeroWhatsappCargado=false;
+    let unsubscribeBilletera=null;
+    let unsubscribeTransacciones=null;
 
     function toNumberSafe(valor, defecto=0){
       const numero=parseFloat(valor);
@@ -642,6 +644,52 @@
       if(snap.exists){
         actualizarResumenCreditos(snap.data()||{});
       }
+    }
+
+    function aplicarDatosBilleteraEnPantalla(data){
+      const datos=data||{};
+      actualizarResumenCreditos(datos);
+      document.getElementById('cartones-valor').textContent = datos.CartonesGratis || 0;
+      const cedulaEl=document.getElementById('cedula');
+      cedulaEl.value=normalizarSoloNumeros(datos.cedula);
+      const pagomovilEl=document.getElementById('pagomovil');
+      pagomovilEl.value=normalizarPagoMovil(datos.pagomovil);
+      document.getElementById('banco').value = datos.banco || '';
+      const cuentaEl=document.getElementById('cuenta');
+      cuentaEl.value=normalizarSoloNumeros(datos.cuenta);
+      if(datos.tipoCuenta){
+        const r=document.querySelector(`input[name='tipo-cuenta'][value='${datos.tipoCuenta}']`);
+        if(r) r.checked=true;
+      }
+      const cuentaToggle=document.getElementById('cuenta-toggle');
+      const cuentaActiva=Boolean((datos.cuenta||'').toString().trim()) || Boolean((datos.tipoCuenta||'').toString().trim());
+      cuentaToggle.checked=cuentaActiva;
+      actualizarEstadoCuentaOpcional(cuentaActiva);
+      document.getElementById('banco-retiro').textContent = 'Banco donde recibirás: '+(datos.banco||'');
+    }
+
+    function suscribirBilleteraUsuario(){
+      if(unsubscribeBilletera){
+        unsubscribeBilletera();
+        unsubscribeBilletera=null;
+      }
+      const user=auth.currentUser;
+      if(!user?.email) return;
+      const billeteraRef=db.collection('Billetera').doc(user.email);
+      unsubscribeBilletera=billeteraRef.onSnapshot(async snap=>{
+        if(snap.exists){
+          aplicarDatosBilleteraEnPantalla(snap.data()||{});
+          return;
+        }
+        try{
+          await billeteraRef.set({creditos:0, CartonesGratis:0, creditostransito:0});
+        }catch(error){
+          console.error('No se pudo crear la billetera inicial del usuario',error);
+        }
+        aplicarDatosBilleteraEnPantalla({creditos:0, CartonesGratis:0, creditostransito:0});
+      },error=>{
+        console.error('Error escuchando la billetera del usuario',error);
+      });
     }
 
     function cargarBancosBilletera(){
@@ -867,36 +915,8 @@
         }
         const billeteraRef = db.collection('Billetera').doc(user.email);
         const doc = await billeteraRef.get();
-        if(doc.exists){
-          const data = doc.data();
-          actualizarResumenCreditos(data);
-          document.getElementById('cartones-valor').textContent = data.CartonesGratis || 0;
-          const cedulaEl=document.getElementById('cedula');
-          cedulaEl.value=normalizarSoloNumeros(data.cedula);
-          const pagomovilEl=document.getElementById('pagomovil');
-          pagomovilEl.value=normalizarPagoMovil(data.pagomovil);
-          document.getElementById('banco').value = data.banco || '';
-          const cuentaEl=document.getElementById('cuenta');
-          cuentaEl.value=normalizarSoloNumeros(data.cuenta);
-          if(data.tipoCuenta){
-            const r=document.querySelector(`input[name='tipo-cuenta'][value='${data.tipoCuenta}']`);
-            if(r) r.checked=true;
-          }
-          const cuentaToggle=document.getElementById('cuenta-toggle');
-          const cuentaActiva=Boolean((data.cuenta||'').toString().trim()) || Boolean((data.tipoCuenta||'').toString().trim());
-          cuentaToggle.checked=cuentaActiva;
-          actualizarEstadoCuentaOpcional(cuentaActiva);
-          document.getElementById('banco-retiro').textContent = 'Banco donde recibirás: '+(data.banco||'');
-        } else {
-          await billeteraRef.set({creditos:0, CartonesGratis:0, creditostransito:0});
-          actualizarResumenCreditos({creditos:0, creditostransito:0});
-          document.getElementById('cartones-valor').textContent='0';
-          document.getElementById('banco-retiro').textContent='Banco donde recibirás:';
-          const cuentaToggle=document.getElementById('cuenta-toggle');
-          cuentaToggle.checked=false;
-          actualizarEstadoCuentaOpcional(false);
-        }
-        cargarTransacciones();
+        suscribirBilleteraUsuario();
+        suscribirTransaccionesUsuario();
         const estadoTutorialActivo = (doc.exists && doc.data()?.tutorialBilleteraEstado === 'Activo');
         tutorialState.datosCargados=true;
         configurarControlesTutorial();
@@ -1811,12 +1831,10 @@
     }
 
 
-  async function cargarTransacciones(){
-      const user=auth.currentUser;
-      const snap=await db.collection('transacciones').where('IDbilletera','==',user.email).get();
+  function procesarSnapshotTransacciones(snap){
       transacciones.length=0;
       snap.forEach(doc=>{
-        const data=doc.data();
+        const data=doc.data()||{};
         data.fechasolicitud=formatearFecha(data.fechasolicitud);
         data.fechagestion=formatearFecha(data.fechagestion);
         const tipoNormalizado = normalizarTipoTransaccion(data);
@@ -1828,6 +1846,19 @@
         return db-da;
       });
       filtrarTransacciones();
+    }
+
+    function suscribirTransaccionesUsuario(){
+      if(unsubscribeTransacciones){
+        unsubscribeTransacciones();
+        unsubscribeTransacciones=null;
+      }
+      const user=auth.currentUser;
+      if(!user?.email) return;
+      unsubscribeTransacciones=db.collection('transacciones').where('IDbilletera','==',user.email).onSnapshot(
+        procesarSnapshotTransacciones,
+        error=>{ console.error('Error escuchando transacciones de la billetera',error); }
+      );
     }
 
     function filtrarTransacciones(){
@@ -2119,7 +2150,7 @@
         comentario:data.comentario
       });
       limpiarCamposTransaccion('recarga');
-      cargarTransacciones();
+      suscribirTransaccionesUsuario();
     });
 
     async function ejecutarRetiro(monto,montoFinal, comentario){
@@ -2173,7 +2204,7 @@
       await refrescarResumenBilletera();
       await mostrarAlertaModal('Solicitud enviada, una vez validada se transferirá a tu pago móvil, serás dirigido a tu WhatsApp para poder enviar el mensaje de solicitud');
       limpiarCamposTransaccion('retiro');
-      cargarTransacciones();
+      suscribirTransaccionesUsuario();
       return { data, billetera: billeteraData };
     }
 

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4513,6 +4513,36 @@
   let cantosRecientesSinAnimacion = false;
   let resumenGanadoresPrevio = new Map();
 
+  function normalizarIdentificadorTexto(valor){
+    return (valor ?? '').toString().trim().toLowerCase();
+  }
+
+  function obtenerIdentificadoresUsuarioActual(){
+    const ids = new Set();
+    const uid = normalizarIdentificadorTexto(usuarioActual?.uid);
+    const email = normalizarIdentificadorTexto(usuarioActual?.email);
+    if(uid) ids.add(uid);
+    if(email) ids.add(email);
+    return ids;
+  }
+
+  function cartonPerteneceAUsuarioActual(carton){
+    if(!carton) return false;
+    const idsUsuario = obtenerIdentificadoresUsuarioActual();
+    if(!idsUsuario.size) return false;
+    const posiblesIds = [
+      carton.userId,
+      carton.uid,
+      carton.usuarioId,
+      carton.email,
+      carton.gmail,
+      carton.correo,
+      carton.IDbilletera,
+      carton.idBilletera
+    ].map(normalizarIdentificadorTexto).filter(Boolean);
+    return posiblesIds.some(id=>idsUsuario.has(id));
+  }
+
   let cartonSeleccionadoId = null;
   const animacionesCartones = new Map();
   const celdasPenalizadasTimers = new Map();
@@ -6282,7 +6312,7 @@
     }
     formasPorCarton.forEach((lista, cartonId)=>{
       const carton=cartonesSorteo.get(cartonId);
-      if(!carton || carton.userId!==usuarioActual.uid || !Array.isArray(lista)) return;
+      if(!carton || !cartonPerteneceAUsuarioActual(carton) || !Array.isArray(lista)) return;
       lista.forEach(item=>{
         const idx=Number(item?.forma?.idx ?? item?.idx);
         if(Number.isInteger(idx)){
@@ -7800,7 +7830,7 @@
   }
 
   function obtenerCartonesJugadorActual(){
-    const listaReales=Array.from(cartonesSorteo.values()).filter(c=>c.userId===(usuarioActual?usuarioActual.uid:null));
+    const listaReales=Array.from(cartonesSorteo.values()).filter(cartonPerteneceAUsuarioActual);
     const estadoSorteoActual=(activeSorteo?.estado || activeSorteo?.estadoSorteo || '').toString().toLowerCase();
     const guardados=simulacionSorteoActiva ? obtenerCartonesSimuladosActivos() : [];
     const datosRealesListos = cartonesRealesCargados || listaReales.length>0;
@@ -9225,7 +9255,7 @@
     if(!usuarioActual || !activeSorteoId) return;
     const cartonesJugador = obtenerCartonesJugadorActual();
     if(modoSimulacionCartones) return;
-    const cartonesReales = cartonesJugador.filter(carton=>carton.userId===usuarioActual.uid);
+    const cartonesReales = cartonesJugador.filter(cartonPerteneceAUsuarioActual);
     if(!cartonesReales.length) return;
     resumenActual.forEach((infoActual, indice)=>{
       const totalActual = Number(infoActual?.total || 0);
@@ -10228,7 +10258,7 @@
     if(simulacionSorteoActiva || simulacionCancelada.has(sorteoId) || simulacionModalMostrada.has(sorteoId)){
       return;
     }
-    const tieneCartonesEnSorteo=Array.from(cartonesSorteo.values()).some(c=>c.userId===(usuarioActual?.uid||''));
+    const tieneCartonesEnSorteo=Array.from(cartonesSorteo.values()).some(cartonPerteneceAUsuarioActual);
     if(tieneCartonesEnSorteo){
       return;
     }


### PR DESCRIPTION
### Motivation
- Garantizar que los premios (créditos y cartones gratis) se acrediten y se muestren en la billetera y en la tabla de transacciones de los usuarios al instante cuando se aprueban. 
- Corregir la ausencia de mini-cartones y mensajes de premios en sorteos finalizados cuando los registros de cartones usan identificadores legacy distintos al `uid`.

### Description
- Se actualizó `public/billetera.html` para usar listeners en tiempo real (`onSnapshot`) sobre `Billetera` y `transacciones`, se añadió `aplicarDatosBilleteraEnPantalla` y manejo de `unsubscribe` para reflejar al instante créditos y cartones gratis en UI. 
- Se modificó `public/juegoactivo.html` para introducir `normalizarIdentificadorTexto`, `obtenerIdentificadoresUsuarioActual` y `cartonPerteneceAUsuarioActual`, y aplicar ese matcher en puntos clave (`obtenerFormasGanadasPorUsuarioActual`, `obtenerCartonesJugadorActual`, `evaluarMensajesSegundoLugar`, `evaluarSolicitudSimulacionInicial`) para reconocer cartones por uid, email o campos legacy. 
- Cambios menores en la lógica de suscripción/recarga para mantener sincronizada la vista de la billetera y la tabla de transacciones sin recargar manualmente.

### Testing
- Ejecuté las pruebas automatizadas con `npm test -- --runInBand`, resultado: 6 suites y 16 tests pasando. 
- Las modificaciones fueron validadas ejecutando la app localmente en modo de pruebas (listeners) y verificando que las subscripciones actualizan UI al cambiar documentos; las suites de `jest` pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990768f09ec83269fdb52a12cc49370)