### PR TITLE
Ajusta tutorial en player y elimina modal de "Cartones jugando" en jugarcartones

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -678,108 +678,12 @@
     #fecha-hora,#derechos{font-size:0.7rem;text-align:center;color:#000;margin:0;}
     #fecha-hora{margin-top:auto;padding-top:12px;}
     #derechos{font-size:0.6rem;padding-bottom:12px;}
-    .info-line{font-family:'Bangers',cursive;font-size:1.5rem;text-align:center;}
-    #info-cartones-diagnostico{
-      display:none;
-      font-family:'Poppins',sans-serif;
-      font-size:0.95rem;
-      padding:8px 10px;
-      border-radius:8px;
-      border:1px solid #f6b26b;
-      background:#fff3cd;
-      color:#8a4b08;
-      text-align:center;
-      font-weight:600;
-      margin-top:-4px;
-    }
-    #info-cartones-diagnostico.visible{display:block;}
     .text-forma-gratis{font-family:'Bangers',cursive;font-weight:bold;color:purple;font-size:1.1rem;text-align:center;}
-    #premios-titulo,#info-cartones-titulo,#back-premios-titulo{font-size:1.1rem;text-align:center;font-family:'Bangers',cursive;}
+    #premios-titulo,#back-premios-titulo{font-size:1.1rem;text-align:center;font-family:'Bangers',cursive;}
     #premios-modal .modal-content{align-items:center;width:min(960px,95vw);max-height:90vh;overflow-y:auto;padding:clamp(16px,2.5vw,32px);gap:clamp(14px,2vw,24px);}
     #premios-modal .modal-content>h2,#premios-modal .modal-content>.text-premio-total{align-self:center;}
     #premios-modal #premios-aceptar{align-self:center;}
-    #info-cartones-modal .modal-content{
-      align-items:stretch;
-      width:min(1024px,96vw);
-      max-height:92vh;
-      min-height:70vh;
-      padding:clamp(16px,2.5vw,28px);
-      gap:clamp(12px,2vw,18px);
-      display:flex;
-      box-shadow:0 16px 45px rgba(0,0,0,0.35);
-    }
-    #info-cartones-modal .modal-content h2{
-      align-self:center;
-    }
-    #info-cartones-modal .modal-buttons{
-      justify-content:center;
-      margin-top:0;
-    }
-    #info-cartones-tabla-contenedor{
-      width:100%;
-      flex:1;
-      display:flex;
-      flex-direction:column;
-      border:2px solid rgba(13,31,89,0.18);
-      border-radius:12px;
-      background:linear-gradient(180deg,rgba(255,255,255,0.98) 0%,rgba(240,244,255,0.96) 100%);
-      box-shadow:inset 0 4px 16px rgba(11,29,96,0.08);
-      overflow:hidden;
-    }
-    #info-cartones-tabla-wrapper{
-      flex:1;
-      overflow:auto;
-    }
-    #info-cartones-tabla{
-      width:100%;
-      border-collapse:collapse;
-      font-family:'Poppins',sans-serif;
-      font-size:clamp(0.68rem,1.5vw,0.82rem);
-      color:#0b1b4d;
-    }
-    #info-cartones-tabla thead th{
-      position:sticky;
-      top:0;
-      z-index:2;
-      background:rgba(255,255,255,0.95);
-      backdrop-filter:blur(6px);
-      font-weight:700;
-      padding:10px 12px;
-      text-align:center;
-      border-bottom:2px solid rgba(11,29,96,0.18);
-      text-transform:uppercase;
-      letter-spacing:0.04em;
-    }
-    #info-cartones-tabla thead th:nth-child(1){color:#0b1b4d;width:15%;min-width:60px;}
-    #info-cartones-tabla thead th:nth-child(2){color:#c35b00;width:45%;}
-    #info-cartones-tabla thead th:nth-child(3){color:#0b6a2b;width:20%;}
-    #info-cartones-tabla thead th:nth-child(4){color:#000;width:20%;}
-    #info-cartones-tabla thead th,
-    #info-cartones-tabla tbody td{
-      text-align:center;
-    }
-    #info-cartones-tabla tbody tr:nth-child(even){background:rgba(233,239,255,0.75);}
-    #info-cartones-tabla tbody tr:nth-child(odd){background:rgba(255,255,255,0.9);}
-    #info-cartones-tabla tbody td{
-      padding:8px 12px;
-      border-bottom:1px solid rgba(11,29,96,0.12);
-      font-weight:600;
-      white-space:nowrap;
-    }
-    #info-cartones-tabla tbody td.alias-col{color:#ff7a00;white-space:normal;}
-    #info-cartones-tabla tbody td.carton-col{color:#111;}
-    #info-cartones-tabla tbody td.tipo-col{font-weight:700;}
-    #info-cartones-tabla tbody td.tipo-col.pagado{color:#0b6a2b;}
-    #info-cartones-tabla tbody td.tipo-col.gratis{color:#0b3d91;}
-    #info-cartones-tabla tbody td.numero-col{text-align:center;}
-    #info-cartones-tabla tbody tr:hover{background:rgba(217,226,255,0.95);}
-    #info-cartones-tabla tbody td.tabla-mensaje{
-      text-align:center;
-      color:#0b1b4d;
-      font-weight:600;
-      padding:18px 12px;
-    }
-    #info-cartones-aceptar,#premios-aceptar{font-size:1.2rem;padding:8px 20px;}
+    #premios-aceptar{font-size:1.2rem;padding:8px 20px;}
     .text-premio-total{font-family:'Bangers',cursive;color:white;font-size:clamp(1.2rem,2.8vw,1.6rem);text-align:center;}
     .text-premio-total div{ text-shadow:0 0 4px darkgreen; }
     .valor-total{font-size:clamp(2.3rem,5.5vw,3.4rem);text-shadow:0 0 4px darkgreen;animation:pulse 1s infinite;}
@@ -818,7 +722,7 @@
       .sorteo-info{gap:14px;}
       #fecha-hora-sorteo{font-size:clamp(1rem,1vw,1.05rem);}
       #fecha-hora,#derechos{font-size:max(0.85rem,0.95vw);}
-      #bingo-board,.sorteo-info,#info-cartones-tabla{width:min(920px,90vw);max-width:90vw;}
+      #bingo-board,.sorteo-info{width:min(920px,90vw);max-width:90vw;}
       table{font-size:clamp(0.9rem,0.95vw,1rem);}
     }
     @media (max-width:480px){#fecha-hora-sorteo .fecha-col{align-items:center;text-align:center;}}
@@ -1162,36 +1066,6 @@
           </div>
       </div>
   </div>
-  <div id="info-cartones-modal" class="modal">
-      <div class="modal-content" onclick="event.stopPropagation();">
-          <h2 id="info-cartones-titulo"></h2>
-          <div id="info-cartones-jugando" class="info-line"></div>
-          <div id="info-cartones-gratis" class="info-line"></div>
-          <div id="info-cartones-diagnostico"></div>
-          <div class="modal-buttons">
-            <button id="info-cartones-aceptar" class="action-btn">Aceptar</button>
-          </div>
-          <div id="info-cartones-tabla-contenedor">
-            <div id="info-cartones-tabla-wrapper">
-              <table id="info-cartones-tabla">
-                <thead>
-                  <tr>
-                    <th scope="col">N°</th>
-                    <th scope="col">Alias</th>
-                    <th scope="col">N° Cartón</th>
-                    <th scope="col">Tipo</th>
-                  </tr>
-                </thead>
-                <tbody id="info-cartones-tabla-body">
-                  <tr>
-                    <td class="tabla-mensaje" colspan="4">Sin cartones registrados</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-      </div>
-  </div>
   <div id="premios-modal" class="modal" onclick="this.style.display='none'">
       <div class="modal-content" onclick="event.stopPropagation();">
           <h2 id="premios-titulo"></h2>
@@ -1294,14 +1168,12 @@
   const formGlows=['#006400','#b8860b','#00008b','#4b0082','#8b4513'];
   const COLOR_CARTONES_GRATIS_DISPONIBLE='#0b3d91';
   const COLOR_CARTONES_GRATIS_LIMITE='#c62828';
-  const COLOR_CARTONES_GRATIS_MODAL='#001b60';
   let editandoTipo=null;
   let editandoId=null;
   const selladoOverlay=document.getElementById('sellado-overlay');
   const selladoCerrarBtn=document.getElementById('sellado-cerrar-btn');
   const CONSECUTIVOS_COLLECTION='ConsecutivosCarton';
   let unsubscribeConsecutivoCarton=null;
-  let unsubscribeInfoCartonesJugando=null;
   let ultimoNumeroCartonAsignado=0;
   let siguienteNumeroCarton=1;
   const premioCartonesGratisEl=document.getElementById('premio-cartones-gratis');
@@ -1346,8 +1218,6 @@
   const cartonProcessingText=document.getElementById('carton-processing-text');
   const cartonProcessingSpinner=cartonProcessingOverlay?cartonProcessingOverlay.querySelector('.carton-processing-spinner'):null;
   const cartonToast=document.getElementById('carton-toast');
-  const infoCartonesTablaBody=document.getElementById('info-cartones-tabla-body');
-  const infoCartonesDiagnostico=document.getElementById('info-cartones-diagnostico');
   const tutorialState={
     activo:false,
     indice:0,
@@ -1377,7 +1247,6 @@
     '#cartones-modal',
     '#sorteos-modal',
     '#jugados-modal',
-    '#info-cartones-modal',
     '#premios-modal',
     '#perfil-pendiente-modal',
     '#datos-bancarios-modal',
@@ -2478,51 +2347,6 @@
     return (valor||'').toString().trim().slice(0,20);
   }
 
-  function mostrarMensajeTablaCartones(mensaje){
-    if(!infoCartonesTablaBody) return;
-    infoCartonesTablaBody.innerHTML='';
-    const fila=document.createElement('tr');
-    const celda=document.createElement('td');
-    celda.colSpan=4;
-    celda.className='tabla-mensaje';
-    celda.textContent=mensaje;
-    fila.appendChild(celda);
-    infoCartonesTablaBody.appendChild(fila);
-  }
-
-  function actualizarResumenCartonesModal({totalRegistrado=0,gratisRegistrado=0,tieneErrorCarga=false}={}){
-    const pagadosRegistrados=Math.max(0,totalRegistrado-gratisRegistrado);
-    const totalOficial=toNumberSafe(cartonesJugando,0)+toNumberSafe(cartonesGratisJugando,0);
-
-    const cj=document.getElementById('info-cartones-jugando');
-    if(cj){
-      cj.innerHTML=`Cartones jugando: <strong style="color:purple;">${formatearEnteroEs(cartonesJugando)}</strong> <span style="font-size:0.75em;">(oficial) / <strong style="color:#0b1b4d;">${formatearEnteroEs(pagadosRegistrados)}</strong> registrado</span>`;
-    }
-
-    const cg=document.getElementById('info-cartones-gratis');
-    if(cg){
-      cg.innerHTML=`Cartones Gratis jugando: <strong style="color:${COLOR_CARTONES_GRATIS_MODAL};">${formatearEnteroEs(cartonesGratisJugando)}</strong> <span style="font-size:0.75em;">(oficial) / <strong style="color:#0b1b4d;">${formatearEnteroEs(gratisRegistrado)}</strong> registrado</span>`;
-    }
-
-    if(!infoCartonesDiagnostico){
-      return;
-    }
-    const hayDiferenciaTotales=totalOficial!==totalRegistrado;
-    const hayDiferenciaGratis=toNumberSafe(cartonesGratisJugando,0)!==gratisRegistrado;
-    if(tieneErrorCarga){
-      infoCartonesDiagnostico.classList.add('visible');
-      infoCartonesDiagnostico.textContent='Error de carga de cartones. Reintenta en unos segundos.';
-      return;
-    }
-    if(hayDiferenciaTotales||hayDiferenciaGratis){
-      infoCartonesDiagnostico.classList.add('visible');
-      infoCartonesDiagnostico.textContent='Datos en sincronización: los contadores oficiales aún no coinciden con los cartones registrados.';
-      return;
-    }
-    infoCartonesDiagnostico.classList.remove('visible');
-    infoCartonesDiagnostico.textContent='';
-  }
-
   function extraerAliasCarton(data){
     const alias=normalizarAliasPerfil(
       data?.alias
@@ -2540,6 +2364,10 @@
     }
     return {orden:-Infinity,texto:'----'};
   }
+
+
+
+
   function normalizarCartonJugado(data){
     const numero=extraerNumeroCartonDatos(data);
     const tipoFuente=(data?.tipocarton??data?.tipoCarton??data?.tipo??'').toString().trim().toLowerCase();
@@ -4405,214 +4233,10 @@ function toggleForma(idx){
     }
   }
 
-  function renderizarFilasCartonesJugando(registros){
-    if(!infoCartonesTablaBody) return;
-    infoCartonesTablaBody.innerHTML='';
-    const total=registros.length;
-    registros.forEach((registro,index)=>{
-      const fila=document.createElement('tr');
-      const numeroTd=document.createElement('td');
-      numeroTd.className='numero-col';
-      numeroTd.textContent=formatearEnteroEs(total-index);
-      const aliasTd=document.createElement('td');
-      aliasTd.className='alias-col';
-      aliasTd.textContent=registro.alias;
-      const cartonTd=document.createElement('td');
-      cartonTd.className='carton-col';
-      cartonTd.textContent=registro.numeroTexto;
-      const tipoTd=document.createElement('td');
-      const tipoClase=registro.tipo==='GRATIS'?'gratis':'pagado';
-      tipoTd.className=`tipo-col ${tipoClase}`;
-      tipoTd.textContent=registro.tipo;
-      fila.append(numeroTd,aliasTd,cartonTd,tipoTd);
-      infoCartonesTablaBody.appendChild(fila);
-    });
-  }
 
-  function cerrarModalCartonesJugando(){
-    const modal=document.getElementById('info-cartones-modal');
-    if(modal){
-      modal.style.display='none';
-    }
-    if(typeof unsubscribeInfoCartonesJugando==='function'){
-      unsubscribeInfoCartonesJugando();
-      unsubscribeInfoCartonesJugando=null;
-    }
-  }
 
-  function coincideSorteoCarton(data,currentSorteoId,currentSorteoNombre){
-    const idActual=(currentSorteoId??'').toString().trim();
-    const nombreActual=(currentSorteoNombre??'').toString().trim();
-    const candidatosId=[data?.sorteoId,data?.idSorteo,data?.sorteo];
-    const candidatosNombre=[data?.sorteoNombre,data?.sorteo];
 
-    const coincideId=idActual!=='' && candidatosId.some((valor)=>{
-      const texto=(valor??'').toString().trim();
-      return texto!=='' && texto===idActual;
-    });
 
-    const coincideNombre=nombreActual!=='' && candidatosNombre.some((valor)=>{
-      const texto=(valor??'').toString().trim();
-      return texto!=='' && texto.localeCompare(nombreActual,'es',{sensitivity:'base'})===0;
-    });
-
-    return coincideId || coincideNombre;
-  }
-
-  function suscribirCartonesJugandoTabla(){
-    if(!infoCartonesTablaBody||!currentSorteo){
-      return;
-    }
-    const user=auth.currentUser;
-    if(!user){
-      mostrarMensajeTablaCartones('Inicia sesión para ver los cartones del sorteo.');
-      return;
-    }
-    if(typeof unsubscribeInfoCartonesJugando==='function'){
-      unsubscribeInfoCartonesJugando();
-      unsubscribeInfoCartonesJugando=null;
-    }
-
-    const filtros=[
-      {campo:'sorteoId',valor:currentSorteo}
-    ];
-    const debugCartonesJugando=window.DEBUG_CARTONES_JUGANDO===true;
-    const nombreSorteoNormalizado=(currentSorteoNombre||'').toString().trim();
-    if(nombreSorteoNormalizado){
-      filtros.push({campo:'sorteoNombre',valor:nombreSorteoNormalizado});
-    }
-    if(currentSorteo){
-      filtros.push({campo:'idSorteo',valor:currentSorteo});
-      filtros.push({campo:'sorteo',valor:currentSorteo});
-    }
-    if(nombreSorteoNormalizado){
-      filtros.push({campo:'sorteo',valor:nombreSorteoNormalizado});
-    }
-
-    if(debugCartonesJugando){
-      console.debug('[CartonesJugandoTabla] Filtro activo',{
-        sorteoId:currentSorteo,
-        sorteoNombre:nombreSorteoNormalizado
-      });
-    }
-
-    mostrarMensajeTablaCartones('Cargando cartones...');
-
-    const docsPorId=new Map();
-    const snapshotsPorFiltro=new Map();
-    const docsRecibidosPorFiltro=new Map();
-    let huboError=false;
-    const unsubscribers=[];
-
-    const renderizarDesdeSnapshots=()=>{
-      docsPorId.clear();
-      let docsRecibidosQuery=0;
-      let docsDescartadosNoCoincidir=0;
-      snapshotsPorFiltro.forEach((snap)=>{
-        docsRecibidosQuery+=snap.size;
-        snap.forEach((doc)=>{
-          const data=doc.data()||{};
-          if(!coincideSorteoCarton(data,currentSorteo,nombreSorteoNormalizado)){
-            docsDescartadosNoCoincidir+=1;
-            return;
-          }
-          docsPorId.set(doc.id,data);
-        });
-      });
-
-      const registros=[];
-      docsPorId.forEach((data)=>{
-        const carton=normalizarCartonJugado(data);
-        registros.push({
-          alias:carton.alias,
-          numeroOrden:carton.cartonNum,
-          numeroTexto:carton.cartonTexto,
-          tipo:carton.tipoEtiqueta
-        });
-      });
-
-      const totalRegistrado=registros.length;
-      const gratisRegistrado=registros.filter((registro)=>registro.tipo==='GRATIS').length;
-
-      if(debugCartonesJugando){
-        console.debug('[CartonesJugandoTabla] Diagnóstico de render',{
-          docsPorQuery:[...docsRecibidosPorFiltro.entries()].map(([key,cantidad])=>({query:key,docs:cantidad})),
-          docsRecibidosQuery,
-          docsDescartadosNoCoincidir,
-          docsParaRender:totalRegistrado
-        });
-      }
-
-      actualizarResumenCartonesModal({totalRegistrado,gratisRegistrado,tieneErrorCarga:huboError});
-
-      if(totalRegistrado===0){
-        const jugadosHeader=toNumberSafe(document.getElementById('cartones-jugando-valor')?.textContent,0);
-        const gratisHeader=toNumberSafe(document.getElementById('cartones-gratis-jugando')?.textContent,0);
-        if(jugadosHeader>0 || gratisHeader>0){
-          console.warn('[CartonesJugandoTabla] Se obtuvo 0 cartones para render, pero el header indica cartones en juego. Revisa el esquema/campos del documento (por ejemplo: sorteoId, sorteoNombre, idSorteo o sorteo) para asegurar que coincidan con el filtro activo.',{
-            sorteoId:currentSorteo,
-            sorteoNombre:nombreSorteoNormalizado,
-            jugadosHeader,
-            gratisHeader
-          });
-        }
-        const mensaje=huboError
-          ? 'Error al cargar cartones: intenta nuevamente en unos segundos.'
-          : 'Sin cartones registrados';
-        mostrarMensajeTablaCartones(mensaje);
-        return;
-      }
-
-      registros.sort((a,b)=>{
-        if(b.numeroOrden!==a.numeroOrden){
-          return b.numeroOrden-a.numeroOrden;
-        }
-        return a.alias.localeCompare(b.alias,'es',{sensitivity:'base'});
-      });
-      renderizarFilasCartonesJugando(registros);
-    };
-
-    filtros.forEach((filtro)=>{
-      const key=`${filtro.campo}:${filtro.valor}`;
-      const query=db.collection('CartonJugado').where(filtro.campo,'==',filtro.valor);
-      const unsubscribe=query.onSnapshot((snap)=>{
-        snapshotsPorFiltro.set(key,snap);
-        docsRecibidosPorFiltro.set(key,snap.size);
-        renderizarDesdeSnapshots();
-      },(error)=>{
-        huboError=true;
-        docsRecibidosPorFiltro.set(key,0);
-        console.error('Error cargando cartones jugados para la tabla',filtro,error);
-        renderizarDesdeSnapshots();
-      });
-      unsubscribers.push(unsubscribe);
-    });
-
-    unsubscribeInfoCartonesJugando=()=>{
-      unsubscribers.forEach((fn)=>{
-        if(typeof fn==='function') fn();
-      });
-    };
-  }
-
-  async function mostrarCartonesJugandoModal(){
-    if(!currentSorteo){
-      alert('Debes selecionar primero un sorteo');
-      abrirSorteosModal();
-      return;
-    }
-    const titulo=document.getElementById('info-cartones-titulo');
-    titulo.innerHTML=`<span style="color:purple;">CARTONES JUGANDO SORTEO:</span><br><span id="info-cartones-nombre">${currentSorteoNombre}</span>`;
-    const infoNombre=document.getElementById('info-cartones-nombre');
-    infoNombre.style.color=currentSorteoTipo==='Sorteo Diario'?'green':'orange';
-    actualizarResumenCartonesModal();
-    const modal=document.getElementById('info-cartones-modal');
-    if(modal){
-      modal.style.display='flex';
-      reiniciarScrollModal(document.getElementById('info-cartones-tabla-wrapper'));
-    }
-    suscribirCartonesJugandoTabla();
-  }
 
   function mostrarPremiosModal(){
     if(!currentSorteo){
@@ -4924,15 +4548,7 @@ document.getElementById('gratis-label').addEventListener('click',()=>{
   document.getElementById('editar-guardado-btn').addEventListener('click',editarCartonGuardado);
   document.getElementById('borrar-guardado-btn').addEventListener('click',eliminarCartonGuardado);
   document.getElementById('cartones-close').addEventListener('click',()=>{document.getElementById('cartones-modal').style.display='none';});
-  document.getElementById('cartones-jugando-valor').addEventListener('click',mostrarCartonesJugandoModal);
-  document.getElementById('cartones-gratis-jugando').addEventListener('click',mostrarCartonesJugandoModal);
   document.getElementById('premio-valor').addEventListener('click',mostrarPremiosModal);
-  document.getElementById('info-cartones-aceptar').addEventListener('click',cerrarModalCartonesJugando);
-  document.getElementById('info-cartones-modal').addEventListener('click',(event)=>{
-    if(event.target===event.currentTarget){
-      cerrarModalCartonesJugando();
-    }
-  });
   document.getElementById('premios-aceptar').addEventListener('click',()=>{document.getElementById('premios-modal').style.display='none';});
   document.getElementById('limpiar-btn').addEventListener('click',async()=>{if(await confirm('¿Deseas limpiar todas las jugadas del carton?')) limpiarcarton();});
   document.getElementById('azar-btn').addEventListener('click',async()=>{if(await confirm('¿Quieres cargar jugadas al azar?')) cargarAzar();});

--- a/public/player.html
+++ b/public/player.html
@@ -764,17 +764,6 @@
           hyphens: auto;
       }
 
-      #tutorial-label .tutorial-cta {
-          margin-top: 6px;
-          display: inline-block;
-          background: #0b5fff;
-          color: #ffffff;
-          padding: 4px 8px;
-          border-radius: 6px;
-          font-size: 11px;
-          font-weight: 700;
-      }
-
       @keyframes tutorial-hand-pulse {
           0% { transform: scale(1); }
           45% { transform: scale(1.17); }
@@ -1341,7 +1330,6 @@
       color: '#3d2500',
       label: 'Perfil del jugador',
       description: 'Actualiza tus datos para jugar y cobrar sin demoras.',
-      ctaLabel: 'Completar perfil',
       ctaAction: () => { window.location.href = 'perfil.html'; },
     },
     {
@@ -1351,7 +1339,6 @@
       color: '#0b7a33',
       label: 'Billetera',
       description: 'Revisa tu saldo y solicita recargas o retiros.',
-      ctaLabel: 'Abrir Billetera',
       ctaAction: () => { window.location.href = 'billetera.html'; },
     },
     {
@@ -1361,7 +1348,6 @@
       color: '#003399',
       label: 'Zona de juego',
       description: 'Compra cartones y participa en el próximo sorteo.',
-      ctaLabel: 'Ir a Jugar',
       ctaAction: () => { window.location.href = 'jugarcartones.html'; },
     },
     {
@@ -1371,7 +1357,6 @@
       color: '#20004d',
       label: 'Sorteos en vivo',
       description: 'Mira sorteos activos y revisa resultados finalizados.',
-      ctaLabel: 'Ver sorteos',
       ctaAction: () => { window.location.href = 'juegoactivo.html'; },
     },
     {
@@ -1381,7 +1366,6 @@
       color: '#7a2f00',
       label: 'Comunidad WhatsApp',
       description: 'Únete al grupo para avisos y novedades de premios.',
-      ctaLabel: 'Abrir mensajes',
       ctaAction: manejarClickWhatsapp,
     },
     {
@@ -1391,7 +1375,6 @@
       color: '#006600',
       label: 'Referidos',
       description: 'Comparte tu código y gana cartones gratis por invitaciones.',
-      ctaLabel: 'Compartir ahora',
       ctaAction: manejarClickReferidos,
     },
   ];
@@ -2183,7 +2166,7 @@
         tutorialLabel.style.visibility = 'visible';
       };
 
-      tutorialLabel.innerHTML = `<strong>${paso.label}</strong><br>${paso.description}<span class="tutorial-cta">${paso.ctaLabel}</span>`;
+      tutorialLabel.innerHTML = `<strong>${paso.label}</strong><br>${paso.description}`;
       tutorialLabel.style.color = paso.color;
       tutorialLabel.style.display = 'block';
       colocarEtiqueta();


### PR DESCRIPTION
### Motivation
- Quitar elementos visuales tipo botón (bloques azules con texto blanco) del modo tutorial en la pantalla `player.html` porque eran decorativos y no tenían acción funcional. 
- Eliminar la ventana modal "CARTONES JUGANDO SORTEO" en `jugarcartones.html` y su lógica asociada porque ya no se usará la visualización actual de cartones en juego.

### Description
- En `public/player.html` se removió el estilo y la inserción del bloque CTA dentro de la etiqueta del tutorial, dejando únicamente el título y la descripción para cada paso del tutorial. 
- En `public/jugarcartones.html` se eliminó el bloque HTML del modal `info-cartones-modal`, sus estilos específicos y todos los manejadores/funciones/refs exclusivos que se usaban para suscribirse, renderizar la tabla y abrir/cerrar ese modal, manteniendo la lógica de juego (compra, edición, premios, etc.).
- Se limpiaron referencias DOM y constantes relacionadas únicamente con el modal (selectores, variables de suscripción, funciones de renderizado y eventos de click que abrían ese modal). 
- Los cambios están limitados a los dos archivos mencionados y preservan demás funcionalidades de cartones, sorteos y tutorial.

### Testing
- Ejecuté verificación de sintaxis del JavaScript embebido con `node --check` sobre los scripts extraídos de `public/player.html` y `public/jugarcartones.html`, y ambos pasaron correctamente. 
- Levanté un servidor local con `python -m http.server 4173 -d public` y tomé capturas con Playwright para inspección visual de `player.html` y `jugarcartones.html`, confirmando que el tutorial ya no muestra CTAs azules y que el modal de cartones en juego ya no aparece. 
- Todas las pruebas automáticas realizadas en el entorno local terminaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2df49eb48326bc27a130e2889dd6)