### PR TITLE
Endurecer acceso de Superadmin a Parámetros con MFA y auditoría

### DIFF
--- a/__tests__/uploadServer-admin-session-utils.test.js
+++ b/__tests__/uploadServer-admin-session-utils.test.js
@@ -41,6 +41,15 @@ describe('uploadServer utilidades de sesión administrativa', () => {
     expect(fromFallback).toBe('10.0.0.1');
   });
 
+
+  test('approximateIp anonimiza IPv4 e IPv6', () => {
+    const { approximateIp } = require('../uploadServer.js');
+
+    expect(approximateIp('201.20.10.35')).toBe('201.20.10.0');
+    expect(approximateIp('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toBe('2001:0db8:85a3::');
+    expect(approximateIp('')).toBe('unknown');
+  });
+
   test('getAuthTimeFromToken usa iat cuando está presente', () => {
     const { getAuthTimeFromToken } = require('../uploadServer.js');
 

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -5,7 +5,6 @@ const SUPERADMIN_DEVICE_KEY = 'bo_superadmin_device_id';
 let firebaseInitPromise = null;
 let firebaseConfigLoadPromise = null;
 let adminSessionWatcher = null;
-let lastAuditStamp = null;
 const nativeAlert = hasWindow() ? window.alert.bind(window) : null;
 const nativeConfirm = hasWindow() ? window.confirm.bind(window) : null;
 const nativePrompt = hasWindow() ? window.prompt.bind(window) : null;
@@ -507,18 +506,110 @@ async function registrarSesionSuperadmin(user, motivo = 'login'){
   }
 }
 
-async function auditarAccesoParametros(user, motivo = 'acceso_parametros'){
+async function auditarAccesoParametros(user, motivo = 'acceso_parametros', options = {}){
   if(!hasWindow() || !user) return;
-  const pathname = window.location?.pathname || '';
-  if(!pathname.endsWith('/parametros.html') && !pathname.endsWith('parametros.html')) return;
-  const auditKey = `${user.uid}:${motivo}`;
-  if(lastAuditStamp === auditKey) return;
+  const {
+    estado = 'exitoso',
+    detalle = '',
+    contexto = ''
+  } = options;
   try{
-    await postToAdminEndpoint('/admin/audit/parametros', user, { motivo });
-    lastAuditStamp = auditKey;
+    await postToAdminEndpoint('/admin/audit/parametros', user, {
+      motivo,
+      estado,
+      detalle,
+      contexto,
+      ruta: window.location?.pathname || ''
+    });
   }catch(error){
     console.warn('No se pudo registrar auditoría de acceso a parámetros', error);
   }
+}
+
+function obtenerFactoresMFAEnrolados(user = auth?.currentUser){
+  if(!user) return [];
+  const factors = user.multiFactor?.enrolledFactors;
+  return Array.isArray(factors) ? factors : [];
+}
+
+function tieneMFAEnrolado(user = auth?.currentUser){
+  return obtenerFactoresMFAEnrolados(user).length > 0;
+}
+
+async function resolverSegundoFactorReautenticacion(error){
+  const code = error?.code;
+  if(code !== 'auth/multi-factor-auth-required') throw error;
+
+  const resolver = error.resolver || firebase.auth.getMultiFactorResolver?.(auth, error);
+  if(!resolver){
+    throw new Error('No fue posible preparar el desafío de segundo factor.');
+  }
+
+  const hints = Array.isArray(resolver.hints) ? resolver.hints : [];
+  if(!hints.length){
+    throw new Error('La cuenta no tiene factores disponibles para completar MFA.');
+  }
+
+  let factorElegido = hints[0];
+  if(hints.length > 1){
+    const menu = hints
+      .map((hint, index) => `${index + 1}. ${hint.displayName || hint.factorId || 'factor'}`)
+      .join('\n');
+    const seleccionRaw = await window.prompt(`Selecciona el segundo factor para continuar:\n${menu}`, '1');
+    const seleccion = Number.parseInt(seleccionRaw, 10);
+    if(!Number.isFinite(seleccion) || seleccion < 1 || seleccion > hints.length){
+      throw new Error('FACTOR_MFA_INVALIDO');
+    }
+    factorElegido = hints[seleccion - 1];
+  }
+
+  if(factorElegido.factorId === firebase.auth.PhoneMultiFactorGenerator.FACTOR_ID){
+    const verifierContainerId = 'mfa-recaptcha-container';
+    let container = document.getElementById(verifierContainerId);
+    if(!container){
+      container = document.createElement('div');
+      container.id = verifierContainerId;
+      container.style.position = 'fixed';
+      container.style.left = '-9999px';
+      container.style.width = '1px';
+      container.style.height = '1px';
+      document.body.appendChild(container);
+    }
+
+    const recaptchaVerifier = new firebase.auth.RecaptchaVerifier(verifierContainerId, { size: 'invisible' });
+    const phoneAuthProvider = new firebase.auth.PhoneAuthProvider();
+    const verificationId = await phoneAuthProvider.verifyPhoneNumber({
+      multiFactorHint: factorElegido,
+      session: resolver.session
+    }, recaptchaVerifier);
+    const verificationCode = await window.prompt('Introduce el código SMS de verificación MFA');
+    if(!verificationCode){
+      throw new Error('CODIGO_MFA_REQUERIDO');
+    }
+    const cred = firebase.auth.PhoneAuthProvider.credential(verificationId, verificationCode.trim());
+    const assertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
+    await resolver.resolveSignIn(assertion);
+    return;
+  }
+
+  if(
+    factorElegido.factorId === 'totp'
+    && firebase.auth.TotpMultiFactorGenerator
+    && typeof firebase.auth.TotpMultiFactorGenerator.assertionForSignIn === 'function'
+  ){
+    const verificationCode = await window.prompt('Introduce el código TOTP de tu autenticador');
+    if(!verificationCode){
+      throw new Error('CODIGO_MFA_REQUERIDO');
+    }
+    const assertion = firebase.auth.TotpMultiFactorGenerator.assertionForSignIn(
+      factorElegido.uid,
+      verificationCode.trim()
+    );
+    await resolver.resolveSignIn(assertion);
+    return;
+  }
+
+  throw new Error('FACTOR_MFA_NO_SOPORTADO');
 }
 
 function stopAdminSessionWatcher(){
@@ -759,7 +850,11 @@ async function reautenticarConPopup(){
   if(!providerInstance || typeof user.reauthenticateWithPopup !== 'function'){
     throw new Error('Proveedor no soportado para reautenticación con popup');
   }
-  await user.reauthenticateWithPopup(providerInstance);
+  try{
+    await user.reauthenticateWithPopup(providerInstance);
+  }catch(error){
+    await resolverSegundoFactorReautenticacion(error);
+  }
   registrarReautenticacionReciente(user);
   await registrarSesionSuperadmin(user, 'reauth');
 }
@@ -823,4 +918,4 @@ function startUserStatusWatcher(){
   },60000);
 }
 
-if (typeof module !== "undefined") { module.exports = { getUserRole, redirectByRole, ensureAuth, setupSuperadminExit, verificarRolFuerte, reautenticarConPopup, registrarReautenticacionReciente, tieneReautenticacionReciente }; }
+if (typeof module !== "undefined") { module.exports = { getUserRole, redirectByRole, ensureAuth, setupSuperadminExit, verificarRolFuerte, reautenticarConPopup, registrarReautenticacionReciente, tieneReautenticacionReciente, tieneMFAEnrolado, obtenerFactoresMFAEnrolados, auditarAccesoParametros }; }

--- a/public/parametros.html
+++ b/public/parametros.html
@@ -220,9 +220,13 @@
       if(!verificacion.ok){
         throw new Error('CLAIMS_SUPERADMIN_NO_VIGENTES');
       }
+      if(!tieneMFAEnrolado(verificacion.user)){
+        throw new Error('MFA_SUPERADMIN_NO_ENROLADO');
+      }
       if(!tieneReautenticacionReciente({ maxAgeMs: 10 * 60 * 1000 })){
         throw new Error('REAUTENTICACION_REQUERIDA_DESDE_MENU_SUPERADMIN');
       }
+      return verificacion.user;
     }
 
     async function migrarContrasenaLegacyParametros(){
@@ -356,14 +360,26 @@
           auth.onAuthStateChanged(async usuario=>{
             if(!usuario || parametrosYaInicializados) return;
             try{
-              await validarAutorizacionFuerteSuperadmin();
+              const usuarioValidado = await validarAutorizacionFuerteSuperadmin();
+              await auditarAccesoParametros(usuarioValidado, 'acceso_parametros', {
+                estado: 'exitoso',
+                detalle: 'Acceso autorizado con claims y MFA enrolado',
+                contexto: 'parametros_page'
+              });
               await iniciarParametros();
               parametrosYaInicializados=true;
             }catch(err){
               parametrosYaInicializados=false;
               console.error('Fallo al cargar parámetros tras autenticar',err);
+              await auditarAccesoParametros(usuario, 'acceso_parametros_denegado', {
+                estado: 'fallido',
+                detalle: err?.message || 'Fallo no identificado',
+                contexto: 'parametros_page'
+              });
               if(err && err.message === 'REAUTENTICACION_REQUERIDA_DESDE_MENU_SUPERADMIN'){
                 alert('Para abrir Parámetros Globales, vuelve al menú Superadmin y toca tu nombre para validar el acceso una sola vez.');
+              }else if(err && err.message === 'MFA_SUPERADMIN_NO_ENROLADO'){
+                alert('Acceso bloqueado: la cuenta Superadmin debe enrolar MFA (TOTP/SMS) en Firebase Authentication antes de abrir Parámetros.');
               }else if(err && err.message === 'CLAIMS_SUPERADMIN_NO_VIGENTES'){
                 alert('Tus claims de Superadmin no están vigentes, cierre y abra sesión.');
               }else{

--- a/public/super.html
+++ b/public/super.html
@@ -141,22 +141,66 @@
   <script src="js/notificationCenter.js"></script>
   <script>
   ensureAuth('Superadmin');
+  function mostrarInstruccionEnrolamientoMFA(){
+    alert(
+      'Acceso bloqueado: la cuenta Superadmin debe tener MFA enrolado para entrar a Parámetros.\n\n'
+      + 'Pasos:\n'
+      + '1) En Firebase Authentication > Multi-factor, habilita TOTP o SMS según política.\n'
+      + '2) Inicia sesión como Superadmin y completa el enrolamiento del segundo factor.\n'
+      + '3) Reintenta el acceso desde este menú.'
+    );
+  }
+
   async function intentarAbrirParametros(){
+    const usuarioActual = auth?.currentUser || null;
     try{
       const verificacion = await verificarRolFuerte('Superadmin', { forceRefresh: true });
       if(!verificacion.ok){
+        if(usuarioActual){
+          await auditarAccesoParametros(usuarioActual, 'acceso_parametros_denegado_claims', {
+            estado: 'fallido',
+            detalle: 'Claims de Superadmin no vigentes',
+            contexto: 'super_menu'
+          });
+        }
         alert('No tienes claims de Superadmin vigentes. Vuelve a iniciar sesión o contacta al administrador del sistema.');
         window.location.href='super.html';
+        return;
+      }
+
+      if(!tieneMFAEnrolado(verificacion.user)){
+        if(verificacion.user){
+          await auditarAccesoParametros(verificacion.user, 'acceso_parametros_denegado_mfa_no_enrolado', {
+            estado: 'fallido',
+            detalle: 'Superadmin sin factores MFA enrolados',
+            contexto: 'super_menu'
+          });
+        }
+        mostrarInstruccionEnrolamientoMFA();
         return;
       }
 
       await reautenticarConPopup();
     }catch(error){
       console.error('No fue posible completar la autorización fuerte para Parámetros', error);
+      if(usuarioActual){
+        await auditarAccesoParametros(usuarioActual, 'acceso_parametros_denegado_reautenticacion', {
+          estado: 'fallido',
+          detalle: error?.message || 'Error durante reautenticación',
+          contexto: 'super_menu'
+        });
+      }
       alert('No fue posible completar la reautenticación de Firebase. Intenta nuevamente.');
       return;
     }
 
+    if(auth?.currentUser){
+      await auditarAccesoParametros(auth.currentUser, 'acceso_parametros_autorizado_super_menu', {
+        estado: 'exitoso',
+        detalle: 'Superadmin validado con claims + MFA',
+        contexto: 'super_menu'
+      });
+    }
     window.location.href='parametros.html';
   }
   document.getElementById("acceder-usuario-btn").addEventListener("click",()=>{window.location.href="accederusuario.html";});

--- a/reglas-firebase.md
+++ b/reglas-firebase.md
@@ -33,3 +33,14 @@ Agregar pruebas automatizadas con `@firebase/rules-unit-testing` para casos por 
 - `Colaborador` intentando promover roles → **denegado**.
 - `Administrador` gestionando transacciones permitidas → **autorizado**.
 - `Superadmin` en ruta administrativa global → **autorizado**.
+
+
+## Endurecimiento de acceso a Parámetros (MFA Superadmin)
+
+Antes de usar `public/super.html` -> `parametros.html`, habilitar MFA para la cuenta Superadmin en **Firebase Authentication**:
+
+1. Abrir **Authentication > Sign-in method > Multi-factor authentication**.
+2. Activar proveedor según política corporativa (recomendado: **TOTP**; alterno: **SMS**).
+3. Verificar que la cuenta Superadmin complete enrolamiento del segundo factor.
+4. Confirmar que los accesos fallidos/satisfactorios a Parámetros queden auditados en `adminAccessAudit`.
+

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -118,6 +118,29 @@ function getClientIp(req) {
   return req.ip || req.socket?.remoteAddress || 'unknown';
 }
 
+
+function approximateIp(ip) {
+  const rawIp = typeof ip === 'string' ? ip.trim() : '';
+  if (!rawIp) return 'unknown';
+
+  if (rawIp.includes('.')) {
+    const parts = rawIp.split('.');
+    if (parts.length === 4) {
+      return `${parts[0]}.${parts[1]}.${parts[2]}.0`;
+    }
+  }
+
+  if (rawIp.includes(':')) {
+    const compact = rawIp.replace(/^::ffff:/, '');
+    const parts = compact.split(':').filter(Boolean);
+    if (parts.length >= 3) {
+      return `${parts.slice(0, 3).join(':')}::`;
+    }
+  }
+
+  return rawIp;
+}
+
 function getAuthTimeFromToken(decodedToken) {
   const iat = Number(decodedToken?.iat || 0);
   return Number.isFinite(iat) && iat > 0 ? iat * 1000 : Date.now();
@@ -366,12 +389,33 @@ app.post('/admin/audit/parametros', async (req, res) => {
   const motivo = typeof req.body?.motivo === 'string' && req.body.motivo.trim()
     ? req.body.motivo.trim().slice(0, 160)
     : 'acceso_parametros';
+  const estado = typeof req.body?.estado === 'string' && req.body.estado.trim()
+    ? req.body.estado.trim().slice(0, 40)
+    : 'exitoso';
+  const detalle = typeof req.body?.detalle === 'string' && req.body.detalle.trim()
+    ? req.body.detalle.trim().slice(0, 240)
+    : null;
+  const contexto = typeof req.body?.contexto === 'string' && req.body.contexto.trim()
+    ? req.body.contexto.trim().slice(0, 120)
+    : null;
+  const ruta = typeof req.body?.ruta === 'string' && req.body.ruta.trim()
+    ? req.body.ruta.trim().slice(0, 200)
+    : null;
+
+  const ip = getClientIp(req);
+  const ipAproximada = approximateIp(ip);
 
   await admin.firestore().collection('adminAccessAudit').add({
     uid: decoded.uid,
     email: validation.email,
     timestamp: admin.firestore.FieldValue.serverTimestamp(),
-    motivo
+    motivo,
+    estado,
+    detalle,
+    contexto,
+    ruta,
+    ipHash: hashValue(ip),
+    ipAproximada
   });
 
   return res.json({ status: 'ok' });
@@ -457,5 +501,6 @@ module.exports = {
   startServer,
   hashValue,
   getClientIp,
-  getAuthTimeFromToken
+  getAuthTimeFromToken,
+  approximateIp
 };


### PR DESCRIPTION
### Motivation
- Reforzar la seguridad del flujo administrativo para que la cuenta `Superadmin` solo acceda a `Parametros` si tiene claims válidos y MFA enrolado, exigiendo reautenticación fuerte cuando corresponda.
- Añadir trazabilidad en auditoría para registrar accesos exitosos y denegados con datos mínimos (UID, email, fecha, IP aproximada y motivo) sin exponer IP completa.

### Description
- Frontend: en `public/js/auth.js` se añadieron utilidades `tieneMFAEnrolado` y `obtenerFactoresMFAEnrolados`, se amplió `reautenticarConPopup()` para manejar desafíos MFA (resolución de segundo factor SMS/TOTP cuando Firebase lo exige) y `auditarAccesoParametros()` ahora acepta `estado`, `detalle`, `contexto` y `ruta` al llamar al endpoint de auditoría.
- UI: en `public/super.html` se bloquea el acceso a `parametros.html` si el Superadmin no tiene MFA enrolado, se muestra una instrucción controlada para enrolamiento y se auditan denegaciones/éxitos; en `public/parametros.html` la validación fuerte ahora exige claims + MFA enrolado + reautenticación reciente y registra auditoría en carga o fallo.
- Backend: en `uploadServer.js` el endpoint `POST /admin/audit/parametros` guarda `motivo`, `estado`, `detalle`, `contexto`, `ruta`, `ipHash` y `ipAproximada`, y se agregó la función `approximateIp()` para anonimizar la IP antes de registrar (exportada para pruebas).
- Documentación y pruebas: se actualizó `reglas-firebase.md` con checklist operativo para habilitar MFA y se añadió una prueba unitaria en `__tests__/uploadServer-admin-session-utils.test.js` que verifica `approximateIp`.

### Testing
- Se ejecutó `npm test -- --runInBand` y todos los suites pasaron (`Test Suites: 7 passed, 7 total`, `Tests: 24 passed, 24 total`).
- La nueva prueba para `approximateIp` en `__tests__/uploadServer-admin-session-utils.test.js` pasó correctamente.
- Las pruebas existentes de `public/js/auth.js` continuaron pasando y no se detectaron regresiones en los tests automatizados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e6dfd2d083269723309d74c3e004)