### PR TITLE
Estandariza estados de premios/transacciones y unifica interpretación en UI

### DIFF
--- a/__tests__/estadoPagoPremio-normalizacion.test.js
+++ b/__tests__/estadoPagoPremio-normalizacion.test.js
@@ -1,0 +1,19 @@
+const EstadosPagoPremio = require('../public/js/estadoPagoPremio.js');
+
+describe('EstadosPagoPremio normalización e interpretación', () => {
+  test('normaliza APROBADO como REALIZADO en lectura', () => {
+    expect(EstadosPagoPremio.normalizarLectura('APROBADO')).toBe('REALIZADO');
+    expect(EstadosPagoPremio.normalizarLectura('realizado')).toBe('REALIZADO');
+  });
+
+  test('estaFinalizado reconoce APROBADO y REALIZADO', () => {
+    expect(EstadosPagoPremio.estaFinalizado('APROBADO')).toBe(true);
+    expect(EstadosPagoPremio.estaFinalizado('REALIZADO')).toBe(true);
+    expect(EstadosPagoPremio.estaFinalizado('PENDIENTE')).toBe(false);
+  });
+
+  test('validarParaGuardar solo permite estados canónicos', () => {
+    expect(EstadosPagoPremio.validarParaGuardar('REALIZADO')).toBe('REALIZADO');
+    expect(() => EstadosPagoPremio.validarParaGuardar('APROBADO')).toThrow(/Estado no reconocido/);
+  });
+});

--- a/public/billetera.html
+++ b/public/billetera.html
@@ -595,6 +595,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/logoSwitcher.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/estadoPagoPremio.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
@@ -1831,6 +1832,14 @@
     }
 
 
+    function normalizarEstadoPremioTransaccion(valor){
+      if(window.EstadosPagoPremio && typeof window.EstadosPagoPremio.normalizarLectura==='function'){
+        return window.EstadosPagoPremio.normalizarLectura(valor, (valor||'').toString().trim().toUpperCase());
+      }
+      const texto=(valor||'').toString().trim().toUpperCase();
+      return texto==='APROBADO'?'REALIZADO':texto;
+    }
+
   function procesarSnapshotTransacciones(snap){
       transacciones.length=0;
       snap.forEach(doc=>{
@@ -1838,7 +1847,7 @@
         data.fechasolicitud=formatearFecha(data.fechasolicitud);
         data.fechagestion=formatearFecha(data.fechagestion);
         const tipoNormalizado = normalizarTipoTransaccion(data);
-        const estadoNormalizado = (data.estado||'').toString().trim().toUpperCase()==='APROBADO' ? 'REALIZADO' : (data.estado||'');
+        const estadoNormalizado = normalizarEstadoPremioTransaccion(data.estado || '');
         transacciones.push({id:doc.id,...data, estado: estadoNormalizado, tipotrans: tipoNormalizado});
       });
       transacciones.sort((a,b)=>{
@@ -1877,7 +1886,7 @@
         if(monto && parseFloat(t.Monto)!=parseFloat(monto)) return;
         const f=formatearFecha(t.estado==='PENDIENTE'?t.fechasolicitud:t.fechagestion);
         if(fecha && f!==fecha) return;
-        if(estado && t.estado!==estado) return;
+        if(estado && normalizarEstadoPremioTransaccion(t.estado)!==normalizarEstadoPremioTransaccion(estado)) return;
         const estadoColor=t.estado==='PENDIENTE'?'orange':t.estado==='ANULADO'?'red':t.estado==='REALIZADO'?'green':'black';
         const tr=document.createElement('tr');
         const montoFmt=parseFloat(t.Monto).toFixed(2).replace(/\.00$/, '').replace(/(\.\d)0$/, '$1');

--- a/public/js/estadoPagoPremio.js
+++ b/public/js/estadoPagoPremio.js
@@ -1,4 +1,11 @@
-(function initEstadoPagoPremio(global){
+(function initEstadoPagoPremio(root, factory){
+  if(typeof module === 'object' && module.exports){
+    module.exports = factory();
+    return;
+  }
+  const api = factory();
+  root.EstadosPagoPremio = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function crearEstadoPagoPremio(){
   const ESTADOS_CANONICOS = Object.freeze({
     PENDIENTE: 'PENDIENTE',
     REALIZADO: 'REALIZADO',
@@ -43,7 +50,7 @@
     return normalizarLectura(valor) === ESTADOS_CANONICOS.REALIZADO;
   }
 
-  const api = Object.freeze({
+  return Object.freeze({
     ESTADOS_CANONICOS,
     ALIAS_LECTURA,
     normalizarLectura,
@@ -51,6 +58,4 @@
     validarParaGuardar,
     estaFinalizado
   });
-
-  global.EstadosPagoPremio = api;
-})(window);
+});

--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -65,6 +65,13 @@
     return (estado || '').toString().trim().toUpperCase();
   }
 
+  function estadoPremioNormalizado(estado){
+    if(window.EstadosPagoPremio && typeof window.EstadosPagoPremio.normalizarLectura === 'function'){
+      return window.EstadosPagoPremio.normalizarLectura(estado);
+    }
+    return estadoNormalizado(estado) === 'APROBADO' ? 'REALIZADO' : estadoNormalizado(estado);
+  }
+
   function historialVacio(){
     const base = {};
     Object.keys(HISTORIAL_FABRICAS).forEach(clave => {
@@ -737,11 +744,12 @@
             snapshot.docChanges().forEach(cambio => {
               const data = cambio.doc.data() || {};
               const tipo = normalizarTipoRecarga(data.tipotrans);
-              const estado = (data.estado || '').toUpperCase();
+              const estado = estadoNormalizado(data.estado);
+              const estadoPremio = estadoPremioNormalizado(data.estado);
               if(tipo === 'recarga' && (estado === 'APROBADO' || estado === 'ANULADO')){
                 this.notificarCambioRecarga(cambio.doc.id, { ...data, tipotrans: tipo }, estado);
               }
-              if(tipo === 'premio' && estado === 'APROBADO'){
+              if(tipo === 'premio' && estadoPremio === 'REALIZADO'){
                 this.notificarPremio(cambio.doc.id, data);
               }
             });

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -178,6 +178,7 @@
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-auth-compat.js"></script>
   <script src="js/logoSwitcher.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/estadoPagoPremio.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script>
@@ -360,7 +361,21 @@
       badgeRet.style.display=pendientesRet?'inline-flex':'none';
     }
     function abreviar(mail){return mail.split('@')[0];}
-    function estadoColor(e){return e==='APROBADO'?'green':e==='ANULADO'?'red':'orange';}
+    function estadoNormalizadoComparable(valor){
+      const texto=(valor||'').toString().trim().toUpperCase();
+      if(window.EstadosPagoPremio && typeof window.EstadosPagoPremio.normalizarLectura==='function'){
+        return window.EstadosPagoPremio.normalizarLectura(texto, texto || 'PENDIENTE');
+      }
+      return texto==='APROBADO'?'REALIZADO':texto;
+    }
+    function estadoEsAprobado(valor){
+      const estado=estadoNormalizadoComparable(valor);
+      return estado==='REALIZADO' || estado==='APROBADO';
+    }
+    function estadoColor(e){
+      if(estadoEsAprobado(e)) return 'green';
+      return e==='ANULADO'?'red':'orange';
+    }
     async function mostrarInfoGmail(mail){
       const overlay=document.createElement('div');
       Object.assign(overlay.style,{position:'fixed',top:0,left:0,right:0,bottom:0,background:'rgba(0,0,0,0.5)',display:'flex',alignItems:'center',justifyContent:'center'});
@@ -477,7 +492,7 @@
         if(filtrosRec.banco && (t.bancoreceptor||'')!==filtrosRec.banco)return false;
         if(filtrosRec.ref && !(t.referencia||'').toString().includes(filtrosRec.ref))return false;
         if(filtrosRec.fecha && fecha!==filtrosRec.fecha)return false;
-        if(filtrosRec.estado && t.estado!==filtrosRec.estado)return false;
+        if(filtrosRec.estado && estadoNormalizadoComparable(t.estado)!==estadoNormalizadoComparable(filtrosRec.estado))return false;
         return true;
       });
       let i=visibles.length;
@@ -521,7 +536,7 @@
         if(filtrosRet.banco && (t.bancoreceptor||'')!==filtrosRet.banco)return false;
         if(filtrosRet.ref && !(t.referencia||'').toString().includes(filtrosRet.ref))return false;
         if(filtrosRet.fecha && fecha!==filtrosRet.fecha)return false;
-        if(filtrosRet.estado && t.estado!==filtrosRet.estado)return false;
+        if(filtrosRet.estado && estadoNormalizadoComparable(t.estado)!==estadoNormalizadoComparable(filtrosRet.estado))return false;
         return true;
       });
       let i=visibles.length;
@@ -568,7 +583,7 @@
         const refTd=c.closest('tr').children[4];
         const id=c.dataset.id;
         const estado=c.dataset.estado;
-        if(c.checked && (estado==='PENDIENTE' || estado==='APROBADO')){
+        if(c.checked && (estado==='PENDIENTE' || estadoEsAprobado(estado))){
           refTd.contentEditable=true;
         }else{
           refTd.contentEditable=false;
@@ -788,7 +803,7 @@
           if(t.estado==='ANULADO'){
             hasAnulado=true;
             chk.checked=false;
-          }else if(t.estado==='APROBADO'){
+          }else if(estadoEsAprobado(t.estado)){
             hasAprobado=true;
             chk.checked=false;
           }else{
@@ -811,7 +826,7 @@
         const invalid=registros.filter(t=>t.estado!=='PENDIENTE');
         if(invalid.length){
           invalid.forEach(t=>document.querySelector(`#tabla-recargas input[data-id="${t.id}"]`).checked=false);
-          const hasAprobado=invalid.some(t=>t.estado==='APROBADO');
+          const hasAprobado=invalid.some(t=>estadoEsAprobado(t.estado));
           alert(hasAprobado?'No se pueden Anular Transacciones APROBADAS':'Solo se pueden Anular Transacciones PENDIENTES');
           return;
         }
@@ -871,7 +886,7 @@
         for(const chk of sel){
           const ref=chk.closest('tr').children[4].textContent.trim();
           const t=datosRet.find(x=>x.id===chk.dataset.id);
-          if(t.estado==='APROBADO'){
+          if(estadoEsAprobado(t.estado)){
             alert('No se pueden aprobar las transacciones APROBADAS');
             chk.checked=false;
           }else if(t.estado==='PENDIENTE'){
@@ -921,7 +936,7 @@
         const invalid=registros.filter(t=>t.estado!=='PENDIENTE');
         if(invalid.length){
           invalid.forEach(t=>document.querySelector(`#tabla-retiros input[data-id="${t.id}"]`).checked=false);
-          const hasAprobado=invalid.some(t=>t.estado==='APROBADO');
+          const hasAprobado=invalid.some(t=>estadoEsAprobado(t.estado));
           alert(hasAprobado?'No se pueden Anular Transacciones APROBADAS':'Solo se pueden Anular Transacciones PENDIENTES');
           actualizarEditable();
           return;

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -7,6 +7,7 @@ const rateLimit = require('express-rate-limit');
 const path = require('path');
 const crypto = require('crypto');
 const admin = require('firebase-admin');
+const EstadosPagoPremio = require('./public/js/estadoPagoPremio.js');
 
 const requiredEnv = ['GOOGLE_APPLICATION_CREDENTIALS', 'FIREBASE_STORAGE_BUCKET'];
 
@@ -328,6 +329,10 @@ function buildPremioDocId({ sorteoId, formaIdx, cartonId, prefijo = '' }) {
 
 function normalizeSorteoState(value) {
   return normalizeString(String(value || ''), 40).toUpperCase();
+}
+
+function normalizePremioTransactionState(value) {
+  return EstadosPagoPremio.normalizarLectura(value);
 }
 
 function canAccreditForSorteoState(value) {
@@ -718,8 +723,8 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
       }
 
       const premioActual = premioSnap.exists ? premioSnap.data() || {} : null;
-      const estadoPremio = normalizeSorteoState(premioActual?.estado);
-      if (estadoPremio === 'REALIZADO' || estadoPremio === 'APROBADO') {
+      const estadoPremio = normalizePremioTransactionState(premioActual?.estado);
+      if (estadoPremio === EstadosPagoPremio.ESTADOS_CANONICOS.REALIZADO) {
         return { status: 'ok', idempotent: true, premioId: normalizedEventoGanadorId };
       }
 


### PR DESCRIPTION
### Motivation
- Unificar la interpretación de estados de premios/transacciones para evitar discrepancias entre `APROBADO` y `REALIZADO` en backend, notificaciones y filtros de UI. 
- Evitar que filtros y reglas de UI oculten o bloqueen premios por diferencias semánticas en el campo `estado`.

### Description
- Añadí un módulo compartido `public/js/estadoPagoPremio.js` que expone la lista canónica de estados (`PENDIENTE`, `REALIZADO`, `ARCHIVADO`), alias de lectura (`APROBADO -> REALIZADO`) y utilidades como `normalizarLectura` y `validarParaGuardar`, con export compatible para navegador y Node. 
- Actualicé `uploadServer.js` para requerir el módulo y usar `normalizePremioTransactionState` (basado en `EstadosPagoPremio.normalizarLectura`) al decidir idempotencia en `/acreditarPremioEvento`, asegurando que `APROBADO` se trate como `REALIZADO` en lectura. 
- Ajusté `public/js/notificationCenter.js` para notificar premios cuando el estado normalizado sea finalizado (`REALIZADO`) usando la normalización centralizada. 
- Modifiqué UI para no filtrar/ocultar premios por diferencias `APROBADO` vs `REALIZADO`: cambios en `public/transacciones.html` y `public/billetera.html` agregando funciones de normalización/comparación de estados y adaptando lógica de color/acciones. 
- Añadí pruebas unitarias `__tests__/estadoPagoPremio-normalizacion.test.js` que verifican normalización, reconocimiento de finalizado y validación de guardado.

### Testing
- Ejecuté las pruebas focales con `npm test -- --runTestsByPath __tests__/estadoPagoPremio-normalizacion.test.js __tests__/uploadServer-acreditar-utils.test.js`, las cuales pasaron pero al ejecutar solo ese subconjunto Jest mostró el umbral global de cobertura; la verificación completa se hizo con el suite completo. 
- Ejecuté el suite completo con `npm test` y todos los tests automatizados pasaron (`10 suites`, `30 tests` pasados). 
- Los cambios están cubiertos por la nueva prueba de normalización y por las utilidades existentes que validan comportamiento de acreditación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997c6b2cf00832696a3217a90ec4d28)