### PR TITLE
Corregir visualización de N°, alias, cartón y tipo en modal "Cartones jugando"

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -2439,7 +2439,19 @@
   }
 
   function extraerAliasCarton(data){
-    const candidatos=[data?.alias,data?.aliascarton,data?.aliasCarton,data?.aliasJugador,data?.aliasjugador];
+    const candidatos=[
+      data?.alias,
+      data?.aliascarton,
+      data?.aliasCarton,
+      data?.aliasJugador,
+      data?.aliasjugador,
+      data?.nombre,
+      data?.nombreJugador,
+      data?.usuarioAlias,
+      data?.userAlias,
+      data?.perfil?.alias,
+      data?.jugador?.alias
+    ];
     for(const candidato of candidatos){
       const normalizado=normalizarAliasPerfil(candidato);
       if(normalizado){
@@ -2450,7 +2462,16 @@
   }
 
   function extraerNumeroCartonDatos(data){
-    const candidatos=[data?.cartonNum,data?.Ncarton,data?.carton];
+    const candidatos=[
+      data?.cartonNum,
+      data?.Ncarton,
+      data?.carton,
+      data?.numero,
+      data?.numeroCarton,
+      data?.cartonNumero,
+      data?.jugada?.cartonNum,
+      data?.jugador?.cartonNum
+    ];
     for(const candidato of candidatos){
       const numero=Number.parseInt(candidato,10);
       if(Number.isFinite(numero)){
@@ -2462,11 +2483,21 @@
   }
 
   function extraerTipoCartonDato(data){
-    const candidatos=[data?.tipocarton,data?.tipoCarton,data?.tipo];
+    const candidatos=[
+      data?.tipocarton,
+      data?.tipoCarton,
+      data?.tipo,
+      data?.categoria,
+      data?.cartonTipo,
+      data?.jugada?.tipocarton
+    ];
     for(const candidato of candidatos){
       const texto=(candidato??'').toString().trim().toLowerCase();
       if(texto){
-        return texto==='gratis'?'GRATIS':'PAGADO';
+        if(['gratis','free','bono'].includes(texto)){
+          return 'GRATIS';
+        }
+        return 'PAGADO';
       }
     }
     return 'PAGADO';
@@ -2490,14 +2521,26 @@
       data?.sorteoID,
       data?.IDSorteo,
       data?.id_sorteo,
-      data?.sorteo
+      data?.sorteo,
+      data?.sorteo?.id,
+      data?.sorteo?.sorteoId,
+      data?.sorteo?.docId,
+      data?.juego?.sorteoId
     ];
     const valores=[];
     candidatos.forEach(valor=>{
       if(valor===undefined || valor===null) return;
       if(typeof valor==='string' || typeof valor==='number'){
         const texto=String(valor).trim();
-        if(texto) valores.push(texto);
+        if(texto){
+          valores.push(texto);
+          if(texto.includes('/')){
+            const segmentos=texto.split('/').filter(Boolean);
+            if(segmentos.length){
+              valores.push(segmentos[segmentos.length-1]);
+            }
+          }
+        }
         return;
       }
       if(typeof valor==='object'){
@@ -2525,7 +2568,9 @@
       data?.sorteoNombre,
       data?.nombreSorteo,
       data?.nombresorteo,
-      data?.sorteo_name
+      data?.sorteo_name,
+      data?.sorteo?.nombre,
+      data?.juego?.sorteoNombre
     ]
       .map(valor=>(valor??'').toString().trim())
       .filter(Boolean);


### PR DESCRIPTION
## Resumen
Se corrigió la extracción de datos que alimenta la tabla del modal **CARTONES JUGANDO** en `public/jugarcartones.html`.

## Problema
En algunos registros de `CartonJugado` los campos venían con variantes de nombre o estructura (por ejemplo rutas de sorteo, objetos anidados o alias/numero/tipo con otros nombres), y la tabla no lograba mapearlos correctamente.

## Cambios realizados
- Amplié los campos candidatos para extraer alias (`alias`, `nombre`, `userAlias`, `perfil.alias`, etc.).
- Amplié los campos candidatos para extraer número de cartón (`cartonNum`, `Ncarton`, `numero`, `numeroCarton`, etc.).
- Amplié la detección del tipo de cartón (`tipocarton`, `tipoCarton`, `tipo`, `categoria`, etc.) y normalización de variantes.
- Fortalecí la detección de `sorteoId` para soportar:
  - valores en objetos anidados (`sorteo.id`, `sorteo.sorteoId`, `juego.sorteoId`),
  - rutas en texto tipo `coleccion/id` extrayendo también el último segmento.
- Añadí más variantes para nombre de sorteo (`sorteo.nombre`, `juego.sorteoNombre`).

## Impacto esperado
La tabla del modal vuelve a mostrar correctamente columnas **N°**, **Alias**, **N° Cartón** y **Tipo** aunque los documentos tengan distintas estructuras heredadas o variantes de campo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699126db78e88326b78da68f2e9613fa)