### PR TITLE
Corregir carga de cartones en modal del sorteo

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -4427,6 +4427,11 @@ function toggleForma(idx){
     if(!infoCartonesTablaBody||!currentSorteo){
       return;
     }
+    const user=auth.currentUser;
+    if(!user){
+      mostrarMensajeTablaCartones('Inicia sesión para ver tus cartones.');
+      return;
+    }
     mostrarMensajeTablaCartones('Cargando cartones...');
     try{
       const consultas=[];
@@ -4435,18 +4440,23 @@ function toggleForma(idx){
         .filter(Boolean);
       const idsObjetivo=[...new Set(posiblesIds)];
       const nombreSorteo=(currentSorteoNombre??'').toString().trim();
+      const camposUsuario=['userId','userid','uid','userUID','userUid'];
       const camposId=['sorteoId','sorteoid','idSorteo','idsorteo','sorteoID','IDSorteo','id_sorteo','sorteo'];
       const camposNombre=['sorteoNombre','nombreSorteo','nombresorteo','sorteo_name'];
 
+      camposUsuario.forEach(campo=>{
+        consultas.push({campo,valor:user.uid});
+      });
+
       camposId.forEach(campo=>{
         posiblesIds.forEach(valor=>{
-          consultas.push({campo,valor});
+          consultas.push({campo,valor,usuario:user.uid});
         });
       });
 
       if(nombreSorteo){
         camposNombre.forEach(campo=>{
-          consultas.push({campo,valor:nombreSorteo});
+          consultas.push({campo,valor:nombreSorteo,usuario:user.uid});
         });
       }
 
@@ -4457,7 +4467,11 @@ function toggleForma(idx){
         if(consultasVistas.has(llave)) continue;
         consultasVistas.add(llave);
         try{
-          const snap=await db.collection('CartonJugado').where(consulta.campo,'==',consulta.valor).get();
+          let ref=db.collection('CartonJugado').where(consulta.campo,'==',consulta.valor);
+          if(consulta.usuario){
+            ref=ref.where('userId','==',consulta.usuario);
+          }
+          const snap=await ref.get();
           if(!snap.empty){
             snaps.push(snap);
           }
@@ -4479,15 +4493,6 @@ function toggleForma(idx){
           registros.push({alias,numeroOrden:numero.orden,numeroTexto:numero.texto,tipo});
       };
       snaps.forEach(snap=>snap.forEach(agregarCarton));
-
-      if(registros.length===0){
-        try{
-          const snapGeneral=await db.collection('CartonJugado').get();
-          snapGeneral.forEach(agregarCarton);
-        }catch(errorGeneral){
-          console.warn('No se pudo ejecutar la consulta de respaldo para CartonJugado',errorGeneral);
-        }
-      }
 
       if(registros.length===0){
         mostrarMensajeTablaCartones('Sin cartones registrados');


### PR DESCRIPTION
### Motivation
- El modal de "Cartones jugando sorteo" aparecía vacío aunque los contadores mostraran cartones porque la consulta no estaba garantizando filtrar por el usuario autenticado y la consulta de respaldo sin filtros podía fallar por reglas de seguridad.
- Es importante mostrar los cartones reales del jugador (pagados y gratis) cuando el usuario ha iniciado sesión y los contadores indican participación.

### Description
- `cargarCartonesJugandoTabla()` ahora valida que exista un `auth.currentUser` y muestra el mensaje `Inicia sesión para ver tus cartones.` si no hay sesión.
- Se añadieron consultas que priorizan campos de usuario (`userId`, `userid`, `uid`, `userUID`, `userUid`) y se aplica el filtro `userId == usuario` en las búsquedas para obtener solo registros del jugador actual.
- Se eliminó la consulta de respaldo global (`get()` sin filtros) que podía ser bloqueada por reglas de Firestore y producir falsos vacíos en la tabla.

### Testing
- Se ejecutó una comprobación estática de diffs (`git diff --check`) y revisión del diff del archivo modificado, sin errores detectados.
- Se verificó que el archivo `public/jugarcartones.html` contiene las nuevas validaciones y consultas esperadas mediante inspección del diff; la lógica de carga y ordenación de filas permanece intacta.
- Se creó el cambio en el repositorio y se preparó la PR para revisión; las comprobaciones automáticas ejecutadas localmente informaron estado limpio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991293f72b8832697bd5658a24542d5)