### PR TITLE
Deshabilitar botón "Aprobar" en PREMIOS JUGADORES de CentroPagos

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -2716,11 +2716,8 @@
 
       const premiosAprobarBtn = document.getElementById('premios-aprobar');
       if(premiosAprobarBtn){
-        premiosAprobarBtn.addEventListener('click', async()=>{
-          const seleccion = obtenerSeleccion('tabla-premios');
-          if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }
-          await aprobarPremiosLegacy(seleccion);
-        });
+        premiosAprobarBtn.disabled = true;
+        premiosAprobarBtn.title = 'Aprobación manual de premios deshabilitada temporalmente';
       }
       const premiosArchivarBtn = document.getElementById('premios-archivar');
       if(premiosArchivarBtn){


### PR DESCRIPTION
### Motivation
- El botón `premios-aprobar` en la sección `PREMIOS JUGADORES` ejecutaba un flujo legacy que estaba lanzando errores, por lo que se decide deshabilitar su acción para evitar fallos y no afectar la operación de otras secciones.

### Description
- En `public/centropagos.html` se eliminó el listener que llamaba a la función `aprobarPremiosLegacy` para el botón `premios-aprobar` y ahora el botón queda `disabled` con un `title` informativo, sin tocar las lógicas de `PAGOS ADMINISTRACIÓN` ni `PAGOS COLABORADORES`.

### Testing
- Se realizaron comprobaciones automatizadas de integración visual y estática: búsqueda con `rg` para confirmar que solo se cambió el bloque de `premios-aprobar`, se levantó un servidor con `python3 -m http.server` y se ejecutó un script Playwright que cargó `public/centropagos.html` y generó una captura de pantalla, todas las verificaciones automatizadas completaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc75d04a48326b114807f568b2fa7)