### PR TITLE
Dejar pagos administrativos en PENDIENTE al confirmar PDF (elimina autoaplicación)

### DIFF
--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -1934,77 +1934,6 @@
     await lote.commit();
   }
 
-  async function ejecutarPagosAdministrativosAutomaticos(ids = []){
-    if(!Array.isArray(ids) || !ids.length) return 0;
-    await ensureFirebaseReady();
-    await initServerTime();
-    const gestorEmail = auth?.currentUser?.email || '';
-    let procesados = 0;
-    for(const id of ids){
-      const ref = db.collection('PagosAdministracion').doc(id);
-      try {
-        const payload = await db.runTransaction(async tx => {
-          const snap = await tx.get(ref);
-          if(!snap.exists) return null;
-          const data = snap.data() || {};
-          if(normalizarEstadoPagoPremio(data.estado) === 'REALIZADO') return null;
-          const billeteraId = normalizarEmail(data.idBilletera || data.gmail || data.email || '');
-          if(!billeteraId){ return null; }
-          const monto = Number(data.creditos) || 0;
-          if(monto <= 0){
-            tx.update(ref, {
-              estado: validarEstadoPagoPremio('REALIZADO', `PagosAdministracion:${id}`),
-              fechaGestion: fechaServidor(),
-              horaGestion: horaServidor(),
-              gestionadoPor: gestorEmail,
-              rolGestor: window.currentRole || '',
-              actualizadoEn: firebase.firestore.FieldValue.serverTimestamp(),
-              pagoAutomatico: true
-            });
-            return null;
-          }
-          const billeteraRef = db.collection('Billetera').doc(billeteraId);
-          const billeteraSnap = await tx.get(billeteraRef);
-          const saldoActual = Number(billeteraSnap.exists ? billeteraSnap.data()?.creditos : 0) || 0;
-          tx.set(billeteraRef, { creditos: saldoActual + monto, actualizadoEn: firebase.firestore.FieldValue.serverTimestamp() }, { merge: true });
-          tx.update(ref, {
-            estado: validarEstadoPagoPremio('REALIZADO', `PagosAdministracion:${id}`),
-            fechaGestion: fechaServidor(),
-            horaGestion: horaServidor(),
-            gestionadoPor: gestorEmail,
-            rolGestor: window.currentRole || '',
-            actualizadoEn: firebase.firestore.FieldValue.serverTimestamp(),
-            pagoAutomatico: true
-          });
-          return { id, data, billeteraId, monto };
-        });
-        if(!payload) continue;
-        await db.collection('transacciones').add({
-          tipotrans: 'pagado',
-          origen: 'pagos_administracion',
-          Monto: payload.monto,
-          estado: validarEstadoPagoPremio('REALIZADO', 'TransaccionPagoAdministracionAuto'),
-          IDbilletera: payload.billeteraId,
-          fechasolicitud: '',
-          horasolicitud: '',
-          fechagestion: fechaServidor(),
-          horagestion: horaServidor(),
-          usuariogestor: gestorEmail,
-          rolusuario: window.currentRole || '',
-          referencia: 'PAGO_ADMINISTRACION_AUTO',
-          sorteoId,
-          sorteoNombre: (payload.data?.sorteoNombre || sorteoData?.nombre || '').toString(),
-          pagoAdministracionId: id,
-          creadoEn: firebase.firestore.FieldValue.serverTimestamp()
-        });
-        procesados += 1;
-      } catch (err) {
-        console.error('No se pudo ejecutar pago administrativo automático', id, err);
-      }
-    }
-    return procesados;
-  }
-
   async function generarSolicitudesCentroPagos(){
     mostrarLoading('Generando solicitudes para Centro de Pagos, por favor espera');
     const timestamp = firebase.firestore.FieldValue.serverTimestamp();
@@ -2017,7 +1946,6 @@
     const administrativos = participantes.filter(item=>esRolAdministrativo(item.role));
     const colaboradores = participantes.filter(item=>!esRolAdministrativo(item.role));
     const operaciones = [];
-    const idsAdministrativos = [];
 
     administrativos.forEach(administrativo => {
       const email = normalizarEmail(administrativo.gmail);
@@ -2040,7 +1968,6 @@
         userIds: administrativo.userIds || [],
         generadoDesde: 'pdfresultados'
       };
-      idsAdministrativos.push(docId);
       operaciones.push(actualizarDocumentoCentroPagos(db.collection('PagosAdministracion').doc(docId), payload));
     });
 
@@ -2101,13 +2028,11 @@
     operaciones.push(resumenRef.set(resumenPayload, { merge: true }));
     await Promise.all(operaciones);
 
-    const pagosAdministrativosAutomaticos = await ejecutarPagosAdministrativosAutomaticos(idsAdministrativos);
     await actualizarFlagsOrquestacionCentroPagos({ timestamp, solicitudesPagosGeneradas: true });
     return {
       ganadores: ganadores.length,
       administrativos: administrativos.length,
-      colaboradores: colaboradores.length,
-      pagosAdministrativosAutomaticos
+      colaboradores: colaboradores.length
     };
   }
 
@@ -3539,7 +3464,7 @@
           `${mensajeCorte}\n`+
           `Solicitudes administrativas creadas: ${resultadoOrquestacion.administrativos}.\n`+
           `Solicitudes de colaboradores creadas: ${resultadoOrquestacion.colaboradores}.\n`+
-          `Pagos administrativos automáticos aplicados: ${resultadoOrquestacion.pagosAdministrativosAutomaticos || 0}.`
+          `Los pagos quedan en estado PENDIENTE hasta ser procesados/aprobados en Centro de Pagos.`
         );
       } else {
         alert('El sorteo se marcó como PDF listo. La generación de premios/pagos se realiza manualmente desde Centro de Pagos.');


### PR DESCRIPTION
### Motivation
- Evitar que la confirmación de `PDF LISTO` aplique pagos administrativos automáticamente y en su lugar que las solicitudes queden en estado `PENDIENTE` para procesarse manualmente desde Centro de Pagos.
- Aclarar el mensaje al usuario para no indicar falsamente que se aplicaron pagos automáticos.

### Description
- Eliminé la función/ejecución automática `ejecutarPagosAdministrativosAutomaticos(...)` del flujo de `public/pdfresultados.html` y su invocación desde el proceso de orquestación posterior a `confirmarPdfListo()`.
- Mantengo la creación de registros en `PagosAdministracion` con `estado: validarEstadoPagoPremio('PENDIENTE', ...)` para administrativos y colaboradores en `generarSolicitudesCentroPagos()`.
- Modifiqué el mensaje final en `confirmarPdfListo()` para eliminar el reporte de pagos automáticos y dejar explícito que "Los pagos quedan en estado PENDIENTE hasta ser procesados/aprobados en Centro de Pagos."
- Verifiqué que en `public/centropagos.html` el procesamiento/aprobado ocurre en `aprobarPagos(ids)` (que actualiza a `REALIZADO`) y que ese flujo se activa sólo al pulsar el botón `#pagos-aprobar` (etiquetado como `Procesar`).

### Testing
- Busqué referencias de los identificadores y funciones relevantes (`ejecutarPagosAdministrativosAutomaticos`, `PagosAdministracion`, `confirmarPdfListo`, `aprobarPagos`, `#pagos-aprobar`) y confirmé que las invocaciones automáticas fueron removidas; búsqueda exitosa.
- Revisé el diff del archivo `public/pdfresultados.html` y confirmé que la rutina de pagos automáticos fue eliminada y que las líneas de creación de solicitudes mantienen `estado: PENDIENTE`; revisión exitosa.
- Inspeccioné `public/centropagos.html` para confirmar que `aprobarPagos(ids)` es el único lugar que marca `REALIZADO` y que está enlazado al botón `#pagos-aprobar`; verificación exitosa.
- No se añadieron tests automatizados unitarios en este cambio y las comprobaciones estáticas descritas fueron satisfactorias.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699902adfa188326aad44c9c2df8caa9)