### PR TITLE
Acreditar premios en vivo y mostrar transacciones de cartones gratis

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -1881,18 +1881,23 @@
         const tr=document.createElement('tr');
         const montoFmt=parseFloat(t.Monto).toFixed(2).replace(/\.00$/, '').replace(/(\.\d)0$/, '$1');
         const tipoTrans=(t.tipotrans||'').toLowerCase();
+        const cartonesGratisNum=Number(t.cartonesGratis)||0;
         const esRecarga=tipoTrans==='recarga';
         const esRetiro=tipoTrans==='retiro';
         const esPremio=tipoTrans==='premio';
         const esPago=tipoTrans==='pago';
+        const esPremioCartones=esPremio && cartonesGratisNum>0 && (Number(t.Monto)||0)===cartonesGratisNum;
         const esResaltado=esPremio||esPago;
         const colorTipo=esRecarga?'green':esRetiro?'red':'#1b5e20';
-        const montoStyle=esResaltado?`background:#1b5e20;color:#fff;`:`color:${colorTipo};`;
+        const montoTexto=esPremioCartones?String(cartonesGratisNum):montoFmt;
+        const montoStyle=esPremioCartones
+          ? 'background:#6a1b9a;color:#fff;'
+          : (esResaltado?`background:#1b5e20;color:#fff;`:`color:${colorTipo};`);
         const fechaStyle=esResaltado?`color:#1b5e20;`:'';
         const celdas = [
           { texto: String(n) },
           { texto: tipoTrans.toUpperCase(), style: `color:${colorTipo}` },
-          { texto: montoFmt, style: montoStyle, className: 'celda-monto' },
+          { texto: montoTexto, style: montoStyle, className: 'celda-monto' },
           { texto: f, style: fechaStyle, className: 'celda-fecha' },
           { texto: t.estado || '', style: `color:${estadoColor}` }
         ];
@@ -2026,10 +2031,17 @@
 
       function mostrarDetalleMonto(t){
         const solicitado=t.tipotrans==='retiro'?parseFloat(t.MontoSolicitado||t.Monto):parseFloat(t.Monto);
+        const cartonesGratisNum=Number(t.cartonesGratis)||0;
+        const esPremioCartones=(t.tipotrans==='premio') && cartonesGratisNum>0 && (Number(t.Monto)||0)===cartonesGratisNum;
         const comB=t.tipotrans==='retiro'?solicitado*porcentajeRetiro/100:0;
         const comG=t.tipotrans==='retiro'?solicitado*porcentajeAdministra/100:0;
         const total=parseFloat(t.Monto);
         const cont=document.querySelector('#modal-detalle .contenido');
+        if(esPremioCartones){
+          cont.innerHTML=
+            `<div style="font-weight:bold;background:#6a1b9a;color:#fff;padding:8px;border-radius:8px;">Cartones gratis ganados: ${cartonesGratisNum}</div>`+
+            `<button id='modal-ok'>Aceptar</button>`;
+        }else
         if(t.tipotrans==='premio' || t.tipotrans==='pago'){
           cont.innerHTML=
             `<div style="font-weight:bold;color:#1b5e20;">Total recibido: ${total.toFixed(2)}</div>`+

--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -4454,11 +4454,14 @@
         }
         const transSnap = await tx.get(transaccionRef);
         if(!transSnap.exists){
+          const creditosNumero = Number(creditos) || 0;
+          const cartonesNumero = Number(cartonesGratis) || 0;
+          const montoTransaccion = creditosNumero > 0 ? creditosNumero : cartonesNumero;
           tx.set(transaccionRef, {
             tipotrans: 'premio',
             origen: 'premios_jugadores',
-            Monto: Number(creditos) || 0,
-            cartonesGratis: Number(cartonesGratis) || 0,
+            Monto: montoTransaccion,
+            cartonesGratis: cartonesNumero,
             estado: 'APROBADO',
             IDbilletera: email,
             fechasolicitud: '',
@@ -4557,11 +4560,12 @@
         }
         const transSnap = await tx.get(transaccionRef);
         if(!transSnap.exists){
+          const cartonesNumero = Number(cartonesGratis) || 0;
           tx.set(transaccionRef, {
             tipotrans: 'premio',
             origen: 'premios_segundo_lugar',
-            Monto: 0,
-            cartonesGratis: Number(cartonesGratis) || 0,
+            Monto: cartonesNumero,
+            cartonesGratis: cartonesNumero,
             estado: 'APROBADO',
             IDbilletera: email,
             fechasolicitud: '',


### PR DESCRIPTION
## Resumen
- Ajusté la acreditación automática de premios en `public/cantarsorteos.html` para que las transacciones de premio que son solo de cartones gratis guarden en `Monto` la cantidad de cartones gratis ganados.
- Mantuve el estado de estas transacciones como `APROBADO` para reflejar que son premios acreditados al instante durante el sorteo en vivo.
- Actualicé `public/billetera.html` para diferenciar visualmente las transacciones de cartones gratis: celda de monto con fondo morado y texto blanco.
- En el detalle de monto de la billetera, ahora los premios de cartones gratis muestran explícitamente la cantidad de cartones ganados.

## Impacto funcional
- Los jugadores pueden ver inmediatamente en su billetera las ganancias en vivo ya aprobadas.
- Las ganancias de cartones gratis se registran y se visualizan como transacción distinguible frente a créditos.

## Validación
- No ejecuté pruebas automáticas; validación por inspección estática y revisión del diff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69966603081883269e3a1a284bc57f71)