### PR TITLE
Restringir reglas de Firestore para colecciones técnicas de acreditación

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -217,6 +217,27 @@ service cloud.firestore {
         );
     }
 
+    // Colecciones técnicas de operación (CentroPagos/CantarSorteos y procesos internos)
+    match /AcreditacionesPendientes/{docId} {
+      allow read, write: if isSystemRequest() || isPrivilegedOperator();
+    }
+
+    match /AcreditacionesPendientesAuditoria/{docId} {
+      allow read, write: if isSystemRequest() || isPrivilegedOperator();
+    }
+
+    match /AcreditacionAuditoriaTecnica/{docId} {
+      allow read, write: if isSystemRequest();
+    }
+
+    match /AcreditacionReconciliacionPendiente/{docId} {
+      allow read, write: if isSystemRequest();
+    }
+
+    match /GanadoresSorteosTiempoReal/{docId} {
+      allow read, write: if isSystemRequest() || isPrivilegedOperator();
+    }
+
     match /{document=**} {
       allow read, write: if false;
     }


### PR DESCRIPTION
### Motivation
- Proteger colecciones técnicas usadas por la UI y procesos internos para evitar accesos no administrativos a datos sensibles de acreditación y ganadores.
- Hacer explícitos los `match` para estas colecciones y aplicar controles de acceso coherentes con las funciones de seguridad ya existentes (`isPrivilegedOperator()` y `isSystemRequest()`).

### Description
- Se agregó reglas explícitas en `firestore.rules` para las colecciones: `AcreditacionesPendientes`, `AcreditacionesPendientesAuditoria`, `AcreditacionAuditoriaTecnica`, `AcreditacionReconciliacionPendiente` y `GanadoresSorteosTiempoReal`.
- Cada `match` aplica permisos de lectura/escritura limitados a `isPrivilegedOperator()` o `isSystemRequest()` según corresponda, separando acceso operativo de acceso de auditoría interna.
- Se mantiene el `match /{document=**}` final con `allow read, write: if false` como política por defecto de denegación.
- El archivo modificado es `firestore.rules` (se insertaron las nuevas reglas en la sección de matches existentes).

### Testing
- Ejecuté `npm test -- --runInBand` y todas las suites terminaron correctamente: 11 suites, 36 tests — todos passed.
- Intenté validar las reglas con el emulador de Firestore (`npx firebase-tools emulators:exec --only firestore`), pero la ejecución falló por falta de configuración de emuladores en este proyecto (`No emulators to start`), por lo que la validación en emulador no se completó.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69990130647483269e70d672ca701da4)