### PR TITLE
Corregir mensaje y permitir selección de celdas vacías en modo tutorial

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -945,11 +945,14 @@
       overflow:auto;
       align-items:center;
       justify-content:center;
-      word-break:break-word;
+      word-break:normal;
+      overflow-wrap:anywhere;
       opacity:0;
       transform:translateX(-24px);
       transition:opacity 0.28s ease, transform 0.28s ease, top 0.2s ease, left 0.2s ease;
     }
+    #tutorial-label p{margin:0;}
+    #tutorial-label .tutorial-nota{color:#d60000;}
     #tutorial-label.adaptado{
       transition:opacity 0.28s ease, transform 0.28s ease, top 0.2s ease, left 0.2s ease;
     }
@@ -1508,6 +1511,11 @@
     tutorialState.focoElemento=elemento;
     elemento.classList.add('tutorial-focus-target');
     elemento.setAttribute('data-tutorial-focus','1');
+    const esCeldaCarton=Boolean(elemento.closest && elemento.closest('#bingo-board td'));
+    if(tutorialState.permitirSeleccionCarton && esCeldaCarton){
+      document.body.classList.remove('tutorial-focus-lock');
+      return;
+    }
     document.body.classList.add('tutorial-focus-lock');
   }
 
@@ -1836,7 +1844,7 @@
     }=opciones;
     const claveMensaje=mensajeHtml||mensaje;
     const mensajePrevio=tutorialLabel.dataset.mensaje ?? '';
-    const necesitaReinicio=tutorialLabel.style.display!=='flex' || mensajePrevio!==claveMensaje;
+    const necesitaReinicio=tutorialLabel.style.display!=='block' || mensajePrevio!==claveMensaje;
     const maxAncho=Math.min(480,viewportWidth*0.9);
     const tamanoFuente=Math.max(16,Math.min(22,maxAncho/18));
     tutorialLabel.style.maxWidth=`${maxAncho}px`;
@@ -1847,7 +1855,7 @@
     if(necesitaReinicio){
       tutorialLabel[mensajeHtml?'innerHTML':'textContent']=mensajeHtml||mensaje;
       tutorialLabel.dataset.mensaje=claveMensaje;
-      tutorialLabel.style.display='flex';
+      tutorialLabel.style.display='block';
       tutorialLabel.classList.add('adaptado');
       tutorialLabel.classList.remove('tutorial-label-visible');
       tutorialLabel.style.visibility='hidden';
@@ -2121,8 +2129,8 @@
     {
       id:'recorrido-carton',
       ejecutar:async ({token})=>{
-        const mensaje='Pulsa una de las celdas del cartón para elegir tu jugada, Nota: no se pueden repetir números en la misma columna';
-        const mensajeHtml='Pulsa una de las celdas del cartón para elegir tu jugada, <span style="color:#d60000;">Nota:</span> no se pueden repetir números en la misma columna';
+        const mensaje='Pulsa una de las celdas del cartón para elegir tu jugada. Nota: no se pueden repetir números en la misma columna';
+        const mensajeHtml='<p>Pulsa una de las celdas del cartón para elegir tu jugada.</p><p><span class="tutorial-nota">Nota:</span> no se pueden repetir números en la misma columna.</p>';
         if(tutorialHand){
           tutorialHand.src='img/Mano-arri-izq.png';
           tutorialHand.classList.remove('tutorial-hand-pulse');
@@ -3339,7 +3347,10 @@ function toggleForma(idx){
             intentarVoltearDesdeCentro();
           });
         }else{
-          td.addEventListener('click',()=>openModal(td));
+          td.addEventListener('click',()=>{
+            const tutorialManual=tutorialState.activo && tutorialState.permitirSeleccionCarton;
+            openModal(td,{tutorialAuto:!tutorialManual});
+          });
         }
         tr.appendChild(td);
       }


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad del mensaje del paso de recorrido del cartón en modo tutorial para que la indicación y la nota se muestren como párrafos correctos y no se rompa la palabra "Nota:".
- Permitir que el usuario pueda seleccionar números tocando las celdas vacías del cartón durante el tutorial cuando el paso permita selección manual, siguiendo la instrucción mostrada.

### Description
- Ajusté estilos de `#tutorial-label` para evitar quiebres extraños de palabra y permitir un ajuste de línea más natural usando `word-break: normal` y `overflow-wrap: anywhere`, y añadí reglas para `#tutorial-label p` y `.tutorial-nota` para presentar párrafos y resaltar la nota.
- Cambié el renderizado de la etiqueta tutorial a `display: block` cuando se inicializa el texto para asegurar una composición de párrafos estable.
- Modifiqué el texto del paso `recorrido-carton` para producir dos párrafos (`mensajeHtml`) con la nota destacada mediante la clase `.tutorial-nota` en vez de una sola línea que rompía visualmente.
- Actualicé la función de foco del tutorial (`fijarFocoTutorial`) para no imponer la clase `tutorial-focus-lock` cuando `tutorialState.permitirSeleccionCarton` es true y el elemento enfocado es una celda del cartón, permitiendo así interacción con la celda.
- Cambié el event handler de las celdas normales para que, si el tutorial está activo y permite selección manual, se abra el modal de números sin forzar auto-selección (`openModal(td,{tutorialAuto:false})`), de modo que el usuario pueda elegir números tocando celdas vacías.

### Testing
- Ejecuté `npm test -- --runInBand`, que pasó correctamente con todas las suites (7/7) y todos los tests verdes.
- No se introdujeron cambios en los tests existentes y las pruebas automatizadas locales completaron sin fallos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69928364e2e88326b1c372f0f207e20c)