### PR TITLE
Ocultar indicador en cantarsorteos y corregir mensajes y aprobación en Centro de Pagos

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -1961,14 +1961,10 @@
 
   function actualizarIndicadorAcreditacionesPendientes(cantidad = 0){
     if(!acreditacionesPendientesAlertaEl) return;
-    const total = Math.max(0, Number(cantidad) || 0);
-    if(total <= 0){
-      acreditacionesPendientesAlertaEl.classList.remove('visible');
-      acreditacionesPendientesAlertaEl.textContent = '';
-      return;
-    }
-    acreditacionesPendientesAlertaEl.classList.add('visible');
-    acreditacionesPendientesAlertaEl.textContent = `⚠ Premios pendientes de acreditar: ${total}`;
+    void cantidad;
+    // Requerimiento de UI: ocultar esta etiqueta en todo momento.
+    acreditacionesPendientesAlertaEl.classList.remove('visible');
+    acreditacionesPendientesAlertaEl.textContent = '';
   }
 
   function programarReintentoPendientes(ms = REINTENTO_BASE_MS){

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -708,6 +708,7 @@
     const pagosColaboradoresMapa = new Map();
     const pagosColaboradoresEdicion = new Map();
     const usuariosInfoCache = new Map();
+    const sorteosNombreCache = new Map();
 
     let unsubscribePremios = null;
     let unsubscribePremiosArchivo = null;
@@ -761,10 +762,31 @@
       await ensureFirebaseListo();
       const db = dbRef();
       const docSorteo = await db.collection('sorteos').doc(id).get();
-      if(docSorteo.exists){ return docSorteo.data() || {}; }
+      if(docSorteo.exists){
+        const data = docSorteo.data() || {};
+        const nombre = (data.nombre || data.nombreSorteo || '').toString().trim();
+        if(nombre){ sorteosNombreCache.set(id, nombre); }
+        return data;
+      }
       const docCantar = await db.collection('cantarsorteos').doc(id).get();
-      if(docCantar.exists){ return docCantar.data() || {}; }
+      if(docCantar.exists){
+        const data = docCantar.data() || {};
+        const nombre = (data.nombre || data.nombreSorteo || '').toString().trim();
+        if(nombre){ sorteosNombreCache.set(id, nombre); }
+        return data;
+      }
       return null;
+    }
+
+    function cpResolverNombreSorteo({ sorteoId = '', sorteoNombre = '' } = {}){
+      const nombreDirecto = (sorteoNombre || '').toString().trim();
+      if(nombreDirecto){
+        if(sorteoId){ sorteosNombreCache.set(sorteoId, nombreDirecto); }
+        return nombreDirecto;
+      }
+      const id = (sorteoId || '').toString().trim();
+      if(!id) return '';
+      return (sorteosNombreCache.get(id) || '').toString().trim();
     }
 
     async function cpCargarSelectorSorteos(){
@@ -779,6 +801,7 @@
           const nombre = (data.nombre || data.nombreSorteo || '').toString().trim();
           const fechaInfo = normalizarFecha(data.fecha || data.fechasorteo || data.fechaSorteo || data.createdAt);
           const etiqueta = `${nombre || 'Sorteo'} - ${fechaInfo.mostrar !== '-' ? fechaInfo.mostrar : 'Sin fecha'}`;
+          if(nombre){ sorteosNombreCache.set(doc.id, nombre); }
           lista.push({ id: doc.id, etiqueta });
         });
         lista.sort((a,b)=>a.etiqueta.localeCompare(b.etiqueta, 'es', { sensitivity: 'base' }));
@@ -808,22 +831,24 @@
           btn.textContent = 'Generando...';
         }
         const sorteoData = await cpResolverDataSorteo(sorteoId);
+        const nombreSorteo = cpResolverNombreSorteo({ sorteoId, sorteoNombre: sorteoData?.nombre || sorteoData?.nombreSorteo || '' }) || sorteoId;
         if(!sorteoData){
-          alert(`No existe el sorteo ${sorteoId} en sorteos/cantarsorteos.`);
+          alert(`No existe el sorteo ${nombreSorteo} en sorteos/cantarsorteos.`);
           return;
         }
         const ctx = cpCrearContextoSorteo(sorteoId, sorteoData);
         const resultado = await cpGenerarSolicitudesParaSorteo(ctx);
         await cpRecargarTablasTrasGeneracion(sorteoId);
         alert(
-          `Solicitudes generadas para el sorteo ${sorteoId}.\n`+
+          `Solicitudes generadas para el sorteo ${nombreSorteo}.\n`+
           `Premios: ${resultado.ganadores}.\n`+
           `Administración: ${resultado.administrativos}.\n`+
           `Colaboradores: ${resultado.colaboradores}.`
         );
       } catch (err) {
         if(err && err.code === 'SOLICITUDES_YA_GENERADAS'){
-          alert(`El sorteo ${sorteoId} ya tiene solicitudes de pagos generadas.`);
+          const nombreSorteo = cpResolverNombreSorteo({ sorteoId }) || sorteoId;
+          alert(`El sorteo ${nombreSorteo} ya tiene solicitudes de pagos generadas.`);
           return;
         }
         console.error('Error generando solicitudes manuales del sorteo', sorteoId, err);
@@ -1631,7 +1656,7 @@
     }
 
     function cpExtraerComponentesEventoGanador(eventoGanadorId){
-      const limpio = cpSanitizarId(eventoGanadorId || '');
+      const limpio = (eventoGanadorId || '').toString().trim();
       if(!limpio) return null;
       const match = limpio.match(/^(?:[^_]+__)?(.+?)__f([^_]+?)__(.+)$/);
       if(!match) return null;
@@ -1671,7 +1696,7 @@
           const email = cpNormalizarEmail(ganador.gmail);
           const alias = ganador.alias || '';
           const docId = cpConstruirIdGanador(ctx, ganador);
-          const eventoGanadorId = cpSanitizarId(docId);
+          const eventoGanadorId = docId;
           const payload = {
           sorteoId: ctx.sorteoId,
           sorteoNombre,
@@ -1985,7 +2010,7 @@
       const sorteoNombre = (data.sorteoNombre || '').toString();
       return {
         id,
-        gmail: gmailRender,
+        gmail,
         nombre,
         creditos,
         fechaMostrar: fechaInfo.mostrar,
@@ -2353,7 +2378,7 @@
 
     // Flujo legacy de acreditación manual de premios (deshabilitado en modo instantáneo).
     async function acreditarPremioBackendLegacy(enRegistro){
-      const eventoGanadorId = cpSanitizarId(enRegistro.eventoGanadorId || enRegistro.winnerKey || enRegistro.id || '');
+      const eventoGanadorId = (enRegistro.eventoGanadorId || enRegistro.winnerKey || enRegistro.id || '').toString().trim();
       if(!eventoGanadorId){ throw new Error('Falta eventoGanadorId para acreditar premio.'); }
       const componentes = cpExtraerComponentesEventoGanador(eventoGanadorId);
       if(!componentes){ throw new Error('No se pudieron extraer los componentes de eventoGanadorId.'); }
@@ -2794,7 +2819,7 @@
           const registro = obtenerRegistroPorTipo('premios', id);
           if(!registro) return;
           if(e.target.closest('td.creditos')){
-            const sorteo = registro.sorteoNombre || 'Sin sorteo asociado.';
+            const sorteo = cpResolverNombreSorteo(registro) || registro.sorteoId || 'Sin sorteo asociado.';
             mostrarModalInfo('Sorteo asignado', sorteo || 'Sin sorteo asociado.');
             return;
           }
@@ -2825,7 +2850,7 @@
           const registro = obtenerRegistroPorTipo('pagos', id);
           if(!registro) return;
           if(e.target.closest('td.creditos')){
-            const sorteo = registro.sorteoNombre || 'Sin sorteo asociado.';
+            const sorteo = cpResolverNombreSorteo(registro) || registro.sorteoId || 'Sin sorteo asociado.';
             mostrarModalInfo('Sorteo asignado', sorteo || 'Sin sorteo asociado.');
             return;
           }


### PR DESCRIPTION
### Motivation
- Quitar la etiqueta roja "Premios pendientes de acreditar" en la ventana de cantar sorteos porque no debe mostrarse en esa pantalla.
- En Centro de Pagos reemplazar la referencia al código del sorteo por el nombre legible en mensajes y modales para mejorar la UX.
- Corregir el error que ocurría al intentar aprobar premios/pagos, que provocaba fallos por manipular indebidamente el `eventoGanadorId` y por un mapeo incorrecto de campos en pagos.

### Description
- En `public/cantarsorteos.html` la función `actualizarIndicadorAcreditacionesPendientes` ahora oculta permanentemente la etiqueta y limpia su texto para que no se muestre en la UI.
- En `public/centropagos.html` añadí un cache local `sorteosNombreCache` y la función `cpResolverNombreSorteo`, y actualicé `cpResolverDataSorteo` y `cpCargarSelectorSorteos` para poblar el cache y usar el nombre del sorteo en alertas y modales en lugar del código.
- Evité la sanitización destructiva del ID de evento ganador; `cpExtraerComponentesEventoGanador` ahora parsea el `eventoGanadorId` tal cual y `cpRegistrarSolicitudes` guarda `eventoGanadorId` igual a `docId`, y `acreditarPremioBackendLegacy` usa el ID original para la llamada al backend, corrigiendo la causa raíz del error de aprobación.
- Corregí un bug en `prepararPago` que referenciaba `gmailRender` inexistente, reemplazándolo por el campo `gmail` correcto para evitar fallos en el renderizado/mapeo de pagos.

### Testing
- Ejecuté los tests del endpoint de acreditación con `npm test -- --runInBand __tests__/uploadServer-acreditar-endpoint.test.js`, y los tests específicos del archivo pasaron correctamente.
- Nota: el proceso de `jest` devolvió código de salida no-cero debido a las reglas globales de umbral de coverage configuradas (no por fallos en los tests ejecutados), por lo que los tests del archivo reportado están verdes pero la ejecución completa devolvió estado distinto de cero por cobertura.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69991dcced9483268be2804736cd21f0)