### PR TITLE
Soportar acreditación manual en /acreditarPremioEvento

### DIFF
--- a/__tests__/uploadServer-acreditar-endpoint.test.js
+++ b/__tests__/uploadServer-acreditar-endpoint.test.js
@@ -1,0 +1,199 @@
+jest.mock('firebase-admin', () => {
+  const firestoreFn = jest.fn();
+  firestoreFn.FieldValue = {
+    serverTimestamp: jest.fn(() => '__SERVER_TIMESTAMP__')
+  };
+
+  return {
+    apps: [],
+    initializeApp: jest.fn(),
+    firestore: firestoreFn,
+    auth: jest.fn(() => ({ verifyIdToken: jest.fn() }))
+  };
+});
+
+const admin = require('firebase-admin');
+
+function makeDocSnapshot(exists, data = {}, id = '') {
+  return {
+    exists,
+    id,
+    data: () => data
+  };
+}
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function buildDbStub({ sorteoData, cartonData, premioData, billeteraData }) {
+  const sets = [];
+
+  const db = {
+    runTransaction: async (cb) => cb(tx),
+    collection(name) {
+      return {
+        doc(id) {
+          return {
+            type: 'doc',
+            collectionName: name,
+            id,
+            collection(subCollection) {
+              return {
+                doc(subId) {
+                  return {
+                    type: 'doc',
+                    collectionName: `${name}/${id}/${subCollection}`,
+                    id: subId
+                  };
+                }
+              };
+            }
+          };
+        },
+        where(field, op, value) {
+          return {
+            type: 'query',
+            collectionName: name,
+            field,
+            op,
+            value,
+            limit(limitValue) {
+              return {
+                ...this,
+                limitValue
+              };
+            }
+          };
+        }
+      };
+    }
+  };
+
+  const tx = {
+    async get(ref) {
+      if (ref.type === 'doc') {
+        if (ref.collectionName === 'sorteos') return makeDocSnapshot(true, sorteoData, ref.id);
+        if (ref.collectionName === 'CartonJugado') return makeDocSnapshot(true, cartonData, ref.id);
+        if (ref.collectionName === 'PremiosSorteos') {
+          if (premioData) return makeDocSnapshot(true, premioData, ref.id);
+          return makeDocSnapshot(false, {}, ref.id);
+        }
+        if (ref.collectionName === 'transacciones') return makeDocSnapshot(false, {}, ref.id);
+        if (ref.collectionName === 'Billetera') {
+          if (billeteraData) return makeDocSnapshot(true, billeteraData, ref.id);
+          return makeDocSnapshot(false, {}, ref.id);
+        }
+        if (ref.collectionName === 'users') return makeDocSnapshot(false, {}, ref.id);
+        return makeDocSnapshot(false, {}, ref.id);
+      }
+
+      if (ref.type === 'query' && ref.collection === 'users') {
+        return { empty: true, docs: [] };
+      }
+
+      return { empty: true, docs: [] };
+    },
+    set(ref, data) {
+      sets.push({ ref, data });
+    }
+  };
+
+  return { db, sets };
+}
+
+describe('endpoint /acreditarPremioEvento por modos', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('modo automático mantiene bloqueo cuando premiosCorteCerrado=true', async () => {
+    const { acreditarPremioEventoHandler, buildPremioDocId } = require('../uploadServer.js');
+
+    const { db } = buildDbStub({
+      sorteoData: { estado: 'Jugando', premiosCorteCerrado: true, nombre: 'Sorteo demo' },
+      cartonData: { sorteoId: 'sorteo-1', userId: 'uid-1', email: 'ganador@example.com', IDbilletera: 'ganador@example.com' }
+    });
+    admin.firestore.mockReturnValue(db);
+
+    const eventoGanadorId = buildPremioDocId({ sorteoId: 'sorteo-1', formaIdx: 2, cartonId: 'carton-1' });
+    const req = {
+      body: {
+        sorteoId: 'sorteo-1',
+        formaIdx: 2,
+        cartonId: 'carton-1',
+        eventoGanadorId,
+        monto: 100,
+        email: 'ganador@example.com',
+        source: 'backend/acreditarPremioEvento'
+      },
+      headers: {},
+      user: { email: 'colab@example.com', role: 'Colaborador' }
+    };
+    const res = makeRes();
+
+    await acreditarPremioEventoHandler(req, res);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({ error: 'El sorteo ya tiene corte de premios cerrado.' });
+  });
+
+  test('modo manual por rol privilegiado permite acreditar con corte cerrado y audita executionMode', async () => {
+    const { acreditarPremioEventoHandler, buildPremioDocId } = require('../uploadServer.js');
+
+    const { db, sets } = buildDbStub({
+      sorteoData: { estado: 'Jugando', premiosCorteCerrado: true, nombre: 'Sorteo demo' },
+      cartonData: { sorteoId: 'sorteo-1', userId: 'uid-1', email: 'ganador@example.com', alias: 'Alias', IDbilletera: 'ganador@example.com' },
+      billeteraData: { creditos: 10, CartonesGratis: 0 }
+    });
+    admin.firestore.mockReturnValue(db);
+
+    const eventoGanadorId = buildPremioDocId({ sorteoId: 'sorteo-1', formaIdx: 2, cartonId: 'carton-1' });
+    const req = {
+      body: {
+        sorteoId: 'sorteo-1',
+        formaIdx: 2,
+        cartonId: 'carton-1',
+        eventoGanadorId,
+        monto: 100,
+        email: 'ganador@example.com',
+        source: 'centropagos/manual',
+        manualApproval: true,
+        requestId: 'req-manual-1'
+      },
+      headers: {},
+      user: { email: 'admin@example.com', role: 'Administrador' }
+    };
+    const res = makeRes();
+
+    await acreditarPremioEventoHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.executionMode).toBe('manual');
+
+    const technicalAudit = sets.find(
+      (entry) => entry.ref.collectionName === 'AcreditacionAuditoriaTecnica'
+    );
+    expect(technicalAudit).toBeTruthy();
+    expect(technicalAudit.data).toEqual(
+      expect.objectContaining({
+        source: 'centropagos/manual',
+        requestId: 'req-manual-1',
+        processedBy: 'admin@example.com',
+        executionMode: 'manual'
+      })
+    );
+  });
+});

--- a/__tests__/uploadServer-acreditar-utils.test.js
+++ b/__tests__/uploadServer-acreditar-utils.test.js
@@ -71,6 +71,56 @@ describe('uploadServer utilidades de acreditación', () => {
     );
   });
 
+
+  test('getAcreditacionExecutionMode diferencia modo automático y manual privilegiado', () => {
+    const { getAcreditacionExecutionMode } = require('../uploadServer.js');
+
+    expect(
+      getAcreditacionExecutionMode({
+        source: 'backend/acreditarPremioEvento',
+        origen: 'premios_jugadores',
+        manualApproval: false,
+        userRole: 'Colaborador'
+      })
+    ).toEqual(
+      expect.objectContaining({
+        mode: 'automatico',
+        manualRequested: false,
+        manualAllowed: false
+      })
+    );
+
+    expect(
+      getAcreditacionExecutionMode({
+        source: 'centropagos/manual',
+        origen: 'premios_jugadores',
+        manualApproval: false,
+        userRole: 'Administrador'
+      })
+    ).toEqual(
+      expect.objectContaining({
+        mode: 'manual',
+        manualRequested: true,
+        manualAllowed: true
+      })
+    );
+
+    expect(
+      getAcreditacionExecutionMode({
+        source: 'centropagos/manual',
+        origen: 'premios_jugadores',
+        manualApproval: true,
+        userRole: 'Colaborador'
+      })
+    ).toEqual(
+      expect.objectContaining({
+        mode: 'automatico',
+        manualRequested: true,
+        manualAllowed: false
+      })
+    );
+  });
+
   test('extractEventoGanadorIdComponents obtiene sorteo, forma y carton', () => {
     const { extractEventoGanadorIdComponents } = require('../uploadServer.js');
 

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -349,6 +349,24 @@ function extractEventoGanadorIdComponents(eventoGanadorId) {
   };
 }
 
+
+function getAcreditacionExecutionMode({ source, origen, manualApproval, userRole }) {
+  const normalizedSource = normalizeString(source, 120).toLowerCase();
+  const normalizedOrigen = normalizeString(origen, 80).toLowerCase();
+  const explicitManualApproval = manualApproval === true;
+  const sourceRequestsManual = normalizedSource === 'centropagos/manual' || normalizedOrigen === 'centropagos/manual';
+  const manualRequested = explicitManualApproval || sourceRequestsManual;
+  const hasPrivilegedRole = ['Superadmin', 'Administrador'].includes(normalizeString(userRole, 40));
+  const manualAllowed = manualRequested && hasPrivilegedRole;
+
+  return {
+    mode: manualAllowed ? 'manual' : 'automatico',
+    manualRequested,
+    manualAllowed,
+    hasPrivilegedRole
+  };
+}
+
 function normalizePremioTransactionState(value) {
   return EstadosPagoPremio.normalizarLectura(value);
 }
@@ -723,7 +741,7 @@ app.post('/admin/purge-sorteo', verificarToken, async (req, res) => {
   }
 });
 
-app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, res) => {
+async function acreditarPremioEventoHandler(req, res) {
   const {
     sorteoId,
     formaIdx,
@@ -740,7 +758,8 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
     segundoLugar,
     alias,
     requestId,
-    source
+    source,
+    manualApproval
   } = req.body || {};
 
   const normalizedSorteoId = normalizeString(sorteoId, 120);
@@ -762,6 +781,12 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
     120
   ) || `acred-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const normalizedSource = normalizeString(source, 120) || 'backend/acreditarPremioEvento';
+  const executionMode = getAcreditacionExecutionMode({
+    source: normalizedSource,
+    origen: normalizedOrigen,
+    manualApproval,
+    userRole: req.user?.role
+  });
 
   if (!normalizedSorteoId || !normalizedCartonId || normalizedFormaIdx === null || !normalizedEventoGanadorId) {
     return res.status(400).json({
@@ -816,11 +841,12 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
       // (Sellado/Jugando/Finalizando/Finalizado) siempre que el corte de premios siga abierto.
       // Se rechaza solamente cuando el estado es incompatible con premiación (p.ej. Activo/Inactivo/Archivado)
       // o cuando el corte ya fue cerrado explícitamente.
+      const premiosCorteCerrado = Boolean(sorteoData?.premiosCorteCerrado);
       if (!isSorteoEligibleForAutoPrize({
         estado: sorteoData.estado,
-        premiosCorteCerrado: sorteoData?.premiosCorteCerrado
+        premiosCorteCerrado: executionMode.manualAllowed ? false : premiosCorteCerrado
       })) {
-        if (Boolean(sorteoData?.premiosCorteCerrado)) {
+        if (premiosCorteCerrado && !executionMode.manualAllowed) {
           throw new Error('SORTEO_CORTE_CERRADO');
         }
         throw new Error('SORTEO_ESTADO_INVALIDO');
@@ -902,6 +928,7 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           idBilleteraInterna: billeteraRef.id,
           source: normalizedSource,
           processedBy: req.user?.email || '',
+          executionMode: executionMode.mode,
           processedAt: timestamp,
           estado: 'PENDIENTE_RECONCILIACION'
         }, { merge: true });
@@ -912,6 +939,8 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           formaIdx: normalizedFormaIdx,
           requestId: normalizedRequestId,
           source: normalizedSource,
+          processedBy: req.user?.email || '',
+          executionMode: executionMode.mode,
           motivo: 'EMAIL_CANONICO_NO_RESUELTO',
           estado: 'PENDIENTE',
           userId: normalizedUserId || cartonData.userId || null,
@@ -1058,6 +1087,7 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           source: normalizedSource,
           requestId: normalizedRequestId,
           processedBy: req.user?.email || '',
+          executionMode: executionMode.mode,
           processedAt: timestamp,
           creadoEn: transaccionSnap.exists ? (transaccionSnap.data()?.creadoEn || timestamp) : timestamp,
           actualizadoEn: timestamp
@@ -1086,6 +1116,7 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           source: normalizedSource,
           requestId: normalizedRequestId,
           processedBy: req.user?.email || '',
+          executionMode: executionMode.mode,
           processedAt: timestamp,
           fechagestion: fechaGestion,
           horagestion: horaGestion,
@@ -1125,6 +1156,7 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
           requestId: normalizedRequestId,
           source: normalizedSource,
           processedBy: req.user?.email || '',
+          executionMode: executionMode.mode,
           role: req.user?.role || '',
           billeteraId: emailVisible,
           emailVisible,
@@ -1143,7 +1175,8 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
         billeteraId: emailVisible,
         billeteraInternaId: billeteraRef.id,
         emailVisible,
-        requestId: normalizedRequestId
+        requestId: normalizedRequestId,
+        executionMode: executionMode.mode
       };
     });
 
@@ -1168,7 +1201,9 @@ app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, async (req, re
     console.error('Error acreditando premio por evento', error);
     return res.status(500).json({ error: 'Error acreditando premio', message: error.message });
   }
-});
+}
+
+app.post('/acreditarPremioEvento', verificarOperadorPrivilegiado, acreditarPremioEventoHandler);
 
 app.post('/upload', verificarToken, upload.single('file'), async (req, res) => {
   if (!req.file) {
@@ -1259,5 +1294,7 @@ module.exports = {
   isSorteoEligibleForAutoPrize,
   buildPremioDocId,
   extractEventoGanadorIdComponents,
-  resolveWinnerIdentity
+  resolveWinnerIdentity,
+  getAcreditacionExecutionMode,
+  acreditarPremioEventoHandler
 };


### PR DESCRIPTION
### Motivation
- Habilitar un modo de acreditación manual controlado para casos de origen `centropagos/manual` o cuando se pasa `manualApproval=true`, con trazabilidad técnica clara. 
- Permitir que operadores con rol privilegiado puedan acreditar premios aun cuando `premiosCorteCerrado` esté en true, manteniendo la seguridad e idempotencia del flujo automático.

### Description
- Añadida la función `getAcreditacionExecutionMode` para resolver si la ejecución debe ser `manual` o `automatico` en base a `source`, `origen`, `manualApproval` y `userRole`.
- Refactorizado el handler `/acreditarPremioEvento` a `acreditarPremioEventoHandler` exportable y aplicado el control de modo de ejecución antes de validar `premiosCorteCerrado` (solo se ignora el corte si `manualAllowed` es true y el usuario es privilegiado).
- Conservadas las validaciones de idempotencia por `eventoGanadorId` y las reglas estrictas del modo automático sin cambios funcionales.
- Añadido registro de `executionMode` en los documentos de auditoría técnica (`AcreditacionAuditoriaTecnica`, `AcreditacionEventosTecnicos`, `AcreditacionReconciliacionPendiente`, transacciones y proyecciones) y devuelto `executionMode` en la respuesta exitosa para trazabilidad.
- Tests: actualizado `__tests__/uploadServer-acreditar-utils.test.js` (se agregó caso para `getAcreditacionExecutionMode`) y agregado `__tests__/uploadServer-acreditar-endpoint.test.js` para cubrir ambos modos; exportados `getAcreditacionExecutionMode` y `acreditarPremioEventoHandler`.
- Archivos modificados: `uploadServer.js`, `__tests__/uploadServer-acreditar-utils.test.js`, y nueva prueba `__tests__/uploadServer-acreditar-endpoint.test.js`.

### Testing
- Ejecuté pruebas unitarias de utilidades: `npm test -- --runTestsByPath __tests__/uploadServer-acreditar-utils.test.js --coverage=false` y pasaron correctamente.
- Ejecuté pruebas del endpoint/handler: `npm test -- --runTestsByPath __tests__/uploadServer-acreditar-endpoint.test.js --coverage=false` y verifiqué los escenarios de bloqueo automático y acreditación manual privilegiada con auditoría presente; pasaron correctamente.
- Ejecuté la suite completa: `npm test -- --coverage=false` y todas las pruebas del repositorio pasaron (11 suites, 36 tests en total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ffcb986883268f9af36d510bbc92)