### PR TITLE
Corregir bloqueo de celda central en modo tutorial de jugar cartones

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -3340,10 +3340,7 @@ function toggleForma(idx){
           info.appendChild(maxSpan);
           td.appendChild(info);
           td.addEventListener('click',()=>{
-            if(tutorialState.activo && tutorialState.permitirSeleccionCarton){
-              openModal(td,{tutorialAuto:false});
-              return;
-            }
+            if(tutorialState.activo && !tutorialState.permitirVolteoCentro) return;
             intentarVoltearDesdeCentro();
           });
         }else{


### PR DESCRIPTION
### Motivation
- El modo tutorial permitía interactuar con la celda central (FREE) fuera del paso concreto de "voltear" y abría el modal de selección de números, lo que rompe el flujo de enseñanza.
- La celda central debe permanecer inactiva durante el recorrido de selección de jugadas y sólo permitir el volteo cuando el tutorial explícitamente enfoque ese paso.

### Description
- Se actualizó el `click` de la celda central en `public/jugarcartones.html` para que, cuando `tutorialState.activo` esté `true`, la acción retorne si `tutorialState.permitirVolteoCentro` es `false` (condición comprobada antes de llamar a `intentarVoltearDesdeCentro`).
- Cambio localizado en la función `createBoard` afectando sólo la lógica del `td` central (FREE); el resto de celdas y la apertura de modal para selección de números permanecen sin modificaciones.

### Testing
- Se ejecutaron las pruebas automatizadas del proyecto con `npm test -- --runInBand` y todas las suites pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699286eabb748326af595609cf3d2569)