### PR TITLE
Corregir modal de cartones para listar todos los cartones del sorteo

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -4429,7 +4429,7 @@ function toggleForma(idx){
     }
     const user=auth.currentUser;
     if(!user){
-      mostrarMensajeTablaCartones('Inicia sesión para ver tus cartones.');
+      mostrarMensajeTablaCartones('Inicia sesión para ver los cartones del sorteo.');
       return;
     }
     mostrarMensajeTablaCartones('Cargando cartones...');
@@ -4440,23 +4440,18 @@ function toggleForma(idx){
         .filter(Boolean);
       const idsObjetivo=[...new Set(posiblesIds)];
       const nombreSorteo=(currentSorteoNombre??'').toString().trim();
-      const camposUsuario=['userId','userid','uid','userUID','userUid'];
       const camposId=['sorteoId','sorteoid','idSorteo','idsorteo','sorteoID','IDSorteo','id_sorteo','sorteo'];
       const camposNombre=['sorteoNombre','nombreSorteo','nombresorteo','sorteo_name'];
 
-      camposUsuario.forEach(campo=>{
-        consultas.push({campo,valor:user.uid});
-      });
-
       camposId.forEach(campo=>{
         posiblesIds.forEach(valor=>{
-          consultas.push({campo,valor,usuario:user.uid});
+          consultas.push({campo,valor});
         });
       });
 
       if(nombreSorteo){
         camposNombre.forEach(campo=>{
-          consultas.push({campo,valor:nombreSorteo,usuario:user.uid});
+          consultas.push({campo,valor:nombreSorteo});
         });
       }
 
@@ -4467,10 +4462,7 @@ function toggleForma(idx){
         if(consultasVistas.has(llave)) continue;
         consultasVistas.add(llave);
         try{
-          let ref=db.collection('CartonJugado').where(consulta.campo,'==',consulta.valor);
-          if(consulta.usuario){
-            ref=ref.where('userId','==',consulta.usuario);
-          }
+          const ref=db.collection('CartonJugado').where(consulta.campo,'==',consulta.valor);
           const snap=await ref.get();
           if(!snap.empty){
             snaps.push(snap);


### PR DESCRIPTION
### Motivation
- El modal "Cartones jugando sorteo" filtraba las consultas por `userId`, provocando que la tabla mostrara "Sin cartones registrados" aunque el sorteo tuviera cartones de otros jugadores.
- La intención es que el modal liste los cartones pertenecientes al sorteo (coherente con los contadores globales) sin limitar la consulta al usuario autenticado.

### Description
- Modifiqué `public/jugarcartones.html` en la función `cargarCartonesJugandoTabla` para eliminar el filtro por `userId` y construir las consultas únicamente por los identificadores y el nombre del sorteo (`sorteoId`, `idSorteo`, etc.).
- Actualicé el mensaje mostrado cuando no hay sesión a `Inicia sesión para ver los cartones del sorteo.`.
- Mantengo la validación de coincidencia con `cartonCoincideSorteo` para filtrar resultados irrelevantes.
- No se cambiaron las rutas críticas de registro de cartones ni la lógica de transacciones al jugar un cartón.

### Testing
- Ejecuté `npm test -- --runInBand` y todas las suites pasaron correctamente (6 suites, 16 tests, todos en verde).
- Los cambios fueron validados localmente mediante los tests automatizados existentes y no introdujeron fallos en la cobertura ejecutada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69912b7dc6388326bea026f5998b034a)