### PR TITLE
Ajustar media queries por ancho en transacciones y jugarcartones

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -64,7 +64,7 @@
       gap:5px;
       font-size:1.2rem;
     }
-    @media (orientation:portrait){
+    @media (max-width:1023px) and (orientation:portrait){
       #volver-btn{width:40px;}
       #volver-btn .label{display:none;}
     }
@@ -812,12 +812,16 @@
     .back-forma-nombre{font-family:'Poppins',sans-serif;font-size:0.7rem;font-weight:600;text-shadow:0 0 4px #fff,0 0 8px #fff;align-self:flex-start;margin-top:-4px;margin-bottom:6px;}
     #back-premios-content{display:flex;flex-direction:column;align-items:center;position:relative;z-index:1;}
     @media (max-width:480px){#fecha-hora-sorteo .fecha-col{align-items:center;text-align:center;}}
-    @media (orientation:landscape) and (max-height:600px){
+    @media (max-width:1023px) and (max-height:600px){
       body{padding-left:clamp(40px,12vw,160px);padding-right:clamp(40px,12vw,160px);}
       .sorteo-info{flex-direction:column;align-items:center;gap:12px;}
       #fecha-hora-sorteo{flex-direction:column;align-items:center;}
       #fecha-hora-sorteo .fecha-col{align-items:center;text-align:center;}
       .datos-sorteo,#alias-section,.carton-box{max-width:560px;width:100%;}
+    }
+    @media (min-width:1024px){
+      #volver-btn{width:120px;}
+      #volver-btn .label{display:inline;}
     }
 
     /* Controles del modo tutorial */

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -22,7 +22,6 @@
     .icon-only{padding:4px;width:24px;height:24px;justify-content:center;gap:0;}
     .archivo-activo{background:#654321;color:#fff;}
     #ver-arch-ret .archivo-text{display:none;}
-    @media (orientation:landscape){#ver-arch-ret .archivo-text{display:inline;}}
     table{margin:5px auto;border-collapse:collapse;width:100%;font-size:0.8rem;font-family:Calibri, Arial, sans-serif;background:rgba(255,255,255,0.6);table-layout:fixed;}
     th,td{border:1px solid #ccc;padding:2px;white-space:nowrap;font-weight:bold;}
     #tabla-recargas th:nth-child(3),#tabla-recargas td:nth-child(3),
@@ -47,7 +46,7 @@
     input:checked + .slider:before{transform:translateX(18px);}
     .badge{display:none;align-items:center;justify-content:center;min-width:25px;height:25px;background:red;color:#fff;border-radius:50%;font-size:0.9rem;animation:pulse 1s infinite;}
     @keyframes pulse{0%{transform:scale(1);}50%{transform:scale(1.1);}100%{transform:scale(1);}}
-    @media (orientation:portrait){
+    @media (max-width:1023px) and (orientation:portrait){
       body{padding:2px;}
       table{font-size:0.6rem;width:100%;margin:2px 0;}
       .acciones{margin:2px 0;}
@@ -62,7 +61,14 @@
       #volver-btn .label{display:none;}
       #ver-arch-ret{padding:4px;width:24px;height:24px;justify-content:center;gap:0;}
     }
-    @media (orientation:landscape){table{font-size:0.9rem;}}
+    @media (min-width:1024px){
+      table{font-size:0.9rem;}
+      #volver-btn{width:120px;}
+      #volver-btn .label{display:inline;}
+      #ver-arch-ret{padding:4px 8px;width:auto;height:auto;gap:4px;}
+      #ver-arch-ret .archivo-text{display:inline;}
+    }
+    @media (min-width:1280px){table{font-size:1rem;}}
 
     #tabla-recargas td:nth-child(5),#tabla-retiros td:nth-child(5){font-size:1rem;}
     td.nota-estado{position:relative;cursor:pointer;}


### PR DESCRIPTION
### Motivation

- Migrar reglas dependientes de `orientation: landscape` a breakpoints por ancho para que el diseño de escritorio dependa del ancho real del viewport.  
- Mantener `orientation: portrait` solo para casos de móvil vertical y evitar efectos colaterales en tablet/desktop.  
- Asegurar que controles compactos (p. ej. `#volver-btn`, `#ver-arch-ret`) no queden en estilo "icon-only" en escritorio.  

### Description

- Reemplacé en `public/transacciones.html` la regla de `orientation:landscape` por `@media (min-width:1024px)` y añadí `@media (min-width:1280px)` para ajuste fino de escritorio.  
- Limité las reglas de retrato a `@media (max-width:1023px) and (orientation:portrait)` en `public/transacciones.html` y `public/jugarcartones.html` para que apliquen solo en móvil vertical.  
- En `public/transacciones.html` forcé que `#volver-btn` y `#ver-arch-ret` muestren la etiqueta en escritorio ajustando padding/width y mostrando `.archivo-text`.  
- En `public/jugarcartones.html` convertí una regla condicionada por `orientation:landscape and (max-height:600px)` a `@media (max-width:1023px) and (max-height:600px)` y añadí `@media (min-width:1024px)` para restaurar el botón volver en escritorio.  

### Testing

- Busqué ocurrencias de `orientation` con `rg` para validar cambios y la búsqueda devolvió solo las reglas esperadas; el comando se ejecutó correctamente.  
- Levanté un servidor local con `python3 -m http.server 8000` y generé capturas con Playwright para `public/transacciones.html` y `public/jugarcartones.html`, y las capturas se produjeron sin errores.  
- Verifiqué el estado de los cambios y realicé el commit con `git commit` (mensajes registrados), operación completada exitosamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994cb3d17a483269947aa7191dec4e4)