### PR TITLE
Corregir error al aprobar premios desde CentroPagos

### DIFF
--- a/__tests__/uploadServer-acreditar-endpoint.test.js
+++ b/__tests__/uploadServer-acreditar-endpoint.test.js
@@ -196,4 +196,42 @@ describe('endpoint /acreditarPremioEvento por modos', () => {
       })
     );
   });
+
+  test('acepta eventoGanadorId con prefijo segundo sin requerir segundoLugar explícito', async () => {
+    const { acreditarPremioEventoHandler, buildPremioDocId } = require('../uploadServer.js');
+
+    const { db, sets } = buildDbStub({
+      sorteoData: { estado: 'Jugando', premiosCorteCerrado: false, nombre: 'Sorteo demo' },
+      cartonData: { sorteoId: 'sorteo-1', userId: 'uid-1', email: 'ganador@example.com', alias: 'Alias', IDbilletera: 'ganador@example.com' },
+      billeteraData: { creditos: 25, CartonesGratis: 0 }
+    });
+    admin.firestore.mockReturnValue(db);
+
+    const eventoGanadorId = buildPremioDocId({ sorteoId: 'sorteo-1', formaIdx: 4, cartonId: 'carton-9', prefijo: 'segundo' });
+    const req = {
+      body: {
+        sorteoId: 'sorteo-1',
+        formaIdx: 4,
+        cartonId: 'carton-9',
+        eventoGanadorId,
+        monto: 50,
+        email: 'ganador@example.com',
+        source: 'centropagos/manual',
+        manualApproval: true,
+        requestId: 'req-segundo-1'
+      },
+      headers: {},
+      user: { email: 'admin@example.com', role: 'Administrador' }
+    };
+    const res = makeRes();
+
+    await acreditarPremioEventoHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const premioWrite = sets.find(
+      (entry) => entry.ref.collectionName === 'PremiosSorteos'
+    );
+    expect(premioWrite).toBeTruthy();
+    expect(premioWrite.data.segundoLugar).toBe(true);
+  });
 });

--- a/__tests__/uploadServer-acreditar-utils.test.js
+++ b/__tests__/uploadServer-acreditar-utils.test.js
@@ -125,6 +125,8 @@ describe('uploadServer utilidades de acreditación', () => {
     const { extractEventoGanadorIdComponents } = require('../uploadServer.js');
 
     expect(extractEventoGanadorIdComponents('segundo__sorteo_a__f3__carton_77')).toEqual({
+      prefijo: 'segundo',
+      segundoLugar: true,
       sorteoId: 'sorteo_a',
       formaIdx: 3,
       cartonId: 'carton_77'

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -1658,11 +1658,17 @@
     function cpExtraerComponentesEventoGanador(eventoGanadorId){
       const limpio = (eventoGanadorId || '').toString().trim();
       if(!limpio) return null;
-      const match = limpio.match(/^(?:[^_]+__)?(.+?)__f([^_]+?)__(.+)$/);
+      const match = limpio.match(/^(?:([^_]+?)__)?(.+?)__f([^_]+?)__(.+)$/);
       if(!match) return null;
-      const formaIdx = Number(match[2]);
+      const formaIdx = Number(match[3]);
       if(!Number.isFinite(formaIdx)) return null;
-      return { sorteoId: match[1], formaIdx, cartonId: match[3] };
+      const prefijo = (match[1] || '').toString().toLowerCase();
+      return {
+        sorteoId: match[2],
+        formaIdx,
+        cartonId: match[4],
+        segundoLugar: prefijo === 'segundo'
+      };
     }
 
     async function cpActualizarDocumentoCentroPagos(ctx, ref, payload){
@@ -2407,7 +2413,9 @@
           origen: 'premios_jugadores',
           referencia: 'PREMIO',
           tipoRegistro: 'GANADOR_SORTEO',
-          source: 'centropagos/aprobarPremios',
+          source: 'centropagos/manual',
+          manualApproval: true,
+          segundoLugar: Boolean(componentes.segundoLugar),
           requestId
         })
       });

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -335,7 +335,7 @@ function extractEventoGanadorIdComponents(eventoGanadorId) {
   const normalized = normalizeString(eventoGanadorId, 220);
   if (!normalized) return null;
 
-  const [, maybeSorteoId = '', maybeForma = '', maybeCartonId = ''] = normalized.match(/^(?:[^_]+__)?(.+?)__f([^_]+?)__(.+)$/) || [];
+  const [, maybePrefijo = '', maybeSorteoId = '', maybeForma = '', maybeCartonId = ''] = normalized.match(/^(?:([^_]+?)__)?(.+?)__f([^_]+?)__(.+)$/) || [];
   const parsedFormaIdx = Number(maybeForma);
 
   if (!maybeSorteoId || !maybeCartonId || !Number.isFinite(parsedFormaIdx)) {
@@ -343,6 +343,8 @@ function extractEventoGanadorIdComponents(eventoGanadorId) {
   }
 
   return {
+    prefijo: maybePrefijo,
+    segundoLugar: maybePrefijo.toLowerCase() === 'segundo',
     sorteoId: maybeSorteoId,
     formaIdx: parsedFormaIdx,
     cartonId: maybeCartonId
@@ -794,11 +796,13 @@ async function acreditarPremioEventoHandler(req, res) {
     });
   }
 
+  const parsedEventoGanadorId = extractEventoGanadorIdComponents(normalizedEventoGanadorId);
+  const segundoLugarEfectivo = normalizedSegundoLugar || Boolean(parsedEventoGanadorId?.segundoLugar);
   const expectedEventoGanadorId = buildPremioDocId({
     sorteoId: normalizedSorteoId,
     formaIdx: normalizedFormaIdx,
     cartonId: normalizedCartonId,
-    prefijo: normalizedSegundoLugar ? 'segundo' : ''
+    prefijo: segundoLugarEfectivo ? 'segundo' : ''
   });
 
   if (normalizedEventoGanadorId !== expectedEventoGanadorId) {
@@ -984,7 +988,7 @@ async function acreditarPremioEventoHandler(req, res) {
           version: normalizeNumber(premioActual?.version) + 1,
           processedAt: timestamp,
           tipoRegistro: normalizedTipoRegistro,
-          segundoLugar: normalizedSegundoLugar,
+          segundoLugar: segundoLugarEfectivo,
           idBilletera: billeteraRef.id,
           idBilleteraInterna: billeteraRef.id,
           estado: 'REALIZADO',
@@ -1021,7 +1025,7 @@ async function acreditarPremioEventoHandler(req, res) {
           userId: normalizedUserId || cartonData.userId || null,
           creditos: normalizedMonto,
           cartonesGratis: normalizedCartonesGratis,
-          segundoLugar: normalizedSegundoLugar,
+          segundoLugar: segundoLugarEfectivo,
           tipoRegistro: normalizedTipoRegistro,
           estado: 'REALIZADO',
           referencia: normalizedReferencia,
@@ -1082,7 +1086,7 @@ async function acreditarPremioEventoHandler(req, res) {
           eventoGanadorId: normalizedEventoGanadorId,
           winnerKey: normalizedEventoGanadorId,
           tipoRegistro: normalizedTipoRegistro,
-          segundoLugar: normalizedSegundoLugar,
+          segundoLugar: segundoLugarEfectivo,
           idBilleteraInterna: billeteraRef.id,
           source: normalizedSource,
           requestId: normalizedRequestId,
@@ -1109,7 +1113,7 @@ async function acreditarPremioEventoHandler(req, res) {
           eventoGanadorId: normalizedEventoGanadorId,
           winnerKey: normalizedEventoGanadorId,
           tipoRegistro: normalizedTipoRegistro,
-          segundoLugar: normalizedSegundoLugar,
+          segundoLugar: segundoLugarEfectivo,
           idBilleteraInterna: billeteraRef.id,
           referencia: normalizedReferencia,
           origen: normalizedOrigen,


### PR DESCRIPTION
## Resumen
Se corrigió el flujo de aprobación de premios en `centropagos` para evitar errores al acreditar premios desde la ventana de administración.

## Cambios principales
- `public/centropagos.html`
  - Se ajustó el parseo de `eventoGanadorId` para detectar prefijo (ej. `segundo__...`) y derivar `segundoLugar` correctamente.
  - El envío a `/acreditarPremioEvento` ahora marca la operación como manual (`source: centropagos/manual`, `manualApproval: true`) para que el backend aplique el modo manual cuando corresponde.
  - Se propaga `segundoLugar` en el payload de acreditación.

- `uploadServer.js`
  - `extractEventoGanadorIdComponents` ahora retorna también `prefijo` y `segundoLugar`.
  - En `/acreditarPremioEvento`, si `eventoGanadorId` incluye prefijo de segundo lugar, se infiere `segundoLugar` aunque no venga explícito en el body.
  - Se usa el valor efectivo de `segundoLugar` en la validación de id esperado y en los documentos persistidos.

## Pruebas
- Se actualizaron pruebas utilitarias de parseo (`__tests__/uploadServer-acreditar-utils.test.js`).
- Se agregó prueba de endpoint para `eventoGanadorId` con prefijo `segundo` sin flag explícito (`__tests__/uploadServer-acreditar-endpoint.test.js`).
- Suite ejecutada:
  - `npm test -- --coverage=false __tests__/uploadServer-acreditar-utils.test.js __tests__/uploadServer-acreditar-endpoint.test.js`

## Impacto
- Reduce falsos errores de aprobación por desajustes entre `eventoGanadorId` y `segundoLugar`.
- Permite acreditar desde CentroPagos en escenarios de aprobación manual administrativa donde el flujo automático podía rechazar por estado/corte.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a20f2c14c8326991d2483660271e8)