### PR TITLE
Agregar previsualización (dryRun) y validación previa para /admin/purge-sorteo

### DIFF
--- a/__tests__/uploadServer-purge-utils.test.js
+++ b/__tests__/uploadServer-purge-utils.test.js
@@ -1,0 +1,63 @@
+jest.mock('firebase-admin', () => ({
+  apps: [],
+  initializeApp: jest.fn()
+}));
+
+describe('uploadServer utilidades de depuración de sorteos', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('countDocumentById devuelve 1 cuando existe y 0 cuando no existe', async () => {
+    const { countDocumentById } = require('../uploadServer.js');
+
+    const db = {
+      collection: jest.fn(() => ({
+        doc: jest.fn((id) => ({
+          get: jest.fn(async () => ({ exists: id === 'exists-id' }))
+        }))
+      }))
+    };
+
+    await expect(countDocumentById({ db, collectionName: 'sorteos', docId: 'exists-id' })).resolves.toBe(1);
+    await expect(countDocumentById({ db, collectionName: 'sorteos', docId: 'missing-id' })).resolves.toBe(0);
+  });
+
+  test('getPurgeCounts en dryRun cuenta sin borrar', async () => {
+    const { getPurgeCounts } = require('../uploadServer.js');
+
+    const queryGet = jest.fn(async () => ({ empty: true, size: 0, docs: [] }));
+    const docGet = jest.fn(async () => ({ exists: false }));
+    const deleteFn = jest.fn(async () => {});
+
+    const db = {
+      collection: jest.fn(() => ({
+        where: jest.fn(() => ({
+          orderBy: jest.fn(() => ({
+            limit: jest.fn(() => ({
+              get: queryGet,
+              startAfter: jest.fn(() => ({ get: queryGet }))
+            }))
+          }))
+        })),
+        doc: jest.fn(() => ({
+          get: docGet,
+          delete: deleteFn
+        }))
+      }))
+    };
+
+    const counts = await getPurgeCounts({ db, sorteoId: 'abc', dryRun: true });
+
+    expect(Object.keys(counts)).toEqual([
+      'CartonJugado',
+      'ConsecutivosCarton',
+      'SorteosCentroPagos',
+      'cantos',
+      'cantarsorteos',
+      'formas',
+      'sorteos'
+    ]);
+    expect(deleteFn).not.toHaveBeenCalled();
+  });
+});

--- a/public/depurardb.html
+++ b/public/depurardb.html
@@ -145,6 +145,14 @@
       background: linear-gradient(135deg, #ef4444, #b91c1c);
     }
 
+    .accion-previsualizar {
+      width: 100%;
+      height: 56px;
+      margin: 0 0 6px;
+      font-size: 1.2rem;
+      background: linear-gradient(135deg, #2563eb, #1d4ed8);
+    }
+
     .accion-depurar:disabled {
       cursor: not-allowed;
       opacity: 0.55;
@@ -178,6 +186,7 @@
       <div id="sorteos-lista" class="sorteos-lista" aria-live="polite">
         Cargando sorteos...
       </div>
+      <button id="previsualizar-btn" class="menu-btn accion-previsualizar" disabled>Previsualizar</button>
       <button id="depurar-btn" class="menu-btn accion-depurar" disabled>Depurar</button>
       <div id="estado" class="estado" aria-live="polite"></div>
     </div>
@@ -193,11 +202,15 @@
     ensureAuth('Administrador');
 
     const listaSorteosEl = document.getElementById('sorteos-lista');
+    const previsualizarBtn = document.getElementById('previsualizar-btn');
     const depurarBtn = document.getElementById('depurar-btn');
     const estadoEl = document.getElementById('estado');
+    const PREVIEW_VALID_WINDOW_MS = 10 * 60 * 1000;
 
     let sorteos = [];
     let sorteoSeleccionado = null;
+    let previsualizacionReciente = null;
+    let previewEnCurso = false;
     let depuracionEnCurso = false;
 
     function setEstado(mensaje, tipo = '') {
@@ -206,7 +219,18 @@
     }
 
     function actualizarBotonDepurar() {
-      depurarBtn.disabled = !sorteoSeleccionado || depuracionEnCurso;
+      const hayPreviewValida = !!(
+        sorteoSeleccionado
+        && previsualizacionReciente
+        && previsualizacionReciente.sorteoId === sorteoSeleccionado.id
+        && (Date.now() - previsualizacionReciente.timestampMs) <= PREVIEW_VALID_WINDOW_MS
+      );
+      const operacionEnCurso = depuracionEnCurso || previewEnCurso;
+
+      previsualizarBtn.disabled = !sorteoSeleccionado || operacionEnCurso;
+      previsualizarBtn.textContent = previewEnCurso ? 'Previsualizando...' : 'Previsualizar';
+
+      depurarBtn.disabled = !sorteoSeleccionado || operacionEnCurso || !hayPreviewValida;
       depurarBtn.textContent = depuracionEnCurso ? 'Depurando...' : 'Depurar';
     }
 
@@ -230,6 +254,9 @@
         radio.id = `sorteo-${index}`;
         radio.addEventListener('change', () => {
           sorteoSeleccionado = sorteo;
+          if (previsualizacionReciente?.sorteoId !== sorteo.id) {
+            previsualizacionReciente = null;
+          }
           setEstado(`Sorteo seleccionado: ${sorteo.nombre} (${sorteo.id}).`);
           actualizarBotonDepurar();
         });
@@ -274,6 +301,18 @@
     async function depurarSorteo() {
       if (depuracionEnCurso || !sorteoSeleccionado) return;
 
+      const hayPreviewValida = !!(
+        previsualizacionReciente
+        && previsualizacionReciente.sorteoId === sorteoSeleccionado.id
+        && (Date.now() - previsualizacionReciente.timestampMs) <= PREVIEW_VALID_WINDOW_MS
+      );
+
+      if (!hayPreviewValida) {
+        setEstado('Debes generar una previsualización reciente del mismo sorteo antes de depurar.', 'error');
+        actualizarBotonDepurar();
+        return;
+      }
+
       const mensajeConfirmacion =
         `¿Segura que deseas borrar en cascada todos los datos del sorteo ${sorteoSeleccionado.nombre}?\n\n` +
         'Esta acción eliminará registros relacionados en múltiples colecciones y no se puede deshacer.';
@@ -305,7 +344,8 @@
           },
           body: JSON.stringify({
             sorteoId: sorteoSeleccionado.id,
-            sorteoNombre: sorteoSeleccionado.nombre
+            sorteoNombre: sorteoSeleccionado.nombre,
+            dryRun: false
           })
         });
 
@@ -324,6 +364,7 @@
           'ok'
         );
 
+        previsualizacionReciente = null;
         await cargarSorteos();
       } catch (error) {
         console.error('Error depurando sorteo', error);
@@ -334,6 +375,65 @@
       }
     }
 
+    async function previsualizarSorteo() {
+      if (previewEnCurso || !sorteoSeleccionado) return;
+
+      previewEnCurso = true;
+      actualizarBotonDepurar();
+      setEstado(`Generando previsualización para ${sorteoSeleccionado.nombre} (${sorteoSeleccionado.id})...`);
+
+      try {
+        await initFirebase();
+        const user = auth.currentUser;
+        if (!user) {
+          throw new Error('No hay sesión activa para autorizar la previsualización.');
+        }
+
+        const idToken = await user.getIdToken(true);
+        const apiBase = typeof getAdminApiBase === 'function' ? getAdminApiBase() : '';
+        const response = await fetch(`${apiBase}/admin/purge-sorteo`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${idToken}`
+          },
+          body: JSON.stringify({
+            sorteoId: sorteoSeleccionado.id,
+            sorteoNombre: sorteoSeleccionado.nombre,
+            dryRun: true
+          })
+        });
+
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(payload.error || payload.message || `Error HTTP ${response.status}`);
+        }
+
+        const conteos = payload.deletedCounts || {};
+        const resumen = Object.keys(conteos)
+          .map((key) => `• ${key}: ${conteos[key]}`)
+          .join('\n');
+
+        previsualizacionReciente = {
+          sorteoId: sorteoSeleccionado.id,
+          timestampMs: Date.now()
+        };
+
+        setEstado(
+          `Previsualización completada para ${sorteoSeleccionado.nombre} (${sorteoSeleccionado.id}).\n\nDocumentos detectados:\n${resumen}`,
+          'ok'
+        );
+      } catch (error) {
+        console.error('Error previsualizando depuración', error);
+        previsualizacionReciente = null;
+        setEstado(`No se pudo generar la previsualización: ${error.message}`, 'error');
+      } finally {
+        previewEnCurso = false;
+        actualizarBotonDepurar();
+      }
+    }
+
+    previsualizarBtn.addEventListener('click', previsualizarSorteo);
     depurarBtn.addEventListener('click', depurarSorteo);
     cargarSorteos();
   </script>

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -149,6 +149,37 @@ async function deleteCollectionBySorteoId({ db, collectionName, sorteoId, pageSi
   return deleted;
 }
 
+async function countCollectionBySorteoId({ db, collectionName, sorteoId, pageSize = 400 }) {
+  let count = 0;
+  let lastDoc = null;
+
+  while (true) {
+    let query = db
+      .collection(collectionName)
+      .where('sorteoId', '==', sorteoId)
+      .orderBy('__name__')
+      .limit(pageSize);
+
+    if (lastDoc) {
+      query = query.startAfter(lastDoc);
+    }
+
+    const snapshot = await query.get();
+    if (snapshot.empty) {
+      break;
+    }
+
+    count += snapshot.size;
+    lastDoc = snapshot.docs[snapshot.docs.length - 1];
+
+    if (snapshot.size < pageSize) {
+      break;
+    }
+  }
+
+  return count;
+}
+
 async function deleteDocumentById({ db, collectionName, docId }) {
   const ref = db.collection(collectionName).doc(docId);
   const snapshot = await ref.get();
@@ -159,6 +190,38 @@ async function deleteDocumentById({ db, collectionName, docId }) {
 
   await ref.delete();
   return 1;
+}
+
+async function countDocumentById({ db, collectionName, docId }) {
+  const ref = db.collection(collectionName).doc(docId);
+  const snapshot = await ref.get();
+  return snapshot.exists ? 1 : 0;
+}
+
+async function getPurgeCounts({ db, sorteoId, dryRun }) {
+  return {
+    CartonJugado: dryRun
+      ? await countCollectionBySorteoId({ db, collectionName: 'CartonJugado', sorteoId })
+      : await deleteCollectionBySorteoId({ db, collectionName: 'CartonJugado', sorteoId }),
+    ConsecutivosCarton: dryRun
+      ? await countDocumentById({ db, collectionName: 'ConsecutivosCarton', docId: sorteoId })
+      : await deleteDocumentById({ db, collectionName: 'ConsecutivosCarton', docId: sorteoId }),
+    SorteosCentroPagos: dryRun
+      ? await countDocumentById({ db, collectionName: 'SorteosCentroPagos', docId: sorteoId })
+      : await deleteDocumentById({ db, collectionName: 'SorteosCentroPagos', docId: sorteoId }),
+    cantos: dryRun
+      ? await countDocumentById({ db, collectionName: 'cantos', docId: sorteoId })
+      : await deleteDocumentById({ db, collectionName: 'cantos', docId: sorteoId }),
+    cantarsorteos: dryRun
+      ? await countDocumentById({ db, collectionName: 'cantarsorteos', docId: sorteoId })
+      : await deleteDocumentById({ db, collectionName: 'cantarsorteos', docId: sorteoId }),
+    formas: dryRun
+      ? await countCollectionBySorteoId({ db, collectionName: 'formas', sorteoId })
+      : await deleteCollectionBySorteoId({ db, collectionName: 'formas', sorteoId }),
+    sorteos: dryRun
+      ? await countDocumentById({ db, collectionName: 'sorteos', docId: sorteoId })
+      : await deleteDocumentById({ db, collectionName: 'sorteos', docId: sorteoId })
+  };
 }
 
 async function validarUsuarioSuperadmin(decodedToken) {
@@ -416,7 +479,9 @@ app.post('/admin/audit/parametros', async (req, res) => {
 });
 
 app.post('/admin/purge-sorteo', verificarToken, async (req, res) => {
-  const { sorteoId, sorteoNombre } = req.body || {};
+  const { sorteoId, sorteoNombre, dryRun } = req.body || {};
+  const normalizedDryRun = dryRun === true;
+  const PREVIEW_VALID_WINDOW_MS = 10 * 60 * 1000;
 
   if (!['Superadmin', 'Administrador'].includes(req.user?.role)) {
     return res.status(403).json({ error: 'Acceso restringido a roles administrativos' });
@@ -434,58 +499,58 @@ app.post('/admin/purge-sorteo', verificarToken, async (req, res) => {
   const db = admin.firestore();
 
   try {
-    const deletedCounts = {
-      CartonJugado: await deleteCollectionBySorteoId({
-        db,
-        collectionName: 'CartonJugado',
-        sorteoId: normalizedSorteoId
-      }),
-      ConsecutivosCarton: await deleteDocumentById({
-        db,
-        collectionName: 'ConsecutivosCarton',
-        docId: normalizedSorteoId
-      }),
-      SorteosCentroPagos: await deleteDocumentById({
-        db,
-        collectionName: 'SorteosCentroPagos',
-        docId: normalizedSorteoId
-      }),
-      cantos: await deleteDocumentById({
-        db,
-        collectionName: 'cantos',
-        docId: normalizedSorteoId
-      }),
-      cantarsorteos: await deleteDocumentById({
-        db,
-        collectionName: 'cantarsorteos',
-        docId: normalizedSorteoId
-      }),
-      formas: await deleteCollectionBySorteoId({
-        db,
-        collectionName: 'formas',
-        sorteoId: normalizedSorteoId
-      }),
-      sorteos: await deleteDocumentById({
-        db,
-        collectionName: 'sorteos',
-        docId: normalizedSorteoId
-      })
-    };
+    if (!normalizedDryRun) {
+      const recentPreviewSnapshot = await db
+        .collection('adminAccessAudit')
+        .where('uid', '==', req.user?.uid || null)
+        .orderBy('timestamp', 'desc')
+        .limit(20)
+        .get();
+
+      const recentPreview = recentPreviewSnapshot.docs.find((doc) => {
+        const data = doc.data() || {};
+        return data.motivo === 'purge_sorteo_preview' && data.sorteoId === normalizedSorteoId;
+      });
+
+      if (!recentPreview) {
+        return res.status(409).json({
+          error: 'Debes hacer una previsualización antes de depurar este sorteo.'
+        });
+      }
+
+      const previewData = recentPreview.data() || {};
+      const previewAtMs = previewData.timestamp?.toMillis ? previewData.timestamp.toMillis() : 0;
+      if (!previewAtMs || Date.now() - previewAtMs > PREVIEW_VALID_WINDOW_MS) {
+        return res.status(409).json({
+          error: 'La previsualización expiró. Genera una nueva antes de depurar.',
+          previewValidWindowMs: PREVIEW_VALID_WINDOW_MS
+        });
+      }
+    }
+
+    const deletedCounts = await getPurgeCounts({
+      db,
+      sorteoId: normalizedSorteoId,
+      dryRun: normalizedDryRun
+    });
 
     await db.collection('adminAccessAudit').add({
       uid: req.user?.uid || null,
       email: req.user?.email || 'desconocido',
       role: req.user?.role || 'desconocido',
       timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      motivo: 'purge_sorteo',
+      motivo: normalizedDryRun ? 'purge_sorteo_preview' : 'purge_sorteo',
       sorteoId: normalizedSorteoId,
       sorteoNombre: normalizedSorteoNombre,
+      dryRun: normalizedDryRun,
       deletedCounts
     });
 
     return res.json({
       status: 'ok',
       sorteoId: normalizedSorteoId,
+      dryRun: normalizedDryRun,
+      previewValidWindowMs: PREVIEW_VALID_WINDOW_MS,
       deletedCounts
     });
   } catch (error) {
@@ -576,5 +641,8 @@ module.exports = {
   getClientIp,
   getAuthTimeFromToken,
   deleteCollectionBySorteoId,
-  deleteDocumentById
+  deleteDocumentById,
+  countCollectionBySorteoId,
+  countDocumentById,
+  getPurgeCounts
 };


### PR DESCRIPTION
### Motivation
- Permitir previsualizar cuántos documentos serían afectados por la depuración sin borrar nada usando un `dryRun` para evitar borrados accidentales.
- Exigir una previsualización reciente del mismo sorteo y del mismo usuario antes de permitir la depuración real como medida de seguridad adicional.
- Registrar tanto la previsualización como la ejecución real en la colección de auditoría `adminAccessAudit` para trazabilidad.
- Mejorar la UI para ofrecer un flujo claro de “Previsualizar” → “Depurar” y evitar ejecuciones accidentales.

### Description
- Backend: agregué `countCollectionBySorteoId`, `countDocumentById` y `getPurgeCounts` y extendí el endpoint `POST /admin/purge-sorteo` para aceptar `dryRun` y devolver conteos sin eliminar cuando `dryRun=true`.
- Backend: cuando `dryRun=false` el endpoint valida que exista una entrada `purge_sorteo_preview` reciente (ventana de 10 minutos) en `adminAccessAudit` para el mismo `sorteoId` y `uid`, y registra ambos eventos (`purge_sorteo_preview` o `purge_sorteo`) con `deletedCounts`.
- UI: en `public/depurardb.html` añadí el botón `Previsualizar`, estado/locking para el botón `Depurar` hasta que haya una previsualización reciente del sorteo seleccionado, y se envía `dryRun` al backend en las solicitudes.
- Tests / exports: exporté las nuevas utilidades y añadí `__tests__/uploadServer-purge-utils.test.js` para cubrir `countDocumentById` y `getPurgeCounts` en modo `dryRun`.

### Testing
- Ejecuté la suite completa con `npm test` y todos los tests pasaron (`8` suites, `25` tests) y la cobertura requerida se alcanzó; la ejecución final fue exitosa.
- Al ejecutar sólo un subconjunto de tests inicialmente, Jest reportó fallo por umbral global de cobertura al no ejecutar todas las pruebas, lo cual no se debe a fallos funcionales de las utilidades nuevas.
- Verifiqué UI estática arrancando un servidor con `python -m http.server 8000` y capturé una captura de pantalla de `public/depurardb.html` para confirmar que el botón `Previsualizar` aparece y el flujo visual está presente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992919102248326858cb236f60818a3)