### PR TITLE
Persistir y sincronizar plantillas de WhatsApp en Firestore

### DIFF
--- a/public/billetera.html
+++ b/public/billetera.html
@@ -833,24 +833,38 @@
     };
     let mensajesWhatsappSolicitudes={...MENSAJES_WHATSAPP_SOLICITUD_DEFAULT};
     let mensajesWhatsappSolicitudesCargados=false;
+    let suscripcionParametrosWhatsapp=null;
+
+    function actualizarMensajesWhatsappSolicitudesDesdeData(data={}){
+      const grupo=data.mensajesWhatsapp||{};
+      mensajesWhatsappSolicitudes={
+        ...MENSAJES_WHATSAPP_SOLICITUD_DEFAULT,
+        mensajeSolicitudRecarga:grupo.mensajeSolicitudRecarga||data.mensajeSolicitudRecarga||MENSAJES_WHATSAPP_SOLICITUD_DEFAULT.mensajeSolicitudRecarga,
+        mensajeSolicitudRetiro:grupo.mensajeSolicitudRetiro||data.mensajeSolicitudRetiro||MENSAJES_WHATSAPP_SOLICITUD_DEFAULT.mensajeSolicitudRetiro
+      };
+      mensajesWhatsappSolicitudesCargados=true;
+    }
+
+    function iniciarSuscripcionMensajesWhatsappSolicitudes(){
+      if(suscripcionParametrosWhatsapp) return;
+      suscripcionParametrosWhatsapp=db.collection('Variablesglobales').doc('Parametros').onSnapshot(snap=>{
+        const data=snap.exists?(snap.data()||{}):{};
+        actualizarMensajesWhatsappSolicitudesDesdeData(data);
+      },error=>{
+        console.error('No se pudo sincronizar la configuración de mensajes WhatsApp en tiempo real',error);
+      });
+    }
 
     async function cargarPlantillasWhatsappSolicitudes(){
+      iniciarSuscripcionMensajesWhatsappSolicitudes();
       if(mensajesWhatsappSolicitudesCargados) return mensajesWhatsappSolicitudes;
       try{
         const snap=await db.collection('Variablesglobales').doc('Parametros').get();
-        if(snap.exists){
-          const data=snap.data()||{};
-          const grupo=data.mensajesWhatsapp||{};
-          mensajesWhatsappSolicitudes={
-            ...MENSAJES_WHATSAPP_SOLICITUD_DEFAULT,
-            mensajeSolicitudRecarga:grupo.mensajeSolicitudRecarga||data.mensajeSolicitudRecarga||MENSAJES_WHATSAPP_SOLICITUD_DEFAULT.mensajeSolicitudRecarga,
-            mensajeSolicitudRetiro:grupo.mensajeSolicitudRetiro||data.mensajeSolicitudRetiro||MENSAJES_WHATSAPP_SOLICITUD_DEFAULT.mensajeSolicitudRetiro
-          };
-        }
+        const data=snap.exists?(snap.data()||{}):{};
+        actualizarMensajesWhatsappSolicitudesDesdeData(data);
       }catch(error){
         console.error('No se pudo cargar la configuración de mensajes de solicitud WhatsApp',error);
       }
-      mensajesWhatsappSolicitudesCargados=true;
       return mensajesWhatsappSolicitudes;
     }
 

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -1496,6 +1496,15 @@
       mensajeReferidoRecordatorio:'Comparte tu código <codigoReferido> en <app> y al llegar a <metaReferidos> referidos obtendrás <premioReferidos>.'
     };
     const mensajesEditables={};
+    const llaveGrupoPorMensaje={
+      ...Object.fromEntries(configuracionMensajesWhatsapp.map(item=>[item.key,'mensajesWhatsapp'])),
+      ...Object.fromEntries(configuracionMensajesReferidos.map(item=>[item.key,'mensajesReferidos']))
+    };
+    function obtenerMensajePersistido(data,key){
+      const grupoEsperado=llaveGrupoPorMensaje[key];
+      const grupo=grupoEsperado && data && typeof data[grupoEsperado]==='object' ? data[grupoEsperado] : {};
+      return grupo?.[key] || data?.[key] || '';
+    }
     function insertarVariableEnCampo(textarea,codigo){
       if(!textarea) return;
       const inicio=textarea.selectionStart ?? textarea.value.length;
@@ -1543,10 +1552,13 @@
             return;
           }
           try{
-            const claveAnidada=`${grupoClave}.${item.key}`;
             await db.collection('Variablesglobales').doc('Parametros').set({
-              [claveAnidada]:valor,
-              [item.key]:valor
+              [grupoClave]:{
+                [item.key]:valor
+              },
+              [item.key]:valor,
+              mensajesVersion:2,
+              mensajesActualizadoEn:firebase.firestore.FieldValue.serverTimestamp()
             },{merge:true});
             mensajesEditables[item.key]=valor;
             alert('Mensaje guardado correctamente.');
@@ -1571,10 +1583,8 @@
       try{
         const doc=await db.collection('Variablesglobales').doc('Parametros').get();
         const data=doc.exists?(doc.data()||{}):{};
-        const grupoWhatsapp=data.mensajesWhatsapp||{};
-        const grupoReferidos=data.mensajesReferidos||{};
         [...configuracionMensajesWhatsapp,...configuracionMensajesReferidos].forEach(item=>{
-          mensajesEditables[item.key]=grupoWhatsapp[item.key]||grupoReferidos[item.key]||data[item.key]||'';
+          mensajesEditables[item.key]=obtenerMensajePersistido(data,item.key);
         });
       }catch(err){
         console.error('No se pudo cargar la configuración de mensajes de WhatsApp',err);

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -608,6 +608,29 @@
     };
     let mensajesWhatsappResultados={...MENSAJES_WHATSAPP_RESULTADOS_DEFAULT};
     let mensajesWhatsappResultadosCargados=false;
+    let suscripcionMensajesWhatsappResultados=null;
+
+    function actualizarMensajesWhatsappResultadosDesdeData(data={}){
+      const grupo=data.mensajesWhatsapp||{};
+      mensajesWhatsappResultados={
+        ...MENSAJES_WHATSAPP_RESULTADOS_DEFAULT,
+        mensajeRecargaAprobada:grupo.mensajeRecargaAprobada||data.mensajeRecargaAprobada||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRecargaAprobada,
+        mensajeRecargaAnulada:grupo.mensajeRecargaAnulada||data.mensajeRecargaAnulada||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRecargaAnulada,
+        mensajeRetiroAprobado:grupo.mensajeRetiroAprobado||data.mensajeRetiroAprobado||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRetiroAprobado,
+        mensajeRetiroAnulado:grupo.mensajeRetiroAnulado||data.mensajeRetiroAnulado||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRetiroAnulado
+      };
+      mensajesWhatsappResultadosCargados=true;
+    }
+
+    function iniciarSuscripcionMensajesWhatsappResultados(){
+      if(suscripcionMensajesWhatsappResultados) return;
+      suscripcionMensajesWhatsappResultados=db.collection('Variablesglobales').doc('Parametros').onSnapshot(snap=>{
+        const data=snap.exists?(snap.data()||{}):{};
+        actualizarMensajesWhatsappResultadosDesdeData(data);
+      },err=>{
+        console.error('No se pudo sincronizar la configuración de mensajes de resultado WhatsApp en tiempo real',err);
+      });
+    }
     function normalizarNumeroWhatsapp(valor){
       const texto=(valor||'').toString();
       let limpio=texto.replace(/[^0-9+]/g,'');
@@ -651,24 +674,15 @@
       return normalizado;
     }
     async function cargarPlantillasWhatsappResultados(){
+      iniciarSuscripcionMensajesWhatsappResultados();
       if(mensajesWhatsappResultadosCargados) return mensajesWhatsappResultados;
       try{
         const snap=await db.collection('Variablesglobales').doc('Parametros').get();
-        if(snap.exists){
-          const data=snap.data()||{};
-          const grupo=data.mensajesWhatsapp||{};
-          mensajesWhatsappResultados={
-            ...MENSAJES_WHATSAPP_RESULTADOS_DEFAULT,
-            mensajeRecargaAprobada:grupo.mensajeRecargaAprobada||data.mensajeRecargaAprobada||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRecargaAprobada,
-            mensajeRecargaAnulada:grupo.mensajeRecargaAnulada||data.mensajeRecargaAnulada||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRecargaAnulada,
-            mensajeRetiroAprobado:grupo.mensajeRetiroAprobado||data.mensajeRetiroAprobado||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRetiroAprobado,
-            mensajeRetiroAnulado:grupo.mensajeRetiroAnulado||data.mensajeRetiroAnulado||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRetiroAnulado
-          };
-        }
+        const data=snap.exists?(snap.data()||{}):{};
+        actualizarMensajesWhatsappResultadosDesdeData(data);
       }catch(err){
         console.error('No se pudo cargar la configuración de mensajes de resultado WhatsApp',err);
       }
-      mensajesWhatsappResultadosCargados=true;
       return mensajesWhatsappResultados;
     }
     function aplicarPlantillaMensaje(plantilla,valores){


### PR DESCRIPTION
### Motivation
- Evitar que las plantillas de WhatsApp queden en caché en la sesión y asegurar que las ediciones en la interfaz de `configuraciones.html` se persistan y se reflejen inmediatamente en los flujos de ejecución.

### Description
- En `public/configuraciones.html` se añadió `llaveGrupoPorMensaje` y `obtenerMensajePersistido` para resolver cada clave desde su grupo esperado en Firestore (`mensajesWhatsapp` o `mensajesReferidos`) y mantener compatibilidad con claves legacy.
- Al guardar una plantilla ahora se persiste dentro del grupo anidado (`mensajesWhatsapp`/`mensajesReferidos`), se mantiene la clave legacy a nivel superior y se agregan metadatos `mensajesVersion` y `mensajesActualizadoEn` usando `firebase.firestore.FieldValue.serverTimestamp()` para trazabilidad.
- En `public/billetera.html` y `public/transacciones.html` se añadieron suscripciones en tiempo real (`onSnapshot`) a `Variablesglobales/Parametros` y funciones auxiliares para actualizar las plantillas en memoria cuando cambian en Firestore, evitando que los mensajes ejecutados queden stale.
- Se refactorizaron los cargadores de plantillas para usar las nuevas funciones de resolución/persistencia y reducir la posibilidad de lectura de valores desactualizados.

### Testing
- Ejecuté la suite de pruebas con `npm test -- --runInBand` y todos los tests pasaron: `11` test suites y `35` tests en verde, por lo que la validación automatizada quedó satisfactoria.
- Las pruebas de integración unitarias existentes y la cobertura configurada se mantuvieron sin fallos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dcc88a5a083268be72646a46f760c)