### PR TITLE
Agregar feature flag 'Manual legacy' y validaciones de generación en Centro de Pagos

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -528,6 +528,11 @@
     </select>
     <input id="cp-sorteo-id" type="text" placeholder="Sorteo ID (query param o selección)">
     <button id="cp-generar-solicitudes" class="btn-pagos-pendientes" type="button">Generar premios/pagos del sorteo</button>
+    <label class="switch-label" for="cp-modo-legacy">Manual legacy</label>
+    <label class="switch" title="Activar flujo manual legacy">
+      <input type="checkbox" id="cp-modo-legacy">
+      <span class="slider"></span>
+    </label>
   </div>
   <section class="section" id="premios-section">
     <div class="section-header">
@@ -539,6 +544,8 @@
     </div>
     <div id="premios-content">
       <div class="acciones">
+        <button class="icon-btn oculto" id="premios-aprobar"><span class="icon check">&#10004;</span><span>Aprobar</span></button>
+        <button class="icon-btn oculto" id="premios-archivar"><span class="icon">&#128452;</span><span>Archivar</span></button>
         <button class="icon-btn" id="premios-archivo"><span class="icon">&#128193;</span><span>Archivo</span></button>
         <button class="icon-btn" id="acreditaciones-reencolar"><span class="icon">&#10227;</span><span>Reencolar TOPE</span></button>
         <button class="icon-btn" id="premios-reconciliar"><span class="icon">&#128269;</span><span>Reconciliar</span></button>
@@ -718,7 +725,7 @@
 
     let mostrarPremiosArchivo = false;
     let mostrarPagosArchivo = false;
-    const MODO_PREMIOS_INSTANTANEOS = true;
+    let MODO_PREMIOS_INSTANTANEOS = true;
 
     const colaboradoresBase = [];
     const premiosActivos = [];
@@ -845,6 +852,7 @@
         }
         const ctx = cpCrearContextoSorteo(sorteoId, sorteoData);
         const resultado = await cpGenerarSolicitudesParaSorteo(ctx);
+        await cpRecargarTablasTrasGeneracion(sorteoId);
         alert(
           `Solicitudes generadas para el sorteo ${sorteoId}.\n`+
           `Premios: ${resultado.ganadores}.\n`+
@@ -852,6 +860,10 @@
           `Colaboradores: ${resultado.colaboradores}.`
         );
       } catch (err) {
+        if(err && err.code === 'SOLICITUDES_YA_GENERADAS'){
+          alert(`El sorteo ${sorteoId} ya tiene solicitudes de pagos generadas.`);
+          return;
+        }
         console.error('Error generando solicitudes manuales del sorteo', sorteoId, err);
         alert('No se pudieron generar las solicitudes. Revisa la consola para más detalle.');
       } finally {
@@ -1812,9 +1824,52 @@
       ]);
     }
 
+    async function cpValidarSolicitudesNoGeneradas(ctx){
+      const [sorteoSnap, cantarSnap] = await Promise.all([
+        ctx.db.collection('sorteos').doc(ctx.sorteoId).get(),
+        ctx.db.collection('cantarsorteos').doc(ctx.sorteoId).get()
+      ]);
+      const yaGeneradas = Boolean(sorteoSnap.data()?.solicitudesPagosGeneradas)
+        || Boolean(cantarSnap.data()?.solicitudesPagosGeneradas)
+        || Boolean(ctx.sorteoData?.solicitudesPagosGeneradas);
+      if(yaGeneradas){
+        const err = new Error(`El sorteo ${ctx.sorteoId} ya tiene solicitudes generadas.`);
+        err.code = 'SOLICITUDES_YA_GENERADAS';
+        throw err;
+      }
+    }
+
+    async function cpRecargarTablasTrasGeneracion(sorteoId){
+      if(!sorteoId) return;
+      const db = dbRef();
+      const [premiosSnap, pagosSnap] = await Promise.all([
+        db.collection('PremiosSorteos').where('sorteoId', '==', sorteoId).get(),
+        db.collection('PagosAdministracion').where('sorteoId', '==', sorteoId).get()
+      ]);
+      premiosSnap.forEach(doc=>{
+        const registro = prepararPremio(doc.id, doc.data());
+        if(!registro) return;
+        premiosMapa.set(doc.id, registro);
+        const idx = premiosActivos.findIndex(item=>item.id === doc.id);
+        if(idx >= 0) premiosActivos[idx] = registro;
+        else premiosActivos.push(registro);
+      });
+      pagosSnap.forEach(doc=>{
+        const registro = prepararPago(doc.id, doc.data());
+        if(!registro) return;
+        pagosAdminMapa.set(doc.id, registro);
+        const idx = pagosAdminActivos.findIndex(item=>item.id === doc.id);
+        if(idx >= 0) pagosAdminActivos[idx] = registro;
+        else pagosAdminActivos.push(registro);
+      });
+      renderPremios();
+      renderPagos();
+    }
+
     async function cpGenerarSolicitudesParaSorteo(ctx, opciones = {}){
       const incluirPremios = opciones.incluirPremios !== false;
       await ensureFirebaseListo();
+      await cpValidarSolicitudesNoGeneradas(ctx);
       let ganadores = [];
       let totalCreditos = 0;
       let totalCartonesGratis = 0;
@@ -2760,6 +2815,19 @@
       });
     }
 
+
+    function aplicarModoPremiosLegacy(legacyActivo){
+      MODO_PREMIOS_INSTANTANEOS = !legacyActivo;
+      const premiosMarcar = document.getElementById('premios-marcar');
+      const premiosAprobar = document.getElementById('premios-aprobar');
+      const premiosArchivar = document.getElementById('premios-archivar');
+      if(premiosMarcar){ premiosMarcar.classList.toggle('oculto', MODO_PREMIOS_INSTANTANEOS); }
+      if(premiosAprobar){ premiosAprobar.classList.toggle('oculto', MODO_PREMIOS_INSTANTANEOS); }
+      if(premiosArchivar){ premiosArchivar.classList.toggle('oculto', MODO_PREMIOS_INSTANTANEOS); }
+      renderPremios();
+      actualizarEstadoBotones();
+    }
+
     function configurarBotones(){
       const inputSorteo = document.getElementById('cp-sorteo-id');
       const selectorSorteo = document.getElementById('cp-sorteo-selector');
@@ -2778,22 +2846,33 @@
         });
       }
 
-      if(!MODO_PREMIOS_INSTANTANEOS){
-        document.getElementById('premios-marcar').addEventListener('click', ()=>seleccionarTodos('tabla-premios'));
+      const toggleModoLegacy = document.getElementById('cp-modo-legacy');
+      if(toggleModoLegacy){
+        toggleModoLegacy.addEventListener('change', ()=>{
+          aplicarModoPremiosLegacy(Boolean(toggleModoLegacy.checked));
+        });
       }
+
+      document.getElementById('premios-marcar').addEventListener('click', ()=>seleccionarTodos('tabla-premios'));
       document.getElementById('pagos-marcar').addEventListener('click', ()=>seleccionarTodos('tabla-pagos'));
 
+      const premiosAprobarBtn = document.getElementById('premios-aprobar');
+      if(premiosAprobarBtn){
+        premiosAprobarBtn.addEventListener('click', async()=>{
+          const seleccion = obtenerSeleccion('tabla-premios');
+          if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }
+          await aprobarPremiosLegacy(seleccion);
+        });
+      }
       const premiosArchivarBtn = document.getElementById('premios-archivar');
       if(premiosArchivarBtn){
-        premiosArchivarBtn.style.display = MODO_PREMIOS_INSTANTANEOS ? 'none' : '';
-        if(!MODO_PREMIOS_INSTANTANEOS){
-          premiosArchivarBtn.addEventListener('click', async()=>{
-            const seleccion = obtenerSeleccion('tabla-premios');
-            if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }
-            await archivarRegistros(seleccion, 'premios');
-          });
-        }
+        premiosArchivarBtn.addEventListener('click', async()=>{
+          const seleccion = obtenerSeleccion('tabla-premios');
+          if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }
+          await archivarRegistros(seleccion, 'premios');
+        });
       }
+      aplicarModoPremiosLegacy(Boolean(toggleModoLegacy?.checked));
       document.getElementById('pagos-aprobar').addEventListener('click', async()=>{
         const seleccion = obtenerSeleccion('tabla-pagos');
         if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }


### PR DESCRIPTION
### Motivation
- Habilitar un modo manual (legacy) para el flujo de premios que permita mostrar acciones manuales (marcar/aprobar/archivar) y desactivar el modo de acreditación instantánea.
- Evitar la creación duplicada de solicitudes de pagos al generar para un sorteo y forzar la recarga inmediata de las tablas relevantes tras la generación.

### Description
- Se añadió un control visual `Manual legacy` (`#cp-modo-legacy`) en `public/centropagos.html` y se cambió `MODO_PREMIOS_INSTANTANEOS` a variable mutable para poder alternar modos en tiempo de ejecución.
- Implementé `aplicarModoPremiosLegacy(legacyActivo)` para ocultar/mostrar controles manuales y forzar `MODO_PREMIOS_INSTANTANEOS = false` cuando está activo el modo legacy, y añadí los botones `premios-aprobar` y `premios-archivar` en la UI.
- Conecté el nuevo toggle y los botones a la lógica existente en `configurarBotones()`, incluyendo listener del botón de generación (`cp-generar-solicitudes`) que llama `cpGenerarSolicitudesManual()` y listeners para aprobar/archivar premios en modo legacy.
- Añadí `cpValidarSolicitudesNoGeneradas(ctx)` para comprobar `solicitudesPagosGeneradas` en `sorteos`/`cantarsorteos` y evitar generación duplicada, y la integré al inicio de `cpGenerarSolicitudesParaSorteo`.
- Añadí `cpRecargarTablasTrasGeneracion(sorteoId)` para recargar inmediatamente `PremiosSorteos` y `PagosAdministracion` en memoria y forzar `renderPremios()`/`renderPagos()` tras una generación manual, y se maneja el caso de error con código `SOLICITUDES_YA_GENERADAS` mostrando alerta al usuario.

### Testing
- Ejecuté `git diff --check` y no devolvió errores (OK).
- Realicé commit de los cambios con `git commit` (OK) y generé el PR automáticamente mediante la herramienta interna (OK).
- Intenté levantar un servidor local con `python3 -m http.server 4173` y capturar una captura con Playwright para validar la UI, pero la conexión al servidor falló en este entorno (FALLÓ por limitaciones del entorno de ejecución).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998fd25b74c8326b66229ae26905d0d)