### PR TITLE
Unificar buildPremioId y reforzar idempotencia de acreditación de ganadores

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -4360,18 +4360,25 @@
     mostrarModalNuevosGanadores(nuevos);
   }
 
-  function construirIdPremioAutomatico(sorteoId, formaIdx, cartonId){
+  function buildPremioId({ sorteoId, formaIdx, cartonId, prefijo = '' } = {}){
     const sorteoSeguro = sanitizarId(sorteoId || 'sorteo');
     const formaSeguro = sanitizarId(`f${formaIdx ?? ''}` || 'forma');
     const cartonSeguro = sanitizarId(cartonId || 'carton');
-    return `${sorteoSeguro}__${formaSeguro}__${cartonSeguro}`;
+    const baseId = `${sorteoSeguro}__${formaSeguro}__${cartonSeguro}`;
+    const prefijoSeguro = sanitizarId(prefijo || '');
+    return prefijoSeguro ? `${prefijoSeguro}__${baseId}` : baseId;
+  }
+
+  async function existeEventoGanadorFinalizado(eventoGanadorId){
+    const eventoSeguro = sanitizarId(eventoGanadorId || '');
+    if(!eventoSeguro) return false;
+    const estadosFinales = new Set(['REALIZADO', 'APROBADO']);
+    const snapshot = await db.collection('PremiosSorteos').where('eventoGanadorId', '==', eventoSeguro).get();
+    return snapshot.docs.some(doc=>estadosFinales.has((doc.data()?.estado || '').toString().trim().toUpperCase()));
   }
 
   function construirIdPremioSegundoLugar(sorteoId, formaIdx, cartonId){
-    const sorteoSeguro = sanitizarId(sorteoId || 'sorteo');
-    const formaSeguro = sanitizarId(`f${formaIdx ?? ''}` || 'forma');
-    const cartonSeguro = sanitizarId(cartonId || 'carton');
-    return `segundo__${sorteoSeguro}__${formaSeguro}__${cartonSeguro}`;
+    return buildPremioId({ sorteoId, formaIdx, cartonId, prefijo: 'segundo' });
   }
 
   function obtenerCartonesSegundoLugar(forma, pasoGanador){
@@ -4407,11 +4414,16 @@
   async function acreditarPremioAutomatico({ carton, forma, totalGanadores }){
     if(!carton || !forma || !currentSorteoId) return;
     const cartonReferencia = carton.id || carton.cartonId || carton.carton || carton.userId || carton.usuarioId || '';
-    const premioId = construirIdPremioAutomatico(currentSorteoId, forma?.idx, cartonReferencia);
+    const eventoGanadorId = buildPremioId({ sorteoId: currentSorteoId, formaIdx: forma?.idx, cartonId: cartonReferencia });
+    const premioId = eventoGanadorId;
     if(premiosAutomaticosProcesados.has(premioId) || premiosAutomaticosEnCurso.has(premioId)) return;
     premiosAutomaticosEnCurso.add(premioId);
     try {
       await asegurarDbListo();
+      if(await existeEventoGanadorFinalizado(eventoGanadorId)){
+        premiosAutomaticosProcesados.add(premioId);
+        return;
+      }
       const identidad = await resolverIdentidadPersona(carton);
       const billeteraIds = obtenerCandidatosBilleteraId(identidad.email, carton?.email, carton?.gmail, carton?.IDbilletera);
       const email = normalizarEmail(identidad.email || billeteraIds[0] || '');
@@ -4483,6 +4495,8 @@
           gestionadoPor: auth?.currentUser?.email || '',
           rolGestor: window.currentRole || '',
           tipoRegistro: 'GANADOR_SORTEO',
+          eventoGanadorId,
+          winnerKey: eventoGanadorId,
           userIds: identidad.userId ? [identidad.userId] : [],
           cartonId: carton.id || carton.cartonId || '',
           formaIdx: Number(forma?.idx) || null,
@@ -4530,13 +4544,18 @@
   async function acreditarPremioSegundoLugar({ carton, forma }){
     if(!carton || !forma || !currentSorteoId) return;
     const cartonReferencia = carton.id || carton.cartonId || carton.carton || carton.userId || carton.usuarioId || '';
-    const premioId = construirIdPremioSegundoLugar(currentSorteoId, forma?.idx, cartonReferencia);
+    const eventoGanadorId = buildPremioId({ sorteoId: currentSorteoId, formaIdx: forma?.idx, cartonId: cartonReferencia, prefijo: 'segundo' });
+    const premioId = eventoGanadorId;
     if(premiosSegundoLugarProcesados.has(premioId) || premiosSegundoLugarEnCurso.has(premioId)) return;
     const cartonesGratis = obtenerCartonesGratisSegundo(forma);
     if(!Number(cartonesGratis) || cartonesGratis <= 0) return;
     premiosSegundoLugarEnCurso.add(premioId);
     try {
       await asegurarDbListo();
+      if(await existeEventoGanadorFinalizado(eventoGanadorId)){
+        premiosSegundoLugarProcesados.add(premioId);
+        return;
+      }
       const identidad = await resolverIdentidadPersona(carton);
       const billeteraIds = obtenerCandidatosBilleteraId(identidad.email, carton?.email, carton?.gmail, carton?.IDbilletera);
       const email = normalizarEmail(identidad.email || billeteraIds[0] || '');
@@ -4602,6 +4621,8 @@
           gestionadoPor: auth?.currentUser?.email || '',
           rolGestor: window.currentRole || '',
           tipoRegistro: 'SEGUNDO_LUGAR_SORTEO',
+          eventoGanadorId,
+          winnerKey: eventoGanadorId,
           segundoLugar: true,
           userIds: identidad.userId ? [identidad.userId] : [],
           cartonId: carton.id || carton.cartonId || '',

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -1452,6 +1452,7 @@
         creditos: item.creditos,
         cartonesGratis: item.cartonesGratis,
         formas: item.formas,
+        cartonesIds: Array.from(item.cartonesIds),
         cartonesGanadores: item.cartonesIds.size,
         userIds: Array.from(item.userIds)
       }));
@@ -1462,10 +1463,30 @@
       return { lista, totalCreditos, totalCartonesGratis };
     }
 
+    function buildPremioId({ sorteoId, formaIdx, cartonId, prefijo = '' } = {}){
+      const sorteoSeguro = cpSanitizarId(sorteoId || 'sorteo');
+      const formaSeguro = cpSanitizarId(`f${formaIdx ?? ''}` || 'forma');
+      const cartonSeguro = cpSanitizarId(cartonId || 'carton');
+      const baseId = `${sorteoSeguro}__${formaSeguro}__${cartonSeguro}`;
+      const prefijoSeguro = cpSanitizarId(prefijo || '');
+      return prefijoSeguro ? `${prefijoSeguro}__${baseId}` : baseId;
+    }
+
     function cpConstruirIdSolicitud(base, identificador){
       const baseSeguro = cpSanitizarId(base || 'sorteo');
       const idSeguro = cpSanitizarId(identificador || 'registro');
       return `${baseSeguro}__${idSeguro}`;
+    }
+
+    function cpConstruirIdGanador(ctx, ganador){
+      const formaIdx = Number(ganador?.formas?.[0]?.idx);
+      const cartonId = (ganador?.cartonesIds?.[0] || ganador?.cartonId || '').toString();
+      if(Number.isFinite(formaIdx) && cartonId){
+        return buildPremioId({ sorteoId: ctx.sorteoId, formaIdx, cartonId });
+      }
+      const email = cpNormalizarEmail(ganador?.gmail || ganador?.email || '');
+      const alias = (ganador?.alias || '').toString();
+      return cpConstruirIdSolicitud(ctx.sorteoId, email || alias || 'ganador');
     }
 
     async function cpActualizarDocumentoCentroPagos(ctx, ref, payload){
@@ -1495,7 +1516,8 @@
         ganadores.forEach(ganador=>{
           const email = cpNormalizarEmail(ganador.gmail);
           const alias = ganador.alias || '';
-          const docId = cpConstruirIdSolicitud(ctx.sorteoId, email || alias || 'ganador');
+          const docId = cpConstruirIdGanador(ctx, ganador);
+          const eventoGanadorId = cpSanitizarId(docId);
           const payload = {
           sorteoId: ctx.sorteoId,
           sorteoNombre,
@@ -1515,6 +1537,8 @@
           creadoEn: timestamp,
           actualizadoEn: timestamp,
           tipoRegistro: 'GANADOR_SORTEO',
+          eventoGanadorId,
+          winnerKey: eventoGanadorId,
           userIds: ganador.userIds || [],
           generadoDesde: 'centropagos'
         };
@@ -1708,7 +1732,9 @@
     }
 
     function prepararPremio(id, data = {}){
-      const gmail = (data.gmail || data.email || id || '').toString();
+      const winnerKey = (data.winnerKey || data.eventoGanadorId || id || '').toString();
+      const gmail = (data.gmail || data.email || '').toString();
+      const gmailRender = gmail || (winnerKey.includes('@') ? winnerKey : '');
       const alias = (data.alias || data.aliasJugador || data.aliasGanador || '').toString();
       const creditos = Number(data.creditosGanados ?? data.creditos ?? data.monto ?? 0) || 0;
       const cartones = Number(data.cartonesGratis ?? data.cartonesGanados ?? data.cartones ?? 0) || 0;
@@ -1717,7 +1743,7 @@
       const billetera = (data.idBilletera || gmail).toString();
       return {
         id,
-        gmail,
+        gmail: gmailRender,
         alias,
         creditos,
         cartones,
@@ -1726,6 +1752,8 @@
         fechaOrden: fechaInfo.orden,
         estado,
         billetera,
+        eventoGanadorId: (data.eventoGanadorId || '').toString(),
+        winnerKey,
         sorteoId: (data.sorteoId || '').toString(),
         sorteoNombre: (data.sorteoNombre || '').toString()
       };
@@ -1742,7 +1770,7 @@
       const sorteoNombre = (data.sorteoNombre || '').toString();
       return {
         id,
-        gmail,
+        gmail: gmailRender,
         nombre,
         creditos,
         fechaMostrar: fechaInfo.mostrar,

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1877,6 +1877,7 @@
       creditos: item.creditos,
       cartonesGratis: item.cartonesGratis,
       formas: item.formas,
+      cartonesIds: Array.from(item.cartonesIds),
       cartonesGanadores: item.cartonesIds.size,
       userIds: Array.from(item.userIds)
     }));
@@ -1887,10 +1888,38 @@
     return { lista, totalCreditos, totalCartonesGratis };
   }
 
+  function buildPremioId({ sorteoId, formaIdx, cartonId, prefijo = '' } = {}){
+    const sorteoSeguro = sanitizarId(sorteoId || 'sorteo');
+    const formaSeguro = sanitizarId(`f${formaIdx ?? ''}` || 'forma');
+    const cartonSeguro = sanitizarId(cartonId || 'carton');
+    const baseId = `${sorteoSeguro}__${formaSeguro}__${cartonSeguro}`;
+    const prefijoSeguro = sanitizarId(prefijo || '');
+    return prefijoSeguro ? `${prefijoSeguro}__${baseId}` : baseId;
+  }
+
   function construirIdSolicitud(base, identificador){
     const baseSeguro = sanitizarId(base || 'sorteo');
     const idSeguro = sanitizarId(identificador || 'registro');
     return `${baseSeguro}__${idSeguro}`;
+  }
+
+  function construirIdGanador(ganador){
+    const formaIdx = Number(ganador?.formas?.[0]?.idx);
+    const cartonId = (ganador?.cartonesIds?.[0] || ganador?.cartonId || '').toString();
+    if(Number.isFinite(formaIdx) && cartonId){
+      return buildPremioId({ sorteoId, formaIdx, cartonId });
+    }
+    const email = normalizarEmail(ganador?.gmail || ganador?.email || '');
+    const alias = (ganador?.alias || '').toString();
+    return construirIdSolicitud(sorteoId, email || alias || 'ganador');
+  }
+
+  async function existeEventoGanadorFinalizado(eventoGanadorId){
+    const eventoSeguro = sanitizarId(eventoGanadorId || '');
+    if(!eventoSeguro) return false;
+    const estadosFinales = new Set(['REALIZADO', 'APROBADO']);
+    const snapshot = await db.collection('PremiosSorteos').where('eventoGanadorId', '==', eventoSeguro).get();
+    return snapshot.docs.some(doc=>estadosFinales.has((doc.data()?.estado || '').toString().trim().toUpperCase()));
   }
 
   async function actualizarDocumentoCentroPagos(ref, payload){
@@ -1912,7 +1941,7 @@
     }
   }
 
-  async function acreditarPremioAutomaticoCentroPagos({ docId, ganador, sorteoNombre, timestamp }){
+  async function acreditarPremioAutomaticoCentroPagos({ docId, ganador, sorteoNombre, timestamp, eventoGanadorId }){
     const billeteraIds = obtenerCandidatosBilleteraId(ganador.gmail, ganador.email, ganador.IDbilletera);
     const email = normalizarEmail(ganador.gmail || ganador.email || billeteraIds[0] || '');
     const alias = ganador.alias || '';
@@ -1923,6 +1952,10 @@
     const transaccionRef = db.collection('transacciones').doc(`premio_${docId}`);
     const creditos = Number(ganador.creditos) || 0;
     const cartonesGratis = Number(ganador.cartonesGratis) || 0;
+
+    if(await existeEventoGanadorFinalizado(eventoGanadorId)){
+      return;
+    }
 
     await db.runTransaction(async tx => {
       const premioSnap = await tx.get(premioRef);
@@ -1973,6 +2006,8 @@
         gestionadoPor: auth?.currentUser?.email || 'sistema',
         rolGestor: window.currentRole || 'Sistema',
         tipoRegistro: 'GANADOR_SORTEO',
+        eventoGanadorId,
+        winnerKey: eventoGanadorId,
         userIds: ganador.userIds || [],
         generadoDesde: 'pdfresultados',
         idBilletera: idBilleteraFinal,
@@ -2019,8 +2054,9 @@
     ganadores.forEach(ganador => {
       const email = normalizarEmail(ganador.gmail);
       const alias = ganador.alias || '';
-      const docId = construirIdSolicitud(sorteoId, email || alias || 'ganador');
-      operaciones.push(acreditarPremioAutomaticoCentroPagos({ docId, ganador, sorteoNombre, timestamp }));
+      const docId = construirIdGanador(ganador);
+      const eventoGanadorId = sanitizarId(docId);
+      operaciones.push(acreditarPremioAutomaticoCentroPagos({ docId, ganador, sorteoNombre, timestamp, eventoGanadorId }));
     });
 
     colaboradores.forEach(colaborador => {


### PR DESCRIPTION
### Motivation
- Unificar la construcción del identificador de premio para todos los flujos y adoptar un esquema orientado a la idempotencia del evento ganador (`sorteoId + formaIdx + cartonId`).
- Evitar acreditaciones duplicadas detectando previamente si ya existe un evento ganador en estado final (`REALIZADO`/`APROBADO`).
- Mantener compatibilidad con históricos cuando no haya datos suficientes para el nuevo esquema (fallback al comportamiento anterior).

### Description
- Se añadió la función reutilizable `buildPremioId` (soporte de `prefijo`) en `public/cantarsorteos.html`, `public/centropagos.html` y `public/pdfresultados.html` y se reemplazaron las construcciones antiguas de ID por llamadas a esta función.
- Se agregó la función `existeEventoGanadorFinalizado` para consultar por `eventoGanadorId` en `PremiosSorteos` y abortar la acreditación si ya existe un registro en estado final.
- Al persistir premios de ganadores ahora se incluyen los campos `eventoGanadorId` y `winnerKey` en los payloads para trazar el evento idempotente; además se adaptó la lectura/render para usar `winnerKey`/`eventoGanadorId` sin romper históricos y se añadió `cartonesIds` al agregado para permitir generar IDs por evento cuando sea posible.
- Se protegieron los flujos de acreditación automático (cantarsorteos / segundo lugar / centro de pagos / pdfresultados) con la comprobación previa por `eventoGanadorId` y se conserva el fallback a esquemas legacy cuando falta información.

### Testing
- Se ejecutó `git diff --check` para validar que no hay errores de diff-check y pasó correctamente.
- Se realizaron búsquedas con `rg` para verificar que las referencias antiguas fueron reemplazadas y que los nuevos símbolos (`buildPremioId`, `eventoGanadorId`, `winnerKey`) aparecen en los tres archivos afectados, y estas comprobaciones automatizadas pasaron.
- Se comprobó el estado de trabajo con `git status --short` para confirmar los archivos modificados (`public/cantarsorteos.html`, `public/centropagos.html`, `public/pdfresultados.html`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b6ecff40832687a467e02b12395c)