### PR TITLE
[PR #1044 follow-up] Prioritize verified email candidates for visible wallet attribution

### DIFF
--- a/uploadServer.js
+++ b/uploadServer.js
@@ -776,16 +776,17 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
         cartonData
       });
       const cartonUserId = normalizeString(cartonData?.userId || cartonData?.usuarioId, 160);
-      const emailCandidates = [
+      const rawEmailCandidates = [
         normalizedEmail,
         normalizeString(cartonData?.email, 160).toLowerCase(),
         normalizeString(cartonData?.gmail, 160).toLowerCase(),
         looksLikeEmail(cartonData?.IDbilletera) ? normalizeString(cartonData?.IDbilletera, 160).toLowerCase() : ''
       ].filter(Boolean);
+      const verifiedEmailCandidates = [];
 
       for (const userIdentity of [normalizedUserId, cartonUserId].filter(Boolean)) {
         if (looksLikeEmail(userIdentity)) {
-          emailCandidates.push(normalizeString(userIdentity, 160).toLowerCase());
+          verifiedEmailCandidates.push(normalizeString(userIdentity, 160).toLowerCase());
           continue;
         }
 
@@ -793,8 +794,8 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
         if (directUserSnap.exists) {
           const data = directUserSnap.data() || {};
           const emailByData = normalizeString(data.email || data.gmail, 160).toLowerCase();
-          if (emailByData) emailCandidates.push(emailByData);
-          if (looksLikeEmail(directUserSnap.id)) emailCandidates.push(directUserSnap.id.toLowerCase());
+          if (emailByData) verifiedEmailCandidates.push(emailByData);
+          if (looksLikeEmail(directUserSnap.id)) verifiedEmailCandidates.push(directUserSnap.id.toLowerCase());
         }
 
         const byUidSnap = await tx.get(db.collection('users').where('uid', '==', userIdentity).limit(1));
@@ -802,14 +803,17 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           const doc = byUidSnap.docs[0];
           const data = doc.data() || {};
           const emailByData = normalizeString(data.email || data.gmail, 160).toLowerCase();
-          if (emailByData) emailCandidates.push(emailByData);
-          if (looksLikeEmail(doc.id)) emailCandidates.push(doc.id.toLowerCase());
+          if (emailByData) verifiedEmailCandidates.push(emailByData);
+          if (looksLikeEmail(doc.id)) verifiedEmailCandidates.push(doc.id.toLowerCase());
         }
       }
 
-      const billeteraVisibleId = Array.from(new Set(emailCandidates))[0] || '';
+      const orderedEmailCandidates = Array.from(new Set([
+        ...verifiedEmailCandidates,
+        ...rawEmailCandidates
+      ].filter(Boolean)));
       const billeteraSearchCandidates = Array.from(new Set([
-        billeteraVisibleId,
+        ...orderedEmailCandidates,
         ...billeteraCandidates
       ].filter(Boolean)));
 
@@ -831,6 +835,11 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
       if (!billeteraSnap) {
         billeteraSnap = await tx.get(billeteraRef);
       }
+
+      const billeteraVisibleId = (() => {
+        if (looksLikeEmail(billeteraRef.id)) return billeteraRef.id.toLowerCase();
+        return orderedEmailCandidates[0] || '';
+      })();
 
       const billeteraActual = billeteraSnap.exists ? billeteraSnap.data() || {} : {};
       const nuevosCreditos = normalizeNumber(billeteraActual.creditos) + normalizedMonto;


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where `billeteraVisibleId` was taken from the first raw email candidate (payload/cartón) and could be stale or mistyped, causing prize writes to appear on the wrong visible wallet. 
- Ensure visible-wallet attribution uses identities verified via `users` lookups (docId/`uid`) or the actually resolved `Billetera` document ID so UI-visible balances and prize projections match the user's visible account.

### Description
- Updated `uploadServer.js` to split email resolution into `rawEmailCandidates` (payload/cartón-derived) and `verifiedEmailCandidates` (emails/docIds discovered from `users` lookups by `userId`/`uid`).
- Built `orderedEmailCandidates` that prioritizes `verifiedEmailCandidates` before `rawEmailCandidates`, and used that ordering as the head of `billeteraSearchCandidates` when resolving `Billetera` docs.
- Derived `billeteraVisibleId` from the resolved `billeteraRef.id` when it looks like an email, otherwise from the first `orderedEmailCandidates` entry, ensuring projection writes (`users/{...}/premios`, `billeteraProyeccion`, etc.) use a verified/public identifier.

### Testing
- Ran `node --check uploadServer.js` to validate syntax and there were no parse errors.
- Ran `npx jest --runInBand __tests__/uploadServer-acreditar-utils.test.js --coverage=false` and the suite passed (3 tests passed).
- Confirmed the modified flows are exercised by the existing unit tests and no new test failures were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c12163788326ba49382bc4421f7a)