### PR TITLE
Corregir transferencia inmediata de premios a la billetera correcta

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -4454,6 +4454,7 @@
         const datosBilletera = billeteraSnap.exists ? billeteraSnap.data() : {};
         const nuevosCreditos = (Number(datosBilletera.creditos) || 0) + (Number(creditos) || 0);
         const nuevosCartones = (Number(datosBilletera.CartonesGratis) || 0) + (Number(cartonesGratis) || 0);
+        const idBilleteraFinal = billeteraRef.id;
         const payloadPremio = {
           sorteoId: currentSorteoId,
           sorteoNombre,
@@ -4485,9 +4486,9 @@
           userIds: identidad.userId ? [identidad.userId] : [],
           cartonId: carton.id || carton.cartonId || '',
           formaIdx: Number(forma?.idx) || null,
-          generadoDesde: 'cantarsorteos'
+          generadoDesde: 'cantarsorteos',
+          idBilletera: idBilleteraFinal
         };
-        if(email){ payloadPremio.idBilletera = email; }
         tx.set(premioRef, payloadPremio, { merge: true });
         if(Number(creditos) || Number(cartonesGratis)){
           tx.set(billeteraRef, { creditos: nuevosCreditos, CartonesGratis: nuevosCartones }, { merge: true });
@@ -4503,7 +4504,7 @@
             Monto: montoTransaccion,
             cartonesGratis: cartonesNumero,
             estado: 'REALIZADO',
-            IDbilletera: email,
+            IDbilletera: idBilleteraFinal,
             fechasolicitud: '',
             horasolicitud: '',
             fechagestion: fechaGestion,
@@ -4573,6 +4574,7 @@
         }
         const datosBilletera = billeteraSnap.exists ? billeteraSnap.data() : {};
         const nuevosCartones = (Number(datosBilletera.CartonesGratis) || 0) + (Number(cartonesGratis) || 0);
+        const idBilleteraFinal = billeteraRef.id;
         const payloadPremio = {
           sorteoId: currentSorteoId,
           sorteoNombre,
@@ -4604,9 +4606,9 @@
           userIds: identidad.userId ? [identidad.userId] : [],
           cartonId: carton.id || carton.cartonId || '',
           formaIdx: Number(forma?.idx) || null,
-          generadoDesde: 'cantarsorteos'
+          generadoDesde: 'cantarsorteos',
+          idBilletera: idBilleteraFinal
         };
-        if(email){ payloadPremio.idBilletera = email; }
         tx.set(premioRef, payloadPremio, { merge: true });
         if(Number(cartonesGratis)){
           tx.set(billeteraRef, { CartonesGratis: nuevosCartones }, { merge: true });
@@ -4620,7 +4622,7 @@
             Monto: cartonesNumero,
             cartonesGratis: cartonesNumero,
             estado: 'REALIZADO',
-            IDbilletera: email,
+            IDbilletera: idBilleteraFinal,
             fechasolicitud: '',
             horasolicitud: '',
             fechagestion: fechaGestion,

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1949,6 +1949,7 @@
       const nuevosCreditos = (Number(billeteraData.creditos) || 0) + creditos;
       const nuevosCartones = (Number(billeteraData.CartonesGratis) || 0) + cartonesGratis;
 
+      const idBilleteraFinal = billeteraRef.id;
       const payloadPremio = {
         sorteoId,
         sorteoNombre,
@@ -1974,7 +1975,7 @@
         tipoRegistro: 'GANADOR_SORTEO',
         userIds: ganador.userIds || [],
         generadoDesde: 'pdfresultados',
-        idBilletera: email,
+        idBilletera: idBilleteraFinal,
         acreditadoAutomaticamente: true
       };
 
@@ -1989,7 +1990,7 @@
           Monto: creditos > 0 ? creditos : cartonesGratis,
           cartonesGratis,
           estado: 'APROBADO',
-          IDbilletera: email,
+          IDbilletera: idBilleteraFinal,
           fechasolicitud: '',
           horasolicitud: '',
           fechagestion: timestamp,


### PR DESCRIPTION
### Motivation
- Detecté que la acreditación automática podía acreditar créditos/cartones en la documentación de billetera encontrada por la transacción pero registrar `IDbilletera`/`idBilletera` usando el email normalizado, causando desalineación y la impresión de que el premio "no se transfirió".
- Se requiere que los premios se acrediten de forma inmediata e independiente de la generación de PDFs o pasos administrativos, por lo que la identificación de la billetera debe coincidir exactamente con la que se actualiza en la transacción.

### Description
- Ajusté la lógica de acreditación automática en `public/cantarsorteos.html` para guardar `idBilletera: billeteraRef.id` en el documento `PremiosSorteos` y usar `idBilleteraFinal` como `IDbilletera` en la transacción asociada. 
- Apliqué la misma corrección en `public/pdfresultados.html` para que `PremiosSorteos.idBilletera` y `transacciones.IDbilletera` reflejen el `id` real del documento de `Billetera` usado en la transacción.
- Eliminé la dependencia de asignar `idBilletera` desde el email normalizado en favor del `billeteraRef.id` resuelto durante la transacción para garantizar coherencia entre premio, transacción y saldo actualizado.

### Testing
- Ejecuté `npm test -- --runInBand` y todos los tests pasaron: 8 suites, 25 tests en verde. 
- Las modificaciones fueron verificadas localmente revisando los flujos afectados de acreditación automática en `cantarsorteos` y `pdfresultados` sin romper cobertura existente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699770d2cf5483269662553f8534af0b)