### PR TITLE
feat(centropagos): procesar premios de jugadores con botón "Procesar"

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -538,7 +538,7 @@
     </div>
     <div id="premios-content">
       <div class="acciones">
-        <button class="icon-btn" id="premios-aprobar"><span class="icon check">&#10004;</span><span>Aprobar</span></button>
+        <button class="icon-btn" id="premios-aprobar"><span class="icon check">&#10004;</span><span>Procesar</span></button>
         <button class="icon-btn" id="premios-archivar"><span class="icon">&#128452;</span><span>Archivar</span></button>
         <button class="icon-btn" id="premios-archivo"><span class="icon">&#128193;</span><span>Archivo</span></button>
       </div>
@@ -2499,24 +2499,33 @@
       return nuevoSaldo;
     }
 
-    async function aprobarPremiosLegacy(ids){
+    async function procesarPremiosJugadores(ids){
       if(!ids.length) return;
-      const db = dbRef();
       await initServerTime();
       const sorteosActualizados = new Set();
+      const errores = [];
+      let procesados = 0;
+      let omitidos = 0;
       for(const id of ids){
         const registro = premiosMapa.get(id);
-        if(!registro){ console.warn('Premio no encontrado', id); continue; }
-        if(window.EstadosPagoPremio.estaFinalizado(registro.estado)){ continue; }
+        if(!registro){
+          console.warn('Premio no encontrado', id);
+          omitidos += 1;
+          continue;
+        }
+        if(window.EstadosPagoPremio.estaFinalizado(registro.estado)){
+          omitidos += 1;
+          continue;
+        }
         try {
           await acreditarPremioBackendLegacy(registro);
+          procesados += 1;
           if(registro.sorteoId){
             sorteosActualizados.add(registro.sorteoId);
           }
         } catch (err) {
           console.error('Error aprobando premio', err);
-          alert('Ocurrió un error al aprobar un premio. Revisa la consola para más detalles.');
-          break;
+          errores.push(id);
         }
       }
       if(sorteosActualizados.size){
@@ -2525,6 +2534,13 @@
         } catch (errIndicador) {
           console.warn('No se pudo actualizar el indicador de pagos tras aprobar premios', errIndicador);
         }
+      }
+      if(errores.length){
+        alert(`Se procesaron ${procesados} premio(s). ${errores.length} registro(s) no se pudieron procesar.`);
+        return;
+      }
+      if(procesados > 0 || omitidos > 0){
+        alert(`Proceso finalizado. Premios procesados: ${procesados}. Registros omitidos: ${omitidos}.`);
       }
     }
 
@@ -2716,8 +2732,13 @@
 
       const premiosAprobarBtn = document.getElementById('premios-aprobar');
       if(premiosAprobarBtn){
-        premiosAprobarBtn.disabled = true;
-        premiosAprobarBtn.title = 'Aprobación manual de premios deshabilitada temporalmente';
+        premiosAprobarBtn.disabled = false;
+        premiosAprobarBtn.title = 'Procesar premios seleccionados';
+        premiosAprobarBtn.addEventListener('click', async()=>{
+          const seleccion = obtenerSeleccion('tabla-premios');
+          if(!seleccion.length){ alert('Selecciona al menos un registro.'); return; }
+          await procesarPremiosJugadores(seleccion);
+        });
       }
       const premiosArchivarBtn = document.getElementById('premios-archivar');
       if(premiosArchivarBtn){


### PR DESCRIPTION
### Motivation
- Implementar en la sección PREMIOS JUGADORES una acción explícita "Procesar" que ejecute el flujo de acreditación de premios para los registros seleccionados, recargando billeteras con créditos y cartones gratis. 
- Reutilizar la lógica de acreditación backend existente para mantener trazabilidad y compatibilidad con el sistema de notificaciones y las preferencias por rol.

### Description
- Se actualizó el texto del botón en la UI de `PREMIOS JUGADORES` de `Aprobar` a `Procesar` y se habilitó su interacción en `public/centropagos.html`.
- Se creó la función `procesarPremiosJugadores(ids)` que valida la selección, omite registros inexistentes o ya finalizados, y llama a `acreditarPremioBackendLegacy(registro)` para acreditar créditos y cartones por cada ganador.
- El nuevo flujo acumula y actualiza indicadores por sorteo llamando a `actualizarIndicadorPagosSorteo`, contabiliza procesados/omitidos/errores y muestra alertas resumen al finalizar.
- El procesamiento reutiliza el backend y deja intacta la integración con `notificationCenter` y las preferencias de notificación por rol para mantener el envío de notificaciones según configuración del usuario.

### Testing
- Se ejecutó la suite completa con `npm test -- --runInBand` y todos los tests pasaron (11 suites, 37 tests) ✅.
- Se intentó correr el test aislado y la captura de UI vía Playwright pero la generación de screenshot falló en el entorno (problema de ejecución del navegador en contenedor), por lo que no se pudo adjuntar imagen ⚠️.
- Los cambios fueron comprometidos (`feat(centropagos): procesar premios jugadores desde botón Procesar`) y se generó el PR con esta descripción.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bcaf75640832681f0c143cbf500ae)