### PR TITLE
Evita doble solicitud de acceso Google al abrir Parámetros Globales

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -1,10 +1,16 @@
 function setupWindow(){
+  const sessionStore = {};
   global.window = {
     location: { href: 'index.html', origin: 'https://app.test' },
     firebaseConfig: { projectId: 'demo-test' },
     alert: () => {},
     confirm: () => true,
-    prompt: () => ''
+    prompt: () => '',
+    sessionStorage: {
+      setItem: (key, value) => { sessionStore[key] = String(value); },
+      getItem: (key) => Object.prototype.hasOwnProperty.call(sessionStore, key) ? sessionStore[key] : null,
+      removeItem: (key) => { delete sessionStore[key]; }
+    }
   };
 }
 
@@ -166,4 +172,59 @@ describe('auth.js', () => {
       expect.objectContaining({ ok: true, reason: 'DOC_ROLE_FALLBACK' })
     );
   });
+  test('tieneReautenticacionReciente retorna true cuando existe registro reciente en sessionStorage', async () => {
+    setupWindow();
+    global.firebase = buildFirebaseMock();
+
+    const fakeUser = {
+      uid: 'uid-demo',
+      metadata: { lastSignInTime: '2000-01-01T00:00:00.000Z' }
+    };
+
+    const authFactory = global.firebase.auth;
+    authFactory.mockImplementation(() => ({
+      setPersistence: jest.fn(async () => undefined),
+      onAuthStateChanged: jest.fn(),
+      getRedirectResult: jest.fn(async () => ({})),
+      currentUser: fakeUser
+    }));
+
+    let registrarReautenticacionReciente, tieneReautenticacionReciente;
+    jest.isolateModules(() => {
+      ({ registrarReautenticacionReciente, tieneReautenticacionReciente } = require('../public/js/auth.js'));
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    registrarReautenticacionReciente(fakeUser);
+    expect(tieneReautenticacionReciente({ maxAgeMs: 60 * 1000, incluirMetadata: false })).toBe(true);
+  });
+
+  test('tieneReautenticacionReciente retorna false cuando no hay sesión reciente', async () => {
+    setupWindow();
+    global.firebase = buildFirebaseMock();
+
+    const fakeUser = {
+      uid: 'uid-demo-2',
+      metadata: { lastSignInTime: '2000-01-01T00:00:00.000Z' }
+    };
+
+    const authFactory = global.firebase.auth;
+    authFactory.mockImplementation(() => ({
+      setPersistence: jest.fn(async () => undefined),
+      onAuthStateChanged: jest.fn(),
+      getRedirectResult: jest.fn(async () => ({})),
+      currentUser: fakeUser
+    }));
+
+    let tieneReautenticacionReciente;
+    jest.isolateModules(() => {
+      ({ tieneReautenticacionReciente } = require('../public/js/auth.js'));
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(tieneReautenticacionReciente({ maxAgeMs: 60 * 1000 })).toBe(false);
+  });
+
 });

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,5 +1,6 @@
 let app, auth, db, provider, appleProvider, appName = 'BingOnline';
 const DISABLED_MSG = "Tu cuenta ha sido deshabilitada, Motivado posiblemente a que has incumplido una o más clausulas en nuestros Terminos y condiciones. Contacta con un administrador del sistema si necesitas información.";
+const STRONG_AUTH_SESSION_KEY = 'bo_superadmin_strong_auth';
 let firebaseInitPromise = null;
 let firebaseConfigLoadPromise = null;
 const nativeAlert = hasWindow() ? window.alert.bind(window) : null;
@@ -351,6 +352,10 @@ async function loginApple(){
 }
 
 function logout(){
+  if(hasWindow() && window.sessionStorage){
+    try{ window.sessionStorage.removeItem(STRONG_AUTH_SESSION_KEY); }
+    catch(error){ console.warn('No se pudo limpiar el estado de reautenticación', error); }
+  }
   auth.signOut();
 }
 
@@ -650,6 +655,49 @@ async function reautenticarConPopup(){
     throw new Error('Proveedor no soportado para reautenticación con popup');
   }
   await user.reauthenticateWithPopup(providerInstance);
+  registrarReautenticacionReciente(user);
+}
+
+function registrarReautenticacionReciente(user = auth?.currentUser){
+  if(!hasWindow() || !window.sessionStorage || !user?.uid) return;
+  try{
+    window.sessionStorage.setItem(STRONG_AUTH_SESSION_KEY, JSON.stringify({
+      uid: user.uid,
+      timestamp: Date.now()
+    }));
+  }catch(error){
+    console.warn('No se pudo registrar la reautenticación reciente', error);
+  }
+}
+
+function tieneReautenticacionReciente(options = {}){
+  const { maxAgeMs = 10 * 60 * 1000, incluirMetadata = true } = options;
+  const user = auth?.currentUser;
+  if(!user) return false;
+
+  if(hasWindow() && window.sessionStorage){
+    try{
+      const raw = window.sessionStorage.getItem(STRONG_AUTH_SESSION_KEY);
+      if(raw){
+        const parsed = JSON.parse(raw);
+        if(parsed?.uid === user.uid && Number.isFinite(parsed?.timestamp)){
+          if((Date.now() - parsed.timestamp) <= maxAgeMs){
+            return true;
+          }
+        }
+      }
+    }catch(error){
+      console.warn('No se pudo leer el estado de reautenticación reciente', error);
+    }
+  }
+
+  if(!incluirMetadata) return false;
+  const lastSignIn = user?.metadata?.lastSignInTime ? Date.parse(user.metadata.lastSignInTime) : NaN;
+  if(Number.isFinite(lastSignIn)){
+    return (Date.now() - lastSignIn) <= maxAgeMs;
+  }
+
+  return false;
 }
 
 let statusWatcher = null;
@@ -669,4 +717,4 @@ function startUserStatusWatcher(){
   },60000);
 }
 
-if (typeof module !== "undefined") { module.exports = { getUserRole, redirectByRole, ensureAuth, setupSuperadminExit, verificarRolFuerte, reautenticarConPopup }; }
+if (typeof module !== "undefined") { module.exports = { getUserRole, redirectByRole, ensureAuth, setupSuperadminExit, verificarRolFuerte, reautenticarConPopup, registrarReautenticacionReciente, tieneReautenticacionReciente }; }

--- a/public/parametros.html
+++ b/public/parametros.html
@@ -220,7 +220,9 @@
       if(!verificacion.ok){
         throw new Error('Sin claims de Superadmin vigentes');
       }
-      await reautenticarConPopup();
+      if(!tieneReautenticacionReciente({ maxAgeMs: 10 * 60 * 1000 })){
+        throw new Error('REAUTENTICACION_REQUERIDA_DESDE_MENU_SUPERADMIN');
+      }
     }
 
     async function migrarContrasenaLegacyParametros(){
@@ -360,7 +362,11 @@
             }catch(err){
               parametrosYaInicializados=false;
               console.error('Fallo al cargar parámetros tras autenticar',err);
-              alert('Tu sesión no cumple la autorización fuerte de Superadmin para acceder a Parámetros.');
+              if(err && err.message === 'REAUTENTICACION_REQUERIDA_DESDE_MENU_SUPERADMIN'){
+                alert('Para abrir Parámetros Globales, vuelve al menú Superadmin y toca tu nombre para validar el acceso una sola vez.');
+              }else{
+                alert('Tu sesión no cumple la autorización fuerte de Superadmin para acceder a Parámetros.');
+              }
               window.location.href='super.html';
             }
           });


### PR DESCRIPTION
### Motivation
- Resolver que en móviles (Brave/Chrome) al entrar desde el enlace de Parámetros se solicitara un segundo popup de Google que a menudo es bloqueado por el navegador. 
- Mantener la seguridad de autorización fuerte para `Superadmin` pero permitir reutilizar una validación reciente para evitar reautenticaciones innecesarias.

### Description
- Se añadió un registro de reautenticación reciente en `sessionStorage` con la clave `bo_superadmin_strong_auth` y la función `registrarReautenticacionReciente` después de `reauthenticateWithPopup` en `public/js/auth.js`.
- Se implementó `tieneReautenticacionReciente(options)` en `public/js/auth.js` para validar si existe una reautenticación reciente (por defecto 10 minutos), usando `sessionStorage` y como fallback la metadata `lastSignInTime`.
- Se modificó el flujo de `public/parametros.html` para que, en vez de abrir otro popup al cargar, exija `verificarRolFuerte('Superadmin')` y que `tieneReautenticacionReciente` devuelva true; si no existe reautenticación reciente, se guía al usuario para validar desde el menú Superadmin (evita el segundo popup bloqueable).
- Se limpia la marca de reautenticación en `logout()` para evitar estado residual entre sesiones y se exportaron las nuevas utilidades (`registrarReautenticacionReciente`, `tieneReautenticacionReciente`) para pruebas y mantenimiento.
- Se actualizaron tests unitarios en `__tests__/auth.test.js` para cubrir el almacenamiento en `sessionStorage` y los escenarios de reautenticación reciente válida/no válida.

### Testing
- Se ejecutó `npx jest --runInBand --coverage=false __tests__/auth.test.js` y todos los tests relevantes pasaron: 7 tests, 7 passed.
- Las pruebas verifican el comportamiento de `getUserRole`, `verificarRolFuerte` y las nuevas funciones `registrarReautenticacionReciente` / `tieneReautenticacionReciente` (casos positivo y negativo).
- No se introdujeron cambios en la lógica del servidor ni en endpoints; las pruebas son unitarias y validaron la integración local de las utilidades añadidas.

Archivos modificados: `public/js/auth.js`, `public/parametros.html`, `__tests__/auth.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991d9d43bdc8326b32d40faa4b04680)