### PR TITLE
Corregir aprobación en CentroPagos usando estado canónico `REALIZADO`

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -563,7 +563,7 @@
               <select id="filtro-premios-estado">
                 <option value="">Estado</option>
                 <option value="PENDIENTE">PENDIENTE</option>
-                <option value="APROBADO">APROBADO</option>
+                <option value="REALIZADO">REALIZADO</option>
                 <option value="ARCHIVADO">ARCHIVADO</option>
               </select>
             </th>
@@ -608,7 +608,7 @@
               <select id="filtro-pagos-estado">
                 <option value="">Estado</option>
                 <option value="PENDIENTE">PENDIENTE</option>
-                <option value="APROBADO">APROBADO</option>
+                <option value="REALIZADO">REALIZADO</option>
                 <option value="ARCHIVADO">ARCHIVADO</option>
               </select>
             </th>
@@ -1678,7 +1678,7 @@
           if(snap.exists){
             const data = snap.data() || {};
             const estadoActual = normalizarEstado(data.estado);
-            if(estadoActual === 'APROBADO'){ return; }
+            if(window.EstadosPagoPremio.estaFinalizado(estadoActual)){ return; }
           }
           if(payload && Object.prototype.hasOwnProperty.call(payload, 'estado')){
             payload.estado = validarEstadoGuardado(payload.estado, `CentroPagos:${ref.path}`);
@@ -2053,7 +2053,7 @@
 
     function obtenerEtiquetaEstado(valorEstado){
       const estado = normalizarEstado(valorEstado);
-      if(estado === 'APROBADO') return 'APROBADO';
+      if(estado === 'REALIZADO') return 'REALIZADO';
       if(estado === 'PENDIENTE') return 'PENDIENTE';
       if(estado === 'ARCHIVADO') return 'ARCHIVADO';
       return estado;
@@ -2180,7 +2180,7 @@
       }
       const filas = lista.map((item, indice)=>{
       const numero = indice + 1;
-      const estadoClase = item.estado === 'APROBADO' ? 'estado-aprobado' : (item.estado === 'PENDIENTE' ? 'estado-pendiente' : 'estado-archivado');
+      const estadoClase = item.estado === 'REALIZADO' ? 'estado-aprobado' : (item.estado === 'PENDIENTE' ? 'estado-pendiente' : 'estado-archivado');
       const rolNormalizado = normalizarTipoUsuario(item.tipo || item.estado || '');
       const estadoHtml = tipo === 'colaboradores'
         ? construirRolBadgeHtml(rolNormalizado)
@@ -2437,7 +2437,7 @@
           tipotrans: (enRegistro.tipotrans || 'pago').toString().toLowerCase(),
           origen: (enRegistro.origen || 'pagos_administracion').toString().toLowerCase(),
           Monto: monto,
-          estado: validarEstadoGuardado('APROBADO', 'TransaccionPagoAdministracion'),
+          estado: validarEstadoGuardado('REALIZADO', 'TransaccionPagoAdministracion'),
           IDbilletera: enRegistro.billetera,
           fechasolicitud: '',
           horasolicitud: '',
@@ -2487,7 +2487,7 @@
       for(const id of ids){
         const registro = premiosMapa.get(id);
         if(!registro){ console.warn('Premio no encontrado', id); continue; }
-        if(registro.estado === 'APROBADO'){ continue; }
+        if(window.EstadosPagoPremio.estaFinalizado(registro.estado)){ continue; }
         try {
           await acreditarPremioBackendLegacy(registro);
           if(registro.sorteoId){
@@ -2516,7 +2516,7 @@
       for(const id of ids){
         const registro = pagosAdminMapa.get(id);
         if(!registro){ console.warn('Pago no encontrado', id); continue; }
-        if(registro.estado === 'APROBADO'){ continue; }
+        if(window.EstadosPagoPremio.estaFinalizado(registro.estado)){ continue; }
         try {
           await db.runTransaction(async tx => {
             const ref = db.collection('PagosAdministracion').doc(id);
@@ -2524,9 +2524,9 @@
             if(!snap.exists) return;
             const data = snap.data();
             const estadoActual = normalizarEstado(data.estado);
-            if(estadoActual === 'APROBADO') return;
+            if(window.EstadosPagoPremio.estaFinalizado(estadoActual)) return;
             tx.update(ref, {
-              estado: validarEstadoGuardado('APROBADO', `PagosAdministracion:${id}`),
+              estado: validarEstadoGuardado('REALIZADO', `PagosAdministracion:${id}`),
               fechaGestion: fechaServidor(),
               horaGestion: horaServidor(),
               gestionadoPor: authInstance().currentUser?.email || '',

--- a/public/js/estadoPagoPremio.js
+++ b/public/js/estadoPagoPremio.js
@@ -8,12 +8,12 @@
 })(typeof globalThis !== 'undefined' ? globalThis : this, function crearEstadoPagoPremio(){
   const ESTADOS_CANONICOS = Object.freeze({
     PENDIENTE: 'PENDIENTE',
-    APROBADO: 'APROBADO',
+    REALIZADO: 'REALIZADO',
     ARCHIVADO: 'ARCHIVADO'
   });
 
   const ALIAS_LECTURA = Object.freeze({
-    REALIZADO: ESTADOS_CANONICOS.APROBADO
+    APROBADO: ESTADOS_CANONICOS.REALIZADO
   });
 
   function normalizarTexto(valor){
@@ -47,7 +47,7 @@
   }
 
   function estaFinalizado(valor){
-    return normalizarLectura(valor) === ESTADOS_CANONICOS.APROBADO;
+    return normalizarLectura(valor) === ESTADOS_CANONICOS.REALIZADO;
   }
 
   return Object.freeze({


### PR DESCRIPTION
### Motivation
- Se detectó una inconsistencia entre la normalización de estados y la lógica de aprobación en `centropagos`: la validación de guardado solo acepta estados canónicos y la UI/lógica intentaba persistir `APROBADO`, lo que provocaba errores al aprobar premios/pagos.
- Las pruebas unitarias de normalización (`estadoPagoPremio`) esperaban que `REALIZADO` fuera el estado canónico y que `APROBADO` fuera solo un alias de lectura, por lo que era necesario alinear la lógica con ese contrato.

### Description
- Se cambió el conjunto de estados canónicos en `public/js/estadoPagoPremio.js` para usar `REALIZADO` como estado canónico y se agregó `APROBADO` como alias de lectura retrocompatible mediante `ALIAS_LECTURA`.
- Se actualizó la función `estaFinalizado` para comparar con `ESTADOS_CANONICOS.REALIZADO` y así reconocer correctamente estados legacy.
- Se modificó `public/centropagos.html` para mostrar `REALIZADO` en los filtros y para que la lógica de aprobación guarde `REALIZADO` en lugar de `APROBADO`, además de reemplazar comparaciones rígidas con llamadas a `window.EstadosPagoPremio.estaFinalizado(...)` donde corresponde.
- Archivos modificados: `public/js/estadoPagoPremio.js` y `public/centropagos.html`.

### Testing
- Se ejecutó la suite de pruebas con `npm test -- --runInBand` y todas las pruebas pasaron (11 suites, 37 tests) con cobertura establecida por la configuración de `jest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a25af50bc832696d744dc32ed4906)