### PR TITLE
Corregir acreditación de premios en billeteras de ganadores

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -2582,6 +2582,26 @@
     return valor.trim().toLowerCase();
   }
 
+  function obtenerCandidatosBilleteraId(...valores){
+    const vistos = new Set();
+    const candidatos = [];
+    valores.forEach(valor=>{
+      if(typeof valor !== 'string') return;
+      const limpio = valor.trim();
+      if(!limpio) return;
+      if(!vistos.has(limpio)){
+        vistos.add(limpio);
+        candidatos.push(limpio);
+      }
+      const normalizado = normalizarEmail(limpio);
+      if(normalizado && !vistos.has(normalizado)){
+        vistos.add(normalizado);
+        candidatos.push(normalizado);
+      }
+    });
+    return candidatos;
+  }
+
   function sanitizarId(valor){
     const texto = (valor || '').toString();
     const limpio = texto.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
@@ -4393,8 +4413,9 @@
     try {
       await asegurarDbListo();
       const identidad = await resolverIdentidadPersona(carton);
-      const email = normalizarEmail(identidad.email);
-      if(!email){
+      const billeteraIds = obtenerCandidatosBilleteraId(identidad.email, carton?.email, carton?.gmail, carton?.IDbilletera);
+      const email = normalizarEmail(identidad.email || billeteraIds[0] || '');
+      if(!email || !billeteraIds.length){
         return;
       }
       const premioTotal = obtenerCreditosForma(forma);
@@ -4408,7 +4429,6 @@
       const timestamp = getServerTimestamp();
       const premioRef = db.collection('PremiosSorteos').doc(premioId);
       const transaccionRef = db.collection('transacciones').doc(`premio_${premioId}`);
-      const billeteraRef = db.collection('Billetera').doc(email);
       await db.runTransaction(async tx => {
         const premioSnap = await tx.get(premioRef);
         if(premioSnap.exists){
@@ -4417,7 +4437,20 @@
             return;
           }
         }
-        const billeteraSnap = await tx.get(billeteraRef);
+        let billeteraRef = db.collection('Billetera').doc(billeteraIds[0]);
+        let billeteraSnap = null;
+        for(const billeteraId of billeteraIds){
+          const ref = db.collection('Billetera').doc(billeteraId);
+          const snap = await tx.get(ref);
+          if(snap.exists){
+            billeteraRef = ref;
+            billeteraSnap = snap;
+            break;
+          }
+        }
+        if(!billeteraSnap){
+          billeteraSnap = await tx.get(billeteraRef);
+        }
         const datosBilletera = billeteraSnap.exists ? billeteraSnap.data() : {};
         const nuevosCreditos = (Number(datosBilletera.creditos) || 0) + (Number(creditos) || 0);
         const nuevosCartones = (Number(datosBilletera.CartonesGratis) || 0) + (Number(cartonesGratis) || 0);
@@ -4504,8 +4537,9 @@
     try {
       await asegurarDbListo();
       const identidad = await resolverIdentidadPersona(carton);
-      const email = normalizarEmail(identidad.email);
-      if(!email){
+      const billeteraIds = obtenerCandidatosBilleteraId(identidad.email, carton?.email, carton?.gmail, carton?.IDbilletera);
+      const email = normalizarEmail(identidad.email || billeteraIds[0] || '');
+      if(!email || !billeteraIds.length){
         return;
       }
       const sorteoNombre = (currentSorteoData?.nombre || '').toString();
@@ -4515,7 +4549,6 @@
       const timestamp = getServerTimestamp();
       const premioRef = db.collection('PremiosSorteos').doc(premioId);
       const transaccionRef = db.collection('transacciones').doc(`premio2_${premioId}`);
-      const billeteraRef = db.collection('Billetera').doc(email);
       await db.runTransaction(async tx => {
         const premioSnap = await tx.get(premioRef);
         if(premioSnap.exists){
@@ -4524,7 +4557,20 @@
             return;
           }
         }
-        const billeteraSnap = await tx.get(billeteraRef);
+        let billeteraRef = db.collection('Billetera').doc(billeteraIds[0]);
+        let billeteraSnap = null;
+        for(const billeteraId of billeteraIds){
+          const ref = db.collection('Billetera').doc(billeteraId);
+          const snap = await tx.get(ref);
+          if(snap.exists){
+            billeteraRef = ref;
+            billeteraSnap = snap;
+            break;
+          }
+        }
+        if(!billeteraSnap){
+          billeteraSnap = await tx.get(billeteraRef);
+        }
         const datosBilletera = billeteraSnap.exists ? billeteraSnap.data() : {};
         const nuevosCartones = (Number(datosBilletera.CartonesGratis) || 0) + (Number(cartonesGratis) || 0);
         const payloadPremio = {

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1507,6 +1507,26 @@
     return reemplazado.replace(/_{2,}/g, '_').replace(/^_+|_+$/g, '') || 'registro';
   }
 
+  function obtenerCandidatosBilleteraId(...valores){
+    const vistos = new Set();
+    const candidatos = [];
+    valores.forEach(valor=>{
+      if(typeof valor !== 'string') return;
+      const limpio = valor.trim();
+      if(!limpio) return;
+      if(!vistos.has(limpio)){
+        vistos.add(limpio);
+        candidatos.push(limpio);
+      }
+      const normalizado = normalizarEmail(limpio);
+      if(normalizado && !vistos.has(normalizado)){
+        vistos.add(normalizado);
+        candidatos.push(normalizado);
+      }
+    });
+    return candidatos;
+  }
+
   function normalizarInfoUsuario(id, data = {}){
     const email = (data.email || id || '').toString();
     let nombre = (data.nombre || data.name || '').toString().trim();
@@ -1893,13 +1913,13 @@
   }
 
   async function acreditarPremioAutomaticoCentroPagos({ docId, ganador, sorteoNombre, timestamp }){
-    const email = normalizarEmail(ganador.gmail);
+    const billeteraIds = obtenerCandidatosBilleteraId(ganador.gmail, ganador.email, ganador.IDbilletera);
+    const email = normalizarEmail(ganador.gmail || ganador.email || billeteraIds[0] || '');
     const alias = ganador.alias || '';
-    if(!email){
+    if(!email || !billeteraIds.length){
       throw new Error(`Ganador sin email válido para acreditación automática: ${alias || docId}`);
     }
     const premioRef = db.collection('PremiosSorteos').doc(docId);
-    const billeteraRef = db.collection('Billetera').doc(email);
     const transaccionRef = db.collection('transacciones').doc(`premio_${docId}`);
     const creditos = Number(ganador.creditos) || 0;
     const cartonesGratis = Number(ganador.cartonesGratis) || 0;
@@ -1911,7 +1931,20 @@
         return;
       }
 
-      const billeteraSnap = await tx.get(billeteraRef);
+      let billeteraRef = db.collection('Billetera').doc(billeteraIds[0]);
+      let billeteraSnap = null;
+      for(const billeteraId of billeteraIds){
+        const ref = db.collection('Billetera').doc(billeteraId);
+        const snap = await tx.get(ref);
+        if(snap.exists){
+          billeteraRef = ref;
+          billeteraSnap = snap;
+          break;
+        }
+      }
+      if(!billeteraSnap){
+        billeteraSnap = await tx.get(billeteraRef);
+      }
       const billeteraData = billeteraSnap.exists ? (billeteraSnap.data() || {}) : {};
       const nuevosCreditos = (Number(billeteraData.creditos) || 0) + creditos;
       const nuevosCartones = (Number(billeteraData.CartonesGratis) || 0) + cartonesGratis;


### PR DESCRIPTION
### Motivation
- Se detectó que la acreditación de premios asumía un único ID de billetera (email normalizado) y, cuando la Billetera del jugador existía bajo otra variante del identificador (por ejemplo distinto casing), el premio podía no reflejarse en su saldo.

### Description
- Se añadió la función `obtenerCandidatosBilleteraId(...)` en `public/cantarsorteos.html` y `public/pdfresultados.html` para generar una lista de candidatos (valor original + valor normalizado) para identificar la doc de `Billetera` correcta.
- Se reemplazó la lectura/escritura directa de `Billetera.doc(email)` por una búsqueda dentro de la misma transacción que itera los `billeteraIds` y selecciona el documento existente antes de actualizar saldos y crear transacciones.
- La corrección se aplicó en los flujos de acreditación automática principales: `acreditarPremioAutomatico` (premio principal), `acreditarPremioSegundoLugar` y `acreditarPremioAutomaticoCentroPagos`.
- Con esto se evita acreditar en un documento distinto por inconsistencias de formato/capitalización en el identificador de billetera.

### Testing
- Ejecuté los tests automáticos con `npm test -- --runInBand` y todos los suites pasaron correctamente.
- Resultado: 8 suites ejecutadas y aprobadas, 25 tests aprobados (`PASS`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699760fe94108326a4ef2b32f71d7606)