### PR TITLE
Corregir modal persistente de notificaciones APROBADO (fallback Firestore + normalización)

### DIFF
--- a/public/js/internalTransactionNotifier.js
+++ b/public/js/internalTransactionNotifier.js
@@ -52,19 +52,59 @@
 
     async verificarPendientes(){
       if(!this.user || this.mostrando) return;
-      const identidades=[this.user.email,this.user.uid].filter(Boolean);
+      const identidades=this.obtenerIdentidadesUsuario();
       let pendiente=null;
       for(const identidad of identidades){
-        const snap=await db.collection('transacciones')
-          .where('IDbilletera','==',identidad)
-          .where('notificacionInterna.pendienteMostrar','==',true)
-          .limit(1)
-          .get();
+        const snap=await this.buscarPendientePorIdentidad(identidad);
         if(!snap.empty){ pendiente=snap.docs[0]; break; }
       }
       if(!pendiente) return;
       this.actual=this.normalizarDoc(pendiente);
       this.mostrar(this.actual);
+    }
+
+    obtenerIdentidadesUsuario(){
+      const identidades=[this.user && this.user.email,this.user && this.user.uid]
+        .map(v=>(v||'').toString().trim())
+        .filter(Boolean);
+      const normalizadas=[];
+      for(const valor of identidades){
+        normalizadas.push(valor);
+        const minuscula=valor.toLowerCase();
+        if(minuscula!==valor) normalizadas.push(minuscula);
+      }
+      return Array.from(new Set(normalizadas));
+    }
+
+    async buscarPendientePorIdentidad(identidad){
+      const ref=db.collection('transacciones');
+      try{
+        return await ref
+          .where('IDbilletera','==',identidad)
+          .where('notificacionInterna.pendienteMostrar','==',true)
+          .limit(1)
+          .get();
+      }catch(err){
+        const codigo=(err && err.code ? err.code.toString() : '').toLowerCase();
+        const mensaje=(err && err.message ? err.message.toString() : '').toLowerCase();
+        const requiereIndice=codigo.includes('failed-precondition') || mensaje.includes('index');
+        if(!requiereIndice){
+          console.warn('No se pudo consultar notificación interna pendiente',err);
+          return {empty:true,docs:[]};
+        }
+        console.warn('Consulta de notificación interna requiere índice compuesto. Usando búsqueda alternativa por identidad.');
+        try{
+          const respaldo=await ref.where('IDbilletera','==',identidad).limit(25).get();
+          const pendiente=respaldo.docs.find(doc=>{
+            const data=doc.data()||{};
+            return Boolean(data.notificacionInterna && data.notificacionInterna.pendienteMostrar===true);
+          });
+          return pendiente ? {empty:false,docs:[pendiente]} : {empty:true,docs:[]};
+        }catch(fallbackErr){
+          console.warn('No se pudo ejecutar la búsqueda alternativa de notificaciones internas',fallbackErr);
+          return {empty:true,docs:[]};
+        }
+      }
     }
 
     normalizarDoc(doc){


### PR DESCRIPTION
### Motivation
- Se detectó que la ventana persistente de notificación no aparecía porque la consulta compuesta a Firestore (`IDbilletera` + `notificacionInterna.pendienteMostrar`) puede fallar si no existe el índice correspondiente. 
- Además, las variaciones de mayúsculas/minúsculas en la identidad (`email` vs `email.toLowerCase()`) provocaban falsos negativos al buscar transacciones por `IDbilletera`.

### Description
- Se agregó la función `obtenerIdentidadesUsuario()` para resolver identidades buscadas (email, uid y variante en minúsculas) y evitar fallos por casing. 
- Se introdujo `buscarPendientePorIdentidad(identidad)` que intenta la consulta compuesta habitual y, si falla por falta de índice, realiza una consulta alternativa por `IDbilletera` y filtra en cliente buscando `notificacionInterna.pendienteMostrar === true`.
- Se actualizó `verificarPendientes()` para usar estas nuevas utilidades y así garantizar que se recupere cualquier notificación interna pendiente y se muestre el modal.
- Cambios aplicados en `public/js/internalTransactionNotifier.js` manteniendo el comportamiento de aceptación que actualiza la transacción (si estaba `APROBADO` pasa a `ACEPTADO`).

### Testing
- Se ejecutó la batería de tests con `npm test -- --runInBand` y todos los suites pasaron correctamente (`11 suites`, `35 tests` pasados). 
- Las pruebas unitarias existentes no se vieron afectadas y los tests de integración locales completaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699def210c9883269d0bfc996b0a0024)