### PR TITLE
Compacta Configuraciones y aplica plantillas guardadas para mensajes WhatsApp

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -827,47 +827,75 @@
       return numeroWhatsappDestino;
     }
 
-    const ICONOS_WHATSAPP={
-      // Se usan emojis ampliamente soportados para que se muestren correctamente en WhatsApp
-      solicitudRecarga:'💵',
-      solicitudRetiro:'💰'
+    const MENSAJES_WHATSAPP_SOLICITUD_DEFAULT={
+      mensajeSolicitudRecarga:'💵 *SOLICITUD DE RECARGA*\nCorreo: <correo>\nUsuario: <usuario>\nBanco receptor: <bancoReceptor>\nMonto: <monto>\nReferencia: <referencia>',
+      mensajeSolicitudRetiro:'💰 *SOLICITUD DE RETIRO*\nCorreo: <correo>\nUsuario: <usuario>\nBanco receptor: <bancoReceptor>\nPago móvil: <pagoMovil>\nCuenta: <cuenta>\nMonto solicitado: <montoSolicitado>\nMonto a recibir: <montoRecibir>'
     };
+    let mensajesWhatsappSolicitudes={...MENSAJES_WHATSAPP_SOLICITUD_DEFAULT};
+    let mensajesWhatsappSolicitudesCargados=false;
 
-    function construirMensajeWhatsapp(tipo,info){
+    async function cargarPlantillasWhatsappSolicitudes(){
+      if(mensajesWhatsappSolicitudesCargados) return mensajesWhatsappSolicitudes;
+      try{
+        const snap=await db.collection('Variablesglobales').doc('Parametros').get();
+        if(snap.exists){
+          const data=snap.data()||{};
+          const grupo=data.mensajesWhatsapp||{};
+          mensajesWhatsappSolicitudes={
+            ...MENSAJES_WHATSAPP_SOLICITUD_DEFAULT,
+            mensajeSolicitudRecarga:grupo.mensajeSolicitudRecarga||data.mensajeSolicitudRecarga||MENSAJES_WHATSAPP_SOLICITUD_DEFAULT.mensajeSolicitudRecarga,
+            mensajeSolicitudRetiro:grupo.mensajeSolicitudRetiro||data.mensajeSolicitudRetiro||MENSAJES_WHATSAPP_SOLICITUD_DEFAULT.mensajeSolicitudRetiro
+          };
+        }
+      }catch(error){
+        console.error('No se pudo cargar la configuración de mensajes de solicitud WhatsApp',error);
+      }
+      mensajesWhatsappSolicitudesCargados=true;
+      return mensajesWhatsappSolicitudes;
+    }
+
+    function aplicarPlantillaMensaje(plantilla,valores){
+      return (plantilla||'').replace(/<([a-zA-Z0-9_]+)>/g,(_,clave)=>{
+        const valor=valores[clave];
+        return valor===undefined || valor===null ? '' : String(valor);
+      }).trim();
+    }
+
+    async function construirMensajeWhatsapp(tipo,info){
       const correo=auth.currentUser?.email||'';
       const nombre=obtenerNombreUsuario();
-      const lineas=[];
       const formatearEnteroSeguro=valor=>Math.trunc(toNumberSafe(valor,0)).toString();
-
       const tipoNormalizado = tipo==='deposito'?'recarga':tipo;
+      const plantillas=await cargarPlantillasWhatsappSolicitudes();
 
       if(tipoNormalizado==='recarga'){
-        lineas.push(`${ICONOS_WHATSAPP.solicitudRecarga} *SOLICITUD DE RECARGA*`);
-        if(correo) lineas.push(`Correo: ${correo}`);
-        if(nombre) lineas.push(`Usuario: ${nombre}`);
-        lineas.push(`Banco receptor: ${info?.banco||'N/D'}`);
-        lineas.push(`Monto: *${formatearEnteroSeguro(info?.monto)}*`);
-        lineas.push(`Referencia: *${info?.referencia||'N/D'}*`);
-        if(info?.comentario){ lineas.push(`Comentario: ${info.comentario}`); }
-      }else if(tipoNormalizado==='retiro'){
-        lineas.push(`${ICONOS_WHATSAPP.solicitudRetiro} *SOLICITUD DE RETIRO*`);
-        if(correo) lineas.push(`Correo: ${correo}`);
-        if(nombre) lineas.push(`Usuario: ${nombre}`);
-        lineas.push(`Banco receptor: ${info?.banco||'N/D'}`);
-        if(info?.pagomovil){ lineas.push(`Pago móvil: ${info.pagomovil}`); }
-        if(info?.cuenta){ lineas.push(`Cuenta: ${info.cuenta}`); }
-        lineas.push(`Monto solicitado: *${formatearEnteroSeguro(info?.montoSolicitado)}*`);
-        lineas.push(`Monto a recibir: *${formatearEnteroSeguro(info?.montoNeto)}*`);
-        if(info?.comentario){ lineas.push(`Comentario: ${info.comentario}`); }
+        return aplicarPlantillaMensaje(plantillas.mensajeSolicitudRecarga,{
+          correo,
+          usuario:nombre,
+          bancoReceptor:info?.banco||'N/D',
+          monto:formatearEnteroSeguro(info?.monto),
+          referencia:info?.referencia||'N/D'
+        });
       }
-      return lineas.filter(Boolean).join('\n');
+      if(tipoNormalizado==='retiro'){
+        return aplicarPlantillaMensaje(plantillas.mensajeSolicitudRetiro,{
+          correo,
+          usuario:nombre,
+          bancoReceptor:info?.banco||'N/D',
+          pagoMovil:info?.pagomovil||'N/D',
+          cuenta:info?.cuenta||'N/D',
+          montoSolicitado:formatearEnteroSeguro(info?.montoSolicitado),
+          montoRecibir:formatearEnteroSeguro(info?.montoNeto)
+        });
+      }
+      return '';
     }
 
     async function notificarSolicitudWhatsapp(tipo,info){
       try{
         const numero=await obtenerNumeroWhatsappConfigurado();
         if(!numero) return;
-        const mensaje=construirMensajeWhatsapp(tipo,info);
+        const mensaje=await construirMensajeWhatsapp(tipo,info);
         const enlace=construirEnlaceWhatsapp(numero,mensaje);
         if(!enlace) return;
         window.open(enlace,'_blank','noopener');

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -197,10 +197,10 @@
     .panel-section,
     .asignacion-section {
       width: 95%;
-      margin-top: 10px;
+      margin-top: 4px;
       background: rgba(255,255,255,0.4);
       border-radius: 12px;
-      padding: 8px 12px 12px;
+      padding: 6px 10px 8px;
       box-sizing: border-box;
     }
     #gestionar-section.panel-section {
@@ -210,12 +210,17 @@
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 10px;
+      gap: 8px;
       color: #4a148c;
+      width: 100%;
+      min-height: 28px;
     }
     .asignacion-header h3 {
       margin: 0;
-      font-size: 1.2rem;
+      font-size: 1.08rem;
+      line-height: 1.1;
+      flex: 1;
+      text-align: left;
     }
     #gestionar-header {
       width: 100%;
@@ -456,10 +461,10 @@
     }
     .whatsapp-section {
       width: 95%;
-      margin-top: 16px;
+      margin-top: 4px;
       background: rgba(255,255,255,0.4);
       border-radius: 12px;
-      padding: 12px 14px 16px;
+      padding: 8px 10px 10px;
       box-sizing: border-box;
       font-family: Calibri, Arial, sans-serif;
       text-align: left;
@@ -1538,8 +1543,9 @@
             return;
           }
           try{
+            const claveAnidada=`${grupoClave}.${item.key}`;
             await db.collection('Variablesglobales').doc('Parametros').set({
-              [grupoClave]:{[item.key]:valor},
+              [claveAnidada]:valor,
               [item.key]:valor
             },{merge:true});
             mensajesEditables[item.key]=valor;

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -600,6 +600,14 @@
     }
 
     const cacheWhatsapp=new Map();
+    const MENSAJES_WHATSAPP_RESULTADOS_DEFAULT={
+      mensajeRecargaAprobada:'✅ *RECARGA APROBADA* Tu recarga por <monto> Créditos en <app> ha sido aprobada.',
+      mensajeRecargaAnulada:'🚫 *RECARGA ANULADA* Tu recarga por <monto> Créditos en <app> fue anulada. Motivo: <motivo>.',
+      mensajeRetiroAprobado:'✅ *RETIRO APROBADO* Tu retiro por <monto> Créditos en <app> ha sido aprobado. Referencia: <referencia>. Total transferidos: <totalTransferido>.',
+      mensajeRetiroAnulado:'🚫 *RETIRO ANULADO* Tu retiro por <monto> Créditos en <app> fue anulado. Motivo: <motivo>.'
+    };
+    let mensajesWhatsappResultados={...MENSAJES_WHATSAPP_RESULTADOS_DEFAULT};
+    let mensajesWhatsappResultadosCargados=false;
     function normalizarNumeroWhatsapp(valor){
       const texto=(valor||'').toString();
       let limpio=texto.replace(/[^0-9+]/g,'');
@@ -642,47 +650,63 @@
       cacheWhatsapp.set(idBilletera,normalizado);
       return normalizado;
     }
-    function construirMensajeWhatsapp(transaccion,estadoFinal,nota){
+    async function cargarPlantillasWhatsappResultados(){
+      if(mensajesWhatsappResultadosCargados) return mensajesWhatsappResultados;
+      try{
+        const snap=await db.collection('Variablesglobales').doc('Parametros').get();
+        if(snap.exists){
+          const data=snap.data()||{};
+          const grupo=data.mensajesWhatsapp||{};
+          mensajesWhatsappResultados={
+            ...MENSAJES_WHATSAPP_RESULTADOS_DEFAULT,
+            mensajeRecargaAprobada:grupo.mensajeRecargaAprobada||data.mensajeRecargaAprobada||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRecargaAprobada,
+            mensajeRecargaAnulada:grupo.mensajeRecargaAnulada||data.mensajeRecargaAnulada||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRecargaAnulada,
+            mensajeRetiroAprobado:grupo.mensajeRetiroAprobado||data.mensajeRetiroAprobado||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRetiroAprobado,
+            mensajeRetiroAnulado:grupo.mensajeRetiroAnulado||data.mensajeRetiroAnulado||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRetiroAnulado
+          };
+        }
+      }catch(err){
+        console.error('No se pudo cargar la configuración de mensajes de resultado WhatsApp',err);
+      }
+      mensajesWhatsappResultadosCargados=true;
+      return mensajesWhatsappResultados;
+    }
+    function aplicarPlantillaMensaje(plantilla,valores){
+      return (plantilla||'').replace(/<([a-zA-Z0-9_]+)>/g,(_,clave)=>{
+        const valor=valores[clave];
+        return valor===undefined || valor===null ? '' : String(valor);
+      }).trim();
+    }
+    async function construirMensajeWhatsapp(transaccion,estadoFinal,nota){
       const tipo=normalizarTipoOperacion(transaccion);
       const montoSolicitadoNum=toNumberSafe(transaccion.MontoSolicitado??transaccion.Monto,transaccion.Monto);
       const montoTransferidoNum=toNumberSafe(transaccion.Monto,transaccion.MontoSolicitado??transaccion.Monto);
       const formatearEnteroSeguro=valor=>Math.trunc(toNumberSafe(valor,0)).toString();
-      const montoSolicitadoBold=`*${formatearEnteroSeguro(montoSolicitadoNum)}*`;
-      const montoTransferido=formatearEnteroSeguro(montoTransferidoNum);
-      const lineas=[];
-      const ICONO_WHATSAPP_ANULADO='🚫';
+      const montoSolicitado=formatearEnteroSeguro(montoSolicitadoNum);
+      const montoTransferido=`${formatearEnteroSeguro(montoTransferidoNum)} Créditos`;
+      const referenciaTexto=(transaccion.referencia||'').toString().trim();
+      const plantillas=await cargarPlantillasWhatsappResultados();
+      const valoresBase={
+        monto:montoSolicitado,
+        app:'BingOnline',
+        motivo:(nota||'No especificado').toString().trim(),
+        referencia:referenciaTexto||'pendiente',
+        totalTransferido:montoTransferido,
+        comisionBancaria:'',
+        comisionGestion:'',
+        usuario:transaccion.IDbilletera||''
+      };
 
       if(estadoFinal==='APROBADO'){
         if(tipo==='recarga'){
-          lineas.push('✅ *RECARGA APROBADA*');
-          lineas.push(`Tu recarga por ${montoSolicitadoBold} Créditos en BingOnline ha sido aprobada.`);
-        }else{
-          lineas.push('✅ *RETIRO APROBADO*');
-          lineas.push(`Tu retiro por ${montoSolicitadoBold} Créditos en BingOnline ha sido aprobado.`);
-          const referenciaTexto=(transaccion.referencia||'').toString().trim();
-          const referencia=referenciaTexto||'pendiente';
-          lineas.push(`Referencia: *${referencia}*`);
-          lineas.push(`Total transferidos: ${montoTransferido} Créditos`);
+          return aplicarPlantillaMensaje(plantillas.mensajeRecargaAprobada,valoresBase);
         }
-      }else{
-        if(tipo==='recarga'){
-          lineas.push(`${ICONO_WHATSAPP_ANULADO} *RECARGA ANULADA*`);
-          lineas.push(`Tu recarga por ${formatearMonto(montoSolicitadoNum)} Créditos en BingOnline fue anulada.`);
-        }else{
-          lineas.push(`${ICONO_WHATSAPP_ANULADO} *RETIRO ANULADO*`);
-          lineas.push(`Tu retiro por ${formatearMonto(montoSolicitadoNum)} Créditos en BingOnline fue anulado.`);
-        }
-        if(nota){
-          lineas[lineas.length-1]+=` Motivo: ${nota}.`;
-        }
-        if(tipo==='retiro'){
-          lineas.push('Se presento un problema. Vuelve a intentarlo');
-        }else{
-          lineas.push('Revisa los datos de tu solicitud y vuelve a intentarlo.');
-        }
+        return aplicarPlantillaMensaje(plantillas.mensajeRetiroAprobado,valoresBase);
       }
-
-      return lineas.filter(Boolean).join('\n');
+      if(tipo==='recarga'){
+        return aplicarPlantillaMensaje(plantillas.mensajeRecargaAnulada,valoresBase);
+      }
+      return aplicarPlantillaMensaje(plantillas.mensajeRetiroAnulado,valoresBase);
     }
     async function notificarWhatsappTransacciones(lista,estadoFinal,nota){
       for(const transaccion of lista){
@@ -695,7 +719,7 @@
           console.warn('La transacción no tiene número de WhatsApp disponible',transaccion.IDbilletera);
           continue;
         }
-        const mensaje=construirMensajeWhatsapp(transaccion,estadoFinal,nota);
+        const mensaje=await construirMensajeWhatsapp(transaccion,estadoFinal,nota);
         const enlace=construirEnlaceWhatsapp(numero,mensaje);
         if(enlace){
           window.open(enlace,'_blank');


### PR DESCRIPTION
### Motivation
- Reducir el espacio visual y unificar la apariencia de las secciones de configuración para que las secciones GESTIÓN DE BANCOS, ASIGNACIÓN RECURSOS USUARIOS, MENSAJES WHATSAPP y MENSAJES SISTEMA REFERIDOS se vean más compactas y alineadas.
- Asegurar que las redacciones de mensajes que edita el administrador en Configuraciones sean persistentes y efectivamente usadas por la lógica de la app al enviar WhatsApp automáticos.

### Description
- Ajusté CSS en `public/configuraciones.html` para reducir márgenes/paddings y unificar la cabecera (título + switch) aplicando tamaños y alineación coherentes entre secciones. (modificado `panel-section`, `asignacion-section`, `.asignacion-header`, `.whatsapp-section`).
- Cambié la lógica de guardado en `public/configuraciones.html` para escribir claves anidadas en Firestore (`mensajesWhatsapp.<clave>` / `mensajesReferidos.<clave>`) y además mantener la clave plana por compatibilidad, evitando sobrescribir objetos completos del documento `Variablesglobales/Parametros`.
- Implementé lectura y aplicación de plantillas guardadas en tiempo de ejecución en `public/billetera.html` para las solicitudes (`mensajeSolicitudRecarga`, `mensajeSolicitudRetiro`) usando placeholders (`<correo>`, `<usuario>`, etc.) y fallback por defecto.
- Implementé lectura y aplicación de plantillas guardadas en `public/transacciones.html` para mensajes de resultado (`mensajeRecargaAprobada`, `mensajeRecargaAnulada`, `mensajeRetiroAprobado`, `mensajeRetiroAnulado`) con reemplazo de variables y fallback por defecto.

### Testing
- Ejecuté el test específico `__tests__/sanitizacion.test.js` con Jest y los casos del archivo pasaron, pero el proceso de Jest terminó con código no-cero debido a las reglas de umbral global de cobertura del proyecto (los tests individuales mostraron PASS).
- Verifiqué `git diff --check` y no arrojó errores de formato (comprobación automática de diff).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc87f01708326892807d73ef993d4)