### PR TITLE
Fix visualización de cartones en sorteo seleccionado

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -7491,6 +7491,21 @@
     return resultado;
   }
 
+  function normalizarPosicionesCarton(posiciones){
+    const lista=Array.isArray(posiciones)?posiciones:[];
+    const resultado=[];
+    lista.forEach(pos=>{
+      if(!pos) return;
+      const fila=Number(pos.r ?? pos.row ?? pos.fila);
+      const col=Number(pos.c ?? pos.col ?? pos.columna);
+      const valor=normalizarNumero(pos.valor ?? pos.numero ?? pos.value);
+      if(Number.isInteger(fila) && Number.isInteger(col) && valor!==null){
+        resultado.push({r:fila,c:col,valor});
+      }
+    });
+    return resultado;
+  }
+
   function obtenerPosicionesNormalizadas(forma){
     if(!forma) return [];
     if(Array.isArray(forma.posicionesNormalizadas) && forma.posicionesNormalizadas.length){
@@ -10128,17 +10143,14 @@
 
   function construirCartonSimulacion(carton){
     if(!carton) return null;
-    const posicionesRaw=Array.isArray(carton.posiciones)?carton.posiciones:[];
-    const posiciones=posicionesRaw
-      .map(p=>({r:Number(p.r),c:Number(p.c),valor:normalizarNumero(p.valor ?? p.numero ?? p.value)}))
-      .filter(p=>Number.isInteger(p.r)&&Number.isInteger(p.c)&&p.valor!==null);
+    const posiciones=normalizarPosicionesCarton(carton.posiciones);
     const valorPorPos=new Map();
     posiciones.forEach(p=>valorPorPos.set(`${p.r}-${p.c}`,p.valor));
     const idCarton=carton.id || carton.cartonId || '';
     return {
       id:idCarton,
-      userId:carton.userId || '',
-      alias:carton.alias || carton.nombre || '',
+      userId:carton.userId || carton.usuarioId || carton.uid || '',
+      alias:carton.alias || carton.nombre || carton.aliascarton || carton.aliasCarton || '',
       cartonNum:carton.cartonNum ?? carton.Ncarton ?? carton.numero ?? carton.numeroCarton,
       posiciones,
       valorPorPos
@@ -10428,22 +10440,21 @@
     const mapa=new Map();
     snapshot.forEach(doc=>{
       const data=doc.data()||{};
-      const posicionesRaw=Array.isArray(data.posiciones)?data.posiciones:[];
-      const posiciones=posicionesRaw
-        .map(p=>({r:Number(p.r),c:Number(p.c),valor:normalizarNumero(p.valor ?? p.numero ?? p.value)}))
-        .filter(p=>Number.isInteger(p.r)&&Number.isInteger(p.c)&&p.valor!==null);
+      const posiciones=normalizarPosicionesCarton(data.posiciones);
       const valorPorPos=new Map();
       posiciones.forEach(p=>{
         valorPorPos.set(`${p.r}-${p.c}`,p.valor);
       });
       mapa.set(doc.id,{
         id:doc.id,
-        sorteoId:data.sorteoId,
-        userId:data.userId||'',
-        alias:data.alias||'',
-        cartonNum:data.cartonNum,
-        Ncarton:data.Ncarton,
-        tipocarton:data.tipocarton||'pagado',
+        sorteoId:data.sorteoId || data.sorteoid || data.idSorteo || '',
+        userId:data.userId||data.usuarioId||data.uid||'',
+        email:data.email||data.gmail||data.IDbilletera||'',
+        gmail:data.gmail||data.email||data.IDbilletera||'',
+        alias:data.alias||data.aliascarton||data.aliasCarton||'',
+        cartonNum:data.cartonNum ?? data.Ncarton ?? data.carton ?? data.numero ?? null,
+        Ncarton:data.Ncarton ?? data.cartonNum ?? data.carton ?? null,
+        tipocarton:normalizarTipoCarton(data),
         posiciones,
         valorPorPos
       });
@@ -10540,17 +10551,14 @@
       const mapa=new Map();
       snapshot.forEach(doc=>{
         const data=doc.data()||{};
-        const posicionesRaw=Array.isArray(data.posiciones)?data.posiciones:[];
-        const posiciones=posicionesRaw
-          .map(p=>({r:Number(p.r),c:Number(p.c),valor:normalizarNumero(p.valor ?? p.numero ?? p.value)}))
-          .filter(p=>Number.isInteger(p.r)&&Number.isInteger(p.c)&&p.valor!==null);
+        const posiciones=normalizarPosicionesCarton(data.posiciones);
         const valorPorPos=new Map();
         posiciones.forEach(p=>{
           valorPorPos.set(`${p.r}-${p.c}`,p.valor);
         });
         mapa.set(doc.id,{
           id:doc.id,
-          userId:data.userId||'',
+          userId:data.userId||data.usuarioId||data.uid||'',
           alias:data.alias||data.nombre||'',
           nombre:data.nombre||data.alias||'',
           nombreGuardado:data.nombre||data.alias||'',


### PR DESCRIPTION
### Motivation
- Los cartones del sorteo seleccionado no se mostraban cuando los documentos usaban esquemas o nombres de campo legacy o inconsistentes, por lo que era necesario un parseo más robusto de posiciones y metadatos para recuperar los cartones reales y simulados.

### Description
- Añadí `normalizarPosicionesCarton` en `public/juegoactivo.html` para aceptar variantes de esquema de posición (`r/c`, `row/col`, `fila/columna`) y normalizar el `valor` numérico de cada celda.  
- Reemplacé el parseo inline de posiciones por la nueva función en los flujos clave: procesamiento de `CartonJugado` (`procesarCartones`), construcción de cartones de simulación (`construirCartonSimulacion`) y suscripción a `CartonGuardado`.  
- Amplié la compatibilidad con campos legacy y variantes de metadatos (`sorteoId/sorteoid/idSorteo`, `userId/usuarioId/uid`, `alias/aliascarton/aliasCarton`, variantes de número de cartón) y normalicé `tipocarton` para evitar que diferencias de esquema oculten cartones válidos.  
- Archivo modificado: `public/juegoactivo.html`.

### Testing
- Ejecuté la suite de pruebas con `npm test -- --runInBand`.  
- Resultado: todas las pruebas automáticas pasaron (`8` suites, `25` tests) exitosamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c22187088326a02acb9f606d9d92)