### PR TITLE
Automatiza premios en vivo, pagos administrativos y filtros en CentroPagos

### DIFF
--- a/__tests__/uploadServer-purge-utils.test.js
+++ b/__tests__/uploadServer-purge-utils.test.js
@@ -56,6 +56,7 @@ describe('uploadServer utilidades de depuración de sorteos', () => {
       'cantos',
       'cantarsorteos',
       'formas',
+      'GanadoresSorteosTiempoReal',
       'sorteos'
     ]);
     expect(deleteFn).not.toHaveBeenCalled();

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -509,7 +509,7 @@
 </head>
 <body>
   <button id="volver-btn" class="menu-btn back-btn" data-compact-back="true"><span class="icon">&#9664;</span><span class="label">Volver</span></button>
-  <h2 class="titulo-principal">GESTIÓN DE PAGOS</h2>
+  <h2 class="titulo-principal">RESUMEN DE PAGOS</h2>
   <section class="section" id="premios-section">
     <div class="section-header">
       <h3>PREMIOS JUGADORES</h3>
@@ -520,7 +520,6 @@
     </div>
     <div id="premios-content">
       <div class="acciones">
-        <button class="icon-btn" id="premios-aprobar"><span class="icon check">&#10004;</span><span>Aprobar</span></button>
         <button class="icon-btn" id="premios-archivar"><span class="icon">&#128452;</span><span>Archivar</span></button>
         <button class="icon-btn" id="premios-archivo"><span class="icon">&#128193;</span><span>Archivo</span></button>
       </div>
@@ -535,13 +534,20 @@
           <col style="width:6%">
         </colgroup>
         <thead>
-          <tr>
+          <tr class="filtros">
             <th>N°</th>
-            <th>Jugador</th>
+            <th><input type="text" id="filtro-premios-jugador" placeholder="Jugador"></th>
             <th>Créditos</th>
             <th>Cart.</th>
-            <th>Fecha</th>
-            <th>Estado</th>
+            <th><input type="text" id="filtro-premios-fecha" placeholder="Fecha"></th>
+            <th>
+              <select id="filtro-premios-estado">
+                <option value="">Estado</option>
+                <option value="PENDIENTE">PENDIENTE</option>
+                <option value="REALIZADO">REALIZADO</option>
+                <option value="ARCHIVADO">ARCHIVADO</option>
+              </select>
+            </th>
             <th><span id="premios-marcar" class="check-header">✔</span></th>
           </tr>
         </thead>
@@ -560,7 +566,6 @@
     </div>
     <div id="pagos-content">
       <div class="acciones">
-        <button class="icon-btn" id="pagos-aprobar"><span class="icon check">&#10004;</span><span>Aprobar</span></button>
         <button class="icon-btn" id="pagos-archivar"><span class="icon">&#128452;</span><span>Archivar</span></button>
         <button class="icon-btn" id="pagos-archivo"><span class="icon">&#128193;</span><span>Archivo</span></button>
       </div>
@@ -574,12 +579,19 @@
           <col style="width:6%">
         </colgroup>
         <thead>
-          <tr>
+          <tr class="filtros">
             <th>N°</th>
-            <th>Jugador</th>
+            <th><input type="text" id="filtro-pagos-jugador" placeholder="Jugador"></th>
             <th>Créditos</th>
-            <th>Fecha</th>
-            <th>Estado</th>
+            <th><input type="text" id="filtro-pagos-fecha" placeholder="Fecha"></th>
+            <th>
+              <select id="filtro-pagos-estado">
+                <option value="">Estado</option>
+                <option value="PENDIENTE">PENDIENTE</option>
+                <option value="REALIZADO">REALIZADO</option>
+                <option value="ARCHIVADO">ARCHIVADO</option>
+              </select>
+            </th>
             <th><span id="pagos-marcar" class="check-header">✔</span></th>
           </tr>
         </thead>
@@ -654,6 +666,8 @@
     const authInstance = ()=>firebase.auth();
 
     const filtrosColaboradores = { gmail:'', creditos:'', tipo:'' };
+    const filtrosPremios = { jugador:'', fecha:'', estado:'' };
+    const filtrosPagos = { jugador:'', fecha:'', estado:'' };
 
     let mostrarPremiosArchivo = false;
     let mostrarPagosArchivo = false;
@@ -2001,11 +2015,23 @@
     }
 
     function aplicarFiltrosPremios(origen){
-      return origen.slice().sort((a,b)=>b.fechaOrden - a.fechaOrden || b.creditos - a.creditos);
+      return origen.filter(item=>{
+        const jugador = `${item.gmail || ''} ${item.alias || ''} ${item.nombre || ''}`.toLowerCase();
+        if(filtrosPremios.jugador && !jugador.includes(filtrosPremios.jugador)) return false;
+        if(filtrosPremios.fecha && !(item.fechaMostrar || '').toLowerCase().includes(filtrosPremios.fecha)) return false;
+        if(filtrosPremios.estado && (item.estado || '').toUpperCase() !== filtrosPremios.estado) return false;
+        return true;
+      }).sort((a,b)=>b.fechaOrden - a.fechaOrden || b.creditos - a.creditos);
     }
 
     function aplicarFiltrosPagos(origen){
-      return origen.slice().sort((a,b)=>b.fechaOrden - a.fechaOrden || b.creditos - a.creditos);
+      return origen.filter(item=>{
+        const jugador = `${item.gmail || ''} ${item.alias || ''} ${item.nombre || ''}`.toLowerCase();
+        if(filtrosPagos.jugador && !jugador.includes(filtrosPagos.jugador)) return false;
+        if(filtrosPagos.fecha && !(item.fechaMostrar || '').toLowerCase().includes(filtrosPagos.fecha)) return false;
+        if(filtrosPagos.estado && (item.estado || '').toUpperCase() !== filtrosPagos.estado) return false;
+        return true;
+      }).sort((a,b)=>b.fechaOrden - a.fechaOrden || b.creditos - a.creditos);
     }
 
     function aplicarFiltrosColaboradores(origen){
@@ -2423,6 +2449,12 @@
     }
 
     function configurarFiltros(){
+      document.getElementById('filtro-premios-jugador').addEventListener('input', e=>{ filtrosPremios.jugador = e.target.value.toLowerCase().trim(); renderPremios(); });
+      document.getElementById('filtro-premios-fecha').addEventListener('input', e=>{ filtrosPremios.fecha = e.target.value.toLowerCase().trim(); renderPremios(); });
+      document.getElementById('filtro-premios-estado').addEventListener('change', e=>{ filtrosPremios.estado = (e.target.value || '').toUpperCase(); renderPremios(); });
+      document.getElementById('filtro-pagos-jugador').addEventListener('input', e=>{ filtrosPagos.jugador = e.target.value.toLowerCase().trim(); renderPagos(); });
+      document.getElementById('filtro-pagos-fecha').addEventListener('input', e=>{ filtrosPagos.fecha = e.target.value.toLowerCase().trim(); renderPagos(); });
+      document.getElementById('filtro-pagos-estado').addEventListener('change', e=>{ filtrosPagos.estado = (e.target.value || '').toUpperCase(); renderPagos(); });
       document.getElementById('filtro-colab-gmail').addEventListener('input', e=>{ filtrosColaboradores.gmail = e.target.value.toLowerCase().trim(); renderColaboradores(); });
       document.getElementById('filtro-colab-creditos').addEventListener('input', e=>{ filtrosColaboradores.creditos = e.target.value.replace(/[^0-9.]/g,''); renderColaboradores(); });
       document.getElementById('colaboradores-filtro-tipo').addEventListener('change', e=>{
@@ -2435,16 +2467,6 @@
       document.getElementById('premios-marcar').addEventListener('click', ()=>seleccionarTodos('tabla-premios'));
       document.getElementById('pagos-marcar').addEventListener('click', ()=>seleccionarTodos('tabla-pagos'));
 
-      document.getElementById('premios-aprobar').addEventListener('click', async()=>{
-        const seleccion = obtenerSeleccion('tabla-premios');
-        if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }
-        await aprobarPremios(seleccion);
-      });
-      document.getElementById('pagos-aprobar').addEventListener('click', async()=>{
-        const seleccion = obtenerSeleccion('tabla-pagos');
-        if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }
-        await aprobarPagos(seleccion);
-      });
       document.getElementById('premios-archivar').addEventListener('click', async()=>{
         const seleccion = obtenerSeleccion('tabla-premios');
         if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1803,9 +1803,14 @@
 
   async function obtenerGanadoresAgrupados(){
     await ensureFirebaseReady();
-    const snap = await db.collection('PremiosSorteos')
+    let snap = await db.collection('GanadoresSorteosTiempoReal')
       .where('sorteoId', '==', sorteoId)
       .get();
+    if(snap.empty){
+      snap = await db.collection('PremiosSorteos')
+        .where('sorteoId', '==', sorteoId)
+        .get();
+    }
 
     const agregados = new Map();
     snap.forEach(doc=>{
@@ -1928,6 +1933,77 @@
     await lote.commit();
   }
 
+  async function ejecutarPagosAdministrativosAutomaticos(ids = []){
+    if(!Array.isArray(ids) || !ids.length) return 0;
+    await ensureFirebaseReady();
+    await initServerTime();
+    const gestorEmail = auth?.currentUser?.email || '';
+    let procesados = 0;
+    for(const id of ids){
+      const ref = db.collection('PagosAdministracion').doc(id);
+      try {
+        const payload = await db.runTransaction(async tx => {
+          const snap = await tx.get(ref);
+          if(!snap.exists) return null;
+          const data = snap.data() || {};
+          if(normalizarEstadoPagoPremio(data.estado) === 'REALIZADO') return null;
+          const billeteraId = normalizarEmail(data.idBilletera || data.gmail || data.email || '');
+          if(!billeteraId){ return null; }
+          const monto = Number(data.creditos) || 0;
+          if(monto <= 0){
+            tx.update(ref, {
+              estado: validarEstadoPagoPremio('REALIZADO', `PagosAdministracion:${id}`),
+              fechaGestion: fechaServidor(),
+              horaGestion: horaServidor(),
+              gestionadoPor: gestorEmail,
+              rolGestor: window.currentRole || '',
+              actualizadoEn: firebase.firestore.FieldValue.serverTimestamp(),
+              pagoAutomatico: true
+            });
+            return null;
+          }
+          const billeteraRef = db.collection('Billetera').doc(billeteraId);
+          const billeteraSnap = await tx.get(billeteraRef);
+          const saldoActual = Number(billeteraSnap.exists ? billeteraSnap.data()?.creditos : 0) || 0;
+          tx.set(billeteraRef, { creditos: saldoActual + monto, actualizadoEn: firebase.firestore.FieldValue.serverTimestamp() }, { merge: true });
+          tx.update(ref, {
+            estado: validarEstadoPagoPremio('REALIZADO', `PagosAdministracion:${id}`),
+            fechaGestion: fechaServidor(),
+            horaGestion: horaServidor(),
+            gestionadoPor: gestorEmail,
+            rolGestor: window.currentRole || '',
+            actualizadoEn: firebase.firestore.FieldValue.serverTimestamp(),
+            pagoAutomatico: true
+          });
+          return { id, data, billeteraId, monto };
+        });
+        if(!payload) continue;
+        await db.collection('transacciones').add({
+          tipotrans: 'pagado',
+          origen: 'pagos_administracion',
+          Monto: payload.monto,
+          estado: validarEstadoPagoPremio('REALIZADO', 'TransaccionPagoAdministracionAuto'),
+          IDbilletera: payload.billeteraId,
+          fechasolicitud: '',
+          horasolicitud: '',
+          fechagestion: fechaServidor(),
+          horagestion: horaServidor(),
+          usuariogestor: gestorEmail,
+          rolusuario: window.currentRole || '',
+          referencia: 'PAGO_ADMINISTRACION_AUTO',
+          sorteoId,
+          sorteoNombre: (payload.data?.sorteoNombre || sorteoData?.nombre || '').toString(),
+          pagoAdministracionId: id,
+          creadoEn: firebase.firestore.FieldValue.serverTimestamp()
+        });
+        procesados += 1;
+      } catch (err) {
+        console.error('No se pudo ejecutar pago administrativo automático', id, err);
+      }
+    }
+    return procesados;
+  }
+
   async function generarSolicitudesCentroPagos(){
     mostrarLoading('Generando solicitudes para Centro de Pagos, por favor espera');
     const timestamp = firebase.firestore.FieldValue.serverTimestamp();
@@ -1940,6 +2016,7 @@
     const administrativos = participantes.filter(item=>esRolAdministrativo(item.role));
     const colaboradores = participantes.filter(item=>!esRolAdministrativo(item.role));
     const operaciones = [];
+    const idsAdministrativos = [];
 
     administrativos.forEach(administrativo => {
       const email = normalizarEmail(administrativo.gmail);
@@ -1962,6 +2039,7 @@
         userIds: administrativo.userIds || [],
         generadoDesde: 'pdfresultados'
       };
+      idsAdministrativos.push(docId);
       operaciones.push(actualizarDocumentoCentroPagos(db.collection('PagosAdministracion').doc(docId), payload));
     });
 
@@ -2022,11 +2100,13 @@
     operaciones.push(resumenRef.set(resumenPayload, { merge: true }));
     await Promise.all(operaciones);
 
+    const pagosAdministrativosAutomaticos = await ejecutarPagosAdministrativosAutomaticos(idsAdministrativos);
     await actualizarFlagsOrquestacionCentroPagos({ timestamp, solicitudesPagosGeneradas: true });
     return {
       ganadores: ganadores.length,
       administrativos: administrativos.length,
-      colaboradores: colaboradores.length
+      colaboradores: colaboradores.length,
+      pagosAdministrativosAutomaticos
     };
   }
 
@@ -2038,6 +2118,7 @@
         ganadores: 0,
         administrativos: 0,
         colaboradores: 0,
+        pagosAdministrativosAutomaticos: 0,
         corteYaEjecutado: true
       };
     }
@@ -3453,7 +3534,8 @@
         `El sorteo se marcó como PDF listo y se ejecutó la orquestación de pagos.\n`+
         `${mensajeCorte}\n`+
         `Solicitudes administrativas creadas: ${resultadoOrquestacion.administrativos}.\n`+
-        `Solicitudes de colaboradores creadas: ${resultadoOrquestacion.colaboradores}.`
+        `Solicitudes de colaboradores creadas: ${resultadoOrquestacion.colaboradores}.\n`+
+        `Pagos administrativos automáticos aplicados: ${resultadoOrquestacion.pagosAdministrativosAutomaticos || 0}.`
       );
       window.location.href = 'cantarsorteos.html';
     } catch (err) {

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -219,6 +219,9 @@ async function getPurgeCounts({ db, sorteoId, dryRun }) {
     formas: dryRun
       ? await countCollectionBySorteoId({ db, collectionName: 'formas', sorteoId })
       : await deleteCollectionBySorteoId({ db, collectionName: 'formas', sorteoId }),
+    GanadoresSorteosTiempoReal: dryRun
+      ? await countCollectionBySorteoId({ db, collectionName: 'GanadoresSorteosTiempoReal', sorteoId })
+      : await deleteCollectionBySorteoId({ db, collectionName: 'GanadoresSorteosTiempoReal', sorteoId }),
     sorteos: dryRun
       ? await countDocumentById({ db, collectionName: 'sorteos', docId: sorteoId })
       : await deleteDocumentById({ db, collectionName: 'sorteos', docId: sorteoId })
@@ -804,6 +807,7 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
         .doc(billeteraRef.id)
         .collection('billeteraProyeccion')
         .doc('resumen');
+      const ganadorTiempoRealRef = db.collection('GanadoresSorteosTiempoReal').doc(normalizedEventoGanadorId);
 
       tx.set(
         premioRef,
@@ -841,6 +845,39 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           rolGestor: req.user?.role || '',
           fechaGestion,
           horaGestion
+        },
+        { merge: true }
+      );
+
+      tx.set(
+        ganadorTiempoRealRef,
+        {
+          sorteoId: normalizedSorteoId,
+          sorteoNombre,
+          eventoGanadorId: normalizedEventoGanadorId,
+          winnerKey: normalizedEventoGanadorId,
+          formaIdx: normalizedFormaIdx,
+          cartonId: normalizedCartonId,
+          idBilletera: billeteraRef.id,
+          email: normalizedEmail || billeteraRef.id,
+          gmail: normalizedEmail || billeteraRef.id,
+          alias: normalizedAlias || cartonData.alias || '',
+          userId: normalizedUserId || cartonData.userId || null,
+          creditos: normalizedMonto,
+          cartonesGratis: normalizedCartonesGratis,
+          segundoLugar: normalizedSegundoLugar,
+          tipoRegistro: normalizedTipoRegistro,
+          estado: 'REALIZADO',
+          referencia: normalizedReferencia,
+          origen: normalizedOrigen,
+          source: normalizedSource,
+          requestId: normalizedRequestId,
+          procesadoPor: req.user?.email || '',
+          procesadoEn: timestamp,
+          fechaGestion,
+          horaGestion,
+          creadoEn: premioActual?.creadoEn || timestamp,
+          actualizadoEn: timestamp
         },
         { merge: true }
       );


### PR DESCRIPTION
## Resumen
- Guardé en tiempo real cada evento ganador en la nueva colección `GanadoresSorteosTiempoReal` desde el flujo backend de acreditación (`/acreditarPremioEvento`), manteniendo también la escritura en `PremiosSorteos` y `transacciones`.
- Incluí `GanadoresSorteosTiempoReal` en el purge de sorteos (`getPurgeCounts`) para evitar residuos de datos al depurar.
- Actualicé `pdfresultados.html` para construir los resultados desde `GanadoresSorteosTiempoReal` (con fallback a `PremiosSorteos`) y mantener la estructura actual del PDF.
- Implementé pago automático de administración al cierre del sorteo (al confirmar **PDF listo**):
  - cambia estado a `REALIZADO` en `PagosAdministracion`
  - acredita créditos en `Billetera`
  - registra transacción en `transacciones` con `tipotrans: "pagado"`
- Ajusté `centropagos.html`:
  - título principal **GESTIÓN DE PAGOS** ➜ **RESUMEN DE PAGOS**
  - eliminados botones **Aprobar** en secciones de **Premios Jugadores** y **Pagos Administración**
  - reactivados filtros en columnas **Jugador**, **Fecha**, **Estado** en ambas tablas
  - se mantienen botones y comportamiento de **Archivar** y **Archivo**

## Pruebas
- Ejecutado: `npm test -- --runInBand`
- Resultado: **10 suites passed / 31 tests passed**

## Notas
- Intenté generar captura de pantalla con la herramienta de browser (`playwright`), pero falló por ruta no encontrada al abrir el HTML en modo `file://` dentro del contenedor de navegador.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998966f32908326993e40a54649e768)