### PR TITLE
Corregir envío de cartones gratis al procesar premios en CentroPagos

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -2428,7 +2428,10 @@
           email: enRegistro.billetera || enRegistro.gmail || '',
           alias: enRegistro.alias || '',
           monto: Number(enRegistro.creditos) || 0,
-          cartonesGratis: Number(enRegistro.cartones) || 0,
+          // El endpoint espera explícitamente `cartonesGratis`.
+          // Algunos registros en Centro de Pagos usan `cartones` al renderizar,
+          // por eso contemplamos ambos para evitar que se envíe 0 por error.
+          cartonesGratis: Number(enRegistro.cartonesGratis ?? enRegistro.cartones) || 0,
           eventoGanadorId,
           origen: 'premios_jugadores',
           referencia: 'PREMIO',


### PR DESCRIPTION
### Motivation
- Arreglar un fallo en el flujo `CentroPagos → PREMIOS JUGADORES → Procesar` donde los premios no acreditaban correctamente los cartones gratis al backend. 
- Detecté que el payload enviado al endpoint `/acreditarPremioEvento` usaba solo `enRegistro.cartones` para poblar `cartonesGratis` aunque los registros pueden venir con `cartonesGratis`.

### Description
- Se actualizó `public/centropagos.html` para enviar `cartonesGratis: Number(enRegistro.cartonesGratis ?? enRegistro.cartones) || 0` en el cuerpo JSON enviado por `acreditarPremioBackendLegacy`, garantizando el mapeo correcto de ambos nombres de campo.
- El cambio mantiene la semántica y contrato del backend (se envía la propiedad `cartonesGratis` esperada) y no modifica otras rutas ni lógica de acreditación.
- Archivo modificado: `public/centropagos.html` (flujo de acreditación manual en la UI de CentroPagos).

### Testing
- Ejecuté `npm test -- --runInBand __tests__/uploadServer-acreditar-utils.test.js __tests__/uploadServer-acreditar-endpoint.test.js`, los tests unitarios pasaron pero el comando falló por la política de cobertura global de `jest` (umbral de cobertura), por lo que el proceso de `npm test` finalizó con error por umbral aunque los tests ejecutados sí pasaron.
- Ejecuté `npx jest --runInBand --coverage=false __tests__/uploadServer-acreditar-utils.test.js __tests__/uploadServer-acreditar-endpoint.test.js` y todas las pruebas pasaron correctamente.
- No se detectaron fallos relacionados con otras funcionalidades durante las pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd34c073883268a822940b8771e78)