### PR TITLE
Corregir fallo de aprobación manual de premios en CentroPagos

### DIFF
--- a/__tests__/uploadServer-acreditar-utils.test.js
+++ b/__tests__/uploadServer-acreditar-utils.test.js
@@ -72,7 +72,7 @@ describe('uploadServer utilidades de acreditación', () => {
   });
 
 
-  test('getAcreditacionExecutionMode diferencia modo automático y manual privilegiado', () => {
+  test('getAcreditacionExecutionMode habilita aprobación manual para operadores autorizados en centropagos', () => {
     const { getAcreditacionExecutionMode } = require('../uploadServer.js');
 
     expect(
@@ -114,9 +114,24 @@ describe('uploadServer utilidades de acreditación', () => {
       })
     ).toEqual(
       expect.objectContaining({
-        mode: 'automatico',
+        mode: 'manual',
         manualRequested: true,
-        manualAllowed: false
+        manualAllowed: true
+      })
+    );
+
+    expect(
+      getAcreditacionExecutionMode({
+        source: 'centropagos/manual',
+        origen: 'premios_jugadores',
+        manualApproval: true,
+        userRole: 'colaborador'
+      })
+    ).toEqual(
+      expect.objectContaining({
+        mode: 'manual',
+        manualRequested: true,
+        manualAllowed: true
       })
     );
   });

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -1671,6 +1671,23 @@
       };
     }
 
+    function cpResolverComponentesPremio(registro, eventoGanadorId){
+      const desdeEvento = cpExtraerComponentesEventoGanador(eventoGanadorId);
+      if(desdeEvento){ return desdeEvento; }
+      const sorteoId = (registro?.sorteoId || '').toString().trim();
+      const formaIdx = Number(registro?.formaIdx ?? registro?.forma);
+      const cartonId = (registro?.cartonId || registro?.carton || '').toString().trim();
+      if(sorteoId && Number.isFinite(formaIdx) && cartonId){
+        return {
+          sorteoId,
+          formaIdx,
+          cartonId,
+          segundoLugar: Boolean(registro?.segundoLugar)
+        };
+      }
+      return null;
+    }
+
     async function cpActualizarDocumentoCentroPagos(ctx, ref, payload){
       try {
         await ctx.db.runTransaction(async tx => {
@@ -2000,6 +2017,9 @@
         winnerKey,
         sorteoId: (data.sorteoId || '').toString(),
         sorteoNombre: (data.sorteoNombre || '').toString(),
+        formaIdx: Number(data.formaIdx ?? data.forma ?? NaN),
+        cartonId: (data.cartonId || data.carton || '').toString(),
+        segundoLugar: Boolean(data.segundoLugar),
         acreditacionesPendientes: normalizarConteoTecnico(data.AcreditacionesPendientes ?? data.acreditacionesPendientes),
         acreditacionesConError: normalizarConteoTecnico(data.AcreditacionesConError ?? data.acreditacionesConError ?? data.acreditacionesErrores ?? data.erroresTecnicos)
       };
@@ -2386,8 +2406,8 @@
     async function acreditarPremioBackendLegacy(enRegistro){
       const eventoGanadorId = (enRegistro.eventoGanadorId || enRegistro.winnerKey || enRegistro.id || '').toString().trim();
       if(!eventoGanadorId){ throw new Error('Falta eventoGanadorId para acreditar premio.'); }
-      const componentes = cpExtraerComponentesEventoGanador(eventoGanadorId);
-      if(!componentes){ throw new Error('No se pudieron extraer los componentes de eventoGanadorId.'); }
+      const componentes = cpResolverComponentesPremio(enRegistro, eventoGanadorId);
+      if(!componentes){ throw new Error('No se pudieron extraer los componentes del premio a acreditar.'); }
       const user = authInstance().currentUser;
       const apiBase = (typeof getAdminApiBase === 'function' ? getAdminApiBase() : '').replace(/\/$/, '');
       if(!user || !apiBase){ throw new Error('Falta sesión autenticada o API base para acreditar premio.'); }

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -355,10 +355,11 @@ function extractEventoGanadorIdComponents(eventoGanadorId) {
 function getAcreditacionExecutionMode({ source, origen, manualApproval, userRole }) {
   const normalizedSource = normalizeString(source, 120).toLowerCase();
   const normalizedOrigen = normalizeString(origen, 80).toLowerCase();
+  const normalizedUserRole = normalizeString(userRole, 40).toLowerCase();
   const explicitManualApproval = manualApproval === true;
   const sourceRequestsManual = normalizedSource === 'centropagos/manual' || normalizedOrigen === 'centropagos/manual';
   const manualRequested = explicitManualApproval || sourceRequestsManual;
-  const hasPrivilegedRole = ['Superadmin', 'Administrador'].includes(normalizeString(userRole, 40));
+  const hasPrivilegedRole = ['superadmin', 'administrador', 'colaborador'].includes(normalizedUserRole);
   const manualAllowed = manualRequested && hasPrivilegedRole;
 
   return {


### PR DESCRIPTION
### Motivation

- Restaurar y asegurar el flujo de aprobación manual desde la ventana CentroPagos que fallaba al intentar acreditar premios, eliminando dependencias frágiles de formatos legacy y de casing de roles.

### Description

- Ajusté la detección de modo de acreditación en `uploadServer.js` para normalizar el rol a minúsculas y permitir explicitamente a `Colaborador` acceder a modo `manual` cuando la solicitud proviene de `centropagos/manual` o solicita aprobación manual.
- Añadí en `public/centropagos.html` la función `cpResolverComponentesPremio` que primero intenta extraer componentes desde `eventoGanadorId` y, si falla, hace fallback a `sorteoId`, `formaIdx` y `cartonId` del registro; reemplacé el uso directo de la extracción por este resolvedor en el flujo de acreditación legacy.
- Extendí la estructura de mapeo/representación de premios en CentroPagos para incluir `formaIdx`, `cartonId` y `segundoLugar`, evitando errores al faltar esos datos en registros legacy.
- Actualicé las pruebas unitarias en `__tests__/uploadServer-acreditar-utils.test.js` para reflejar el nuevo comportamiento (case-insensitive y aceptación de `Colaborador` para aprobaciones manuales desde CentroPagos).

### Testing

- Ejecuté las suites afectadas con `npx jest --runTestsByPath __tests__/uploadServer-acreditar-utils.test.js __tests__/uploadServer-acreditar-endpoint.test.js --coverage=false` y todos los tests objetivos pasaron (2 suites, 9 tests pasados).  
- Ejecuté `npm test -- --runTestsByPath __tests__/uploadServer-acreditar-utils.test.js __tests__/uploadServer-acreditar-endpoint.test.js` donde los tests funcionales pasaron pero la ejecución inicial señaló fallo por umbral global de cobertura; repetí con `--coverage=false` para validar correctamente y pasó.
- Cambios commiteados: `uploadServer.js`, `public/centropagos.html`, `__tests__/uploadServer-acreditar-utils.test.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b292e4a048326a87822d8ca40444c)