### PR TITLE
Restringe lectura de Variablesglobales/Parametros a Superadmin fuerte

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Cada secreto debe contener el valor correspondiente del proyecto de Firebase. Si
 - Cuando cree o actualice sorteos, guarde los campos `fecha`, `hora` y `horacierre` en formato `DD/MM/YYYY` y `HH:mm` (24 horas) para asegurar que `cronActualizarEstadosSorteos.js` pueda interpretar los datos sin errores.
 - Documente cualquier ajuste en la colección `Variablesglobales/Parametros` (especialmente `ZonaHoraria`, `Pais` y `Aplicacion`) y coordínelo con los responsables del cron para mantener sincronizados el frontend y las tareas programadas.
 
+## Seguridad de `Variablesglobales/Parametros`
+
+- El documento `Variablesglobales/Parametros` contiene configuración sensible y se trata como **confidencial**.
+- En `firestore.rules`, su lectura y escritura requieren privilegio fuerte de **Superadmin** (`isStrongSuperadmin()`).
+- La página `public/parametros.html` está diseñada para este mismo nivel de privilegio; usuarios autenticados sin rol fuerte de Superadmin deben recibir denegación de acceso al intentar leer ese documento.
 
 
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -79,7 +79,7 @@ service cloud.firestore {
     }
 
     match /Variablesglobales/{docId} {
-      allow read: if isSignedIn();
+      allow read: if docId == 'Parametros' ? isStrongSuperadmin() : isSignedIn();
       allow write: if docId == 'Parametros' ? isStrongSuperadmin() : isAdmin();
     }
 

--- a/reglas-firebase.md
+++ b/reglas-firebase.md
@@ -9,12 +9,21 @@ Este repositorio actualmente valida permisos por rol principalmente en `firestor
 - **Administrador**: acceso ampliado para gestión de operaciones y usuarios.
 - **Superadmin**: acceso total para soporte y administración global.
 
+## Colección `Variablesglobales`
+
+- El documento `Variablesglobales/Parametros` se considera **confidencial**.
+- Solo puede leerse y escribirse con una sesión que cumpla `isStrongSuperadmin()`.
+- El resto de documentos de `Variablesglobales` mantiene lectura para usuarios autenticados (`isSignedIn()`) y escritura administrativa (`isAdmin()`).
+
 ## Checklist de verificación manual (sin emulador)
 
 1. Revisar condiciones de rol en reglas con helpers reutilizables (`isSignedIn`, `isAdminLike`, etc.).
 2. Confirmar que las rutas sensibles (`users`, `billeteras`, `transacciones`) restringen por `request.auth` y rol.
 3. Confirmar que no existen `allow read, write: if true;` en colecciones sensibles.
 4. Verificar que una cuenta sin claim de rol administrativo no puede escribir datos de otros usuarios.
+5. Verificar que `Variablesglobales/Parametros`:
+   - carga correctamente en `public/parametros.html` con cuenta **Superadmin**,
+   - y devuelve permiso denegado para cuentas autenticadas sin privilegio fuerte de Superadmin.
 
 ## Opción recomendada (si el equipo habilita Firebase Emulator)
 
@@ -24,4 +33,3 @@ Agregar pruebas automatizadas con `@firebase/rules-unit-testing` para casos por 
 - `Colaborador` intentando promover roles → **denegado**.
 - `Administrador` gestionando transacciones permitidas → **autorizado**.
 - `Superadmin` en ruta administrativa global → **autorizado**.
-


### PR DESCRIPTION
### Motivation

- Proteger el documento de configuración sensible `Variablesglobales/Parametros` para que solo sea accesible por una sesión con privilegio fuerte de Superadmin (`isStrongSuperadmin()`), evitando fugas de parámetros críticos.

### Description

- Actualiza `firestore.rules` en el bloque `match /Variablesglobales/{docId}` para que la lectura de `Parametros` requiera `isStrongSuperadmin()` y mantiene la política previa para escritura (`isStrongSuperadmin()` para `Parametros`, `isAdmin()` para otros docs).
- Documenta en `reglas-firebase.md` que `Variablesglobales/Parametros` es confidencial y añade la verificación en el checklist para `public/parametros.html` (acceso permitido solo a Superadmin fuerte / denegado para usuarios no privilegiados).
- Añade nota en `README.md` indicando que `Variablesglobales/Parametros` es sensible y que su lectura/escritura exige `isStrongSuperadmin()`; confirma que `public/parametros.html` mantiene `ensureAuth('Superadmin')` en el frontend.

### Testing

- Ejecuté los tests de unidad con `npm test -- --runInBand` y todos los suites pasaron (`6` test suites, `20` tests) correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e282a73c83268fe3ba5473900f24)