### PR TITLE
Agregar reencolado manual TOPE_REINTENTOS y reconciliación de premios huérfanos

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node uploadServer.js",
     "cron": "node cronActualizarEstadosSorteos.js",
     "assign-role": "node scripts/assignRoleClaims.js",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "reconciliar-premios": "node scripts/reconciliarPremiosPendientes.js"
   },
   "keywords": [],
   "author": "",

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -521,6 +521,8 @@
     <div id="premios-content">
       <div class="acciones">
         <button class="icon-btn" id="premios-archivo"><span class="icon">&#128193;</span><span>Archivo</span></button>
+        <button class="icon-btn" id="acreditaciones-reencolar"><span class="icon">&#10227;</span><span>Reencolar TOPE</span></button>
+        <button class="icon-btn" id="premios-reconciliar"><span class="icon">&#128269;</span><span>Reconciliar</span></button>
         <span class="switch-label" id="premios-auditoria-label">Vista de auditoría: Procesados / Con error / Reintentos</span>
       </div>
       <table id="tabla-premios">
@@ -553,6 +555,29 @@
         </thead>
         <tbody></tbody>
       </table>
+
+      <div id="acreditaciones-tope-panel" style="margin-top:8px;">
+        <div class="acciones">
+          <span class="switch-label" id="acreditaciones-tope-label">Acreditaciones técnicas en TOPE_REINTENTOS</span>
+        </div>
+        <table id="tabla-acreditaciones-tope">
+          <colgroup>
+            <col style="width:6%">
+            <col style="width:20%">
+            <col style="width:16%">
+            <col style="width:10%">
+            <col style="width:18%">
+            <col style="width:24%">
+            <col style="width:6%">
+          </colgroup>
+          <thead>
+            <tr class="filtros">
+              <th>N°</th><th>Evento</th><th>Sorteo</th><th>Intentos</th><th>Próx. reintento</th><th>Error</th><th><span id="acreditaciones-tope-marcar" class="check-header">✔</span></th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
     </div>
   </section>
 
@@ -687,6 +712,8 @@
     const pagosAdminArchivoMapa = new Map();
     const pagosColaboradoresMapa = new Map();
     const pagosColaboradoresEdicion = new Map();
+    const acreditacionesTopeActivas = [];
+    const acreditacionesTopeMapa = new Map();
     const usuariosInfoCache = new Map();
 
     let unsubscribePremios = null;
@@ -695,6 +722,7 @@
     let unsubscribePagosArchivo = null;
     let unsubscribeColaboradores = null;
     let unsubscribeUsuariosCentro = null;
+    let unsubscribeAcreditacionesTope = null;
 
     const formatNumber = new Intl.NumberFormat('es-ES', { maximumFractionDigits: 2, minimumFractionDigits: 0 });
     const formatNumberEntero = new Intl.NumberFormat('es-ES', { maximumFractionDigits: 0, minimumFractionDigits: 0 });
@@ -1986,6 +2014,132 @@
       capa.classList.remove('activo');
     }
 
+
+    function prepararAcreditacionTope(id, data = {}){
+      const estado = normalizarEstado(data.estado);
+      if(estado !== 'TOPE_REINTENTOS') return null;
+      const nextRetryDate = data.nextRetryAt?.toDate ? data.nextRetryAt.toDate() : null;
+      const eventoGanadorId = (data.eventoGanadorId || id || '').toString();
+      return {
+        id,
+        eventoGanadorId,
+        sorteoId: (data.sorteoId || '').toString(),
+        cartonId: (data.cartonId || '').toString(),
+        intentos: Math.max(0, Number(data.intentos) || 0),
+        estado,
+        nextRetryAt: nextRetryDate,
+        nextRetryAtTexto: nextRetryDate instanceof Date ? nextRetryDate.toLocaleString('es-ES') : '-',
+        error: (data.error || '').toString().slice(0, 160),
+        payload: (data.payload && typeof data.payload === 'object') ? data.payload : null
+      };
+    }
+
+    function renderAcreditacionesTope(){
+      const tbody = document.querySelector('#tabla-acreditaciones-tope tbody');
+      if(!tbody) return;
+      const lista = [...acreditacionesTopeActivas].sort((a,b)=>(b.intentos-a.intentos) || ((b.nextRetryAt?.getTime?.()||0)-(a.nextRetryAt?.getTime?.()||0)));
+      if(!lista.length){
+        tbody.innerHTML = '<tr><td colspan="7"><div class="mensaje-tabla">No hay registros en TOPE_REINTENTOS.</div></td></tr>';
+        return;
+      }
+      tbody.innerHTML = lista.map((item, idx)=>`<tr data-id="${item.id}"><td>${idx+1}</td><td>${escapeHtml(item.eventoGanadorId)}</td><td>${escapeHtml(item.sorteoId || '-')}</td><td>${item.intentos}</td><td>${escapeHtml(item.nextRetryAtTexto)}</td><td>${escapeHtml(item.error || '-')}</td><td><input type="checkbox" data-id="${item.id}"></td></tr>`).join('');
+    }
+
+    function obtenerSeleccionAcreditacionesTope(){
+      const checks = Array.from(document.querySelectorAll('#tabla-acreditaciones-tope tbody input[type="checkbox"]:checked'));
+      return checks.map(chk=>chk.dataset.id).filter(Boolean);
+    }
+
+    async function registrarAuditoriaReencolado({ ids = [], motivo = '' } = {}){
+      if(!ids.length) return;
+      const db = dbRef();
+      const user = authInstance().currentUser;
+      const email = (user?.email || 'desconocido').toString();
+      const rol = (window.currentRole || '').toString();
+      const razon = (motivo || '').toString().trim() || 'Sin motivo especificado';
+      await Promise.all(ids.map(async (id)=>{
+        const ref = db.collection('AcreditacionesPendientesAuditoria').doc();
+        await ref.set({
+          accion: 'REENCOLAR_TOPE_REINTENTOS',
+          registroId: id,
+          motivo: razon.slice(0, 400),
+          ejecutadoPor: email,
+          rolEjecutor: rol,
+          ejecutadoAt: firebase.firestore.FieldValue.serverTimestamp()
+        });
+      }));
+    }
+
+    async function reencolarAcreditacionesTope(ids = []){
+      if(!ids.length){ alert('No hay registros seleccionados para reencolar.'); return; }
+      const motivo = await window.prompt('Indica el motivo del relanzamiento manual:');
+      if(motivo === null) return;
+      const motivoFinal = String(motivo || '').trim();
+      if(!motivoFinal){ alert('Debes ingresar un motivo para continuar.'); return; }
+      const db = dbRef();
+      const ahora = firebase.firestore.Timestamp.fromDate(new Date());
+      const user = authInstance().currentUser;
+      const batch = db.batch();
+      ids.forEach((id)=>{
+        const ref = db.collection('AcreditacionesPendientes').doc(id);
+        batch.set(ref, {
+          estado: 'PENDIENTE',
+          intentos: 0,
+          nextRetryAt: ahora,
+          relanzadoManual: {
+            por: user?.email || '',
+            rol: window.currentRole || '',
+            motivo: motivoFinal.slice(0, 400),
+            fecha: firebase.firestore.FieldValue.serverTimestamp()
+          },
+          updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+        }, { merge: true });
+      });
+      await batch.commit();
+      await registrarAuditoriaReencolado({ ids, motivo: motivoFinal });
+      alert(`Se reencolaron ${ids.length} registro(s) en TOPE_REINTENTOS.`);
+    }
+
+    async function ejecutarReconciliacionPremios(){
+      const db = dbRef();
+      const [premiosSnap, pendientesSnap] = await Promise.all([
+        db.collection('PremiosSorteos').get(),
+        db.collection('AcreditacionesPendientes').get()
+      ]);
+      const pendientesMap = new Map();
+      pendientesSnap.forEach(doc=>{
+        const data = doc.data() || {};
+        const evento = (data.eventoGanadorId || doc.id || '').toString();
+        if(evento){ pendientesMap.set(evento, { id: doc.id, estado: normalizarEstado(data.estado) }); }
+      });
+      const huerfanos = [];
+      premiosSnap.forEach(doc=>{
+        const data = doc.data() || {};
+        const estado = normalizarEstado(data.estado);
+        if(estado === 'REALIZADO' || estado === 'ARCHIVADO') return;
+        const eventoGanadorId = (data.eventoGanadorId || doc.id || '').toString();
+        const pendiente = pendientesMap.get(eventoGanadorId);
+        if(!pendiente || pendiente.estado === 'REALIZADO'){
+          huerfanos.push({ id: doc.id, eventoGanadorId, sorteoId: (data.sorteoId || '').toString(), estado });
+        }
+      });
+      await db.collection('AcreditacionesReconciliacion').add({
+        tipo: 'PREMIOS_VS_ACREDITACIONES',
+        totalPremios: premiosSnap.size,
+        totalPendientes: pendientesSnap.size,
+        totalHuerfanos: huerfanos.length,
+        huerfanos: huerfanos.slice(0, 200),
+        ejecutadoPor: authInstance().currentUser?.email || '',
+        ejecutadoAt: firebase.firestore.FieldValue.serverTimestamp()
+      });
+      if(!huerfanos.length){
+        mostrarModalInfo('Reconciliación completada', 'No se detectaron premios huérfanos no realizados.');
+        return;
+      }
+      const preview = huerfanos.slice(0, 8).map(item=>`• ${item.eventoGanadorId || item.id} | sorteo ${item.sorteoId || '-'} | ${item.estado}`).join('\n');
+      mostrarModalInfo('Premios huérfanos detectados', `Se detectaron ${huerfanos.length} premio(s) huérfano(s).\n${preview}`);
+    }
+
     function renderTabla(lista, tbodyId, opciones = {}){
       const tbody = document.querySelector(`#${tbodyId} tbody`);
       if(!tbody) return;
@@ -2535,6 +2689,26 @@
         renderPagos();
       });
 
+      const reencolarBtn = document.getElementById('acreditaciones-reencolar');
+      if(reencolarBtn){
+        reencolarBtn.addEventListener('click', async()=>{
+          const seleccion = obtenerSeleccionAcreditacionesTope();
+          const ids = seleccion.length ? seleccion : acreditacionesTopeActivas.map(item=>item.id);
+          if(!ids.length){ alert('No hay registros en TOPE_REINTENTOS para reencolar.'); return; }
+          await reencolarAcreditacionesTope(ids);
+        });
+      }
+      const reconciliarBtn = document.getElementById('premios-reconciliar');
+      if(reconciliarBtn){
+        reconciliarBtn.addEventListener('click', async()=>{
+          await ejecutarReconciliacionPremios();
+        });
+      }
+      const marcarTope = document.getElementById('acreditaciones-tope-marcar');
+      if(marcarTope){
+        marcarTope.addEventListener('click', ()=>seleccionarTodos('tabla-acreditaciones-tope'));
+      }
+
       document.getElementById('colaboradores-marcar').addEventListener('click', ()=>seleccionarTodos('tabla-colaboradores'));
       document.getElementById('colaboradores-aprobar').addEventListener('click', async()=>{
         const seleccion = obtenerSeleccion('tabla-colaboradores');
@@ -2754,6 +2928,25 @@
         });
         if(mostrarPagosArchivo) renderPagos();
       });
+
+      unsubscribeAcreditacionesTope = db.collection('AcreditacionesPendientes')
+        .where('estado','==','TOPE_REINTENTOS')
+        .onSnapshot(snapshot => {
+          acreditacionesTopeActivas.length = 0;
+          acreditacionesTopeMapa.clear();
+          snapshot.forEach(doc=>{
+            const registro = prepararAcreditacionTope(doc.id, doc.data() || {});
+            if(!registro) return;
+            acreditacionesTopeActivas.push(registro);
+            acreditacionesTopeMapa.set(doc.id, registro);
+          });
+          const label = document.getElementById('acreditaciones-tope-label');
+          if(label){
+            label.textContent = `Acreditaciones técnicas en TOPE_REINTENTOS: ${acreditacionesTopeActivas.length}`;
+          }
+          renderAcreditacionesTope();
+        }, err => console.error('Error escuchando AcreditacionesPendientes en TOPE_REINTENTOS', err));
+
       unsubscribeUsuariosCentro = db.collection('users').onSnapshot(async snapshot => {
         colaboradoresBase.length = 0;
         pagosColaboradoresEdicion.clear();
@@ -2823,7 +3016,8 @@
         unsubscribePremiosArchivo,
         unsubscribePagos,
         unsubscribePagosArchivo,
-        unsubscribeUsuariosCentro
+        unsubscribeUsuariosCentro,
+        unsubscribeAcreditacionesTope
       ].forEach(unsub=>{
         if(typeof unsub === 'function') unsub();
       });

--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -31,6 +31,7 @@
         { clave: 'selladoSorteo', titulo: 'Notificación Sellado Sorteo', descripcion: 'Cuando llega la hora de sellado de un sorteo.' },
         { clave: 'juegoEnVivoSorteo', titulo: 'Notificación Juego en vivo Sorteo', descripcion: 'Cuando llega la hora de inicio de un sorteo.' },
         { clave: 'gestionPagos', titulo: 'Notificación Gestión Pagos', descripcion: 'Aviso único si hay gestiones de pagos pendientes.' },
+        { clave: 'topeReintentosAcreditacion', titulo: 'Notificación TOPE_REINTENTOS', descripcion: 'Te avisa cuando existan acreditaciones técnicas bloqueadas por tope de reintentos.' },
         { clave: 'mensajeRecargaAprobada', titulo: 'Redacción de mensajes RECARGA APROBADA', descripcion: '✅ Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Recarga', color: '#0b6b27' },
         { clave: 'mensajeRetiroAprobado', titulo: 'Redacción de mensajes RETIRO APROBADO', descripcion: '✅ Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Retiro', color: '#8b0000' },
         { clave: 'mensajeRecargaAnulada', titulo: 'Redacción de mensajes RECARGA ANULADA', descripcion: '🚫 Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Recarga Anulada', color: '#0a8800' },
@@ -42,7 +43,8 @@
   const INTERVALOS_REPETICION = {
     recargasPendientes: 600000,
     retirosPendientes: 600000,
-    gestionPagos: 600000
+    gestionPagos: 600000,
+    topeReintentosAcreditacion: 600000
   };
 
   const HISTORIAL_FABRICAS = {
@@ -53,6 +55,7 @@
     recargasPendientes: () => ({ ultimoEnvio: 0 }),
     retirosPendientes: () => ({ ultimoEnvio: 0 }),
     gestionPagos: () => ({ ultimoEnvio: 0 }),
+    topeReintentosAcreditacion: () => ({ ultimoEnvio: 0 }),
     selladoSorteo: () => ({ ids: {} }),
     juegoEnVivoSorteo: () => ({ ids: {} })
   };
@@ -221,7 +224,8 @@
         pendientes: {
           recargasPendientes: new Set(),
           retirosPendientes: new Set(),
-          gestionPagos: 0
+          gestionPagos: 0,
+          topeReintentosAcreditacion: 0
         },
         resumenPagos: { premios: 0, pagos: 0 },
         verificadorSorteos: null
@@ -405,7 +409,8 @@
         pendientes: {
           recargasPendientes: new Set(),
           retirosPendientes: new Set(),
-          gestionPagos: 0
+          gestionPagos: 0,
+          topeReintentosAcreditacion: 0
         },
         resumenPagos: { premios: 0, pagos: 0 },
         verificadorSorteos: null
@@ -837,6 +842,17 @@
       }catch(err){
         console.error('No se pudieron observar las gestiones de pagos', err);
       }
+      try{
+        const unsubTope = db.collection('AcreditacionesPendientes')
+          .where('estado','==','TOPE_REINTENTOS')
+          .onSnapshot(snapshot => {
+            this.cache.pendientes.topeReintentosAcreditacion = snapshot.size;
+            this.gestionarTopeReintentos();
+          }, err => console.error('Error escuchando TOPE_REINTENTOS de acreditaciones', err));
+        this.desuscriptores.push(unsubTope);
+      }catch(err){
+        console.error('No se pudieron observar acreditaciones en TOPE_REINTENTOS', err);
+      }
       this.iniciarVerificacionSorteos();
     }
 
@@ -986,6 +1002,7 @@
 
     obtenerConteoPendiente(clave){
       if(clave === 'gestionPagos') return this.cache.pendientes.gestionPagos || 0;
+      if(clave === 'topeReintentosAcreditacion') return this.cache.pendientes.topeReintentosAcreditacion || 0;
       const conjunto = this.cache.pendientes[clave];
       return conjunto ? conjunto.size : 0;
     }
@@ -1026,6 +1043,22 @@
           historial.ultimoEnvio = 0;
           this.programarGuardadoHistorial();
         }
+      }
+    }
+
+    gestionarTopeReintentos(){
+      const total = this.cache.pendientes.topeReintentosAcreditacion || 0;
+      const historial = this.config.historial.topeReintentosAcreditacion;
+      if(total > 0){
+        const mensaje = `Hay ${total} acreditación(es) en TOPE_REINTENTOS. Ingresa a Centro de Pagos para reencolar.`;
+        if(historial && historial.ultimoEnvio === 0 && this.puedeNotificar('topeReintentosAcreditacion')){
+          historial.ultimoEnvio = Date.now();
+          this.programarGuardadoHistorial();
+          this.emitirNotificacion('topeReintentosAcreditacion', mensaje, 'Acreditaciones bloqueadas');
+        }
+      }else if(historial){
+        historial.ultimoEnvio = 0;
+        this.programarGuardadoHistorial();
       }
     }
 

--- a/scripts/reconciliarPremiosPendientes.js
+++ b/scripts/reconciliarPremiosPendientes.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+const admin = require('firebase-admin');
+const fs = require('fs');
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function resolveCredentialsPath() {
+  const provided = process.env.GOOGLE_APPLICATION_CREDENTIALS || './serviceAccountKey.json';
+  if (!fs.existsSync(provided)) {
+    throw new Error(`No se encontró el archivo de credenciales en: ${provided}`);
+  }
+  return provided;
+}
+
+function normalizarEstado(estado) {
+  return (estado || '').toString().trim().toUpperCase();
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const sorteoIdFiltro = String(args.sorteoId || '').trim();
+  const guardar = args.guardar !== 'false';
+
+  const credentialsPath = resolveCredentialsPath();
+  admin.initializeApp({
+    credential: admin.credential.cert(require(credentialsPath))
+  });
+
+  const db = admin.firestore();
+  const [premiosSnap, pendientesSnap] = await Promise.all([
+    sorteoIdFiltro
+      ? db.collection('PremiosSorteos').where('sorteoId', '==', sorteoIdFiltro).get()
+      : db.collection('PremiosSorteos').get(),
+    sorteoIdFiltro
+      ? db.collection('AcreditacionesPendientes').where('sorteoId', '==', sorteoIdFiltro).get()
+      : db.collection('AcreditacionesPendientes').get()
+  ]);
+
+  const pendientesPorEvento = new Map();
+  pendientesSnap.forEach(doc => {
+    const data = doc.data() || {};
+    const eventoGanadorId = (data.eventoGanadorId || doc.id || '').toString();
+    if (!eventoGanadorId) return;
+    pendientesPorEvento.set(eventoGanadorId, {
+      id: doc.id,
+      estado: normalizarEstado(data.estado)
+    });
+  });
+
+  const huerfanos = [];
+  premiosSnap.forEach(doc => {
+    const data = doc.data() || {};
+    const estado = normalizarEstado(data.estado);
+    if (estado === 'REALIZADO' || estado === 'ARCHIVADO') return;
+    const eventoGanadorId = (data.eventoGanadorId || doc.id || '').toString();
+    const match = pendientesPorEvento.get(eventoGanadorId);
+    if (!match || match.estado === 'REALIZADO') {
+      huerfanos.push({
+        premioId: doc.id,
+        eventoGanadorId,
+        sorteoId: (data.sorteoId || '').toString(),
+        estadoPremio: estado,
+        creditos: Number(data.creditos) || 0,
+        cartones: Number(data.cartones) || 0
+      });
+    }
+  });
+
+  const resumen = {
+    tipo: 'PREMIOS_VS_ACREDITACIONES',
+    sorteoIdFiltro: sorteoIdFiltro || null,
+    totalPremios: premiosSnap.size,
+    totalAcreditacionesPendientes: pendientesSnap.size,
+    totalHuerfanos: huerfanos.length,
+    huerfanos: huerfanos.slice(0, 500),
+    ejecutadoAt: admin.firestore.FieldValue.serverTimestamp(),
+    ejecutadoPor: 'script:reconciliarPremiosPendientes'
+  };
+
+  if (guardar) {
+    await db.collection('AcreditacionesReconciliacion').add(resumen);
+  }
+
+  console.log('Resumen de reconciliación:');
+  console.log(JSON.stringify({
+    sorteoIdFiltro: resumen.sorteoIdFiltro,
+    totalPremios: resumen.totalPremios,
+    totalAcreditacionesPendientes: resumen.totalAcreditacionesPendientes,
+    totalHuerfanos: resumen.totalHuerfanos
+  }, null, 2));
+
+  if (huerfanos.length) {
+    console.log('\nMuestra de huérfanos:');
+    huerfanos.slice(0, 20).forEach((item, idx) => {
+      console.log(`${idx + 1}. premioId=${item.premioId} eventoGanadorId=${item.eventoGanadorId} sorteoId=${item.sorteoId} estado=${item.estadoPremio}`);
+    });
+  }
+}
+
+main().then(() => process.exit(0)).catch(err => {
+  console.error('Error ejecutando reconciliación:', err.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Añadir una herramienta administrativa para relanzar manualmente acreditaciones técnicas que hayan llegado a `TOPE_REINTENTOS` y permitir auditar esa acción. 
- Notificar a administradores cuando existan acreditaciones bloqueadas por tope de reintentos para evitar pérdida de premios. 
- Detectar premios huérfanos (registros en `PremiosSorteos` sin acreditación pendiente/realizada) y proporcionar un mecanismo de reconciliación tanto desde UI como vía CLI.

### Description
- Se añadió en el panel de Centro de Pagos (`public/centropagos.html`) un panel técnico `tabla-acreditaciones-tope` y botones `Reencolar TOPE` y `Reconciliar` para gestionar registros con `estado='TOPE_REINTENTOS'` y lanzar la reconciliación visual. 
- Se implementaron funciones cliente para preparar, renderizar y seleccionar registros en TOPE, y la acción `reencolarAcreditacionesTope` que resetea `intentos`, pone `estado='PENDIENTE'`, actualiza `nextRetryAt` y escribe metadatos `relanzadoManual` en el documento. 
- Se agregó registro de auditoría en Firestore a través de la colección `AcreditacionesPendientesAuditoria` con quién, rol y motivo del reencolado. 
- Se añadió la función de reconciliación `ejecutarReconciliacionPremios` que compara `PremiosSorteos` vs `AcreditacionesPendientes`, persiste un resumen en `AcreditacionesReconciliacion` y muestra un resumen/preview en la UI. 
- Se suscribió el panel a `AcreditacionesPendientes` filtrando por `TOPE_REINTENTOS` y se añadió limpieza correcta de los desuscriptores al salir de la página. 
- Se extendió `public/js/notificationCenter.js` con la notificación `topeReintentosAcreditacion` y lógica para monitorear y notificar a administradores cuando haya registros en `TOPE_REINTENTOS`. 
- Se añadió script CLI `scripts/reconciliarPremiosPendientes.js` y comando npm `reconciliar-premios` en `package.json` para ejecutar la reconciliación desde línea de comandos.

### Testing
- Se ejecutó la verificación de sintaxis con `node --check scripts/reconciliarPremiosPendientes.js` y `node --check public/js/notificationCenter.js`, ambas sin errores. 
- Se ejecutaron los tests automáticos con `npm test -- --runInBand` y todos los suites pasaron (10 suites, 33 tests, OK). 
- Se generó una captura de pantalla local del panel (`centropagos`) para validar visualmente la inserción del panel y botones; la operación completó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998d00018c88326ac77520f26f583f9)