### PR TITLE
Corregir acceso a Parámetros Superadmin y evitar selector de cuenta repetido

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -611,17 +611,26 @@ async function verificarRolFuerte(roleExpected = 'Superadmin', options = {}){
   if(!user){
     return { ok: false, reason: 'NO_AUTH', claims: null, user: null };
   }
-  const tokenResult = await user.getIdTokenResult(forceRefresh);
-  const claims = tokenResult?.claims || {};
+  let claims = {};
+  try{
+    const tokenResult = await user.getIdTokenResult(forceRefresh);
+    claims = tokenResult?.claims || {};
+  }catch(error){
+    console.warn('No se pudo leer el ID token para validar rol fuerte, se intentará con resincronización y rol persistente.', error);
+  }
   if(claimIncluyeRol(claims, roleExpected)){
     return { ok: true, reason: null, claims, user };
   }
 
-  await intentarResincronizarClaims(user, roleExpected);
-  const tokenPostSync = await user.getIdTokenResult(true);
-  const claimsPostSync = tokenPostSync?.claims || {};
-  if(claimIncluyeRol(claimsPostSync, roleExpected)){
-    return { ok: true, reason: 'CLAIMS_RESYNC', claims: claimsPostSync, user };
+  try{
+    await intentarResincronizarClaims(user, roleExpected);
+    const tokenPostSync = await user.getIdTokenResult(true);
+    const claimsPostSync = tokenPostSync?.claims || {};
+    if(claimIncluyeRol(claimsPostSync, roleExpected)){
+      return { ok: true, reason: 'CLAIMS_RESYNC', claims: claimsPostSync, user };
+    }
+  }catch(error){
+    console.warn('No fue posible resincronizar custom claims para validación fuerte.', error);
   }
 
   const { role } = await getUserRole(user);
@@ -644,7 +653,6 @@ async function reautenticarConPopup(){
   let providerInstance = null;
   if(providerId === 'google.com'){
     providerInstance = new firebase.auth.GoogleAuthProvider();
-    providerInstance.setCustomParameters({ prompt: 'select_account' });
   }else if(providerId === 'apple.com'){
     providerInstance = new firebase.auth.OAuthProvider('apple.com');
     providerInstance.addScope('email');


### PR DESCRIPTION
### Motivation
- Resolver fallos al abrir `Parámetros Globales` donde la validación fuerte de Superadmin fallaba por errores transitorios de token/claims y además Google forzaba la selección de cuenta repetidamente.

### Description
- Se actualizó `public/js/auth.js` para que `verificarRolFuerte` capture errores al leer/refresh del ID token y no bloquee la ejecución ante fallos transitorios, intentando resincronizar claims dentro de un `try/catch` antes de caer al fallback por rol persistente.
- Se suprimió el parámetro `prompt: 'select_account'` en `reautenticarConPopup()` para evitar que Google muestre el selector de cuentas en cada reautenticación.
- Las modificaciones generan logs de advertencia en caso de problemas con el ID token o la resincronización para facilitar diagnóstico sin negar acceso si el rol persistente es válido.

### Testing
- Ejecutado `npm test -- --runInBand` y todos los tests pasaron (`6` test suites, `20` tests) con cobertura configurada según el proyecto; la suite completa obtuvo `PASS`.
- Se verificó el diff resultante de `public/js/auth.js` para confirmar las inserciones y eliminaciones esperadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991dd43131c832691acc91f201e504b)