### PR TITLE
Actualizar suscripción de billetera para refresco instantáneo de créditos

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -692,27 +692,37 @@
       if(!user?.email) return;
       const billeteraRef=db.collection('Billetera').doc(user.email);
       const proyeccionRef=db.collection('users').doc(user.email).collection('billeteraProyeccion').doc('resumen');
-      let recibioProyeccion=false;
+      let resumenProyeccionReciente=false;
 
       unsubscribeBilleteraProyeccion=proyeccionRef.onSnapshot(snap=>{
         if(snap.exists){
-          recibioProyeccion=true;
+          resumenProyeccionReciente=true;
           const data=snap.data()||{};
           actualizarResumenCreditos(data);
           if(Object.prototype.hasOwnProperty.call(data,'CartonesGratis')){
             document.getElementById('cartones-valor').textContent = data.CartonesGratis || 0;
           }
+          return;
         }
+        resumenProyeccionReciente=false;
       },error=>{
         console.error('Error escuchando la proyección de billetera del usuario',error);
       });
 
       unsubscribeBilletera=billeteraRef.onSnapshot(async snap=>{
-        if(recibioProyeccion){
-          return;
-        }
         if(snap.exists){
-          aplicarDatosBilleteraEnPantalla(snap.data()||{});
+          const datosBilletera=snap.data()||{};
+          if(!resumenProyeccionReciente){
+            aplicarDatosBilleteraEnPantalla(datosBilletera);
+            return;
+          }
+          const creditosProyeccion=toNumberSafe(creditosTotales,0);
+          const creditosBilletera=toNumberSafe(datosBilletera.creditos,0);
+          const transitoBilletera=Math.max(0,toNumberSafe(datosBilletera.creditostransito,0));
+          const disponiblesBilletera=Math.max(0,creditosBilletera-transitoBilletera);
+          if(disponiblesBilletera>creditosProyeccion){
+            aplicarDatosBilleteraEnPantalla(datosBilletera);
+          }
           return;
         }
         try{


### PR DESCRIPTION
### Motivation
- Se detectó que la UI de la billetera no mostraba créditos de premios de forma instantánea cuando el documento `users/.../billeteraProyeccion/resumen` tardaba en actualizarse, porque el listener de `Billetera/{email}` quedaba ignorado. 
- La intención es priorizar datos reales de `Billetera` cuando reflejen un saldo disponible mayor, sin eliminar la lógica de Centropagos ni su flujo de acreditación.

### Description
- Modifiqué `public/billetera.html` para reemplazar la bandera `recibioProyeccion` por `resumenProyeccionReciente` y mantener ambos listeners activos (`billeteraProyeccion` y `Billetera/{email}`).
- Eliminé el `return` temprano que descartaba snapshots de `Billetera` cuando existía la proyección, evitando que la UI quedara bloqueada por la proyección retrasada.
- Añadí una reconciliación simple que compara `disponiblesBilletera` con `creditosProyeccion` y aplica los datos de `Billetera` inmediatamente si el saldo disponible real es mayor.
- Archivo afectado: `public/billetera.html` (cambios centrados en la función `suscribirBilleteraUsuario`).

### Testing
- Ejecuté `git diff -- public/billetera.html` para revisar el diff y la modificación aplicada, y la operación devolvió la diff esperada (éxito).
- Verifiqué el estado del árbol con `git status --short` y confirmé el archivo modificado (éxito).
- Hice `git commit -m "Fix instant wallet credit refresh when projection lags"` y el commit se creó correctamente (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e79f0f508326a80b04e6d62797e1)