### PR TITLE
Mejora de audio: formatos preferidos, precarga crítica, normalización y caché SW

### DIFF
--- a/public/js/audioControls.js
+++ b/public/js/audioControls.js
@@ -117,13 +117,14 @@
   function resolverDescriptorDesdeManifest(manifestKey) {
     if (!manifestKey || !window.audioManager?.getManifestNode) return null;
     const descriptor = window.audioManager.getManifestNode(manifestKey);
-    if (!descriptor?.urlPrimary) return null;
+    if (!descriptor) return null;
     return {
       manifestKey,
-      urlPrimary: descriptor.urlPrimary,
-      urlFallback: descriptor.urlFallback || null,
       license: descriptor.license || null,
       attribution: descriptor.attribution || null,
+      preload: descriptor.preload || null,
+      maxBytes: descriptor.maxBytes || null,
+      normalizationGain: descriptor.normalizationGain || null,
     };
   }
 

--- a/public/js/audioManager.js
+++ b/public/js/audioManager.js
@@ -32,6 +32,8 @@
 
       this.manifestStorageKey = 'bingoAudioManifestCache';
       this.manifest = null;
+      this.defaultMaxSfxBytes = 120 * 1024;
+      this.defaultMaxMusicBytes = 1024 * 1024;
     }
 
     getCachedManifest() {
@@ -80,12 +82,61 @@
         .reduce((acc, segment) => (acc && acc[segment] ? acc[segment] : null), manifest);
     }
 
+    resolveSources(node = {}) {
+      const preferredFormats = Array.isArray(node.preferredFormats) && node.preferredFormats.length
+        ? node.preferredFormats
+        : ['mp3', 'ogg'];
+
+      const candidates = [];
+      if (Array.isArray(node.sources)) {
+        node.sources.forEach((source) => {
+          if (source?.url) {
+            candidates.push({
+              url: source.url,
+              format: (source.format || '').toLowerCase() || null,
+              kind: source.kind || null,
+            });
+          }
+        });
+      }
+
+      if (node.urlPrimary) {
+        candidates.push({ url: node.urlPrimary, format: (node.formatPrimary || '').toLowerCase() || null, kind: 'primary' });
+      }
+      if (node.urlFallback) {
+        candidates.push({ url: node.urlFallback, format: (node.formatFallback || '').toLowerCase() || null, kind: 'fallback' });
+      }
+
+      const dedup = new Set();
+      const ordered = [];
+
+      preferredFormats.forEach((format) => {
+        candidates.forEach((candidate) => {
+          if (!candidate?.url || dedup.has(candidate.url)) return;
+          if (candidate.format && candidate.format !== format) return;
+          dedup.add(candidate.url);
+          ordered.push(candidate.url);
+        });
+      });
+
+      candidates.forEach((candidate) => {
+        if (!candidate?.url || dedup.has(candidate.url)) return;
+        dedup.add(candidate.url);
+        ordered.push(candidate.url);
+      });
+
+      return ordered;
+    }
+
     normalizeSourceDescriptor(source) {
       if (!source) return null;
       if (typeof source === 'string') {
         return {
-          urlPrimary: source,
-          urlFallback: null,
+          urls: [source],
+          preferredFormats: ['mp3', 'ogg'],
+          normalizationGain: 1,
+          category: 'sfx',
+          maxBytes: this.defaultMaxSfxBytes,
         };
       }
 
@@ -93,36 +144,53 @@
         const manifestNode = this.getManifestNode(source.manifestKey);
         if (manifestNode) {
           return {
-            urlPrimary: manifestNode.urlPrimary || null,
-            urlFallback: manifestNode.urlFallback || null,
+            urls: this.resolveSources(manifestNode),
+            preferredFormats: manifestNode.preferredFormats || ['mp3', 'ogg'],
             license: manifestNode.license || null,
             attribution: manifestNode.attribution || null,
+            normalizationGain: Number.isFinite(manifestNode.normalizationGain)
+              ? clamp(manifestNode.normalizationGain, 0.1, 2)
+              : 1,
+            category: manifestNode.category || source.category || 'sfx',
+            maxBytes: Number.isFinite(manifestNode.maxBytes)
+              ? Math.max(32 * 1024, Math.floor(manifestNode.maxBytes))
+              : (manifestNode.category === 'music' ? this.defaultMaxMusicBytes : this.defaultMaxSfxBytes),
+            preload: manifestNode.preload || source.preload || null,
+            preloadCritical: !!manifestNode.preloadCritical,
           };
         }
       }
 
+      const urls = this.resolveSources(source);
       return {
-        urlPrimary: source.urlPrimary || source.src || null,
-        urlFallback: source.urlFallback || null,
+        urls,
+        preferredFormats: source.preferredFormats || ['mp3', 'ogg'],
         license: source.license || null,
         attribution: source.attribution || null,
+        normalizationGain: Number.isFinite(source.normalizationGain) ? clamp(source.normalizationGain, 0.1, 2) : 1,
+        category: source.category || 'sfx',
+        maxBytes: Number.isFinite(source.maxBytes)
+          ? Math.max(32 * 1024, Math.floor(source.maxBytes))
+          : (source.category === 'music' ? this.defaultMaxMusicBytes : this.defaultMaxSfxBytes),
+        preload: source.preload || null,
+        preloadCritical: !!source.preloadCritical,
       };
     }
 
     registerMusicTrack(trackId, source) {
       if (!trackId || !source) return;
       const descriptor = this.normalizeSourceDescriptor(source);
-      if (!descriptor?.urlPrimary) return;
+      if (!descriptor?.urls?.length) return;
       this.musicTracks.set(trackId, descriptor);
     }
 
     registerSfxEvent(eventName, source, options = {}) {
       if (!eventName || !source) return;
       const descriptor = this.normalizeSourceDescriptor(source);
-      if (!descriptor?.urlPrimary) return;
+      if (!descriptor?.urls?.length) return;
       this.sfxEvents.set(eventName, {
         source: descriptor,
-        critical: !!options.critical,
+        critical: !!options.critical || !!descriptor.preloadCritical,
         duckAmount: Number.isFinite(options.duckAmount) ? clamp(options.duckAmount, 0.05, 1) : 0.35,
         duckDurationMs: Number.isFinite(options.duckDurationMs) ? Math.max(120, options.duckDurationMs) : 1800,
         duckFadeMs: Number.isFinite(options.duckFadeMs) ? Math.max(50, options.duckFadeMs) : 220,
@@ -211,7 +279,7 @@
       return !!this.autoplayBlocked;
     }
 
-    async fetchAndDecode(src) {
+    async fetchAndDecode(src, descriptor = null) {
       if (!this.audioContext) {
         await this.init();
       }
@@ -220,7 +288,20 @@
       if (!response.ok) {
         throw new Error(`No se pudo descargar audio: ${src}`);
       }
+
+      const maxBytes = Number.isFinite(descriptor?.maxBytes)
+        ? descriptor.maxBytes
+        : (descriptor?.category === 'music' ? this.defaultMaxMusicBytes : this.defaultMaxSfxBytes);
+      const contentLength = Number(response.headers.get('content-length'));
+      if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+        throw new Error(`Audio supera límite recomendado (${contentLength} > ${maxBytes}): ${src}`);
+      }
+
       const data = await response.arrayBuffer();
+      if (data.byteLength > maxBytes) {
+        throw new Error(`Audio supera límite recomendado (${data.byteLength} > ${maxBytes}): ${src}`);
+      }
+
       const decoded = await this.audioContext.decodeAudioData(data);
       this.buffers.set(src, decoded);
       return decoded;
@@ -228,29 +309,54 @@
 
     async loadBufferBySource(source) {
       const descriptor = this.normalizeSourceDescriptor(source);
-      if (!descriptor?.urlPrimary) return null;
+      if (!descriptor?.urls?.length) return null;
 
-      const { urlPrimary, urlFallback } = descriptor;
+      const urls = descriptor.urls;
 
-      if (this.buffers.has(urlPrimary)) {
-        return this.buffers.get(urlPrimary);
-      }
-
-      try {
-        return await this.fetchAndDecode(urlPrimary);
-      } catch (primaryError) {
-        if (!urlFallback) {
-          throw primaryError;
+      for (let i = 0; i < urls.length; i += 1) {
+        const url = urls[i];
+        if (this.buffers.has(url)) {
+          if (urls[0] && !this.buffers.has(urls[0])) {
+            this.buffers.set(urls[0], this.buffers.get(url));
+          }
+          return this.buffers.get(url);
         }
 
-        if (this.buffers.has(urlFallback)) {
-          return this.buffers.get(urlFallback);
+        try {
+          const decoded = await this.fetchAndDecode(url, descriptor);
+          if (urls[0] && url !== urls[0]) {
+            this.buffers.set(urls[0], decoded);
+          }
+          return decoded;
+        } catch (err) {
+          if (i === urls.length - 1) {
+            throw err;
+          }
         }
-
-        const fallbackBuffer = await this.fetchAndDecode(urlFallback);
-        this.buffers.set(urlPrimary, fallbackBuffer);
-        return fallbackBuffer;
       }
+
+      return null;
+    }
+
+    async preloadCriticalSfx() {
+      const criticalSources = [];
+      this.sfxEvents.forEach((config) => {
+        if (config?.critical && config?.source) {
+          criticalSources.push(config.source);
+        }
+      });
+
+      const uniqueKeys = new Set();
+      const jobs = criticalSources
+        .filter((source) => {
+          const key = source.urls?.[0] || '';
+          if (!key || uniqueKeys.has(key)) return false;
+          uniqueKeys.add(key);
+          return true;
+        })
+        .map((source) => this.loadBufferBySource(source).catch(() => null));
+
+      await Promise.all(jobs);
     }
 
     async playMusic(trackId, options = {}) {
@@ -275,7 +381,13 @@
       const source = this.audioContext.createBufferSource();
       source.buffer = buffer;
       source.loop = true;
-      source.connect(this.musicGain);
+
+      const sourceGain = this.audioContext.createGain();
+      sourceGain.gain.value = Number.isFinite(sourceDescriptor.normalizationGain)
+        ? sourceDescriptor.normalizationGain
+        : 1;
+      source.connect(sourceGain);
+      sourceGain.connect(this.musicGain);
 
       if (fadeInMs > 0) {
         const now = this.audioContext.currentTime;
@@ -301,12 +413,19 @@
 
       const source = this.audioContext.createBufferSource();
       source.buffer = buffer;
-      source.connect(this.sfxGain);
+
+      const sourceGain = this.audioContext.createGain();
+      sourceGain.gain.value = Number.isFinite(eventConfig.source.normalizationGain)
+        ? eventConfig.source.normalizationGain
+        : 1;
+      source.connect(sourceGain);
+      sourceGain.connect(this.sfxGain);
 
       this.activeSfxNodes.add(source);
       source.onended = () => {
         this.activeSfxNodes.delete(source);
         source.disconnect();
+        sourceGain.disconnect();
       };
 
       source.start(0);

--- a/public/js/audioManifest.js
+++ b/public/js/audioManifest.js
@@ -1,36 +1,116 @@
 (function () {
   const manifest = {
-    manifestVersion: '2026.02.18-v1',
+    manifestVersion: '2026.02.18-v2',
+    globalAudioPolicy: {
+      preferredFormats: ['mp3', 'ogg'],
+      musicPreload: 'deferred',
+      criticalSfxPreload: 'on-game-enter',
+      maxSfxBytes: 122880,
+      maxMusicBytes: 1048576,
+      normalizationNote: 'Aplicar normalización de loudness en origen (objetivo sugerido -16 LUFS música / -14 LUFS SFX).',
+    },
     music: {
       backgroundMain: {
-        urlPrimary: 'https://assets.mixkit.co/music/preview/mixkit-game-level-music-689.mp3',
-        urlFallback: 'https://cdn.pixabay.com/audio/2021/08/09/audio_d0a0250f6f.mp3',
+        category: 'music',
+        preferredFormats: ['mp3', 'ogg'],
+        preload: 'deferred',
+        maxBytes: 1048576,
+        normalizationGain: 0.92,
+        sources: [
+          {
+            format: 'mp3',
+            url: 'https://assets.mixkit.co/music/preview/mixkit-game-level-music-689.mp3',
+            kind: 'primary',
+          },
+          {
+            format: 'mp3',
+            url: 'https://cdn.pixabay.com/audio/2021/08/09/audio_d0a0250f6f.mp3',
+            kind: 'fallback',
+          },
+        ],
         license: 'Mixkit Free Sound Effects License / Pixabay Content License',
         attribution: 'Mixkit (principal) y Pixabay (respaldo)',
       },
     },
     sfx: {
       drawNumber: {
-        urlPrimary: 'https://assets.mixkit.co/sfx/preview/mixkit-select-click-1109.mp3',
-        urlFallback: 'https://cdn.pixabay.com/audio/2022/03/15/audio_c8f9f250f0.mp3',
+        category: 'sfx',
+        preferredFormats: ['mp3', 'ogg'],
+        maxBytes: 122880,
+        normalizationGain: 0.95,
+        sources: [
+          {
+            format: 'mp3',
+            url: 'https://assets.mixkit.co/sfx/preview/mixkit-select-click-1109.mp3',
+            kind: 'primary',
+          },
+          {
+            format: 'mp3',
+            url: 'https://cdn.pixabay.com/audio/2022/03/15/audio_c8f9f250f0.mp3',
+            kind: 'fallback',
+          },
+        ],
         license: 'Mixkit Free Sound Effects License / Pixabay Content License',
         attribution: 'Mixkit (principal) y Pixabay (respaldo)',
       },
       markCell: {
-        urlPrimary: 'https://assets.mixkit.co/sfx/preview/mixkit-modern-technology-select-3124.mp3',
-        urlFallback: 'https://cdn.pixabay.com/audio/2022/03/10/audio_c6ccf2fb18.mp3',
+        category: 'sfx',
+        preferredFormats: ['mp3', 'ogg'],
+        maxBytes: 122880,
+        normalizationGain: 0.9,
+        sources: [
+          {
+            format: 'mp3',
+            url: 'https://assets.mixkit.co/sfx/preview/mixkit-modern-technology-select-3124.mp3',
+            kind: 'primary',
+          },
+          {
+            format: 'mp3',
+            url: 'https://cdn.pixabay.com/audio/2022/03/10/audio_c6ccf2fb18.mp3',
+            kind: 'fallback',
+          },
+        ],
         license: 'Mixkit Free Sound Effects License / Pixabay Content License',
         attribution: 'Mixkit (principal) y Pixabay (respaldo)',
       },
       openModal: {
-        urlPrimary: 'https://assets.mixkit.co/sfx/preview/mixkit-software-interface-start-2574.mp3',
-        urlFallback: 'https://cdn.pixabay.com/audio/2022/03/22/audio_c72f61d4f1.mp3',
+        category: 'sfx',
+        preferredFormats: ['mp3', 'ogg'],
+        maxBytes: 122880,
+        normalizationGain: 0.88,
+        sources: [
+          {
+            format: 'mp3',
+            url: 'https://assets.mixkit.co/sfx/preview/mixkit-software-interface-start-2574.mp3',
+            kind: 'primary',
+          },
+          {
+            format: 'mp3',
+            url: 'https://cdn.pixabay.com/audio/2022/03/22/audio_c72f61d4f1.mp3',
+            kind: 'fallback',
+          },
+        ],
         license: 'Mixkit Free Sound Effects License / Pixabay Content License',
         attribution: 'Mixkit (principal) y Pixabay (respaldo)',
       },
       win: {
-        urlPrimary: 'https://assets.mixkit.co/sfx/preview/mixkit-winning-chimes-2015.mp3',
-        urlFallback: 'https://cdn.pixabay.com/audio/2022/03/10/audio_c87cfcbad6.mp3',
+        category: 'sfx',
+        preferredFormats: ['mp3', 'ogg'],
+        preloadCritical: true,
+        maxBytes: 122880,
+        normalizationGain: 0.86,
+        sources: [
+          {
+            format: 'mp3',
+            url: 'https://assets.mixkit.co/sfx/preview/mixkit-winning-chimes-2015.mp3',
+            kind: 'primary',
+          },
+          {
+            format: 'mp3',
+            url: 'https://cdn.pixabay.com/audio/2022/03/10/audio_c87cfcbad6.mp3',
+            kind: 'fallback',
+          },
+        ],
         license: 'Mixkit Free Sound Effects License / Pixabay Content License',
         attribution: 'Mixkit (principal) y Pixabay (respaldo)',
       },

--- a/public/js/serviceWorkerRegistration.js
+++ b/public/js/serviceWorkerRegistration.js
@@ -1,0 +1,6 @@
+(function () {
+  if (!('serviceWorker' in navigator)) return;
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(() => {});
+  });
+})();

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4368,6 +4368,7 @@
   <script src="js/audioManifest.js"></script>
   <script src="js/audioManager.js"></script>
   <script src="js/audioControls.js"></script>
+  <script src="js/serviceWorkerRegistration.js"></script>
   <script>
   ensureAuth();
   initFechaHora('fecha-hora');
@@ -4505,6 +4506,10 @@
   }
 
   registrarEventosAudioJuego();
+  if(window.audioManager && typeof window.audioManager.preloadCriticalSfx === 'function'){
+    window.audioManager.preloadCriticalSfx().catch(()=>{});
+  }
+
   const sinSorteoContenedorEl = document.getElementById('sin-sorteo-contenedor');
   const seleccionarFinalizadoBtn = document.getElementById('seleccionar-finalizado-btn');
   const sinSorteoMensajeEl = document.getElementById('sin-sorteo-mensaje');

--- a/public/player.html
+++ b/public/player.html
@@ -1291,6 +1291,7 @@
   <script src="js/audioManifest.js"></script>
   <script src="js/audioManager.js"></script>
   <script src="js/audioControls.js"></script>
+  <script src="js/serviceWorkerRegistration.js"></script>
 <script>
 (function(){
   const AVATAR_FALLBACK = 'img/avatar-generico.svg';

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,47 @@
+const CACHE_VERSION = 'bingo-audio-v1';
+const AUDIO_CACHE = `bingo-audio-runtime-${CACHE_VERSION}`;
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key.startsWith('bingo-audio-runtime-') && key !== AUDIO_CACHE)
+          .map((key) => caches.delete(key)),
+      ),
+    ).then(() => self.clients.claim()),
+  );
+});
+
+function isAudioRequest(request) {
+  const url = new URL(request.url);
+  if (request.destination === 'audio') return true;
+  return /\.(mp3|ogg)(\?|$)/i.test(url.pathname);
+}
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  if (!isAudioRequest(event.request)) return;
+
+  event.respondWith(
+    caches.open(AUDIO_CACHE).then(async (cache) => {
+      const cached = await cache.match(event.request, { ignoreSearch: false });
+      if (cached) return cached;
+
+      try {
+        const networkResponse = await fetch(event.request);
+        if (networkResponse && (networkResponse.ok || networkResponse.type === 'opaque')) {
+          cache.put(event.request, networkResponse.clone());
+        }
+        return networkResponse;
+      } catch (_) {
+        if (cached) return cached;
+        throw _;
+      }
+    }),
+  );
+});


### PR DESCRIPTION
### Motivation
- Priorizar formatos de audio (`mp3` y `ogg` como alternativa) y permitir múltiples fuentes por asset para reducir fallos y controlar costos de red.
- Precargar solo los SFX críticos y diferir la música para mejorar latencia en eventos importantes y evitar cargar bucles grandes innecesariamente.
- Aplicar normalización por pista y límites de tamaño por archivo para evitar picos/desbalances y proteger el cliente de archivos excesivamente grandes.
- Mejorar resiliencia y rendimiento con un Service Worker que cachee recursos de audio.

### Description
- El manifiesto `public/js/audioManifest.js` se amplió con `globalAudioPolicy`, `preferredFormats`, `sources[]`, `preload`, `preloadCritical`, `maxBytes` y `normalizationGain` por asset para declarar formatos, políticas de precarga, límites y meta de normalización.
- `public/js/audioManager.js` fue extendido para resolver fuentes por formato preferido (`resolveSources`), normalizar descriptores con múltiples `urls`, validar `maxBytes` antes de decodificar, aplicar `normalizationGain` mediante un gain por fuente, y añadir `preloadCriticalSfx()` para precargar SFX marcados como críticos.
- `public/js/audioControls.js` actualizó `resolverDescriptorDesdeManifest` para usar la nueva estructura del manifiesto (ya no depende de `urlPrimary/urlFallback`) y exponer `preload`, `maxBytes` y `normalizationGain` al UI.
- Se añadió un Service Worker `public/sw.js` que cachea peticiones de audio (`.mp3`/`.ogg` o requests con `destination === 'audio'`) con estrategia cache-first y limpieza de versiones, y un pequeño registro en `public/js/serviceWorkerRegistration.js` que se incluye en `player.html` y `juegoactivo.html`.
- `public/juegoactivo.html` dispara `audioManager.preloadCriticalSfx()` al inicio del juego para garantizar disponibilidad rápida de SFX críticos.

### Testing
- Se ejecutaron las pruebas automatizadas con `npm test -- --runInBand` y todas las suites pasaron (8 suites, 25 tests en verde).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952c5d306c8326ab358cd5208b338d)