### PR TITLE
Fortalece acreditación de premios con email canónico y fallback por id interno

### DIFF
--- a/__tests__/uploadServer-acreditar-utils.test.js
+++ b/__tests__/uploadServer-acreditar-utils.test.js
@@ -39,6 +39,38 @@ describe('uploadServer utilidades de acreditación', () => {
     expect(id).toBe('auto_premio__sorteo_1__f2__carton_abc');
   });
 
+
+  test('resolveWinnerIdentity resuelve email canónico cuando solo llega userId en cartón', async () => {
+    const { resolveWinnerIdentity } = require('../uploadServer.js');
+
+    const resolved = await resolveWinnerIdentity({
+      normalizedEmail: '',
+      normalizedUserId: 'uid-ganador-1',
+      cartonData: {
+        userId: 'uid-ganador-1',
+        email: '',
+        gmail: '',
+        IDbilletera: 'uid-ganador-1'
+      },
+      loadUserById: async () => null,
+      loadUserByUid: async (uid) => {
+        if (uid !== 'uid-ganador-1') return null;
+        return {
+          id: 'ganador@example.com',
+          data: {
+            uid: 'uid-ganador-1',
+            email: 'ganador@example.com'
+          }
+        };
+      }
+    });
+
+    expect(resolved.emailVisible).toBe('ganador@example.com');
+    expect(resolved.billeteraCandidates).toEqual(
+      expect.arrayContaining(['ganador@example.com', 'uid-ganador-1'])
+    );
+  });
+
   test('extractEventoGanadorIdComponents obtiene sorteo, forma y carton', () => {
     const { extractEventoGanadorIdComponents } = require('../uploadServer.js');
 

--- a/public/billetera.html
+++ b/public/billetera.html
@@ -1923,25 +1923,79 @@
       const user=auth.currentUser;
       if(!user?.email) return;
 
-      unsubscribePremiosProyeccion=db.collection('users').doc(user.email).collection('premios').onSnapshot(snapshot=>{
-        transaccionesPremioProyeccion.clear();
-        snapshot.forEach(doc=>{
-          const normalizado=normalizarTransaccionParaTabla(doc.id,doc.data()||{});
-          transaccionesPremioProyeccion.set(doc.id,normalizado);
-        });
-        sincronizarTransaccionesEnTabla();
-      },error=>{
-        console.error('Error escuchando la proyección de premios del usuario',error);
-      });
+      const identidadesLectura = Array.from(new Set([user.email, user.uid].filter(Boolean)));
+      const premiosPorIdentidad = new Map();
+      const transaccionesPorIdentidad = new Map();
 
-      unsubscribeTransacciones=db.collection('transacciones').where('IDbilletera','==',user.email).onSnapshot(snapshot=>{
-        transaccionesGlobales.clear();
-        snapshot.forEach(doc=>{
-          const normalizado=normalizarTransaccionParaTabla(doc.id,doc.data()||{});
-          transaccionesGlobales.set(doc.id,normalizado);
+      const resyncPremios = () => {
+        transaccionesPremioProyeccion.clear();
+        premiosPorIdentidad.forEach((mapaDocs)=>{
+          mapaDocs.forEach((valor,id)=>{
+            if(!transaccionesPremioProyeccion.has(id)){
+              transaccionesPremioProyeccion.set(id, valor);
+            }
+          });
         });
         sincronizarTransaccionesEnTabla();
-      },error=>{ console.error('Error escuchando transacciones de la billetera',error); });
+      };
+
+      const resyncTransacciones = () => {
+        transaccionesGlobales.clear();
+        transaccionesPorIdentidad.forEach((mapaDocs)=>{
+          mapaDocs.forEach((valor,id)=>{
+            if(!transaccionesGlobales.has(id)){
+              transaccionesGlobales.set(id, valor);
+            }
+          });
+        });
+        sincronizarTransaccionesEnTabla();
+      };
+
+      const unsubsPremios = identidadesLectura.map((identidad)=>db.collection('users').doc(identidad).collection('premios').onSnapshot(snapshot=>{
+        const docs = new Map();
+        snapshot.forEach(doc=>{
+          const normalizado=normalizarTransaccionParaTabla(doc.id,doc.data()||{});
+          docs.set(doc.id, normalizado);
+        });
+        premiosPorIdentidad.set(identidad, docs);
+        resyncPremios();
+      },error=>{
+        console.error('Error escuchando la proyección de premios del usuario',error, identidad);
+      }));
+
+      unsubscribePremiosProyeccion = () => {
+        unsubsPremios.forEach((fn)=>{ try{ fn(); }catch(_err){} });
+      };
+
+      const unsubsTransacciones = [
+        db.collection('transacciones').where('IDbilletera','==',user.email).onSnapshot(snapshot=>{
+          const docs = new Map();
+          snapshot.forEach(doc=>{
+            const normalizado=normalizarTransaccionParaTabla(doc.id,doc.data()||{});
+            docs.set(doc.id,normalizado);
+          });
+          transaccionesPorIdentidad.set('emailVisible', docs);
+          resyncTransacciones();
+        },error=>{ console.error('Error escuchando transacciones de la billetera',error); })
+      ];
+
+      if(identidadesLectura.length){
+        unsubsTransacciones.push(
+          db.collection('transacciones').where('idBilleteraInterna','in',identidadesLectura).onSnapshot(snapshot=>{
+            const docs = new Map();
+            snapshot.forEach(doc=>{
+              const normalizado=normalizarTransaccionParaTabla(doc.id,doc.data()||{});
+              docs.set(doc.id,normalizado);
+            });
+            transaccionesPorIdentidad.set('idBilleteraInterna', docs);
+            resyncTransacciones();
+          },error=>{ console.error('Error escuchando transacciones por idBilleteraInterna',error); })
+        );
+      }
+
+      unsubscribeTransacciones = () => {
+        unsubsTransacciones.forEach((fn)=>{ try{ fn(); }catch(_err){} });
+      };
     }
 
     function filtrarTransacciones(){

--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -733,44 +733,57 @@
 
       try{
         const correo = this.usuario.email;
-        const unsubTrans = db.collection('transacciones')
+        const identidadesInternas = Array.from(new Set([correo, this.usuario.uid].filter(Boolean)));
+        const manejarSnapshot = (snapshot) => {
+          if(!this.inicializaciones.transJugador){
+            this.inicializaciones.transJugador = true;
+            return;
+          }
+          snapshot.docChanges().forEach(cambio => {
+            const data = cambio.doc.data() || {};
+            const tipo = normalizarTipoRecarga(data.tipotrans);
+            const estado = estadoNormalizado(data.estado);
+            if(tipo === 'recarga' && (estado === 'APROBADO' || estado === 'ANULADO')){
+              this.notificarCambioRecarga(cambio.doc.id, { ...data, tipotrans: tipo }, estado);
+            }
+          });
+        };
+
+        const unsubTransEmail = db.collection('transacciones')
           .where('IDbilletera','==', correo)
           .where('tipotrans','in',['recarga','deposito'])
-          .onSnapshot(snapshot => {
-            if(!this.inicializaciones.transJugador){
-              this.inicializaciones.transJugador = true;
-              return;
-            }
-            snapshot.docChanges().forEach(cambio => {
-              const data = cambio.doc.data() || {};
-              const tipo = normalizarTipoRecarga(data.tipotrans);
-              const estado = estadoNormalizado(data.estado);
-              if(tipo === 'recarga' && (estado === 'APROBADO' || estado === 'ANULADO')){
-                this.notificarCambioRecarga(cambio.doc.id, { ...data, tipotrans: tipo }, estado);
-              }
-            });
-          }, err => console.error('Error escuchando transacciones del jugador', err));
-        this.desuscriptores.push(unsubTrans);
+          .onSnapshot(manejarSnapshot, err => console.error('Error escuchando transacciones del jugador', err));
+        this.desuscriptores.push(unsubTransEmail);
+
+        identidadesInternas.forEach((identidad) => {
+          const unsubInterno = db.collection('transacciones')
+            .where('idBilleteraInterna','==', identidad)
+            .where('tipotrans','in',['recarga','deposito'])
+            .onSnapshot(manejarSnapshot, err => console.error('Error escuchando transacciones por idBilleteraInterna', err));
+          this.desuscriptores.push(unsubInterno);
+        });
       }catch(err){
         console.error('No se pudo observar las transacciones del jugador', err);
       }
 
       try{
-        const correo = this.usuario.email;
-        const unsubPremios = db.collection('users')
-          .doc(correo)
-          .collection('premios')
-          .onSnapshot(snapshot => {
-            snapshot.docChanges().forEach(cambio => {
-              if(cambio.type === 'removed') return;
-              const data = cambio.doc.data() || {};
-              const estadoPremio = estadoPremioNormalizado(data.estado);
-              if(estadoPremio === 'REALIZADO'){
-                this.notificarPremio(cambio.doc.id, data);
-              }
-            });
-          }, err => console.error('Error escuchando proyección de premios del jugador', err));
-        this.desuscriptores.push(unsubPremios);
+        const identidadesPremio = Array.from(new Set([this.usuario.email, this.usuario.uid].filter(Boolean)));
+        identidadesPremio.forEach((identidad) => {
+          const unsubPremios = db.collection('users')
+            .doc(identidad)
+            .collection('premios')
+            .onSnapshot(snapshot => {
+              snapshot.docChanges().forEach(cambio => {
+                if(cambio.type === 'removed') return;
+                const data = cambio.doc.data() || {};
+                const estadoPremio = estadoPremioNormalizado(data.estado);
+                if(estadoPremio === 'REALIZADO'){
+                  this.notificarPremio(cambio.doc.id, data);
+                }
+              });
+            }, err => console.error('Error escuchando proyección de premios del jugador', err));
+          this.desuscriptores.push(unsubPremios);
+        });
       }catch(err){
         console.error('No se pudo observar la proyección de premios del jugador', err);
       }

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -368,6 +368,79 @@ function looksLikeEmail(value) {
   return typeof value === 'string' && /@/.test(value.trim());
 }
 
+async function resolveWinnerIdentity({
+  normalizedEmail,
+  normalizedUserId,
+  cartonData,
+  loadUserById,
+  loadUserByUid
+}) {
+  const cartonUserId = normalizeString(cartonData?.userId || cartonData?.usuarioId, 160);
+  const emailCandidates = [
+    normalizeString(normalizedEmail, 160).toLowerCase(),
+    normalizeString(cartonData?.email, 160).toLowerCase(),
+    normalizeString(cartonData?.gmail, 160).toLowerCase(),
+    looksLikeEmail(cartonData?.IDbilletera) ? normalizeString(cartonData?.IDbilletera, 160).toLowerCase() : ''
+  ].filter(Boolean);
+  const internalCandidates = [
+    normalizeString(normalizedUserId, 160),
+    cartonUserId,
+    looksLikeEmail(cartonData?.IDbilletera) ? '' : normalizeString(cartonData?.IDbilletera, 160)
+  ].filter(Boolean);
+
+  const identities = [normalizeString(normalizedUserId, 160), cartonUserId].filter(Boolean);
+  for (const identity of identities) {
+    if (looksLikeEmail(identity)) {
+      emailCandidates.push(normalizeString(identity, 160).toLowerCase());
+      continue;
+    }
+
+    const directUser = await loadUserById(identity);
+    if (directUser) {
+      const emailByData = normalizeString(directUser.data?.email || directUser.data?.gmail, 160).toLowerCase();
+      if (emailByData) emailCandidates.push(emailByData);
+      if (looksLikeEmail(directUser.id)) {
+        emailCandidates.push(directUser.id.toLowerCase());
+      } else if (directUser.id) {
+        internalCandidates.push(normalizeString(directUser.id, 160));
+      }
+      if (directUser.data?.uid) {
+        internalCandidates.push(normalizeString(directUser.data.uid, 160));
+      }
+    }
+
+    const uidUser = await loadUserByUid(identity);
+    if (uidUser) {
+      const emailByData = normalizeString(uidUser.data?.email || uidUser.data?.gmail, 160).toLowerCase();
+      if (emailByData) emailCandidates.push(emailByData);
+      if (looksLikeEmail(uidUser.id)) {
+        emailCandidates.push(uidUser.id.toLowerCase());
+      } else if (uidUser.id) {
+        internalCandidates.push(normalizeString(uidUser.id, 160));
+      }
+      if (uidUser.data?.uid) {
+        internalCandidates.push(normalizeString(uidUser.data.uid, 160));
+      }
+    }
+  }
+
+  const uniqueEmails = Array.from(new Set(emailCandidates.filter(Boolean)));
+  const uniqueInternals = Array.from(new Set(internalCandidates.filter(Boolean)));
+  const emailVisible = uniqueEmails[0] || '';
+  const billeteraCandidates = Array.from(new Set([
+    emailVisible,
+    ...getBilleteraCandidates({ userEmail: normalizedEmail, payloadUserId: normalizedUserId, cartonData }),
+    ...uniqueInternals
+  ].filter(Boolean)));
+
+  return {
+    emailVisible,
+    canonicalEmail: emailVisible,
+    billeteraCandidates,
+    internalCandidates: uniqueInternals
+  };
+}
+
 app.post('/toggleUser', verificarToken, async (req, res) => {
   const { email, disabled } = req.body || {};
   if (!email || typeof disabled !== 'boolean') {
@@ -769,48 +842,24 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
         return { status: 'ok', idempotent: true, premioId: normalizedEventoGanadorId, requestId: normalizedRequestId };
       }
 
-      const billeteraCandidates = getBilleteraCandidates({
-        userEmail: normalizedEmail,
-        payloadUserId: normalizedUserId,
-        cartonData
-      });
-      const cartonUserId = normalizeString(cartonData?.userId || cartonData?.usuarioId, 160);
-      const emailCandidates = [
+      const identityResolution = await resolveWinnerIdentity({
         normalizedEmail,
-        normalizeString(cartonData?.email, 160).toLowerCase(),
-        normalizeString(cartonData?.gmail, 160).toLowerCase(),
-        looksLikeEmail(cartonData?.IDbilletera) ? normalizeString(cartonData?.IDbilletera, 160).toLowerCase() : ''
-      ].filter(Boolean);
-
-      for (const userIdentity of [normalizedUserId, cartonUserId].filter(Boolean)) {
-        if (looksLikeEmail(userIdentity)) {
-          emailCandidates.push(normalizeString(userIdentity, 160).toLowerCase());
-          continue;
-        }
-
-        const directUserSnap = await tx.get(db.collection('users').doc(userIdentity));
-        if (directUserSnap.exists) {
-          const data = directUserSnap.data() || {};
-          const emailByData = normalizeString(data.email || data.gmail, 160).toLowerCase();
-          if (emailByData) emailCandidates.push(emailByData);
-          if (looksLikeEmail(directUserSnap.id)) emailCandidates.push(directUserSnap.id.toLowerCase());
-        }
-
-        const byUidSnap = await tx.get(db.collection('users').where('uid', '==', userIdentity).limit(1));
-        if (!byUidSnap.empty) {
+        normalizedUserId,
+        cartonData,
+        loadUserById: async (identity) => {
+          const directUserSnap = await tx.get(db.collection('users').doc(identity));
+          if (!directUserSnap.exists) return null;
+          return { id: directUserSnap.id, data: directUserSnap.data() || {} };
+        },
+        loadUserByUid: async (identity) => {
+          const byUidSnap = await tx.get(db.collection('users').where('uid', '==', identity).limit(1));
+          if (byUidSnap.empty) return null;
           const doc = byUidSnap.docs[0];
-          const data = doc.data() || {};
-          const emailByData = normalizeString(data.email || data.gmail, 160).toLowerCase();
-          if (emailByData) emailCandidates.push(emailByData);
-          if (looksLikeEmail(doc.id)) emailCandidates.push(doc.id.toLowerCase());
+          return { id: doc.id, data: doc.data() || {} };
         }
-      }
-
-      const billeteraVisibleId = Array.from(new Set(emailCandidates))[0] || '';
-      const billeteraSearchCandidates = Array.from(new Set([
-        billeteraVisibleId,
-        ...billeteraCandidates
-      ].filter(Boolean)));
+      });
+      const emailVisible = identityResolution.emailVisible;
+      const billeteraSearchCandidates = identityResolution.billeteraCandidates;
 
       if (!billeteraSearchCandidates.length) {
         throw new Error('BILLETERA_NO_IDENTIFICABLE');
@@ -838,16 +887,50 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
       const fecha = new Date();
       const fechaGestion = fecha.toISOString().slice(0, 10).split('-').reverse().join('/');
       const horaGestion = fecha.toTimeString().slice(0, 5);
-      const premioProyeccionRef = db
-        .collection('users')
-        .doc(billeteraVisibleId || billeteraRef.id)
-        .collection('premios')
-        .doc(normalizedEventoGanadorId);
-      const resumenProyeccionRef = db
-        .collection('users')
-        .doc(billeteraVisibleId || billeteraRef.id)
-        .collection('billeteraProyeccion')
-        .doc('resumen');
+      if (!emailVisible) {
+        const eventoTecnicoRef = db.collection('AcreditacionEventosTecnicos').doc(`${normalizedEventoGanadorId}__${normalizedRequestId}`);
+        const reconciliacionRef = db.collection('AcreditacionReconciliacionPendiente').doc(normalizedEventoGanadorId);
+        tx.set(eventoTecnicoRef, {
+          tipo: 'EMAIL_CANONICO_NO_RESUELTO',
+          severidad: 'warning',
+          sorteoId: normalizedSorteoId,
+          cartonId: normalizedCartonId,
+          formaIdx: normalizedFormaIdx,
+          eventoGanadorId: normalizedEventoGanadorId,
+          requestId: normalizedRequestId,
+          userId: normalizedUserId || cartonData.userId || null,
+          idBilleteraInterna: billeteraRef.id,
+          source: normalizedSource,
+          processedBy: req.user?.email || '',
+          processedAt: timestamp,
+          estado: 'PENDIENTE_RECONCILIACION'
+        }, { merge: true });
+        tx.set(reconciliacionRef, {
+          eventoGanadorId: normalizedEventoGanadorId,
+          sorteoId: normalizedSorteoId,
+          cartonId: normalizedCartonId,
+          formaIdx: normalizedFormaIdx,
+          requestId: normalizedRequestId,
+          source: normalizedSource,
+          motivo: 'EMAIL_CANONICO_NO_RESUELTO',
+          estado: 'PENDIENTE',
+          userId: normalizedUserId || cartonData.userId || null,
+          idBilleteraInterna: billeteraRef.id,
+          creadoEn: timestamp,
+          actualizadoEn: timestamp
+        }, { merge: true });
+
+        return {
+          status: 'pending_reconciliation',
+          idempotent: false,
+          premioId: normalizedEventoGanadorId,
+          billeteraInternaId: billeteraRef.id,
+          requestId: normalizedRequestId
+        };
+      }
+
+      const premioProyeccionRef = db.collection('users').doc(emailVisible).collection('premios').doc(normalizedEventoGanadorId);
+      const resumenProyeccionRef = db.collection('users').doc(emailVisible).collection('billeteraProyeccion').doc('resumen');
       const ganadorTiempoRealRef = db.collection('GanadoresSorteosTiempoReal').doc(normalizedEventoGanadorId);
 
       tx.set(
@@ -855,8 +938,9 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
         {
           sorteoId: normalizedSorteoId,
           sorteoNombre,
-          email: billeteraVisibleId || billeteraRef.id,
-          gmail: billeteraVisibleId || billeteraRef.id,
+          email: emailVisible,
+          gmail: emailVisible,
+          emailVisible,
           alias: normalizedAlias || cartonData.alias || '',
           aliasJugador: normalizedAlias || cartonData.alias || '',
           aliasGanador: normalizedAlias || cartonData.alias || '',
@@ -873,6 +957,7 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           tipoRegistro: normalizedTipoRegistro,
           segundoLugar: normalizedSegundoLugar,
           idBilletera: billeteraRef.id,
+          idBilleteraInterna: billeteraRef.id,
           estado: 'REALIZADO',
           actualizadoEn: timestamp,
           fechaRegistro: premioActual?.fechaRegistro || timestamp,
@@ -900,8 +985,9 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           formaIdx: normalizedFormaIdx,
           cartonId: normalizedCartonId,
           idBilletera: billeteraRef.id,
-          email: billeteraVisibleId || billeteraRef.id,
-          gmail: billeteraVisibleId || billeteraRef.id,
+          email: emailVisible,
+          gmail: emailVisible,
+          emailVisible,
           alias: normalizedAlias || cartonData.alias || '',
           userId: normalizedUserId || cartonData.userId || null,
           creditos: normalizedMonto,
@@ -933,9 +1019,9 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
         { merge: true }
       );
 
-      if (billeteraVisibleId && billeteraVisibleId !== billeteraRef.id) {
+      if (emailVisible && emailVisible !== billeteraRef.id) {
         tx.set(
-          db.collection('Billetera').doc(billeteraVisibleId),
+          db.collection('Billetera').doc(emailVisible),
           {
             creditos: nuevosCreditos,
             CartonesGratis: nuevosCartones,
@@ -953,7 +1039,8 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           Monto: normalizedMonto > 0 ? normalizedMonto : normalizedCartonesGratis,
           cartonesGratis: normalizedCartonesGratis,
           estado: 'REALIZADO',
-          IDbilletera: billeteraVisibleId || billeteraRef.id,
+          IDbilletera: emailVisible,
+          emailVisible,
           fechasolicitud: '',
           horasolicitud: '',
           fechagestion: fechaGestion,
@@ -983,7 +1070,8 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
         {
           tipotrans: 'premio',
           estado: 'REALIZADO',
-          IDbilletera: billeteraVisibleId || billeteraRef.id,
+          IDbilletera: emailVisible,
+          emailVisible,
           Monto: normalizedMonto > 0 ? normalizedMonto : normalizedCartonesGratis,
           cartonesGratis: normalizedCartonesGratis,
           sorteoId: normalizedSorteoId,
@@ -1038,7 +1126,8 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           source: normalizedSource,
           processedBy: req.user?.email || '',
           role: req.user?.role || '',
-          billeteraId: billeteraVisibleId || billeteraRef.id,
+          billeteraId: emailVisible,
+          emailVisible,
           billeteraInternaId: billeteraRef.id,
           monto: normalizedMonto,
           cartonesGratis: normalizedCartonesGratis,
@@ -1051,8 +1140,9 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
         status: 'ok',
         idempotent: false,
         premioId: normalizedEventoGanadorId,
-        billeteraId: billeteraVisibleId || billeteraRef.id,
+        billeteraId: emailVisible,
         billeteraInternaId: billeteraRef.id,
+        emailVisible,
         requestId: normalizedRequestId
       };
     });
@@ -1168,5 +1258,6 @@ module.exports = {
   getPurgeCounts,
   isSorteoEligibleForAutoPrize,
   buildPremioDocId,
-  extractEventoGanadorIdComponents
+  extractEventoGanadorIdComponents,
+  resolveWinnerIdentity
 };


### PR DESCRIPTION
### Motivation
- Evitar escrituras en rutas observadas por el cliente cuando no se puede resolver un email canónico del ganador. 
- Garantizar consistencia entre la billetera interna y la identidad visible para el frontend usando campos claros. 
- No perder notificaciones ni visualización si la identidad canónica difiere de identificadores internos (`userId`/`idBilleteraInterna`).

### Description
- Añadida la utilidad `resolveWinnerIdentity` en `uploadServer.js` que prioriza la resolución de `emailVisible` (desde payload/cartón/doc `users` y por `uid`) y construye candidatos de billetera internos; se exportó para pruebas. 
- Refactorizado `/acreditarPremioEvento` para usar la resolución anterior antes de escribir proyecciones y transacciones visibles, persistir `emailVisible` + `idBilleteraInterna` y usar `emailVisible` en `IDbilletera` y en `users/{email}/premios` cuando esté disponible. 
- Si no se logra resolver un email canónico, ahora se registra un evento técnico en `AcreditacionEventosTecnicos` y se crea/actualiza una tarea en `AcreditacionReconciliacionPendiente`, devolviendo un resultado `pending_reconciliation` y evitando escribir en rutas cliente. 
- Frontend: en `public/billetera.html` y `public/js/notificationCenter.js` se añadió fallback de lectura para combinar suscripciones por `users/{email|uid}/premios` y para escuchar `transacciones` tanto por `IDbilletera` (email) como por `idBilleteraInterna` (email/uid), consolidando y deduplicando entradas para mantener la visualización y notificaciones. 
- Añadida prueba unitaria en `__tests__/uploadServer-acreditar-utils.test.js` que cubre el caso “winner con `userId` pero sin email directo en cartón” validando que se resuelva `emailVisible` a partir del `uid`.

### Testing
- Ejecuté comprobación de sintaxis de los assets con `node -c uploadServer.js` y `node -c public/js/notificationCenter.js`, y ambas pasaron. (OK)
- Ejecuté la suite específica con `npm test -- --runTestsByPath __tests__/uploadServer-acreditar-utils.test.js --coverage=false` y todas las pruebas incluidas en ese archivo pasaron (5/5). (OK)
- Ejecuté la misma prueba con cobertura habilitada y el `jest` global threshold falló por cobertura global al ejecutar un único archivo; las pruebas unitarias del archivo en sí pasaron. (tests del archivo: OK; cobertura global: no alcanzada)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998cb1d97ec8326a4ecbc38e0b6f17a)