### PR TITLE
Ampliar elegibilidad de acreditación automática según flujo real de sorteos

### DIFF
--- a/__tests__/uploadServer-acreditar-utils.test.js
+++ b/__tests__/uploadServer-acreditar-utils.test.js
@@ -8,13 +8,22 @@ describe('uploadServer utilidades de acreditación', () => {
     jest.resetModules();
   });
 
-  test('canAccreditForSorteoState permite solo Jugando y Finalizado', () => {
-    const { canAccreditForSorteoState } = require('../uploadServer.js');
+  test('isSorteoEligibleForAutoPrize permite estados operativos y transicionales válidos', () => {
+    const { isSorteoEligibleForAutoPrize } = require('../uploadServer.js');
 
-    expect(canAccreditForSorteoState('Jugando')).toBe(true);
-    expect(canAccreditForSorteoState('FINALIZADO')).toBe(true);
-    expect(canAccreditForSorteoState('Activo')).toBe(false);
-    expect(canAccreditForSorteoState('Sellado')).toBe(false);
+    expect(isSorteoEligibleForAutoPrize({ estado: 'Jugando', premiosCorteCerrado: false })).toBe(true);
+    expect(isSorteoEligibleForAutoPrize({ estado: 'FINALIZADO', premiosCorteCerrado: false })).toBe(true);
+    expect(isSorteoEligibleForAutoPrize({ estado: 'sellado', premiosCorteCerrado: false })).toBe(true);
+    expect(isSorteoEligibleForAutoPrize({ estado: 'Finalizando', premiosCorteCerrado: false })).toBe(true);
+  });
+
+  test('isSorteoEligibleForAutoPrize rechaza estados incompatibles y corte cerrado', () => {
+    const { isSorteoEligibleForAutoPrize } = require('../uploadServer.js');
+
+    expect(isSorteoEligibleForAutoPrize({ estado: 'Activo', premiosCorteCerrado: false })).toBe(false);
+    expect(isSorteoEligibleForAutoPrize({ estado: 'Inactivo', premiosCorteCerrado: false })).toBe(false);
+    expect(isSorteoEligibleForAutoPrize({ estado: 'Archivado', premiosCorteCerrado: false })).toBe(false);
+    expect(isSorteoEligibleForAutoPrize({ estado: 'Jugando', premiosCorteCerrado: true })).toBe(false);
   });
 
   test('buildPremioDocId genera id sanitizado y estable', () => {

--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -1774,6 +1774,7 @@
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
   <script src="js/estadoPagoPremio.js"></script>
+  <script src="js/sorteoAutoPrizeEligibility.js"></script>
   <script>
   ensureAuth('Administrador');
   initServerTime().then(()=>{
@@ -1791,6 +1792,16 @@
 
   function estadoPagoPremioFinalizado(valor){
     return window.EstadosPagoPremio.estaFinalizado(valor);
+  }
+
+  function sorteoElegibleParaPremioAutomatico(data){
+    if(!window.SorteoAutoPrizeEligibility || typeof window.SorteoAutoPrizeEligibility.isSorteoEligibleForAutoPrize !== 'function'){
+      return false;
+    }
+    return window.SorteoAutoPrizeEligibility.isSorteoEligibleForAutoPrize({
+      estado: data?.estado,
+      premiosCorteCerrado: data?.premiosCorteCerrado
+    });
   }
 
   let sorteos = [];
@@ -4672,6 +4683,7 @@
 
   async function acreditarPremioAutomatico({ carton, forma, totalGanadores }){
     if(!carton || !forma || !currentSorteoId) return;
+    if(!sorteoElegibleParaPremioAutomatico(currentSorteoData)) return;
     const cartonReferencia = carton.id || carton.cartonId || carton.carton || carton.userId || carton.usuarioId || '';
     const eventoGanadorId = buildPremioId({ sorteoId: currentSorteoId, formaIdx: forma?.idx, cartonId: cartonReferencia });
     const premioId = eventoGanadorId;
@@ -4746,6 +4758,7 @@
 
   async function acreditarPremioSegundoLugar({ carton, forma }){
     if(!carton || !forma || !currentSorteoId) return;
+    if(!sorteoElegibleParaPremioAutomatico(currentSorteoData)) return;
     const cartonReferencia = carton.id || carton.cartonId || carton.carton || carton.userId || carton.usuarioId || '';
     const eventoGanadorId = buildPremioId({ sorteoId: currentSorteoId, formaIdx: forma?.idx, cartonId: cartonReferencia, prefijo: 'segundo' });
     const premioId = eventoGanadorId;

--- a/public/js/sorteoAutoPrizeEligibility.js
+++ b/public/js/sorteoAutoPrizeEligibility.js
@@ -1,0 +1,31 @@
+(function initSorteoAutoPrizeEligibility(root, factory){
+  if(typeof module === 'object' && module.exports){
+    module.exports = factory();
+    return;
+  }
+  root.SorteoAutoPrizeEligibility = factory();
+})(typeof globalThis !== 'undefined' ? globalThis : this, function crearSorteoAutoPrizeEligibility(){
+  const ESTADOS_PERMITIDOS_ACREDITACION_AUTOMATICA = Object.freeze([
+    'SELLADO',
+    'JUGANDO',
+    'FINALIZANDO',
+    'FINALIZADO'
+  ]);
+
+  const ESTADOS_PERMITIDOS_SET = new Set(ESTADOS_PERMITIDOS_ACREDITACION_AUTOMATICA);
+
+  function normalizeSorteoState(value){
+    return (value || '').toString().trim().toUpperCase();
+  }
+
+  function isSorteoEligibleForAutoPrize({ estado, premiosCorteCerrado } = {}){
+    if(Boolean(premiosCorteCerrado)) return false;
+    return ESTADOS_PERMITIDOS_SET.has(normalizeSorteoState(estado));
+  }
+
+  return Object.freeze({
+    ESTADOS_PERMITIDOS_ACREDITACION_AUTOMATICA,
+    normalizeSorteoState,
+    isSorteoEligibleForAutoPrize
+  });
+});

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -8,6 +8,7 @@ const path = require('path');
 const crypto = require('crypto');
 const admin = require('firebase-admin');
 const EstadosPagoPremio = require('./public/js/estadoPagoPremio.js');
+const { isSorteoEligibleForAutoPrize } = require('./public/js/sorteoAutoPrizeEligibility.js');
 
 const requiredEnv = ['GOOGLE_APPLICATION_CREDENTIALS', 'FIREBASE_STORAGE_BUCKET'];
 
@@ -348,17 +349,8 @@ function extractEventoGanadorIdComponents(eventoGanadorId) {
   };
 }
 
-function normalizeSorteoState(value) {
-  return normalizeString(String(value || ''), 40).toUpperCase();
-}
-
 function normalizePremioTransactionState(value) {
   return EstadosPagoPremio.normalizarLectura(value);
-}
-
-function canAccreditForSorteoState(value) {
-  const allowed = new Set(['JUGANDO', 'FINALIZADO']);
-  return allowed.has(normalizeSorteoState(value));
 }
 
 function getBilleteraCandidates({ userEmail, cartonData, payloadUserId }) {
@@ -747,10 +739,17 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
       }
 
       const sorteoData = sorteoSnap.data() || {};
-      if (Boolean(sorteoData?.premiosCorteCerrado)) {
-        throw new Error('SORTEO_CORTE_CERRADO');
-      }
-      if (!canAccreditForSorteoState(sorteoData.estado)) {
+      // Estados compatibles con acreditación automática: etapas activas/finales del flujo
+      // (Sellado/Jugando/Finalizando/Finalizado) siempre que el corte de premios siga abierto.
+      // Se rechaza solamente cuando el estado es incompatible con premiación (p.ej. Activo/Inactivo/Archivado)
+      // o cuando el corte ya fue cerrado explícitamente.
+      if (!isSorteoEligibleForAutoPrize({
+        estado: sorteoData.estado,
+        premiosCorteCerrado: sorteoData?.premiosCorteCerrado
+      })) {
+        if (Boolean(sorteoData?.premiosCorteCerrado)) {
+          throw new Error('SORTEO_CORTE_CERRADO');
+        }
         throw new Error('SORTEO_ESTADO_INVALIDO');
       }
 
@@ -1167,7 +1166,7 @@ module.exports = {
   countCollectionBySorteoId,
   countDocumentById,
   getPurgeCounts,
-  canAccreditForSorteoState,
+  isSorteoEligibleForAutoPrize,
   buildPremioDocId,
   extractEventoGanadorIdComponents
 };


### PR DESCRIPTION
### Motivation
- Alinear la política de estados permitidos para acreditación automática con el flujo real de `cantarsorteos` y evitar divergencias entre frontend y backend.

### Description
- Añadí un módulo UMD compartido `public/js/sorteoAutoPrizeEligibility.js` que expone `isSorteoEligibleForAutoPrize({ estado, premiosCorteCerrado })` y define los estados permitidos (`SELLADO`, `JUGANDO`, `FINALIZANDO`, `FINALIZADO`).
- Reemplacé la comprobación puntual anterior en `uploadServer.js` por una llamada a `isSorteoEligibleForAutoPrize`, y añadí comentarios de negocio que documentan que solo se rechaza cuando el estado es incompatible o `premiosCorteCerrado` está activo.
- Integré la misma función en el frontend `public/cantarsorteos.html` y la usé para abortar la lógica de disparo de acreditaciones automáticas (premio estándar y segundo lugar), evitando desalineación entre cliente y servidor.
- Actualicé `__tests__/uploadServer-acreditar-utils.test.js` para cubrir los estados transicionales permitidos, estados incompatibles y el caso de `premiosCorteCerrado`.

### Testing
- Ejecuté `npx jest --coverage=false --runTestsByPath __tests__/uploadServer-acreditar-utils.test.js` y los tests focalizados pasaron (`4 passed`).
- Al ejecutar `npm test -- --runTestsByPath __tests__/uploadServer-acreditar-utils.test.js` las pruebas unitarias también pasaron pero la ejecución global falló por los umbrales de cobertura del proyecto; por eso la validación final se realizó con `--coverage=false` y fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c727744c8326a8cde19284e28b6d)