### PR TITLE
Acreditación server-side idempotente para premios y bloqueo de escrituras cliente

### DIFF
--- a/__tests__/uploadServer-acreditar-utils.test.js
+++ b/__tests__/uploadServer-acreditar-utils.test.js
@@ -1,0 +1,32 @@
+jest.mock('firebase-admin', () => ({
+  apps: [],
+  initializeApp: jest.fn()
+}));
+
+describe('uploadServer utilidades de acreditación', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  test('canAccreditForSorteoState permite solo Jugando y Finalizado', () => {
+    const { canAccreditForSorteoState } = require('../uploadServer.js');
+
+    expect(canAccreditForSorteoState('Jugando')).toBe(true);
+    expect(canAccreditForSorteoState('FINALIZADO')).toBe(true);
+    expect(canAccreditForSorteoState('Activo')).toBe(false);
+    expect(canAccreditForSorteoState('Sellado')).toBe(false);
+  });
+
+  test('buildPremioDocId genera id sanitizado y estable', () => {
+    const { buildPremioDocId } = require('../uploadServer.js');
+
+    const id = buildPremioDocId({
+      sorteoId: 'sorteo 1',
+      formaIdx: 2,
+      cartonId: 'carton/abc',
+      prefijo: 'auto premio'
+    });
+
+    expect(id).toBe('auto_premio__sorteo_1__f2__carton_abc');
+  });
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -44,6 +44,11 @@ service cloud.firestore {
       return isAdmin() || hasRole(['Colaborador']);
     }
 
+    function isProductionLockEnabled() {
+      return exists(/databases/$(database)/documents/Variablesglobales/Parametros)
+        && get(/databases/$(database)/documents/Variablesglobales/Parametros).data.bloquearEscriturasClientePremios == true;
+    }
+
     function blockedUserFields() {
       return ['role', 'disabled', 'contrasenasu', 'emailVerified', 'customClaims', 'uid'];
     }
@@ -74,7 +79,8 @@ service cloud.firestore {
 
     match /Billetera/{email} {
       allow read: if isAdmin() || isOwner(email);
-      allow create, update: if isAdmin() || isOwner(email) || isPrivilegedOperator();
+      allow create, update: if isSystemRequest()
+        || (!isProductionLockEnabled() && (isAdmin() || isOwner(email) || isPrivilegedOperator()));
       allow delete: if isAdmin();
     }
 
@@ -89,13 +95,15 @@ service cloud.firestore {
 
     match /transacciones/{id} {
       allow read: if isAdmin() || (isSignedIn() && resource.data.IDbilletera == request.auth.token.email);
-      allow create: if isAdmin()
-        || (isSignedIn() && request.resource.data.IDbilletera == request.auth.token.email)
-        || (isPrivilegedOperator() && request.resource.data.tipotrans == 'premio');
-      allow update: if isAdmin()
-        || (isPrivilegedOperator()
-          && resource.data.tipotrans == 'premio'
-          && request.resource.data.tipotrans == 'premio');
+      allow create: if isSystemRequest()
+        || (!isProductionLockEnabled() && (isAdmin()
+          || (isSignedIn() && request.resource.data.IDbilletera == request.auth.token.email)
+          || (isPrivilegedOperator() && request.resource.data.tipotrans == 'premio')));
+      allow update: if isSystemRequest()
+        || (!isProductionLockEnabled() && (isAdmin()
+          || (isPrivilegedOperator()
+            && resource.data.tipotrans == 'premio'
+            && request.resource.data.tipotrans == 'premio')));
       allow delete: if isAdmin();
     }
 
@@ -128,7 +136,7 @@ service cloud.firestore {
 
     match /PremiosSorteos/{docId} {
       allow read: if isSignedIn();
-      allow write: if isPrivilegedOperator();
+      allow write: if isSystemRequest() || (!isProductionLockEnabled() && isPrivilegedOperator());
     }
 
     match /PremiosSorteosArchivo/{docId} {

--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -4427,112 +4427,42 @@
       const identidad = await resolverIdentidadPersona(carton);
       const billeteraIds = obtenerCandidatosBilleteraId(identidad.email, carton?.email, carton?.gmail, carton?.IDbilletera);
       const email = normalizarEmail(identidad.email || billeteraIds[0] || '');
-      if(!email || !billeteraIds.length){
+      const userId = identidad.userId || carton?.userId || carton?.usuarioId || '';
+      if(!email && !userId){
         return;
       }
       const premioTotal = obtenerCreditosForma(forma);
       const ganadoresNumero = Math.max(1, Number(totalGanadores) || 1);
       const creditos = ganadoresNumero > 0 ? Math.floor(Number(premioTotal) / ganadoresNumero) : 0;
       const cartonesGratis = obtenerCartonesGratisPorGanador(forma, ganadoresNumero);
-      const sorteoNombre = (currentSorteoData?.nombre || '').toString();
-      const ahora = getServerNow();
-      const fechaGestion = formatearFechaCorta(ahora);
-      const horaGestion = formatearHoraCorta(ahora);
-      const timestamp = getServerTimestamp();
-      const premioRef = db.collection('PremiosSorteos').doc(premioId);
-      const transaccionRef = db.collection('transacciones').doc(`premio_${premioId}`);
-      await db.runTransaction(async tx => {
-        const premioSnap = await tx.get(premioRef);
-        if(premioSnap.exists){
-          const estadoActual = (premioSnap.data()?.estado || '').toString().trim().toUpperCase();
-          if(estadoActual === 'REALIZADO' || estadoActual === 'APROBADO'){
-            return;
-          }
-        }
-        let billeteraRef = db.collection('Billetera').doc(billeteraIds[0]);
-        let billeteraSnap = null;
-        for(const billeteraId of billeteraIds){
-          const ref = db.collection('Billetera').doc(billeteraId);
-          const snap = await tx.get(ref);
-          if(snap.exists){
-            billeteraRef = ref;
-            billeteraSnap = snap;
-            break;
-          }
-        }
-        if(!billeteraSnap){
-          billeteraSnap = await tx.get(billeteraRef);
-        }
-        const datosBilletera = billeteraSnap.exists ? billeteraSnap.data() : {};
-        const nuevosCreditos = (Number(datosBilletera.creditos) || 0) + (Number(creditos) || 0);
-        const nuevosCartones = (Number(datosBilletera.CartonesGratis) || 0) + (Number(cartonesGratis) || 0);
-        const idBilleteraFinal = billeteraRef.id;
-        const payloadPremio = {
+      const user = auth?.currentUser;
+      const apiBase = (typeof getAdminApiBase === 'function' ? getAdminApiBase() : '').replace(/\/$/, '');
+      if(!user || !apiBase){
+        console.warn('No se pudo acreditar premio automático vía backend por falta de sesión o API base.');
+        return;
+      }
+      const token = await user.getIdToken();
+      const response = await fetch(`${apiBase}/acreditarPremioEvento`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({
           sorteoId: currentSorteoId,
-          sorteoNombre,
-          gmail: email,
-          email,
-          alias: identidad.alias || carton.alias || '',
-          aliasJugador: identidad.alias || carton.alias || '',
-          aliasGanador: identidad.alias || carton.alias || '',
-          creditos: Number(creditos) || 0,
-          creditosGanados: Number(creditos) || 0,
-          cartonesGratis: Number(cartonesGratis) || 0,
-          cartonesGanados: 1,
-          formasGanadoras: [{
-            idx: Number(forma?.idx) || null,
-            nombre: forma?.nombre || '',
-            creditos: Number(creditos) || 0,
-            cartonesGratis: Number(cartonesGratis) || 0
-          }],
-          estado: 'REALIZADO',
-          fechaGanado: timestamp,
-          fechaRegistro: timestamp,
-          creadoEn: timestamp,
-          actualizadoEn: timestamp,
-          fechaGestion,
-          horaGestion,
-          gestionadoPor: auth?.currentUser?.email || '',
-          rolGestor: window.currentRole || '',
-          tipoRegistro: 'GANADOR_SORTEO',
-          eventoGanadorId,
-          winnerKey: eventoGanadorId,
-          userIds: identidad.userId ? [identidad.userId] : [],
+          formaIdx: Number(forma?.idx) || 0,
           cartonId: carton.id || carton.cartonId || '',
-          formaIdx: Number(forma?.idx) || null,
-          generadoDesde: 'cantarsorteos',
-          idBilletera: idBilleteraFinal
-        };
-        tx.set(premioRef, payloadPremio, { merge: true });
-        if(Number(creditos) || Number(cartonesGratis)){
-          tx.set(billeteraRef, { creditos: nuevosCreditos, CartonesGratis: nuevosCartones }, { merge: true });
-        }
-        const transSnap = await tx.get(transaccionRef);
-        if(!transSnap.exists){
-          const creditosNumero = Number(creditos) || 0;
-          const cartonesNumero = Number(cartonesGratis) || 0;
-          const montoTransaccion = creditosNumero > 0 ? creditosNumero : cartonesNumero;
-          tx.set(transaccionRef, {
-            tipotrans: 'premio',
-            origen: 'premios_jugadores',
-            Monto: montoTransaccion,
-            cartonesGratis: cartonesNumero,
-            estado: 'REALIZADO',
-            IDbilletera: idBilleteraFinal,
-            fechasolicitud: '',
-            horasolicitud: '',
-            fechagestion: fechaGestion,
-            horagestion: horaGestion,
-            usuariogestor: auth?.currentUser?.email || '',
-            rolusuario: window.currentRole || '',
-            referencia: 'PREMIO',
-            sorteoId: currentSorteoId,
-            sorteoNombre,
-            rolInterno: '',
-            rolinterno: ''
-          }, { merge: true });
-        }
+          userId,
+          email,
+          monto: Number(creditos) || 0,
+          cartonesGratis: Number(cartonesGratis) || 0,
+          eventoGanadorId
+        })
       });
+      if(!response.ok){
+        const data = await response.json().catch(()=>({}));
+        throw new Error(data?.error || `HTTP ${response.status}`);
+      }
       premiosAutomaticosProcesados.add(premioId);
     } catch (err) {
       console.error('Error acreditando premio automático', err);

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -277,6 +277,75 @@ async function verificarToken(req, res, next) {
   }
 }
 
+async function verificarOperadorPrivilegiado(req, res, next) {
+  const authHeader = req.headers.authorization || '';
+  const match = authHeader.match(/^Bearer (.+)$/);
+  if (!match) {
+    return res.status(401).json({ error: 'No autorizado' });
+  }
+
+  let decoded;
+  try {
+    decoded = await admin.auth().verifyIdToken(match[1]);
+  } catch (e) {
+    console.error('Error verificando token', e);
+    return res.status(401).json({ error: 'Token inválido' });
+  }
+
+  const email = decoded.email;
+  if (!email) {
+    return res.status(401).json({ error: 'Token sin correo asociado' });
+  }
+
+  try {
+    const doc = await admin.firestore().collection('users').doc(email).get();
+    const role = doc.exists ? doc.data().role : undefined;
+    if (!['Superadmin', 'Administrador', 'Colaborador'].includes(role)) {
+      return res.status(403).json({ error: 'Acceso restringido a operadores autorizados' });
+    }
+    req.user = { uid: decoded.uid, email, role };
+    next();
+  } catch (e) {
+    console.error('Error obteniendo el rol del usuario', e);
+    return res.status(500).json({ error: 'Error verificando permisos', message: e.message });
+  }
+}
+
+function normalizeString(value, maxLength = 200) {
+  return typeof value === 'string' ? value.trim().slice(0, maxLength) : '';
+}
+
+function normalizeNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function buildPremioDocId({ sorteoId, formaIdx, cartonId, prefijo = '' }) {
+  const sanitize = (value) => normalizeString(String(value || ''), 120).replace(/[^\w-]/g, '_');
+  const baseId = `${sanitize(sorteoId)}__f${sanitize(formaIdx)}__${sanitize(cartonId)}`;
+  return prefijo ? `${sanitize(prefijo)}__${baseId}` : baseId;
+}
+
+function normalizeSorteoState(value) {
+  return normalizeString(String(value || ''), 40).toUpperCase();
+}
+
+function canAccreditForSorteoState(value) {
+  const allowed = new Set(['JUGANDO', 'FINALIZADO']);
+  return allowed.has(normalizeSorteoState(value));
+}
+
+function getBilleteraCandidates({ userEmail, cartonData, payloadUserId }) {
+  const values = [
+    normalizeString(userEmail, 160).toLowerCase(),
+    normalizeString(payloadUserId, 160).toLowerCase(),
+    normalizeString(cartonData?.email, 160).toLowerCase(),
+    normalizeString(cartonData?.gmail, 160).toLowerCase(),
+    normalizeString(cartonData?.IDbilletera, 160)
+  ].filter(Boolean);
+  return Array.from(new Set(values));
+}
+
 app.post('/toggleUser', verificarToken, async (req, res) => {
   const { email, disabled } = req.body || {};
   if (!email || typeof disabled !== 'boolean') {
@@ -559,6 +628,212 @@ app.post('/admin/purge-sorteo', verificarToken, async (req, res) => {
   }
 });
 
+app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, res) => {
+  const {
+    sorteoId,
+    formaIdx,
+    cartonId,
+    userId,
+    email,
+    monto,
+    cartonesGratis,
+    eventoGanadorId
+  } = req.body || {};
+
+  const normalizedSorteoId = normalizeString(sorteoId, 120);
+  const normalizedCartonId = normalizeString(cartonId, 120);
+  const normalizedFormaIdx = Number.isFinite(Number(formaIdx)) ? Number(formaIdx) : null;
+  const normalizedMonto = Math.max(0, Math.floor(normalizeNumber(monto)));
+  const normalizedCartonesGratis = Math.max(0, Math.floor(normalizeNumber(cartonesGratis)));
+  const normalizedUserId = normalizeString(userId, 160);
+  const normalizedEmail = normalizeString(email, 160).toLowerCase();
+  const normalizedEventoGanadorId = normalizeString(
+    eventoGanadorId,
+    220
+  ) || buildPremioDocId({ sorteoId: normalizedSorteoId, formaIdx: normalizedFormaIdx, cartonId: normalizedCartonId });
+
+  if (!normalizedSorteoId || !normalizedCartonId || normalizedFormaIdx === null || !normalizedEventoGanadorId) {
+    return res.status(400).json({
+      error: 'Entradas inválidas. Se requiere sorteoId, formaIdx, cartonId y eventoGanadorId.'
+    });
+  }
+
+  if (!normalizedMonto && !normalizedCartonesGratis) {
+    return res.status(400).json({ error: 'Debe existir monto o cartonesGratis mayor que cero.' });
+  }
+
+  if (!normalizedEmail && !normalizedUserId) {
+    return res.status(400).json({ error: 'Se requiere userId o email.' });
+  }
+
+  const db = admin.firestore();
+  const timestamp = admin.firestore.FieldValue.serverTimestamp();
+
+  try {
+    const result = await db.runTransaction(async (tx) => {
+      const sorteoRef = db.collection('sorteos').doc(normalizedSorteoId);
+      const cartonRef = db.collection('CartonJugado').doc(normalizedCartonId);
+      const premioRef = db.collection('PremiosSorteos').doc(normalizedEventoGanadorId);
+      const transaccionRef = db.collection('transacciones').doc(`premio_${normalizedEventoGanadorId}`);
+
+      const [sorteoSnap, cartonSnap, premioSnap, transaccionSnap] = await Promise.all([
+        tx.get(sorteoRef),
+        tx.get(cartonRef),
+        tx.get(premioRef),
+        tx.get(transaccionRef)
+      ]);
+
+      if (!sorteoSnap.exists) {
+        throw new Error('SORTEO_NO_EXISTE');
+      }
+
+      const sorteoData = sorteoSnap.data() || {};
+      if (!canAccreditForSorteoState(sorteoData.estado)) {
+        throw new Error('SORTEO_ESTADO_INVALIDO');
+      }
+
+      if (!cartonSnap.exists) {
+        throw new Error('CARTON_NO_EXISTE');
+      }
+
+      const cartonData = cartonSnap.data() || {};
+      const cartonSorteoId = normalizeString(cartonData.sorteoId, 120);
+      if (cartonSorteoId !== normalizedSorteoId) {
+        throw new Error('CARTON_NO_PERTENECE_SORTEO');
+      }
+
+      const premioActual = premioSnap.exists ? premioSnap.data() || {} : null;
+      const estadoPremio = normalizeSorteoState(premioActual?.estado);
+      if (estadoPremio === 'REALIZADO' || estadoPremio === 'APROBADO') {
+        return { status: 'ok', idempotent: true, premioId: normalizedEventoGanadorId };
+      }
+
+      const billeteraCandidates = getBilleteraCandidates({
+        userEmail: normalizedEmail,
+        payloadUserId: normalizedUserId,
+        cartonData
+      });
+      if (!billeteraCandidates.length) {
+        throw new Error('BILLETERA_NO_IDENTIFICABLE');
+      }
+
+      let billeteraRef = db.collection('Billetera').doc(billeteraCandidates[0]);
+      let billeteraSnap = null;
+      for (const billeteraId of billeteraCandidates) {
+        const candidateRef = db.collection('Billetera').doc(billeteraId);
+        const candidateSnap = await tx.get(candidateRef);
+        if (candidateSnap.exists) {
+          billeteraRef = candidateRef;
+          billeteraSnap = candidateSnap;
+          break;
+        }
+      }
+      if (!billeteraSnap) {
+        billeteraSnap = await tx.get(billeteraRef);
+      }
+
+      const billeteraActual = billeteraSnap.exists ? billeteraSnap.data() || {} : {};
+      const nuevosCreditos = normalizeNumber(billeteraActual.creditos) + normalizedMonto;
+      const nuevosCartones = normalizeNumber(billeteraActual.CartonesGratis) + normalizedCartonesGratis;
+      const sorteoNombre = normalizeString(sorteoData.nombre, 200);
+      const fecha = new Date();
+      const fechaGestion = fecha.toISOString().slice(0, 10).split('-').reverse().join('/');
+      const horaGestion = fecha.toTimeString().slice(0, 5);
+
+      tx.set(
+        premioRef,
+        {
+          sorteoId: normalizedSorteoId,
+          sorteoNombre,
+          email: normalizedEmail || billeteraRef.id,
+          gmail: normalizedEmail || billeteraRef.id,
+          userId: normalizedUserId || cartonData.userId || null,
+          cartonId: normalizedCartonId,
+          formaIdx: normalizedFormaIdx,
+          creditos: normalizedMonto,
+          creditosGanados: normalizedMonto,
+          cartonesGratis: normalizedCartonesGratis,
+          eventoGanadorId: normalizedEventoGanadorId,
+          winnerKey: normalizedEventoGanadorId,
+          idBilletera: billeteraRef.id,
+          estado: 'REALIZADO',
+          actualizadoEn: timestamp,
+          fechaRegistro: premioActual?.fechaRegistro || timestamp,
+          creadoEn: premioActual?.creadoEn || timestamp,
+          fechaGanado: timestamp,
+          generadoDesde: 'backend/acreditarPremioEvento',
+          gestionadoPor: req.user?.email || '',
+          rolGestor: req.user?.role || '',
+          fechaGestion,
+          horaGestion
+        },
+        { merge: true }
+      );
+
+      tx.set(
+        billeteraRef,
+        {
+          creditos: nuevosCreditos,
+          CartonesGratis: nuevosCartones,
+          actualizadoEn: timestamp
+        },
+        { merge: true }
+      );
+
+      if (!transaccionSnap.exists) {
+        tx.set(
+          transaccionRef,
+          {
+            tipotrans: 'premio',
+            origen: 'premios_jugadores',
+            Monto: normalizedMonto > 0 ? normalizedMonto : normalizedCartonesGratis,
+            cartonesGratis: normalizedCartonesGratis,
+            estado: 'REALIZADO',
+            IDbilletera: billeteraRef.id,
+            fechasolicitud: '',
+            horasolicitud: '',
+            fechagestion: fechaGestion,
+            horagestion: horaGestion,
+            usuariogestor: req.user?.email || '',
+            rolusuario: req.user?.role || '',
+            referencia: 'PREMIO',
+            sorteoId: normalizedSorteoId,
+            sorteoNombre,
+            eventoGanadorId: normalizedEventoGanadorId,
+            creadoEn: timestamp
+          },
+          { merge: true }
+        );
+      }
+
+      return {
+        status: 'ok',
+        idempotent: false,
+        premioId: normalizedEventoGanadorId,
+        billeteraId: billeteraRef.id
+      };
+    });
+
+    return res.json(result);
+  } catch (error) {
+    if (error.message === 'SORTEO_NO_EXISTE') {
+      return res.status(404).json({ error: 'No existe el sorteo indicado.' });
+    }
+    if (error.message === 'SORTEO_ESTADO_INVALIDO') {
+      return res.status(409).json({ error: 'El sorteo no está en estado elegible para acreditar premios.' });
+    }
+    if (error.message === 'CARTON_NO_EXISTE' || error.message === 'CARTON_NO_PERTENECE_SORTEO') {
+      return res.status(409).json({ error: 'El cartón no es elegible para el sorteo indicado.' });
+    }
+    if (error.message === 'BILLETERA_NO_IDENTIFICABLE') {
+      return res.status(409).json({ error: 'No se pudo resolver la billetera destino del premio.' });
+    }
+
+    console.error('Error acreditando premio por evento', error);
+    return res.status(500).json({ error: 'Error acreditando premio', message: error.message });
+  }
+});
+
 app.post('/upload', verificarToken, upload.single('file'), async (req, res) => {
   if (!req.file) {
     registrarAuditoria({ email: req.user?.email, result: 'rechazado', reason: 'Archivo requerido' });
@@ -644,5 +919,7 @@ module.exports = {
   deleteDocumentById,
   countCollectionBySorteoId,
   countDocumentById,
-  getPurgeCounts
+  getPurgeCounts,
+  canAccreditForSorteoState,
+  buildPremioDocId
 };


### PR DESCRIPTION
### Motivation
- Garantizar un flujo server-side para acreditar premios de sorteo de forma inmutable y idempotente, evitando escrituras directas desde el cliente que puedan generar condiciones de carrera o manipulación.
- Sustituir la lógica de acreditación local en `cantarsorteos` por una llamada autenticada al backend para centralizar validaciones y transacciones atómicas.

### Description
- Se añadió el endpoint `POST /acreditarPremioEvento` en `uploadServer.js` con middleware `verificarOperadorPrivilegiado`, normalización de entradas y validaciones mínimas (`sorteoId`, `formaIdx`, `cartonId`, `userId/email`, `monto` o `cartonesGratis`, `eventoGanadorId`).
- La acreditación se ejecuta dentro de una `runTransaction` atómica e idempotente que hace `upsert` en `PremiosSorteos`, actualiza `Billetera` y crea la `transacciones` si no existe; además resuelve candidatos de billetera y valida estado del sorteo y pertenencia del cartón.
- Se actualizó `public/cantarsorteos.html` para reemplazar la lógica local de `acreditarPremioAutomatico` por una llamada autenticada al nuevo endpoint (`/acreditarPremioEvento`) usando el token de Firebase.
- Se modificaron las reglas en `firestore.rules` para añadir un candado de producción (`Variablesglobales/Parametros.bloquearEscriturasClientePremios`) que deshabilita escrituras cliente directas sobre `PremiosSorteos`, `Billetera` y `transacciones` (permitiendo solo `isSystemRequest`).
- Se añadieron utilidades y tests unitarios en `__tests__/uploadServer-acreditar-utils.test.js` para `canAccreditForSorteoState` y `buildPremioDocId` y se exportaron las utilidades relevantes desde `uploadServer.js`.

### Testing
- Se ejecutó `npm test -- --runInBand` y todos los tests pasaron (`9 suites`, `27 tests` pasando).
- Se verificó la sintaxis de servidor con `node --check uploadServer.js` sin errores.
- Las reglas `firestore.rules` no se pueden validar con `node --check` en este entorno porque no es un fichero JS; revisar con las herramientas de Firebase antes de desplegar en producción.
- Resultado de los tests y comprobaciones: todos los tests automatizados añadidos y existentes pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997be7044c8832693c8a2439977d8af)