### PR TITLE
Acreditación inmediata de premios en billeteras para ganadores

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -2664,12 +2664,19 @@
     }
     let info = null;
     try {
-      await asegurarDbListo();
-      const snap = await db.collection('users').where('uid','==',clave).limit(1).get();
-      if(!snap.empty){
-        const doc = snap.docs[0];
-        info = normalizarInfoUsuario(doc.id, doc.data() || {});
-        almacenarUsuarioEnCaches(info);
+      info = await obtenerUsuarioPorDocId(clave);
+    } catch (err) {
+      console.warn('No se pudo obtener usuario por coincidencia directa de userId', err);
+    }
+    try {
+      if(!info){
+        await asegurarDbListo();
+        const snap = await db.collection('users').where('uid','==',clave).limit(1).get();
+        if(!snap.empty){
+          const doc = snap.docs[0];
+          info = normalizarInfoUsuario(doc.id, doc.data() || {});
+          almacenarUsuarioEnCaches(info);
+        }
       }
     } catch (err) {
       console.warn('No se pudo obtener usuario por UID', err);

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -3982,6 +3982,9 @@ function toggleForma(idx){
         // { userId, sorteoId, sorteoNombre, cartonNum, Ncarton, tipocarton, alias, posiciones, createdAt }
         tx.set(cartonRef,{
           userId:user.uid,
+          email:user.email||'',
+          gmail:user.email||'',
+          IDbilletera:user.email||'',
           sorteoId:currentSorteo,
           sorteoNombre:currentSorteoNombre,
           cartonNum:siguienteNumero,


### PR DESCRIPTION
### Motivation
- Corregir por qué los premios en créditos y cartones gratis no se estaban acreditando en las billeteras de los ganadores al momento de ganar la forma.
- Evitar pérdidas de premio por no poder resolver la identidad del ganador o por falta de email en el registro del cartón.

### Description
- Mejoré la resolución de identidad en `public/cantarsorteos.html` para que `obtenerUsuarioPorUserId` intente primero buscar por ID de documento (`obtenerUsuarioPorDocId`) antes de consultar por `uid`, aumentando la probabilidad de obtener el email del ganador.
- Almacené explícitamente `email`, `gmail` e `IDbilletera` cuando se crea el documento de `CartonJugado` en `public/jugarcartones.html` para que la acreditación automática encuentre la billetera inmediatamente. 
- Mantengo la lógica de transacción existente que actualiza `PremiosSorteos`, `Billetera` y `transacciones` dentro de transacciones Firestore para que el efecto sea atómico y efectivo justo al ganar.

### Testing
- Ejecuté la suite completa de pruebas con `npm test -- --runInBand` y todos los tests pasaron (8 suites, 25 tests en verde). 
- Ejecuté un test individual con `npm test -- --runInBand __tests__/player.test.js`, el test pasó, aunque la ejecución aislada produjo un código de salida no cero por umbrales de coverage de Jest cuando se corrió solo esa suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69967f3ccbfc83269a21e4909ac90a1d)