### PR TITLE
Centralizar audio en manifest con fallback y caché local

### DIFF
--- a/public/js/audioControls.js
+++ b/public/js/audioControls.js
@@ -20,6 +20,19 @@
     return audioEl?.currentSrc || audioEl?.src || null;
   }
 
+  function resolverDescriptorDesdeManifest(manifestKey) {
+    if (!manifestKey || !window.audioManager?.getManifestNode) return null;
+    const descriptor = window.audioManager.getManifestNode(manifestKey);
+    if (!descriptor?.urlPrimary) return null;
+    return {
+      manifestKey,
+      urlPrimary: descriptor.urlPrimary,
+      urlFallback: descriptor.urlFallback || null,
+      license: descriptor.license || null,
+      attribution: descriptor.attribution || null,
+    };
+  }
+
   function initBingoAudioControl(config) {
     if (!config || !window.audioManager) return;
 
@@ -31,6 +44,7 @@
       storageKeyPrefix = 'bingoAudio',
       defaultVolume = DEFAULT_VOLUME,
       musicTrackId = 'bg-music',
+      musicManifestKey = null,
       sfxEvents = {},
       mostrarPrompt = false,
     } = config;
@@ -42,16 +56,19 @@
 
     if (!container || !toggle || !volumeInput) return;
 
+    const musicDescriptor = resolverDescriptorDesdeManifest(musicManifestKey);
     const musicSrc = resolverFuenteAudioDesdeId(audioId);
-    if (musicSrc) {
-      window.audioManager.registerMusicTrack(musicTrackId, musicSrc);
+    if (musicDescriptor || musicSrc) {
+      window.audioManager.registerMusicTrack(musicTrackId, musicDescriptor || musicSrc);
     }
 
     Object.entries(sfxEvents).forEach(([eventName, cfg]) => {
       if (!cfg) return;
+      const manifestDescriptor = resolverDescriptorDesdeManifest(cfg.manifestKey);
       const src = cfg.src || resolverFuenteAudioDesdeId(cfg.audioId);
-      if (!src) return;
-      window.audioManager.registerSfxEvent(eventName, src, cfg);
+      const resolvedSource = manifestDescriptor || src;
+      if (!resolvedSource) return;
+      window.audioManager.registerSfxEvent(eventName, resolvedSource, cfg);
     });
 
     let estado = obtenerEstadoAudio(storageKeyPrefix);
@@ -123,7 +140,7 @@
     }
 
     async function intentarReproducirMusica(desdePrompt = false) {
-      if (estado.muted || !musicSrc) return;
+      if (estado.muted || (!musicDescriptor && !musicSrc)) return;
       try {
         await window.audioManager.init();
         await window.audioManager.playMusic(musicTrackId);

--- a/public/js/audioManager.js
+++ b/public/js/audioManager.js
@@ -27,17 +27,99 @@
       this.musicDuckToken = 0;
       this.initialized = false;
       this.pendingInitPromise = null;
+
+      this.manifestStorageKey = 'bingoAudioManifestCache';
+      this.manifest = null;
     }
 
-    registerMusicTrack(trackId, src) {
-      if (!trackId || !src) return;
-      this.musicTracks.set(trackId, src);
+    getCachedManifest() {
+      try {
+        const raw = localStorage.getItem(this.manifestStorageKey);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        if (!parsed || !parsed.manifestVersion) return null;
+        return parsed;
+      } catch (_) {
+        return null;
+      }
     }
 
-    registerSfxEvent(eventName, src, options = {}) {
-      if (!eventName || !src) return;
+    setCachedManifest(manifest) {
+      if (!manifest || !manifest.manifestVersion) return;
+      try {
+        localStorage.setItem(this.manifestStorageKey, JSON.stringify(manifest));
+      } catch (_) {}
+    }
+
+    loadManifest() {
+      if (this.manifest) return this.manifest;
+
+      const runtimeManifest = window.BINGO_AUDIO_MANIFEST;
+      const cachedManifest = this.getCachedManifest();
+
+      if (runtimeManifest?.manifestVersion) {
+        this.manifest = runtimeManifest;
+        if (cachedManifest?.manifestVersion !== runtimeManifest.manifestVersion) {
+          this.setCachedManifest(runtimeManifest);
+        }
+        return this.manifest;
+      }
+
+      this.manifest = cachedManifest || null;
+      return this.manifest;
+    }
+
+    getManifestNode(path) {
+      if (!path) return null;
+      const manifest = this.loadManifest();
+      if (!manifest) return null;
+      return String(path)
+        .split('.')
+        .reduce((acc, segment) => (acc && acc[segment] ? acc[segment] : null), manifest);
+    }
+
+    normalizeSourceDescriptor(source) {
+      if (!source) return null;
+      if (typeof source === 'string') {
+        return {
+          urlPrimary: source,
+          urlFallback: null,
+        };
+      }
+
+      if (source.manifestKey) {
+        const manifestNode = this.getManifestNode(source.manifestKey);
+        if (manifestNode) {
+          return {
+            urlPrimary: manifestNode.urlPrimary || null,
+            urlFallback: manifestNode.urlFallback || null,
+            license: manifestNode.license || null,
+            attribution: manifestNode.attribution || null,
+          };
+        }
+      }
+
+      return {
+        urlPrimary: source.urlPrimary || source.src || null,
+        urlFallback: source.urlFallback || null,
+        license: source.license || null,
+        attribution: source.attribution || null,
+      };
+    }
+
+    registerMusicTrack(trackId, source) {
+      if (!trackId || !source) return;
+      const descriptor = this.normalizeSourceDescriptor(source);
+      if (!descriptor?.urlPrimary) return;
+      this.musicTracks.set(trackId, descriptor);
+    }
+
+    registerSfxEvent(eventName, source, options = {}) {
+      if (!eventName || !source) return;
+      const descriptor = this.normalizeSourceDescriptor(source);
+      if (!descriptor?.urlPrimary) return;
       this.sfxEvents.set(eventName, {
-        src,
+        source: descriptor,
         critical: !!options.critical,
         duckAmount: Number.isFinite(options.duckAmount) ? clamp(options.duckAmount, 0.05, 1) : 0.35,
         duckDurationMs: Number.isFinite(options.duckDurationMs) ? Math.max(120, options.duckDurationMs) : 1800,
@@ -97,32 +179,57 @@
       }
     }
 
-    async loadBufferBySrc(src) {
-      if (!src) return null;
-      if (this.buffers.has(src)) {
-        return this.buffers.get(src);
-      }
-
+    async fetchAndDecode(src) {
       if (!this.audioContext) {
         await this.init();
       }
 
       const response = await fetch(src);
+      if (!response.ok) {
+        throw new Error(`No se pudo descargar audio: ${src}`);
+      }
       const data = await response.arrayBuffer();
       const decoded = await this.audioContext.decodeAudioData(data);
       this.buffers.set(src, decoded);
       return decoded;
     }
 
+    async loadBufferBySource(source) {
+      const descriptor = this.normalizeSourceDescriptor(source);
+      if (!descriptor?.urlPrimary) return null;
+
+      const { urlPrimary, urlFallback } = descriptor;
+
+      if (this.buffers.has(urlPrimary)) {
+        return this.buffers.get(urlPrimary);
+      }
+
+      try {
+        return await this.fetchAndDecode(urlPrimary);
+      } catch (primaryError) {
+        if (!urlFallback) {
+          throw primaryError;
+        }
+
+        if (this.buffers.has(urlFallback)) {
+          return this.buffers.get(urlFallback);
+        }
+
+        const fallbackBuffer = await this.fetchAndDecode(urlFallback);
+        this.buffers.set(urlPrimary, fallbackBuffer);
+        return fallbackBuffer;
+      }
+    }
+
     async playMusic(trackId) {
       if (!trackId) return;
       this.currentMusicTrackId = trackId;
 
-      const src = this.musicTracks.get(trackId);
-      if (!src) return;
+      const sourceDescriptor = this.musicTracks.get(trackId);
+      if (!sourceDescriptor) return;
 
       await this.init();
-      const buffer = await this.loadBufferBySrc(src);
+      const buffer = await this.loadBufferBySource(sourceDescriptor);
       if (!buffer) return;
 
       if (this.currentMusicSource) {
@@ -147,7 +254,7 @@
       if (this.activeSfxNodes.size >= this.maxSfxConcurrency) return;
 
       await this.init();
-      const buffer = await this.loadBufferBySrc(eventConfig.src);
+      const buffer = await this.loadBufferBySource(eventConfig.source);
       if (!buffer) return;
 
       const source = this.audioContext.createBufferSource();

--- a/public/js/audioManifest.js
+++ b/public/js/audioManifest.js
@@ -1,0 +1,41 @@
+(function () {
+  const manifest = {
+    manifestVersion: '2026.02.18-v1',
+    music: {
+      backgroundMain: {
+        urlPrimary: 'https://assets.mixkit.co/music/preview/mixkit-game-level-music-689.mp3',
+        urlFallback: 'https://cdn.pixabay.com/audio/2021/08/09/audio_d0a0250f6f.mp3',
+        license: 'Mixkit Free Sound Effects License / Pixabay Content License',
+        attribution: 'Mixkit (principal) y Pixabay (respaldo)',
+      },
+    },
+    sfx: {
+      drawNumber: {
+        urlPrimary: 'https://assets.mixkit.co/sfx/preview/mixkit-select-click-1109.mp3',
+        urlFallback: 'https://cdn.pixabay.com/audio/2022/03/15/audio_c8f9f250f0.mp3',
+        license: 'Mixkit Free Sound Effects License / Pixabay Content License',
+        attribution: 'Mixkit (principal) y Pixabay (respaldo)',
+      },
+      markCell: {
+        urlPrimary: 'https://assets.mixkit.co/sfx/preview/mixkit-modern-technology-select-3124.mp3',
+        urlFallback: 'https://cdn.pixabay.com/audio/2022/03/10/audio_c6ccf2fb18.mp3',
+        license: 'Mixkit Free Sound Effects License / Pixabay Content License',
+        attribution: 'Mixkit (principal) y Pixabay (respaldo)',
+      },
+      openModal: {
+        urlPrimary: 'https://assets.mixkit.co/sfx/preview/mixkit-software-interface-start-2574.mp3',
+        urlFallback: 'https://cdn.pixabay.com/audio/2022/03/22/audio_c72f61d4f1.mp3',
+        license: 'Mixkit Free Sound Effects License / Pixabay Content License',
+        attribution: 'Mixkit (principal) y Pixabay (respaldo)',
+      },
+      win: {
+        urlPrimary: 'https://assets.mixkit.co/sfx/preview/mixkit-winning-chimes-2015.mp3',
+        urlFallback: 'https://cdn.pixabay.com/audio/2022/03/10/audio_c87cfcbad6.mp3',
+        license: 'Mixkit Free Sound Effects License / Pixabay Content License',
+        attribution: 'Mixkit (principal) y Pixabay (respaldo)',
+      },
+    },
+  };
+
+  window.BINGO_AUDIO_MANIFEST = manifest;
+})();

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4339,9 +4339,6 @@
     </button>
   </div>
 
-  <audio id="bg-audio-game" preload="none" loop src="https://assets.mixkit.co/music/preview/mixkit-game-level-music-689.mp3"></audio>
-  <audio id="win-audio" preload="metadata" src="https://assets.mixkit.co/sfx/preview/mixkit-winning-chimes-2015.mp3"></audio>
-
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
@@ -4349,6 +4346,7 @@
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
+  <script src="js/audioManifest.js"></script>
   <script src="js/audioManager.js"></script>
   <script src="js/audioControls.js"></script>
   <script>
@@ -4372,13 +4370,13 @@
     containerId: 'audio-control-game',
     toggleId: 'audio-toggle-game',
     volumeId: 'audio-volume-game',
-    audioId: 'bg-audio-game',
+    musicManifestKey: 'music.backgroundMain',
     storageKeyPrefix: 'bingoAudio',
     defaultVolume: 0.22,
     musicTrackId: 'game-background',
     sfxEvents: {
       winner: {
-        audioId: 'win-audio',
+        manifestKey: 'sfx.win',
         critical: true,
         duckAmount: 0.3,
         duckDurationMs: 2200,

--- a/public/player.html
+++ b/public/player.html
@@ -1217,8 +1217,6 @@
     </button>
   </div>
 
-  <audio id="bg-audio-player" preload="none" loop src="https://assets.mixkit.co/music/preview/mixkit-game-level-music-689.mp3"></audio>
-
   <!-- Importar el SDK de Firebase (compatibilidad para evitar problemas de CORS al abrir el archivo localmente) -->
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
@@ -1271,6 +1269,7 @@
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
+  <script src="js/audioManifest.js"></script>
   <script src="js/audioManager.js"></script>
   <script src="js/audioControls.js"></script>
 <script>
@@ -2490,7 +2489,7 @@
     containerId: 'audio-control-player',
     toggleId: 'audio-toggle-player',
     volumeId: 'audio-volume-player',
-    audioId: 'bg-audio-player',
+    musicManifestKey: 'music.backgroundMain',
     storageKeyPrefix: 'bingoAudio',
     defaultVolume: 0.22,
     musicTrackId: 'player-background',


### PR DESCRIPTION
### Motivation
- Centralizar definiciones de audio fuera del HTML para evitar URLs hardcodeadas y facilitar actualizaciones de assets.
- Añadir soporte de fallback automático y evitar latencia repetida mediante caché del manifest en `localStorage`.
- Permitir que el `AudioManager` y los controles consuman fuentes versionadas desde un manifest para facilitar migraciones y auditoría de licencias.

### Description
- Se creó `public/js/audioManifest.js` con `manifestVersion` y nodos para `music.backgroundMain` y SFX (`drawNumber`, `markCell`, `openModal`, `win`) incluyendo `urlPrimary`, `urlFallback`, `license` y `attribution`.
- `public/js/audioManager.js` ahora carga/lee el manifest desde `window.BINGO_AUDIO_MANIFEST`, lo guarda/lee en caché en `localStorage` bajo la clave `bingoAudioManifestCache`, normaliza descriptores de fuente y realiza `fetch`/decodificado con fallback `urlPrimary -> urlFallback` al descargar buffers.
- `public/js/audioControls.js` se actualizó para aceptar `musicManifestKey` y `sfxEvents[*].manifestKey` y resolver fuentes desde el manifest manteniendo compatibilidad con `audioId`/`src` legados.
- Se modificaron `public/juegoactivo.html` y `public/player.html` para remover los elementos `<audio src="...">`, añadir `js/audioManifest.js` antes de `audioManager.js` y usar las claves del manifest (`music.backgroundMain`, `sfx.win`) en la inicialización.

### Testing
- Ejecuté los tests con `npm test -- --runInBand` y todos los suites pasaron correctamente (8 suites, 25 tests) sin fallos.
- No se añadieron tests unitarios nuevos para el manifiesto, pero la integración conserva compatibilidad retroactiva con `audioId`/`src` y la suite existente sigue pasando.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995252da68883268cbd8d2428df451e)