### PR TITLE
Normalizar y comparar roles para corregir acceso a Parámetros (Superadmin)

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -136,4 +136,34 @@ describe('auth.js', () => {
       expect.objectContaining({ method: 'POST' })
     );
   });
+
+  test('verificarRolFuerte acepta variantes de mayúsculas/minúsculas en rol persistente', async () => {
+    setupWindow();
+    window.fetch = jest.fn(async () => ({ ok: false, status: 500 }));
+    global.fetch = window.fetch;
+    global.firebase = buildFirebaseMock({ userExists: true, role: 'superadmin' });
+
+    let verificarRolFuerte;
+    jest.isolateModules(() => {
+      ({ verificarRolFuerte } = require('../public/js/auth.js'));
+    });
+
+    const fakeUser = {
+      email: 'superadmin@correo.com',
+      getIdToken: jest.fn(async () => 'token-demo'),
+      getIdTokenResult: jest.fn(async () => ({ claims: {} }))
+    };
+
+    const authFactory = global.firebase.auth;
+    authFactory.mockImplementation(() => ({
+      setPersistence: jest.fn(async () => undefined),
+      onAuthStateChanged: jest.fn(),
+      getRedirectResult: jest.fn(async () => ({})),
+      currentUser: fakeUser
+    }));
+
+    await expect(verificarRolFuerte('Superadmin', { forceRefresh: true })).resolves.toEqual(
+      expect.objectContaining({ ok: true, reason: 'DOC_ROLE_FALLBACK' })
+    );
+  });
 });

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -10,6 +10,24 @@ function hasWindow(){
   return typeof window !== 'undefined';
 }
 
+function normalizeRole(role){
+  if(typeof role !== 'string') return null;
+  const limpio = role.trim().toLowerCase();
+  if(!limpio) return null;
+  if(limpio === 'superadmin' || limpio === 'super administrador' || limpio === 'super-administrador') return 'Superadmin';
+  if(limpio === 'administrador' || limpio === 'admin') return 'Administrador';
+  if(limpio === 'colaborador') return 'Colaborador';
+  if(limpio === 'jugador' || limpio === 'player') return 'Jugador';
+  return role.trim();
+}
+
+function roleEquals(left, right){
+  const leftNormalized = normalizeRole(left);
+  const rightNormalized = normalizeRole(right);
+  if(!leftNormalized || !rightNormalized) return false;
+  return leftNormalized === rightNormalized;
+}
+
 function getConfigFromWindow(){
   if(!hasWindow()) return null;
   const cfg = window.firebaseConfig || window.__FIREBASE_CONFIG__;
@@ -372,11 +390,15 @@ async function getUserRole(user){
   try{
     const token = await user.getIdTokenResult(true);
     const claims = token?.claims || {};
-    if(typeof claims.role === 'string' && claims.role.trim()){
-      return { role: claims.role.trim(), exists: true };
+    const roleFromClaim = normalizeRole(claims.role);
+    if(roleFromClaim){
+      return { role: roleFromClaim, exists: true };
     }
-    if(Array.isArray(claims.roles) && claims.roles.length && typeof claims.roles[0] === 'string'){
-      return { role: claims.roles[0], exists: true };
+    if(Array.isArray(claims.roles) && claims.roles.length){
+      const roleFromArray = claims.roles.map(normalizeRole).find(Boolean);
+      if(roleFromArray){
+        return { role: roleFromArray, exists: true };
+      }
     }
   }catch(e){
     console.error('No se pudieron leer los custom claims del usuario', e);
@@ -389,7 +411,7 @@ async function getUserRole(user){
       return { role: 'Jugador', exists: false };
     }
     const data = doc.data() || {};
-    const rolPersistente = data.role || 'Jugador';
+    const rolPersistente = normalizeRole(data.role) || 'Jugador';
 
     if(rolPersistente && user && (rolPersistente === 'Superadmin' || rolPersistente === 'Administrador' || rolPersistente === 'Colaborador')){
       const resincronizado = await intentarResincronizarClaims(user, rolPersistente);
@@ -453,7 +475,7 @@ async function intentarResincronizarClaims(user, roleExpected){
 }
 
 function redirectByRole(role){
-  switch(role){
+  switch(normalizeRole(role)){
     case 'Colaborador':
       window.location.href = 'collab.html';
       break;
@@ -507,7 +529,9 @@ function setupSuperadminExit(buttonSelector = '#salir-super-btn', redirect = 'su
 }
 
 function ensureAuth(roleExpected){
-  const rolesEsperados = Array.isArray(roleExpected) ? roleExpected : (roleExpected ? [roleExpected] : []);
+  const rolesEsperados = (Array.isArray(roleExpected) ? roleExpected : (roleExpected ? [roleExpected] : []))
+    .map(normalizeRole)
+    .filter(Boolean);
   initFirebase()
     .then(() => {
       auth.onAuthStateChanged(async user => {
@@ -524,7 +548,7 @@ function ensureAuth(roleExpected){
           window.location.href = 'registrarse.html';
           return;
         }
-        if(rolesEsperados.length && !rolesEsperados.includes(role) && role !== 'Superadmin'){
+        if(rolesEsperados.length && !rolesEsperados.some(rol => roleEquals(rol, role)) && !roleEquals(role, 'Superadmin')){
           redirectByRole(role);
           return;
         }
@@ -570,8 +594,8 @@ function ensureAuth(roleExpected){
 function claimIncluyeRol(claims, role){
   if(!claims || !role) return false;
   if(claims.admin === true) return true;
-  if(claims.role === role) return true;
-  if(Array.isArray(claims.roles) && claims.roles.includes(role)) return true;
+  if(roleEquals(claims.role, role)) return true;
+  if(Array.isArray(claims.roles) && claims.roles.some(claimRole => roleEquals(claimRole, role))) return true;
   return false;
 }
 
@@ -596,7 +620,7 @@ async function verificarRolFuerte(roleExpected = 'Superadmin', options = {}){
   }
 
   const { role } = await getUserRole(user);
-  if(role === roleExpected){
+  if(roleEquals(role, roleExpected)){
     console.warn(`Autorización fuerte: se permitió acceso por rol persistente (${roleExpected}) aunque faltan custom claims vigentes.`);
     return { ok: true, reason: 'DOC_ROLE_FALLBACK', claims, user };
   }


### PR DESCRIPTION
### Motivation
- Resolver un fallo donde usuarios Superadmin autenticados recibían el mensaje de "Sin claims de Superadmin vigentes" al abrir Parámetros debido a variantes en mayúsculas/minúsculas o formato del rol en claims o en el documento de usuario. 

### Description
- Añadí `normalizeRole` y `roleEquals` en `public/js/auth.js` para normalizar y comparar roles tolerantemente (ej. `superadmin`, `Superadmin`, `admin`).
- Actualicé la lógica de resolución y verificación de rol en `getUserRole`, `claimIncluyeRol`, `ensureAuth`, `redirectByRole` y `verificarRolFuerte` para usar la normalización y evitar falsos negativos por formato. 
- Migrué la lectura del rol persistente desde el documento `users/{email}` para normalizar su valor antes de usarlo como fallback. 
- Agregué un caso de prueba en `__tests__/auth.test.js` que valida que `verificarRolFuerte` permita acceso mediante el fallback seguro cuando el rol persistente viene en minúsculas (`superadmin`).

### Testing
- Ejecuté las pruebas unitarias con `npm test -- --runInBand` y todas las suites pasaron (`6` suites, `18` tests) con éxito. 
- Las pruebas confirman que la resincronización de claims se invoca y que el fallback por rol persistente funciona con variantes de formato de rol.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d528c52483269f4eca97657f01af)