### PR TITLE
Implementa AudioManager global con Web Audio API y ducking de música

### DIFF
--- a/public/js/audioControls.js
+++ b/public/js/audioControls.js
@@ -14,8 +14,15 @@
     localStorage.setItem(`${prefix}:volume`, String(estado.volume));
   }
 
+  function resolverFuenteAudioDesdeId(audioId) {
+    if (!audioId) return null;
+    const audioEl = document.getElementById(audioId);
+    return audioEl?.currentSrc || audioEl?.src || null;
+  }
+
   function initBingoAudioControl(config) {
-    if (!config) return;
+    if (!config || !window.audioManager) return;
+
     const {
       containerId,
       toggleId,
@@ -23,17 +30,29 @@
       audioId,
       storageKeyPrefix = 'bingoAudio',
       defaultVolume = DEFAULT_VOLUME,
-      unlockAudioIds = [],
+      musicTrackId = 'bg-music',
+      sfxEvents = {},
       mostrarPrompt = false,
     } = config;
 
     const container = document.getElementById(containerId);
     const toggle = document.getElementById(toggleId);
     const volumeInput = document.getElementById(volumeId);
-    const audioEl = document.getElementById(audioId);
     const volumeWrap = container?.querySelector('.audio-control__volume');
 
-    if (!container || !toggle || !volumeInput || !audioEl) return;
+    if (!container || !toggle || !volumeInput) return;
+
+    const musicSrc = resolverFuenteAudioDesdeId(audioId);
+    if (musicSrc) {
+      window.audioManager.registerMusicTrack(musicTrackId, musicSrc);
+    }
+
+    Object.entries(sfxEvents).forEach(([eventName, cfg]) => {
+      if (!cfg) return;
+      const src = cfg.src || resolverFuenteAudioDesdeId(cfg.audioId);
+      if (!src) return;
+      window.audioManager.registerSfxEvent(eventName, src, cfg);
+    });
 
     let estado = obtenerEstadoAudio(storageKeyPrefix);
     if (!Number.isFinite(estado.volume)) {
@@ -41,9 +60,7 @@
     }
 
     let hideTimer = null;
-    let audioDesbloqueado = false;
     let promptEl = null;
-    let promptBtn = null;
 
     function actualizarUI() {
       container.classList.toggle('is-muted', estado.muted);
@@ -70,8 +87,7 @@
     }
 
     function crearPromptAudio() {
-      if (!mostrarPrompt) return;
-      if (promptEl) return;
+      if (!mostrarPrompt || promptEl) return;
       promptEl = document.createElement('div');
       promptEl.className = 'audio-control__prompt';
       promptEl.setAttribute('role', 'dialog');
@@ -80,9 +96,13 @@
       promptEl.innerHTML =
         '<p>Para escuchar la música necesitamos tu interacción.</p>' +
         '<button type="button" class="audio-control__prompt-btn">Activar audio</button>';
-      promptBtn = promptEl.querySelector('.audio-control__prompt-btn');
+
+      const promptBtn = promptEl.querySelector('.audio-control__prompt-btn');
       promptBtn?.addEventListener('click', async () => {
-        await intentarReproducir(true);
+        await window.audioManager.init();
+        if (!estado.muted) {
+          await window.audioManager.playMusic(musicTrackId);
+        }
         ocultarPromptAudio();
       });
       container.appendChild(promptEl);
@@ -102,69 +122,35 @@
       promptEl.setAttribute('aria-hidden', 'true');
     }
 
-    async function intentarReproducir(desdePrompt = false) {
-      if (estado.muted) return;
+    async function intentarReproducirMusica(desdePrompt = false) {
+      if (estado.muted || !musicSrc) return;
       try {
-        audioEl.load();
-        await audioEl.play();
+        await window.audioManager.init();
+        await window.audioManager.playMusic(musicTrackId);
         ocultarPromptAudio();
       } catch (err) {
-        // Bloqueado por el navegador hasta interacción del usuario.
         if (!desdePrompt) {
           mostrarPromptAudio();
         }
       }
     }
 
-    function desbloquearAudioEnInteraccion() {
-      if (audioDesbloqueado) return;
-      const audios = [audioEl]
-        .concat(
-          unlockAudioIds
-            .map((id) => document.getElementById(id))
-            .filter((el) => el)
-        );
-      audios.forEach((audio) => {
-        const mutedPrevio = audio.muted;
-        audio.muted = true;
-        const intento = audio.play();
-        if (intento && typeof intento.then === 'function') {
-          intento
-            .then(() => {
-              audio.pause();
-              audio.currentTime = 0;
-            })
-            .catch(() => {})
-            .finally(() => {
-              audio.muted = mutedPrevio;
-            });
-        } else {
-          audio.muted = mutedPrevio;
-        }
-      });
-      audioDesbloqueado = true;
-      intentarReproducir();
-    }
-
     function aplicarEstadoInicial() {
-      audioEl.volume = estado.volume;
-      audioEl.muted = estado.muted;
+      window.audioManager.setVolume('music', estado.volume);
+      window.audioManager.setMuted(estado.muted);
       volumeInput.value = estado.volume.toFixed(2);
       if (estado.muted) {
         ocultarVolumen();
-        audioEl.pause();
       }
       actualizarUI();
     }
 
     toggle.addEventListener('click', async () => {
-      estado.muted = !estado.muted;
-      audioEl.muted = estado.muted;
+      estado.muted = window.audioManager.toggleMute();
       if (estado.muted) {
-        audioEl.pause();
         ocultarVolumen();
       } else {
-        await intentarReproducir();
+        await intentarReproducirMusica();
         mostrarVolumenTemporal();
       }
       guardarEstadoAudio(storageKeyPrefix, estado);
@@ -175,7 +161,7 @@
       const value = parseFloat(volumeInput.value);
       if (!Number.isFinite(value)) return;
       estado.volume = Math.min(Math.max(value, 0), 1);
-      audioEl.volume = estado.volume;
+      window.audioManager.setVolume('music', estado.volume);
       guardarEstadoAudio(storageKeyPrefix, estado);
     });
 
@@ -183,7 +169,7 @@
       document.addEventListener(
         evento,
         () => {
-          desbloquearAudioEnInteraccion();
+          window.audioManager.init().catch(() => {});
         },
         { once: true }
       );
@@ -191,20 +177,17 @@
 
     aplicarEstadoInicial();
     if (!estado.muted) {
-      intentarReproducir();
+      intentarReproducirMusica();
     }
 
     window.bingoAudioState = estado;
   }
 
-  function reproducirSonidoGanador(audioId = 'win-audio', storageKeyPrefix = 'bingoAudio') {
+  function reproducirSonidoGanador(eventName = 'winner', storageKeyPrefix = 'bingoAudio') {
+    if (!window.audioManager) return;
     const estado = obtenerEstadoAudio(storageKeyPrefix);
     if (estado.muted) return;
-    const audioEl = document.getElementById(audioId);
-    if (!audioEl) return;
-    audioEl.currentTime = 0;
-    audioEl.load();
-    audioEl.play().catch(() => {});
+    window.audioManager.playSfx(eventName).catch(() => {});
   }
 
   window.initBingoAudioControl = initBingoAudioControl;

--- a/public/js/audioManager.js
+++ b/public/js/audioManager.js
@@ -1,0 +1,245 @@
+(function () {
+  const clamp = (value, min = 0, max = 1) => Math.min(Math.max(value, min), max);
+
+  class AudioManager {
+    constructor(options = {}) {
+      this.maxSfxConcurrency = Number.isFinite(options.maxSfxConcurrency)
+        ? Math.max(1, Math.floor(options.maxSfxConcurrency))
+        : 6;
+
+      this.masterVolume = 1;
+      this.musicVolume = 0.22;
+      this.sfxVolume = 1;
+      this.muted = false;
+
+      this.audioContext = null;
+      this.masterGain = null;
+      this.musicGain = null;
+      this.sfxGain = null;
+
+      this.buffers = new Map();
+      this.musicTracks = new Map();
+      this.sfxEvents = new Map();
+      this.activeSfxNodes = new Set();
+
+      this.currentMusicTrackId = null;
+      this.currentMusicSource = null;
+      this.musicDuckToken = 0;
+      this.initialized = false;
+      this.pendingInitPromise = null;
+    }
+
+    registerMusicTrack(trackId, src) {
+      if (!trackId || !src) return;
+      this.musicTracks.set(trackId, src);
+    }
+
+    registerSfxEvent(eventName, src, options = {}) {
+      if (!eventName || !src) return;
+      this.sfxEvents.set(eventName, {
+        src,
+        critical: !!options.critical,
+        duckAmount: Number.isFinite(options.duckAmount) ? clamp(options.duckAmount, 0.05, 1) : 0.35,
+        duckDurationMs: Number.isFinite(options.duckDurationMs) ? Math.max(120, options.duckDurationMs) : 1800,
+        duckFadeMs: Number.isFinite(options.duckFadeMs) ? Math.max(50, options.duckFadeMs) : 220,
+      });
+    }
+
+    async init() {
+      if (this.initialized && this.audioContext) {
+        if (this.audioContext.state === 'suspended') {
+          await this.audioContext.resume();
+        }
+        return;
+      }
+
+      if (this.pendingInitPromise) {
+        await this.pendingInitPromise;
+        return;
+      }
+
+      this.pendingInitPromise = (async () => {
+        const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+        if (!AudioContextCtor) {
+          throw new Error('Web Audio API no soportada en este navegador.');
+        }
+
+        this.audioContext = new AudioContextCtor();
+        this.masterGain = this.audioContext.createGain();
+        this.musicGain = this.audioContext.createGain();
+        this.sfxGain = this.audioContext.createGain();
+
+        this.musicGain.connect(this.masterGain);
+        this.sfxGain.connect(this.masterGain);
+        this.masterGain.connect(this.audioContext.destination);
+
+        this.applyGains();
+
+        const unlock = () => {
+          this.init().catch(() => {});
+        };
+
+        ['pointerdown', 'touchstart', 'keydown'].forEach((eventName) => {
+          document.addEventListener(eventName, unlock, { once: true });
+        });
+
+        this.initialized = true;
+
+        if (this.audioContext.state === 'suspended') {
+          await this.audioContext.resume();
+        }
+      })();
+
+      try {
+        await this.pendingInitPromise;
+      } finally {
+        this.pendingInitPromise = null;
+      }
+    }
+
+    async loadBufferBySrc(src) {
+      if (!src) return null;
+      if (this.buffers.has(src)) {
+        return this.buffers.get(src);
+      }
+
+      if (!this.audioContext) {
+        await this.init();
+      }
+
+      const response = await fetch(src);
+      const data = await response.arrayBuffer();
+      const decoded = await this.audioContext.decodeAudioData(data);
+      this.buffers.set(src, decoded);
+      return decoded;
+    }
+
+    async playMusic(trackId) {
+      if (!trackId) return;
+      this.currentMusicTrackId = trackId;
+
+      const src = this.musicTracks.get(trackId);
+      if (!src) return;
+
+      await this.init();
+      const buffer = await this.loadBufferBySrc(src);
+      if (!buffer) return;
+
+      if (this.currentMusicSource) {
+        try {
+          this.currentMusicSource.stop();
+        } catch (_) {}
+        this.currentMusicSource.disconnect();
+      }
+
+      const source = this.audioContext.createBufferSource();
+      source.buffer = buffer;
+      source.loop = true;
+      source.connect(this.musicGain);
+      source.start(0);
+      this.currentMusicSource = source;
+    }
+
+    async playSfx(eventName) {
+      if (!eventName) return;
+      const eventConfig = this.sfxEvents.get(eventName);
+      if (!eventConfig) return;
+      if (this.activeSfxNodes.size >= this.maxSfxConcurrency) return;
+
+      await this.init();
+      const buffer = await this.loadBufferBySrc(eventConfig.src);
+      if (!buffer) return;
+
+      const source = this.audioContext.createBufferSource();
+      source.buffer = buffer;
+      source.connect(this.sfxGain);
+
+      this.activeSfxNodes.add(source);
+      source.onended = () => {
+        this.activeSfxNodes.delete(source);
+        source.disconnect();
+      };
+
+      source.start(0);
+
+      if (eventConfig.critical || this.isCriticalEvent(eventName)) {
+        this.duckMusicTemporarily(eventConfig);
+      }
+    }
+
+    isCriticalEvent(eventName) {
+      const normalized = String(eventName || '').toLowerCase();
+      return normalized.includes('winner') || normalized.includes('ganador') || normalized.includes('win');
+    }
+
+    duckMusicTemporarily(config = {}) {
+      if (!this.audioContext || !this.musicGain) return;
+      const durationMs = Number.isFinite(config.duckDurationMs) ? config.duckDurationMs : 1800;
+      const fadeMs = Number.isFinite(config.duckFadeMs) ? config.duckFadeMs : 220;
+      const duckAmount = Number.isFinite(config.duckAmount) ? clamp(config.duckAmount, 0.05, 1) : 0.35;
+
+      const token = ++this.musicDuckToken;
+      const now = this.audioContext.currentTime;
+      const fadeSeconds = fadeMs / 1000;
+      const targetDuckGain = this.muted ? 0 : this.getEffectiveMusicGain() * duckAmount;
+      const restoreGain = this.muted ? 0 : this.getEffectiveMusicGain();
+
+      this.musicGain.gain.cancelScheduledValues(now);
+      this.musicGain.gain.setValueAtTime(this.musicGain.gain.value, now);
+      this.musicGain.gain.linearRampToValueAtTime(targetDuckGain, now + fadeSeconds);
+
+      setTimeout(() => {
+        if (token !== this.musicDuckToken || !this.audioContext || !this.musicGain) return;
+        const restoreNow = this.audioContext.currentTime;
+        this.musicGain.gain.cancelScheduledValues(restoreNow);
+        this.musicGain.gain.setValueAtTime(this.musicGain.gain.value, restoreNow);
+        this.musicGain.gain.linearRampToValueAtTime(restoreGain, restoreNow + fadeSeconds);
+      }, durationMs);
+    }
+
+    setVolume(type, value) {
+      const normalized = clamp(Number(value));
+      if (!Number.isFinite(normalized)) return;
+
+      if (type === 'master') this.masterVolume = normalized;
+      if (type === 'music') this.musicVolume = normalized;
+      if (type === 'sfx') this.sfxVolume = normalized;
+
+      this.applyGains();
+    }
+
+    toggleMute() {
+      this.muted = !this.muted;
+      this.applyGains();
+      return this.muted;
+    }
+
+    setMuted(value) {
+      this.muted = !!value;
+      this.applyGains();
+    }
+
+    getEffectiveMusicGain() {
+      return this.masterVolume * this.musicVolume;
+    }
+
+    getEffectiveSfxGain() {
+      return this.masterVolume * this.sfxVolume;
+    }
+
+    applyGains() {
+      if (!this.masterGain || !this.musicGain || !this.sfxGain) return;
+      const safeNow = this.audioContext ? this.audioContext.currentTime : 0;
+      const master = this.muted ? 0 : this.masterVolume;
+      const music = this.muted ? 0 : this.musicVolume;
+      const sfx = this.muted ? 0 : this.sfxVolume;
+
+      this.masterGain.gain.setValueAtTime(master, safeNow);
+      this.musicGain.gain.setValueAtTime(music, safeNow);
+      this.sfxGain.gain.setValueAtTime(sfx, safeNow);
+    }
+  }
+
+  window.AudioManager = AudioManager;
+  window.audioManager = window.audioManager || new AudioManager();
+})();

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4349,6 +4349,7 @@
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
+  <script src="js/audioManager.js"></script>
   <script src="js/audioControls.js"></script>
   <script>
   ensureAuth();
@@ -4374,7 +4375,16 @@
     audioId: 'bg-audio-game',
     storageKeyPrefix: 'bingoAudio',
     defaultVolume: 0.22,
-    unlockAudioIds: ['win-audio'],
+    musicTrackId: 'game-background',
+    sfxEvents: {
+      winner: {
+        audioId: 'win-audio',
+        critical: true,
+        duckAmount: 0.3,
+        duckDurationMs: 2200,
+        duckFadeMs: 260,
+      },
+    },
   });
   const sinSorteoContenedorEl = document.getElementById('sin-sorteo-contenedor');
   const seleccionarFinalizadoBtn = document.getElementById('seleccionar-finalizado-btn');
@@ -9347,7 +9357,7 @@
     if(detalles.length){
       mostrarModalCelebracionGanador(detalles, esSimulacion);
       if(!esSimulacion){
-        reproducirSonidoGanador('win-audio', 'bingoAudio');
+        reproducirSonidoGanador('winner', 'bingoAudio');
       }
     }
   }

--- a/public/player.html
+++ b/public/player.html
@@ -1271,6 +1271,7 @@
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
+  <script src="js/audioManager.js"></script>
   <script src="js/audioControls.js"></script>
 <script>
 (function(){
@@ -2492,6 +2493,7 @@
     audioId: 'bg-audio-player',
     storageKeyPrefix: 'bingoAudio',
     defaultVolume: 0.22,
+    musicTrackId: 'player-background',
   });
 
   inicializarVistaJugador();


### PR DESCRIPTION
### Motivation
- Centralizar la reproducción y control de audio para permitir mezcla por canal, control fino de volúmenes y mute global usando la Web Audio API. 
- Reemplazar reproducciones directas con `<audio>.play()` por una API estable para facilitar ducking y limitar concurrencia de SFX. 
- Añadir ducking automático para eventos críticos (por ejemplo ganador) para bajar temporalmente la música y restaurarla con fade.

### Description
- Se añadió `public/js/audioManager.js` que expone la clase `AudioManager` y la instancia global `window.audioManager` con métodos principales `init()`, `playMusic(trackId)`, `playSfx(eventName)`, `setVolume(type, value)` y `toggleMute()` y soporte para `registerMusicTrack` / `registerSfxEvent`.
- `AudioManager` usa `AudioContext` y `GainNode` para mezclar tres canales (`master`, `music`, `sfx`), mantiene `masterVolume`, `musicVolume`, `sfxVolume` y `muted`, y limita concurrencia de SFX con `maxSfxConcurrency`.
- Implementé ducking: cuando un SFX marcado como crítico (o eventos que contienen `winner`/`ganador`) suena se reduce la ganancia de música por un `duckAmount` y se restaura tras `duckDurationMs` usando fades (`duckFadeMs`).
- Modifiqué `public/js/audioControls.js` para delegar en `window.audioManager` (registro de pista de música y SFX desde elementos `<audio>` existentes) y adapté `reproducirSonidoGanador` para usar eventos semánticos (`'winner'`).
- Actualicé `public/juegoactivo.html` y `public/player.html` para cargar `js/audioManager.js` antes de `js/audioControls.js`, registrar el `musicTrackId` y configurar el SFX crítico `winner` con parámetros de ducking.

### Testing
- Se comprobó sintaxis de los bundles JavaScript con `node --check public/js/audioManager.js` y `node --check public/js/audioControls.js`, ambos sin errores. ✅
- Se verificó mediante búsquedas que la reproducción directa con `.play()` fue eliminada de los módulos migrados con un `rg` (no quedan llamadas directas relevantes). ✅
- No se ejecutaron tests de integración en navegador automatizados en este PR, por lo que se recomienda validar reproducción, permisos y ducking en navegadores reales después del merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995238f75848326b38a353984aa98bc)