### PR TITLE
Agregar diagnóstico opcional en suscribirCartonesJugandoTabla

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -4459,6 +4459,7 @@ function toggleForma(idx){
     const filtros=[
       {campo:'sorteoId',valor:currentSorteo}
     ];
+    const debugCartonesJugando=window.DEBUG_CARTONES_JUGANDO===true;
     const nombreSorteoNormalizado=(currentSorteoNombre||'').toString().trim();
     if(nombreSorteoNormalizado){
       filtros.push({campo:'sorteoNombre',valor:nombreSorteoNormalizado});
@@ -4471,19 +4472,31 @@ function toggleForma(idx){
       filtros.push({campo:'sorteo',valor:nombreSorteoNormalizado});
     }
 
+    if(debugCartonesJugando){
+      console.debug('[CartonesJugandoTabla] Filtro activo',{
+        sorteoId:currentSorteo,
+        sorteoNombre:nombreSorteoNormalizado
+      });
+    }
+
     mostrarMensajeTablaCartones('Cargando cartones...');
 
     const docsPorId=new Map();
     const snapshotsPorFiltro=new Map();
+    const docsRecibidosPorFiltro=new Map();
     let huboError=false;
     const unsubscribers=[];
 
     const renderizarDesdeSnapshots=()=>{
       docsPorId.clear();
+      let docsRecibidosQuery=0;
+      let docsDescartadosNoCoincidir=0;
       snapshotsPorFiltro.forEach((snap)=>{
+        docsRecibidosQuery+=snap.size;
         snap.forEach((doc)=>{
           const data=doc.data()||{};
           if(!coincideSorteoCarton(data,currentSorteo,nombreSorteoNormalizado)){
+            docsDescartadosNoCoincidir+=1;
             return;
           }
           docsPorId.set(doc.id,data);
@@ -4503,9 +4516,29 @@ function toggleForma(idx){
 
       const totalRegistrado=registros.length;
       const gratisRegistrado=registros.filter((registro)=>registro.tipo==='GRATIS').length;
+
+      if(debugCartonesJugando){
+        console.debug('[CartonesJugandoTabla] Diagnóstico de render',{
+          docsPorQuery:[...docsRecibidosPorFiltro.entries()].map(([key,cantidad])=>({query:key,docs:cantidad})),
+          docsRecibidosQuery,
+          docsDescartadosNoCoincidir,
+          docsParaRender:totalRegistrado
+        });
+      }
+
       actualizarResumenCartonesModal({totalRegistrado,gratisRegistrado,tieneErrorCarga:huboError});
 
       if(totalRegistrado===0){
+        const jugadosHeader=toNumberSafe(document.getElementById('cartones-jugando-valor')?.textContent,0);
+        const gratisHeader=toNumberSafe(document.getElementById('cartones-gratis-jugando')?.textContent,0);
+        if(jugadosHeader>0 || gratisHeader>0){
+          console.warn('[CartonesJugandoTabla] Se obtuvo 0 cartones para render, pero el header indica cartones en juego. Revisa el esquema/campos del documento (por ejemplo: sorteoId, sorteoNombre, idSorteo o sorteo) para asegurar que coincidan con el filtro activo.',{
+            sorteoId:currentSorteo,
+            sorteoNombre:nombreSorteoNormalizado,
+            jugadosHeader,
+            gratisHeader
+          });
+        }
         const mensaje=huboError
           ? 'Error al cargar cartones: intenta nuevamente en unos segundos.'
           : 'Sin cartones registrados';
@@ -4527,9 +4560,11 @@ function toggleForma(idx){
       const query=db.collection('CartonJugado').where(filtro.campo,'==',filtro.valor);
       const unsubscribe=query.onSnapshot((snap)=>{
         snapshotsPorFiltro.set(key,snap);
+        docsRecibidosPorFiltro.set(key,snap.size);
         renderizarDesdeSnapshots();
       },(error)=>{
         huboError=true;
+        docsRecibidosPorFiltro.set(key,0);
         console.error('Error cargando cartones jugados para la tabla',filtro,error);
         renderizarDesdeSnapshots();
       });


### PR DESCRIPTION
### Motivation
- Facilitar la depuración cuando la tabla de "cartones jugando" no muestra filas aunque los contadores del header indiquen presencia de cartones, sin ensuciar la consola en producción. 
- Detectar discrepancias debidas a campos inconsistentes en documentos (`sorteoId`, `sorteoNombre`, `idSorteo`, `sorteo`) y ofrecer una pista clara para revisar el esquema de los documentos.

### Description
- En `public/jugarcartones.html` se añadió el flag local `debugCartonesJugando` derivado de `window.DEBUG_CARTONES_JUGANDO === true` para mantener los logs apagados por defecto. 
- Se introdujo `docsRecibidosPorFiltro` y contadores temporales para computar y recolectar la cantidad de documentos recibidos por cada query y los descartes por no coincidir con el sorteo. 
- Se añadieron `console.debug` condicionados al flag que informan el filtro activo (`sorteoId`, `sorteoNombre`), cantidad de docs por query, cantidad descartada por no coincidir y cantidad final para render. 
- Se agregó un `console.warn` específico cuando el render final resulta en `0` filas pero los contadores del header (`cartones-jugando-valor` / `cartones-gratis-jugando`) son mayores a `0`, con sugerencia de revisar el esquema/campos.

### Testing
- No se ejecutaron pruebas automatizadas para este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c7ef91e88326a54f9591831b6e7c)