### PR TITLE
Simplifica consulta canónica en cargarCartonesJugandoTabla

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -4434,57 +4434,24 @@ function toggleForma(idx){
     }
     mostrarMensajeTablaCartones('Cargando cartones...');
     try{
-      const consultas=[];
-      const posiblesIds=[currentSorteo,(currentSorteo??'').toString().trim()]
-        .map(valor=>(valor??'').toString().trim())
-        .filter(Boolean);
-      const idsObjetivo=[...new Set(posiblesIds)];
-      const nombreSorteo=(currentSorteoNombre??'').toString().trim();
-      const camposId=['sorteoId','sorteoid','idSorteo','idsorteo','sorteoID','IDSorteo','id_sorteo','sorteo'];
-      const camposNombre=['sorteoNombre','nombreSorteo','nombresorteo','sorteo_name'];
-
-      camposId.forEach(campo=>{
-        posiblesIds.forEach(valor=>{
-          consultas.push({campo,valor});
-        });
-      });
-
-      if(nombreSorteo){
-        camposNombre.forEach(campo=>{
-          consultas.push({campo,valor:nombreSorteo});
-        });
-      }
-
-      const snaps=[];
-      const consultasVistas=new Set();
-      for(const consulta of consultas){
-        const llave=`${consulta.campo}::${String(consulta.valor)}`;
-        if(consultasVistas.has(llave)) continue;
-        consultasVistas.add(llave);
-        try{
-          const ref=db.collection('CartonJugado').where(consulta.campo,'==',consulta.valor);
-          const snap=await ref.get();
-          if(!snap.empty){
-            snaps.push(snap);
-          }
-        }catch(errorConsulta){
-          console.warn(`Consulta alterna no disponible para ${consulta.campo}`,errorConsulta);
-        }
-      }
+      const ref=db.collection('CartonJugado')
+        .where('sorteoId','==',currentSorteo)
+        .where('userId','==',user.uid)
+        .orderBy('cartonNum','asc');
+      const snap=await ref.get();
 
       const registros=[];
       const idsVistos=new Set();
       const agregarCarton=(doc)=>{
           if(idsVistos.has(doc.id)) return;
           const data=doc.data()||{};
-          if(!cartonCoincideSorteo(data,{ids:idsObjetivo,nombre:nombreSorteo})) return;
           idsVistos.add(doc.id);
           const alias=extraerAliasCarton(data);
           const numero=extraerNumeroCartonDatos(data);
           const tipo=extraerTipoCartonDato(data);
           registros.push({alias,numeroOrden:numero.orden,numeroTexto:numero.texto,tipo});
       };
-      snaps.forEach(snap=>snap.forEach(agregarCarton));
+      snap.forEach(agregarCarton);
 
       if(registros.length===0){
         mostrarMensajeTablaCartones('Sin cartones registrados');


### PR DESCRIPTION
### Motivation
- Reducir la complejidad y las consultas alternas por variantes de campo al recuperar los cartones que pertenecen al sorteo en curso.
- Garantizar que la ruta de la tabla muestre solo los cartones del usuario autenticado y que el procesamiento posterior sea consistente y simple.

### Description
- Eliminé la construcción y ejecución de múltiples consultas por variantes de campo (`camposId`, `camposNombre`, `consultas`) dentro de `cargarCartonesJugandoTabla()` en `public/jugarcartones.html`.
- Reemplacé esa lógica por una única consulta canónica a `CartonJugado` con `where('sorteoId','==',currentSorteo)` y `where('userId','==',user.uid)` y añadí `orderBy('cartonNum','asc')`.
- Eliminé el filtro redundante `cartonCoincideSorteo(...)` en esta ruta y dejé solo el parseo/render de documentos usando `extraerAliasCarton`, `extraerNumeroCartonDatos` y `extraerTipoCartonDato`.
- Actualicé el recorrido de resultados a `snap.forEach(agregarCarton)` y mantuve el ordenamiento/ renderizado de la tabla; cambios commiteados en la rama `work`.

### Testing
- Ejecuté búsquedas y visualización de archivo con `rg` y `sed` para verificar ubicaciones y contextos del cambio (comandos ejecutados con salida exitosa).
- Revisé el diff con `git diff -- public/jugarcartones.html` y confirmé las líneas eliminadas y añadidas; el comando se ejecutó correctamente.
- Realicé `git add` y `git commit` para persistir el cambio y verifiqué el estado con `git status` y `git log` exitosamente.
- Creé el PR localmente con el título y cuerpo descriptivos; todas las verificaciones automáticas de git en este flujo completaron sin errores.

Nota: la nueva consulta compuesta puede requerir la creación de un índice compuesto en Firestore (`sorteoId + userId + cartonNum`) si el entorno lo solicita.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ecbe87ec8326a1db67636725e89d)