### PR TITLE
Ajustes CSS desktop: media queries (min-width:1024px) en páginas públicas

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -811,6 +811,16 @@
     .back-forma-line .back-forma-valor,.back-forma-line .back-forma-cartones{font-size:1.2rem;}
     .back-forma-nombre{font-family:'Poppins',sans-serif;font-size:0.7rem;font-weight:600;text-shadow:0 0 4px #fff,0 0 8px #fff;align-self:flex-start;margin-top:-4px;margin-bottom:6px;}
     #back-premios-content{display:flex;flex-direction:column;align-items:center;position:relative;z-index:1;}
+    @media (min-width:1024px){
+      body{font-size:1.02rem;}
+      .menu-btn{width:clamp(260px,30vw,380px);}
+      #sorteo-btn{width:clamp(280px,34vw,420px);font-size:clamp(1rem,1vw,1.1rem);}
+      .sorteo-info{gap:14px;}
+      #fecha-hora-sorteo{font-size:clamp(1rem,1vw,1.05rem);}
+      #fecha-hora,#derechos{font-size:max(0.85rem,0.95vw);}
+      #bingo-board,.sorteo-info,#info-cartones-tabla{width:min(920px,90vw);max-width:90vw;}
+      table{font-size:clamp(0.9rem,0.95vw,1rem);}
+    }
     @media (max-width:480px){#fecha-hora-sorteo .fecha-col{align-items:center;text-align:center;}}
     @media (orientation:landscape) and (max-height:600px){
       body{padding-left:clamp(40px,12vw,160px);padding-right:clamp(40px,12vw,160px);}

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -418,6 +418,24 @@
           box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
           outline: none;
       }
+      @media (min-width: 1024px) {
+          body { font-size: 1.02rem; }
+          main#perfil-contenido { width: min(760px, 84vw); }
+          input, select { font-size: clamp(1rem, 1vw, 1.05rem); }
+          .nombre-apellido-row { gap: 14px; }
+          .menu-btn { width: clamp(220px, 24vw, 320px); }
+          #guardar-perfil-btn, #jugar-carton-btn { width: clamp(240px, 28vw, 340px); }
+          .notificaciones-panel { width: min(760px, 84vw); }
+          .notificaciones-opcion,
+          .notificaciones-opcion-titulo small,
+          .nota-campos,
+          .nota-celular,
+          .mensaje-validacion,
+          #session-info,
+          #logout-link,
+          #fecha-hora,
+          #derechos { font-size: max(0.85rem, 0.95vw); }
+      }
       @media (orientation: portrait) {
           .modal-whatsapp {
               align-items: center;

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -221,6 +221,20 @@
       50%{transform:scale(1.08);}
       100%{transform:scale(1);}
     }
+    @media (min-width:1024px){
+      body{font-size:1.02rem;}
+      input,select{font-size:clamp(1rem,1vw,1.05rem);}
+      input{width:clamp(280px,34vw,420px);}
+      .step-panel{max-width:min(560px,78vw);}
+      .action-btn{width:clamp(220px,28vw,320px);font-size:clamp(1.2rem,1.8vw,1.45rem);}
+      .secondary-btn{font-size:0.9rem;min-width:clamp(130px,20vw,190px);}
+      #terms-container,.step-pill,#status-cuenta,#resumen-confirmacion,.field-msg,.small-label,.nota-registro,#fecha-hora,#derechos{font-size:max(0.85rem,1vw);}
+      #terms-container{gap:8px;}
+      .step-pill{padding:6px 14px;}
+      #resumen-confirmacion{max-width:min(520px,74vw);padding:12px 14px;}
+      .celular-row{width:min(520px,78vw);}
+      #codigo-pais{width:clamp(130px,18vw,180px);flex:0 0 clamp(130px,18vw,180px);}
+    }
   </style>
   <link rel="stylesheet" href="css/desktopFrame.css">
 </head>

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -47,6 +47,13 @@
     input:checked + .slider:before{transform:translateX(18px);}
     .badge{display:none;align-items:center;justify-content:center;min-width:25px;height:25px;background:red;color:#fff;border-radius:50%;font-size:0.9rem;animation:pulse 1s infinite;}
     @keyframes pulse{0%{transform:scale(1);}50%{transform:scale(1.1);}100%{transform:scale(1);}}
+    @media (min-width:1024px){
+      body{font-size:1.02rem;padding:8px;}
+      .acciones{gap:8px;padding:6px 0;}
+      .icon-btn{font-size:max(0.85rem,0.95vw);padding:6px 10px;}
+      table{width:min(1200px,96vw);font-size:clamp(0.9rem,0.95vw,1rem);}
+      th,td{padding:5px 6px;}
+    }
     @media (orientation:portrait){
       body{padding:2px;}
       table{font-size:0.6rem;width:100%;margin:2px 0;}


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad y la ergonomía en pantallas de escritorio aumentando la tipografía base y evitando que labels/notas/footer queden por debajo de `0.85rem`.
- Hacer controles clave (inputs, botones, paneles, tablas) más fluidos en desktop sustituyendo anchos fijos por rangos con `clamp()` o anchos relativos.
- Mantener intactas las reglas existentes para `@media (orientation: portrait)` y para tamaños pequeños, y aplicar ajustes solo en escritorio (>=1024px). 

### Description
- Inserté un bloque `@media (min-width:1024px)` en `public/registrarse.html` que eleva la tipografía a ~`1.02rem`, aplica `clamp()` a `input`, botones y contenedores, y ajusta selectores revisados como `#terms-container`, `.step-pill`, `#fecha-hora` y `#derechos` para garantizar un mínimo tipográfico de `0.85rem`.
- Inserté un bloque `@media (min-width:1024px)` en `public/perfil.html` que amplía el contenedor principal (`main#perfil-contenido`), escala `input/select` con `clamp()` y ajusta botones/paneles y textos auxiliares para escritorio.
- Inserté un bloque `@media (min-width:1024px)` en `public/jugarcartones.html` que ajusta `#sorteo-btn`, la zona del tablero/paneles y tablas para anchos fluidos y tipografía de footer, sin tocar las media queries de portrait existentes.
- Inserté un bloque `@media (min-width:1024px)` en `public/transacciones.html` que mejora la legibilidad de `.icon-btn` y las tablas (ancho, paddings y tamaño de fuente) usando `clamp()` y anchos máximos relativos.

### Testing
- Ejecuté `git diff --check` para comprobar errores de diff y no se reportaron problemas, resultado: exitoso.
- Levanté un servidor de prueba con `python -m http.server 4173 --bind 0.0.0.0` y verifiqué que las páginas solicitadas responden correctamente, resultado: exitoso.
- Generé una captura visual de `public/registrarse.html` con Playwright para validar cambios en desktop, la captura se generó correctamente y el script finalizó sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994cb3326148326842ced39bb5c3a13)