### PR TITLE
Unificar contrato de estados para premios y pagos

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -1753,12 +1753,25 @@
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
+  <script src="js/estadoPagoPremio.js"></script>
   <script>
   ensureAuth('Administrador');
   initServerTime().then(()=>{
     inicializarFechaHoraFooter();
     iniciarActualizacionesActuales();
   });
+
+  function normalizarEstadoPagoPremio(valor){
+    return window.EstadosPagoPremio.normalizarLectura(valor);
+  }
+
+  function validarEstadoPagoPremio(estado, contexto){
+    return window.EstadosPagoPremio.validarParaGuardar(estado, contexto);
+  }
+
+  function estadoPagoPremioFinalizado(valor){
+    return window.EstadosPagoPremio.estaFinalizado(valor);
+  }
 
   let sorteos = [];
   let currentSorteoId = null;
@@ -4372,9 +4385,8 @@
   async function existeEventoGanadorFinalizado(eventoGanadorId){
     const eventoSeguro = sanitizarId(eventoGanadorId || '');
     if(!eventoSeguro) return false;
-    const estadosFinales = new Set(['REALIZADO', 'APROBADO']);
     const snapshot = await db.collection('PremiosSorteos').where('eventoGanadorId', '==', eventoSeguro).get();
-    return snapshot.docs.some(doc=>estadosFinales.has((doc.data()?.estado || '').toString().trim().toUpperCase()));
+    return snapshot.docs.some(doc=>estadoPagoPremioFinalizado(doc.data()?.estado));
   }
 
   function construirIdPremioSegundoLugar(sorteoId, formaIdx, cartonId){
@@ -4502,8 +4514,8 @@
       await db.runTransaction(async tx => {
         const premioSnap = await tx.get(premioRef);
         if(premioSnap.exists){
-          const estadoActual = (premioSnap.data()?.estado || '').toString().trim().toUpperCase();
-          if(estadoActual === 'REALIZADO' || estadoActual === 'APROBADO'){
+          const estadoActual = normalizarEstadoPagoPremio(premioSnap.data()?.estado);
+          if(estadoActual === 'REALIZADO'){
             return;
           }
         }
@@ -4541,7 +4553,7 @@
             nombre: forma?.nombre || '',
             cartonesGratis: Number(cartonesGratis) || 0
           }],
-          estado: 'REALIZADO',
+          estado: validarEstadoPagoPremio('REALIZADO', `PremiosSorteos:${premioId}`),
           fechaGanado: timestamp,
           fechaRegistro: timestamp,
           creadoEn: timestamp,
@@ -4572,7 +4584,7 @@
             origen: 'premios_segundo_lugar',
             Monto: cartonesNumero,
             cartonesGratis: cartonesNumero,
-            estado: 'REALIZADO',
+            estado: validarEstadoPagoPremio('REALIZADO', `PremiosSorteos:${premioId}`),
             IDbilletera: idBilleteraFinal,
             fechasolicitud: '',
             horasolicitud: '',

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -645,6 +645,7 @@
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
+  <script src="js/estadoPagoPremio.js"></script>
   <script>
     ensureAuth('Administrador');
     initServerTime();
@@ -1495,8 +1496,11 @@
           const snap = await tx.get(ref);
           if(snap.exists){
             const data = snap.data() || {};
-            const estadoActual = (data.estado || '').toString().trim().toUpperCase();
+            const estadoActual = normalizarEstado(data.estado);
             if(estadoActual === 'REALIZADO'){ return; }
+          }
+          if(payload && Object.prototype.hasOwnProperty.call(payload, 'estado')){
+            payload.estado = validarEstadoGuardado(payload.estado, `CentroPagos:${ref.path}`);
           }
           tx.set(ref, payload, { merge: true });
         });
@@ -1531,7 +1535,7 @@
           cartonesGratis: Number(ganador.cartonesGratis) || 0,
           cartonesGanados: Number(ganador.cartonesGanadores) || 0,
           formasGanadoras: ganador.formas || [],
-          estado: 'PENDIENTE',
+            estado: validarEstadoGuardado('PENDIENTE', `PremiosSorteos:${docId}`),
           fechaGanado: timestamp,
           fechaRegistro: timestamp,
           creadoEn: timestamp,
@@ -1558,7 +1562,7 @@
           nombre: administrativo.nombre || administrativo.alias || '',
           alias: administrativo.alias || '',
           creditos: Number(administrativo.creditos) || 0,
-          estado: 'PENDIENTE',
+            estado: validarEstadoGuardado('PENDIENTE', `PagosAdministracion:${docId}`),
           fechaAsignacion: timestamp,
           fecha: timestamp,
           creadoEn: timestamp,
@@ -1697,10 +1701,15 @@
     }
 
     function normalizarEstado(valor){
-      const texto = (valor || '').toString().trim().toUpperCase();
-      if(texto === 'APROBADO') return 'REALIZADO';
-      if(texto === 'REALIZADO' || texto === 'PENDIENTE' || texto === 'ARCHIVADO') return texto;
-      return 'PENDIENTE';
+      return window.EstadosPagoPremio.normalizarLectura(valor);
+    }
+
+    function validarEstadoGuardado(estado, contexto){
+      return window.EstadosPagoPremio.validarParaGuardar(estado, contexto);
+    }
+
+    function esEstadoPendiente(valor){
+      return normalizarEstado(valor) === 'PENDIENTE';
     }
 
     async function actualizarIndicadorPagosSorteo(sorteoId){
@@ -1712,8 +1721,8 @@
           db.collection('PremiosSorteos').where('sorteoId', '==', sorteoId).get(),
           db.collection('PagosAdministracion').where('sorteoId', '==', sorteoId).get()
         ]);
-        const hayPremiosPendientes = premiosSnap.docs.some(doc=>normalizarEstado(doc.data()?.estado) !== 'REALIZADO');
-        const hayPagosPendientes = pagosSnap.docs.some(doc=>normalizarEstado(doc.data()?.estado) !== 'REALIZADO');
+        const hayPremiosPendientes = premiosSnap.docs.some(doc=>esEstadoPendiente(doc.data()?.estado));
+        const hayPagosPendientes = pagosSnap.docs.some(doc=>esEstadoPendiente(doc.data()?.estado));
         const indicadorCompletado = !hayPremiosPendientes && !hayPagosPendientes;
         const payload = {
           pagosCentroAprobados: indicadorCompletado,
@@ -2076,13 +2085,13 @@
         premiosActivos.forEach(registro => {
           if(!registro.sorteoId) return;
           const info = estadoPorSorteo.get(registro.sorteoId) || { pendientesPremios: 0, pendientesPagos: 0 };
-          if(registro.estado !== 'REALIZADO'){ info.pendientesPremios = (info.pendientesPremios || 0) + 1; }
+          if(esEstadoPendiente(registro.estado)){ info.pendientesPremios = (info.pendientesPremios || 0) + 1; }
           estadoPorSorteo.set(registro.sorteoId, info);
         });
         pagosAdminActivos.forEach(registro => {
           if(!registro.sorteoId) return;
           const info = estadoPorSorteo.get(registro.sorteoId) || { pendientesPremios: 0, pendientesPagos: 0 };
-          if(registro.estado !== 'REALIZADO'){ info.pendientesPagos = (info.pendientesPagos || 0) + 1; }
+          if(esEstadoPendiente(registro.estado)){ info.pendientesPagos = (info.pendientesPagos || 0) + 1; }
           estadoPorSorteo.set(registro.sorteoId, info);
         });
         premiosArchivados.forEach(registro => {
@@ -2150,7 +2159,7 @@
           tipotrans: tipoTransaccion,
           origen,
           Monto: monto,
-          estado: 'REALIZADO',
+          estado: validarEstadoGuardado('REALIZADO', 'TransaccionPremio'),
           IDbilletera: enRegistro.billetera,
           fechasolicitud: '',
           horasolicitud: '',
@@ -2225,7 +2234,7 @@
             const estadoActual = normalizarEstado(data.estado);
             if(estadoActual === 'REALIZADO') return;
             tx.update(ref, {
-              estado: 'REALIZADO',
+              estado: validarEstadoGuardado('REALIZADO', `PremiosSorteos:${id}`),
               fechaGestion: fechaServidor(),
               horaGestion: horaServidor(),
               gestionadoPor: authInstance().currentUser?.email || '',
@@ -2269,7 +2278,7 @@
             const estadoActual = normalizarEstado(data.estado);
             if(estadoActual === 'REALIZADO') return;
             tx.update(ref, {
-              estado: 'REALIZADO',
+              estado: validarEstadoGuardado('REALIZADO', `PagosAdministracion:${id}`),
               fechaGestion: fechaServidor(),
               horaGestion: horaServidor(),
               gestionadoPor: authInstance().currentUser?.email || '',
@@ -2394,7 +2403,7 @@
             const data = snap.data();
             const datosArchivo = {
               ...data,
-              estado: normalizarEstado(data.estado),
+              estado: validarEstadoGuardado('ARCHIVADO', `${tipo}:${id}`),
               archivadoEn: fechaServidor(),
               horaArchivado: horaServidor(),
               archivadoPor: authInstance().currentUser?.email || ''

--- a/public/js/estadoPagoPremio.js
+++ b/public/js/estadoPagoPremio.js
@@ -1,0 +1,56 @@
+(function initEstadoPagoPremio(global){
+  const ESTADOS_CANONICOS = Object.freeze({
+    PENDIENTE: 'PENDIENTE',
+    REALIZADO: 'REALIZADO',
+    ARCHIVADO: 'ARCHIVADO'
+  });
+
+  const ALIAS_LECTURA = Object.freeze({
+    APROBADO: ESTADOS_CANONICOS.REALIZADO
+  });
+
+  function normalizarTexto(valor){
+    return (valor || '').toString().trim().toUpperCase();
+  }
+
+  function normalizarLectura(valor, fallback = ESTADOS_CANONICOS.PENDIENTE){
+    const texto = normalizarTexto(valor);
+    if(!texto) return fallback;
+    if(Object.prototype.hasOwnProperty.call(ESTADOS_CANONICOS, texto)){
+      return ESTADOS_CANONICOS[texto];
+    }
+    if(Object.prototype.hasOwnProperty.call(ALIAS_LECTURA, texto)){
+      return ALIAS_LECTURA[texto];
+    }
+    return fallback;
+  }
+
+  function esCanonico(valor){
+    const texto = normalizarTexto(valor);
+    return Boolean(texto && Object.prototype.hasOwnProperty.call(ESTADOS_CANONICOS, texto));
+  }
+
+  function validarParaGuardar(valor, contexto = ''){
+    const texto = normalizarTexto(valor);
+    if(!esCanonico(texto)){
+      const sufijo = contexto ? ` en ${contexto}` : '';
+      throw new Error(`Estado no reconocido${sufijo}: ${valor}`);
+    }
+    return ESTADOS_CANONICOS[texto];
+  }
+
+  function estaFinalizado(valor){
+    return normalizarLectura(valor) === ESTADOS_CANONICOS.REALIZADO;
+  }
+
+  const api = Object.freeze({
+    ESTADOS_CANONICOS,
+    ALIAS_LECTURA,
+    normalizarLectura,
+    esCanonico,
+    validarParaGuardar,
+    estaFinalizado
+  });
+
+  global.EstadosPagoPremio = api;
+})(window);

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1398,6 +1398,7 @@
   <script src="js/logoSwitcher.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
+  <script src="js/estadoPagoPremio.js"></script>
   <script>
   ensureAuth('Administrador');
 
@@ -1428,6 +1429,18 @@
   const orientacionModal = document.getElementById('orientacion-modal');
   const orientacionAceptarBtn = document.getElementById('orientacion-modal-aceptar');
   let generarPdfTrasOrientacion = false;
+
+  function normalizarEstadoPagoPremio(valor){
+    return window.EstadosPagoPremio.normalizarLectura(valor);
+  }
+
+  function validarEstadoPagoPremio(estado, contexto){
+    return window.EstadosPagoPremio.validarParaGuardar(estado, contexto);
+  }
+
+  function estadoPagoPremioFinalizado(valor){
+    return window.EstadosPagoPremio.estaFinalizado(valor);
+  }
 
   let sorteoData = null;
   let formasData = [];
@@ -1929,9 +1942,8 @@
   async function existeEventoGanadorFinalizado(eventoGanadorId){
     const eventoSeguro = sanitizarId(eventoGanadorId || '');
     if(!eventoSeguro) return false;
-    const estadosFinales = new Set(['REALIZADO', 'APROBADO']);
     const snapshot = await db.collection('PremiosSorteos').where('eventoGanadorId', '==', eventoSeguro).get();
-    return snapshot.docs.some(doc=>estadosFinales.has((doc.data()?.estado || '').toString().trim().toUpperCase()));
+    return snapshot.docs.some(doc=>estadoPagoPremioFinalizado(doc.data()?.estado));
   }
 
   async function actualizarDocumentoCentroPagos(ref, payload){
@@ -1940,10 +1952,13 @@
         const snap = await tx.get(ref);
         if(snap.exists){
           const data = snap.data() || {};
-          const estadoActual = (data.estado || '').toString().trim().toUpperCase();
-          if(estadoActual === 'APROBADO'){
+          const estadoActual = normalizarEstadoPagoPremio(data.estado);
+          if(estadoActual === 'REALIZADO'){
             return;
           }
+        }
+        if(payload && Object.prototype.hasOwnProperty.call(payload, 'estado')){
+          payload.estado = validarEstadoPagoPremio(payload.estado, `CentroPagos:${ref.path}`);
         }
         tx.set(ref, payload, { merge: true });
       });
@@ -1972,7 +1987,7 @@
     await db.runTransaction(async tx => {
       const premioSnap = await tx.get(premioRef);
       const premioPrevio = premioSnap.exists ? (premioSnap.data() || {}) : {};
-      if((premioPrevio.estado || '').toString().trim().toUpperCase() === 'APROBADO' && premioPrevio.acreditadoAutomaticamente){
+      if(estadoPagoPremioFinalizado(premioPrevio.estado) && premioPrevio.acreditadoAutomaticamente){
         return;
       }
 
@@ -2008,7 +2023,7 @@
         cartonesGratis,
         cartonesGanados: Number(ganador.cartonesGanadores) || 0,
         formasGanadoras: ganador.formas || [],
-        estado: 'APROBADO',
+        estado: validarEstadoPagoPremio('REALIZADO', `PremiosSorteos:${docId}`),
         fechaGanado: timestamp,
         fechaRegistro: timestamp,
         creadoEn: premioPrevio.creadoEn || timestamp,
@@ -2036,7 +2051,7 @@
           origen: 'premios_jugadores',
           Monto: creditos > 0 ? creditos : cartonesGratis,
           cartonesGratis,
-          estado: 'APROBADO',
+          estado: validarEstadoPagoPremio('REALIZADO', `transacciones:premio_${docId}`),
           IDbilletera: idBilleteraFinal,
           fechasolicitud: '',
           horasolicitud: '',
@@ -2127,7 +2142,7 @@
         nombre: administrativo.nombre || administrativo.alias || '',
         alias: administrativo.alias || '',
         creditos: Number(administrativo.creditos) || 0,
-        estado: 'PENDIENTE',
+        estado: validarEstadoPagoPremio('PENDIENTE', `PagosAdministracion:${docId}`),
         fechaAsignacion: timestamp,
         fecha: timestamp,
         creadoEn: timestamp,
@@ -2151,7 +2166,7 @@
         nombre: colaborador.nombre || colaborador.alias || '',
         alias: colaborador.alias || '',
         creditos: Number(colaborador.creditos) || 0,
-        estado: 'PENDIENTE',
+        estado: validarEstadoPagoPremio('PENDIENTE', `PagosAdministracion:${docId}`),
         fechaAsignacion: timestamp,
         fecha: timestamp,
         creadoEn: timestamp,


### PR DESCRIPTION
### Motivation
- Unificar y estandarizar el manejo de estados de premios y pagos para evitar escrituras con variantes legacy y asegurar un único conjunto canónico de valores.
- Mantener compatibilidad de lectura con estados históricos (p.ej. `APROBADO`) mientras se fuerza escritura solo con estados canónicos.

### Description
- Se agregó un contrato central en `public/js/estadoPagoPremio.js` que define estados canónicos (`PENDIENTE`, `REALIZADO`, `ARCHIVADO`), mapeos de lectura backward-compatible (`APROBADO -> REALIZADO`) y utilidades de normalización y validación (`normalizarLectura`, `validarParaGuardar`, `estaFinalizado`).
- Se integró el contrato en las vistas y flujos de Centro de Pagos, PDF de resultados y canto de sorteos (`public/centropagos.html`, `public/pdfresultados.html`, `public/cantarsorteos.html`) reemplazando normalizaciones locales y usando la API central para lectura y validación en escritura.
- Las escrituras ahora usan únicamente estados canónicos mediante llamadas a la función de validación antes de `set`/`update`, y las comprobaciones de finalización se realizan con la normalización central manteniendo compatibilidad histórica.
- Se actualizó la lógica de indicadores y conteos (p.ej. `pagosCentroAprobados`, badges y reconciliación de pendientes) para calcular pendientes sobre el estado normalizado único; además se añadió rechazo explícito al intentar guardar estados no reconocidos.

### Testing
- Ejecuté `npm test -- --runInBand` y todos los suites de Jest pasaron correctamente (9 suites, 27 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997c019f8048326967bc3a9467b6666)