### PR TITLE
Corregir permisos para acreditar premios en billeteras de jugadores

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -74,7 +74,7 @@ service cloud.firestore {
 
     match /Billetera/{email} {
       allow read: if isAdmin() || isOwner(email);
-      allow create, update: if isAdmin() || isOwner(email);
+      allow create, update: if isAdmin() || isOwner(email) || isPrivilegedOperator();
       allow delete: if isAdmin();
     }
 
@@ -89,8 +89,14 @@ service cloud.firestore {
 
     match /transacciones/{id} {
       allow read: if isAdmin() || (isSignedIn() && resource.data.IDbilletera == request.auth.token.email);
-      allow create: if isAdmin() || (isSignedIn() && request.resource.data.IDbilletera == request.auth.token.email);
-      allow update, delete: if isAdmin();
+      allow create: if isAdmin()
+        || (isSignedIn() && request.resource.data.IDbilletera == request.auth.token.email)
+        || (isPrivilegedOperator() && request.resource.data.tipotrans == 'premio');
+      allow update: if isAdmin()
+        || (isPrivilegedOperator()
+          && resource.data.tipotrans == 'premio'
+          && request.resource.data.tipotrans == 'premio');
+      allow delete: if isAdmin();
     }
 
     match /CartonGuardado/{id} {


### PR DESCRIPTION
### Motivation
- Se detectó que la acreditación de premios en `public/cantarsorteos.html` se ejecuta dentro de una transacción que escribe en `PremiosSorteos`, `Billetera` y `transacciones`, y si alguna de esas escrituras falla por permisos la transacción se aborta y no se acreditan ni créditos ni cartones gratis. 
- Las reglas previas de Firestore permitían a operadores privilegiados escribir en `PremiosSorteos` pero bloqueaban `Billetera` y `transacciones` cuando el objetivo era otra billetera, causando la falla observada. 
- El objetivo del cambio es permitir que operadores privilegiados (Administrador/Colaborador) procesen premios completos sin relajar permisos para otros tipos de transacciones.

### Description
- Actualicé `firestore.rules` para permitir `create`/`update` en `Billetera` también a `isPrivilegedOperator()` además de `isAdmin()` e `isOwner(email)`. 
- Modifiqué la regla de `transacciones` para permitir `create` a `isPrivilegedOperator()` únicamente cuando `request.resource.data.tipotrans == 'premio'`. 
- Añadí `allow update` para `isPrivilegedOperator()` solo si tanto el documento existente como el nuevo mantienen `tipotrans == 'premio'`, y mantuve `delete` restringido a `isAdmin()`.

### Testing
- Ejecuté la suite de tests con `npm test -- --runInBand` y todos los tests automatizados pasaron (8 suites, 25 tests). 
- Las pruebas unitarias y de utilidades relacionadas con el servidor siguen pasando tras el cambio, por lo que la modificación de reglas no rompió la cobertura verificable en CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997672950348326989abad1f0d22a90)