### PR TITLE
Endurecer verificación fuerte de Superadmin por custom claims

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -143,7 +143,7 @@ describe('auth.js', () => {
     );
   });
 
-  test('verificarRolFuerte acepta variantes de mayúsculas/minúsculas en rol persistente', async () => {
+  test('verificarRolFuerte falla cuando no hay custom claims válidos', async () => {
     setupWindow();
     window.fetch = jest.fn(async () => ({ ok: false, status: 500 }));
     global.fetch = window.fetch;
@@ -169,7 +169,7 @@ describe('auth.js', () => {
     }));
 
     await expect(verificarRolFuerte('Superadmin', { forceRefresh: true })).resolves.toEqual(
-      expect.objectContaining({ ok: true, reason: 'DOC_ROLE_FALLBACK' })
+      expect.objectContaining({ ok: false, reason: 'MISSING_CLAIM' })
     );
   });
   test('tieneReautenticacionReciente retorna true cuando existe registro reciente en sessionStorage', async () => {

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -616,7 +616,7 @@ async function verificarRolFuerte(roleExpected = 'Superadmin', options = {}){
     const tokenResult = await user.getIdTokenResult(forceRefresh);
     claims = tokenResult?.claims || {};
   }catch(error){
-    console.warn('No se pudo leer el ID token para validar rol fuerte, se intentará con resincronización y rol persistente.', error);
+    console.warn('No se pudo leer el ID token para validar rol fuerte, se intentará con resincronización de claims.', error);
   }
   if(claimIncluyeRol(claims, roleExpected)){
     return { ok: true, reason: null, claims, user };
@@ -631,12 +631,6 @@ async function verificarRolFuerte(roleExpected = 'Superadmin', options = {}){
     }
   }catch(error){
     console.warn('No fue posible resincronizar custom claims para validación fuerte.', error);
-  }
-
-  const { role } = await getUserRole(user);
-  if(roleEquals(role, roleExpected)){
-    console.warn(`Autorización fuerte: se permitió acceso por rol persistente (${roleExpected}) aunque faltan custom claims vigentes.`);
-    return { ok: true, reason: 'DOC_ROLE_FALLBACK', claims, user };
   }
 
   return { ok: false, reason: 'MISSING_CLAIM', claims, user };

--- a/public/parametros.html
+++ b/public/parametros.html
@@ -218,7 +218,7 @@
     async function validarAutorizacionFuerteSuperadmin(){
       const verificacion = await verificarRolFuerte('Superadmin', { forceRefresh: true });
       if(!verificacion.ok){
-        throw new Error('Sin claims de Superadmin vigentes');
+        throw new Error('CLAIMS_SUPERADMIN_NO_VIGENTES');
       }
       if(!tieneReautenticacionReciente({ maxAgeMs: 10 * 60 * 1000 })){
         throw new Error('REAUTENTICACION_REQUERIDA_DESDE_MENU_SUPERADMIN');
@@ -364,6 +364,8 @@
               console.error('Fallo al cargar parámetros tras autenticar',err);
               if(err && err.message === 'REAUTENTICACION_REQUERIDA_DESDE_MENU_SUPERADMIN'){
                 alert('Para abrir Parámetros Globales, vuelve al menú Superadmin y toca tu nombre para validar el acceso una sola vez.');
+              }else if(err && err.message === 'CLAIMS_SUPERADMIN_NO_VIGENTES'){
+                alert('Tus claims de Superadmin no están vigentes, cierre y abra sesión.');
               }else{
                 alert('Tu sesión no cumple la autorización fuerte de Superadmin para acceder a Parámetros.');
               }


### PR DESCRIPTION
### Motivation

- Evitar que usuarios con rol persistente en documento obtengan acceso fuerte sin custom claims válidos; la autorización fuerte debe basarse en custom claims y, si aplica, en la resincronización de los mismos.

### Description

- Eliminé el fallback por rol persistente (`DOC_ROLE_FALLBACK`) en `verificarRolFuerte` para que solo autorice por custom claims (`admin`, `role`, `roles`) y por resincronización de claims en `public/js/auth.js`.
- Ajusté el texto de advertencia al fallar la lectura del token para clarificar que se intentará resincronizar claims.
- Actualicé `public/parametros.html` para lanzar y detectar la excepción `CLAIMS_SUPERADMIN_NO_VIGENTES` y mostrar al usuario el mensaje: "Tus claims de Superadmin no están vigentes, cierre y abra sesión.".
- Modifiqué la prueba en `__tests__/auth.test.js` para cubrir que cuando no hay custom claims válidos `verificarRolFuerte` devuelve `{ ok: false, reason: 'MISSING_CLAIM' }`.

### Testing

- Ejecuté `npm test -- __tests__/auth.test.js` y la suite pasó, pero la ejecución con cobertura global falló por el umbral de cobertura configurado; la salida mostró los tests verdes pero la verificación de cobertura global falló.
- Ejecuté `npm test -- __tests__/auth.test.js --collectCoverage=false` y todas las pruebas pasaron (`7 passed`).
- Inicié la aplicación con `npm start` y verifiqué la página `parametros.html` mediante un script de Playwright que generó una captura (`parametros-page.png`) para validación visual.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e39cf2ec832693d6deb0f6e41ede)