### PR TITLE
Agregar proyección de premios por usuario y usarla en billetera/notificaciones

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -70,6 +70,16 @@ service cloud.firestore {
       match /role/{docId} {
         allow read, write: if isSystemRequest();
       }
+
+      match /premios/{premioId} {
+        allow read: if isOwner(email) || isAdmin();
+        allow write: if isSystemRequest() || isPrivilegedOperator();
+      }
+
+      match /billeteraProyeccion/{docId} {
+        allow read: if isOwner(email) || isAdmin();
+        allow write: if isSystemRequest() || isPrivilegedOperator();
+      }
     }
 
     match /sorteos/{sorteoId} {

--- a/public/billetera.html
+++ b/public/billetera.html
@@ -607,7 +607,11 @@
     let numeroWhatsappDestino='';
     let numeroWhatsappCargado=false;
     let unsubscribeBilletera=null;
+    let unsubscribeBilleteraProyeccion=null;
     let unsubscribeTransacciones=null;
+    let unsubscribePremiosProyeccion=null;
+    const transaccionesPremioProyeccion=new Map();
+    const transaccionesGlobales=new Map();
 
     function toNumberSafe(valor, defecto=0){
       const numero=parseFloat(valor);
@@ -640,6 +644,12 @@
     async function refrescarResumenBilletera(){
       const user=auth.currentUser;
       if(!user) return;
+      const proyeccionRef=db.collection('users').doc(user.email).collection('billeteraProyeccion').doc('resumen');
+      const proyeccionSnap=await proyeccionRef.get();
+      if(proyeccionSnap.exists){
+        actualizarResumenCreditos(proyeccionSnap.data()||{});
+        return;
+      }
       const billeteraRef=db.collection('Billetera').doc(user.email);
       const snap=await billeteraRef.get();
       if(snap.exists){
@@ -670,6 +680,10 @@
     }
 
     function suscribirBilleteraUsuario(){
+      if(unsubscribeBilleteraProyeccion){
+        unsubscribeBilleteraProyeccion();
+        unsubscribeBilleteraProyeccion=null;
+      }
       if(unsubscribeBilletera){
         unsubscribeBilletera();
         unsubscribeBilletera=null;
@@ -677,7 +691,26 @@
       const user=auth.currentUser;
       if(!user?.email) return;
       const billeteraRef=db.collection('Billetera').doc(user.email);
+      const proyeccionRef=db.collection('users').doc(user.email).collection('billeteraProyeccion').doc('resumen');
+      let recibioProyeccion=false;
+
+      unsubscribeBilleteraProyeccion=proyeccionRef.onSnapshot(snap=>{
+        if(snap.exists){
+          recibioProyeccion=true;
+          const data=snap.data()||{};
+          actualizarResumenCreditos(data);
+          if(Object.prototype.hasOwnProperty.call(data,'CartonesGratis')){
+            document.getElementById('cartones-valor').textContent = data.CartonesGratis || 0;
+          }
+        }
+      },error=>{
+        console.error('Error escuchando la proyección de billetera del usuario',error);
+      });
+
       unsubscribeBilletera=billeteraRef.onSnapshot(async snap=>{
+        if(recibioProyeccion){
+          return;
+        }
         if(snap.exists){
           aplicarDatosBilleteraEnPantalla(snap.data()||{});
           return;
@@ -1840,16 +1873,33 @@
       return texto==='APROBADO'?'REALIZADO':texto;
     }
 
-  function procesarSnapshotTransacciones(snap){
+    function normalizarTransaccionParaTabla(id,data){
+      const payload={...(data||{})};
+      payload.fechasolicitud=formatearFecha(payload.fechasolicitud);
+      payload.fechagestion=formatearFecha(payload.fechagestion);
+      const tipoNormalizado = normalizarTipoTransaccion(payload);
+      const estadoNormalizado = normalizarEstadoPremioTransaccion(payload.estado || '');
+      return {id,...payload, estado: estadoNormalizado, tipotrans: tipoNormalizado};
+    }
+
+    function sincronizarTransaccionesEnTabla(){
       transacciones.length=0;
-      snap.forEach(doc=>{
-        const data=doc.data()||{};
-        data.fechasolicitud=formatearFecha(data.fechasolicitud);
-        data.fechagestion=formatearFecha(data.fechagestion);
-        const tipoNormalizado = normalizarTipoTransaccion(data);
-        const estadoNormalizado = normalizarEstadoPremioTransaccion(data.estado || '');
-        transacciones.push({id:doc.id,...data, estado: estadoNormalizado, tipotrans: tipoNormalizado});
+      const premiosEnProyeccion=new Set();
+      transaccionesPremioProyeccion.forEach((valor)=>{
+        transacciones.push(valor);
+        const llave=(valor.eventoGanadorId||valor.winnerKey||valor.id||'').toString();
+        if(llave){ premiosEnProyeccion.add(llave); }
       });
+
+      transaccionesGlobales.forEach((valor)=>{
+        const tipo=(valor.tipotrans||'').toLowerCase();
+        if(tipo==='premio'){
+          const llave=(valor.eventoGanadorId||valor.winnerKey||valor.id||'').toString();
+          if(llave && premiosEnProyeccion.has(llave)) return;
+        }
+        transacciones.push(valor);
+      });
+
       transacciones.sort((a,b)=>{
         const da=parseFechaHora(a.fechagestion||a.fechasolicitud,a.horagestion||a.horasolicitud);
         const db=parseFechaHora(b.fechagestion||b.fechasolicitud,b.horagestion||b.horasolicitud);
@@ -1859,16 +1909,39 @@
     }
 
     function suscribirTransaccionesUsuario(){
+      if(unsubscribePremiosProyeccion){
+        unsubscribePremiosProyeccion();
+        unsubscribePremiosProyeccion=null;
+      }
       if(unsubscribeTransacciones){
         unsubscribeTransacciones();
         unsubscribeTransacciones=null;
       }
+      transaccionesPremioProyeccion.clear();
+      transaccionesGlobales.clear();
+
       const user=auth.currentUser;
       if(!user?.email) return;
-      unsubscribeTransacciones=db.collection('transacciones').where('IDbilletera','==',user.email).onSnapshot(
-        procesarSnapshotTransacciones,
-        error=>{ console.error('Error escuchando transacciones de la billetera',error); }
-      );
+
+      unsubscribePremiosProyeccion=db.collection('users').doc(user.email).collection('premios').onSnapshot(snapshot=>{
+        transaccionesPremioProyeccion.clear();
+        snapshot.forEach(doc=>{
+          const normalizado=normalizarTransaccionParaTabla(doc.id,doc.data()||{});
+          transaccionesPremioProyeccion.set(doc.id,normalizado);
+        });
+        sincronizarTransaccionesEnTabla();
+      },error=>{
+        console.error('Error escuchando la proyección de premios del usuario',error);
+      });
+
+      unsubscribeTransacciones=db.collection('transacciones').where('IDbilletera','==',user.email).onSnapshot(snapshot=>{
+        transaccionesGlobales.clear();
+        snapshot.forEach(doc=>{
+          const normalizado=normalizarTransaccionParaTabla(doc.id,doc.data()||{});
+          transaccionesGlobales.set(doc.id,normalizado);
+        });
+        sincronizarTransaccionesEnTabla();
+      },error=>{ console.error('Error escuchando transacciones de la billetera',error); });
     }
 
     function filtrarTransacciones(){

--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -735,7 +735,7 @@
         const correo = this.usuario.email;
         const unsubTrans = db.collection('transacciones')
           .where('IDbilletera','==', correo)
-          .where('tipotrans','in',['recarga','premio','deposito'])
+          .where('tipotrans','in',['recarga','deposito'])
           .onSnapshot(snapshot => {
             if(!this.inicializaciones.transJugador){
               this.inicializaciones.transJugador = true;
@@ -745,18 +745,34 @@
               const data = cambio.doc.data() || {};
               const tipo = normalizarTipoRecarga(data.tipotrans);
               const estado = estadoNormalizado(data.estado);
-              const estadoPremio = estadoPremioNormalizado(data.estado);
               if(tipo === 'recarga' && (estado === 'APROBADO' || estado === 'ANULADO')){
                 this.notificarCambioRecarga(cambio.doc.id, { ...data, tipotrans: tipo }, estado);
-              }
-              if(tipo === 'premio' && estadoPremio === 'REALIZADO'){
-                this.notificarPremio(cambio.doc.id, data);
               }
             });
           }, err => console.error('Error escuchando transacciones del jugador', err));
         this.desuscriptores.push(unsubTrans);
       }catch(err){
         console.error('No se pudo observar las transacciones del jugador', err);
+      }
+
+      try{
+        const correo = this.usuario.email;
+        const unsubPremios = db.collection('users')
+          .doc(correo)
+          .collection('premios')
+          .onSnapshot(snapshot => {
+            snapshot.docChanges().forEach(cambio => {
+              if(cambio.type === 'removed') return;
+              const data = cambio.doc.data() || {};
+              const estadoPremio = estadoPremioNormalizado(data.estado);
+              if(estadoPremio === 'REALIZADO'){
+                this.notificarPremio(cambio.doc.id, data);
+              }
+            });
+          }, err => console.error('Error escuchando proyección de premios del jugador', err));
+        this.desuscriptores.push(unsubPremios);
+      }catch(err){
+        console.error('No se pudo observar la proyección de premios del jugador', err);
       }
     }
 

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -794,6 +794,16 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
       const fecha = new Date();
       const fechaGestion = fecha.toISOString().slice(0, 10).split('-').reverse().join('/');
       const horaGestion = fecha.toTimeString().slice(0, 5);
+      const premioProyeccionRef = db
+        .collection('users')
+        .doc(billeteraRef.id)
+        .collection('premios')
+        .doc(normalizedEventoGanadorId);
+      const resumenProyeccionRef = db
+        .collection('users')
+        .doc(billeteraRef.id)
+        .collection('billeteraProyeccion')
+        .doc('resumen');
 
       tx.set(
         premioRef,
@@ -872,6 +882,52 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           processedBy: req.user?.email || '',
           processedAt: timestamp,
           creadoEn: transaccionSnap.exists ? (transaccionSnap.data()?.creadoEn || timestamp) : timestamp,
+          actualizadoEn: timestamp
+        },
+        { merge: true }
+      );
+
+      tx.set(
+        premioProyeccionRef,
+        {
+          tipotrans: 'premio',
+          estado: 'REALIZADO',
+          IDbilletera: billeteraRef.id,
+          Monto: normalizedMonto > 0 ? normalizedMonto : normalizedCartonesGratis,
+          cartonesGratis: normalizedCartonesGratis,
+          sorteoId: normalizedSorteoId,
+          sorteoNombre,
+          eventoGanadorId: normalizedEventoGanadorId,
+          winnerKey: normalizedEventoGanadorId,
+          tipoRegistro: normalizedTipoRegistro,
+          segundoLugar: normalizedSegundoLugar,
+          referencia: normalizedReferencia,
+          origen: normalizedOrigen,
+          source: normalizedSource,
+          requestId: normalizedRequestId,
+          processedBy: req.user?.email || '',
+          processedAt: timestamp,
+          fechagestion: fechaGestion,
+          horagestion: horaGestion,
+          creadoEn: premioActual?.creadoEn || timestamp,
+          actualizadoEn: timestamp
+        },
+        { merge: true }
+      );
+
+      tx.set(
+        resumenProyeccionRef,
+        {
+          creditos: nuevosCreditos,
+          CartonesGratis: nuevosCartones,
+          creditostransito: normalizeNumber(billeteraActual.creditostransito),
+          ultimoPremio: {
+            eventoGanadorId: normalizedEventoGanadorId,
+            monto: normalizedMonto,
+            cartonesGratis: normalizedCartonesGratis,
+            fechaGestion,
+            horaGestion
+          },
           actualizadoEn: timestamp
         },
         { merge: true }


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia usuario haciendo disponible inmediatamente la información de premios acreditados sin depender de listas globales ni del retrazo en observadores generales.
- Reducir la latencia y evitar duplicados en la UI priorizando una proyección por usuario para lectura rápida de `billetera` y notificaciones.
- Asegurar que las escrituras de acreditación sean atómicas y consistentes incluyendo la proyección del usuario junto con `Billetera` y `transacciones`.

### Description
- Backend: durante la ruta de acreditación (`/acreditarPremioEvento`) se escribe, dentro de la misma transacción, la proyección del premio en `users/{email}/premios/{eventoGanadorId}` y un resumen en `users/{email}/billeteraProyeccion/resumen` además de `PremiosSorteos`, `Billetera` y `transacciones` (`uploadServer.js`).
- Cliente billetera: `public/billetera.html` ahora prioriza leer `users/{email}/billeteraProyeccion/resumen` en `refrescarResumenBilletera()` y se suscribe a la proyección; además combina la vista de transacciones priorizando premios desde `users/{email}/premios` y evitando mostrar duplicados con `transacciones` globales.
- Notificaciones: `public/js/notificationCenter.js` escucha la proyección `users/{email}/premios` para emitir notificaciones de premios realizados, mientras mantiene `transacciones` para recargas/depósitos.
- Reglas: `firestore.rules` se actualizó para permitir lectura por propietario y escritura por operadores/sistema en `users/{email}/premios` y `users/{email}/billeteraProyeccion`.

### Testing
- Ejecuté las suites de pruebas automatizadas con `npm test -- --runInBand` que corrieron 10 suites y 31 tests en total y finalizaron exitosamente.
- Resultado: todas las pruebas pasaron (`10 suites passed, 31 tests passed`).
- También verifiqué lint básico y que los cambios se hayan aplicado en los archivos `uploadServer.js`, `public/billetera.html`, `public/js/notificationCenter.js` y `firestore.rules` mediante commits locales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ca0ca5f48326a049ff41a6705a67)