### PR TITLE
Alinear estados de billetera (PENDIENTE/APROBADO/ACEPTADO) y remover redacción WhatsApp en gestión

### DIFF
--- a/__tests__/estadoPagoPremio-normalizacion.test.js
+++ b/__tests__/estadoPagoPremio-normalizacion.test.js
@@ -1,19 +1,21 @@
 const EstadosPagoPremio = require('../public/js/estadoPagoPremio.js');
 
 describe('EstadosPagoPremio normalización e interpretación', () => {
-  test('normaliza APROBADO como REALIZADO en lectura', () => {
-    expect(EstadosPagoPremio.normalizarLectura('APROBADO')).toBe('REALIZADO');
-    expect(EstadosPagoPremio.normalizarLectura('realizado')).toBe('REALIZADO');
+  test('normaliza REALIZADO como APROBADO en lectura', () => {
+    expect(EstadosPagoPremio.normalizarLectura('APROBADO')).toBe('APROBADO');
+    expect(EstadosPagoPremio.normalizarLectura('realizado')).toBe('APROBADO');
   });
 
-  test('estaFinalizado reconoce APROBADO y REALIZADO', () => {
+  test('estaFinalizado reconoce APROBADO, ACEPTADO y REALIZADO', () => {
     expect(EstadosPagoPremio.estaFinalizado('APROBADO')).toBe(true);
+    expect(EstadosPagoPremio.estaFinalizado('ACEPTADO')).toBe(true);
     expect(EstadosPagoPremio.estaFinalizado('REALIZADO')).toBe(true);
     expect(EstadosPagoPremio.estaFinalizado('PENDIENTE')).toBe(false);
   });
 
   test('validarParaGuardar solo permite estados canónicos', () => {
-    expect(EstadosPagoPremio.validarParaGuardar('REALIZADO')).toBe('REALIZADO');
-    expect(() => EstadosPagoPremio.validarParaGuardar('APROBADO')).toThrow(/Estado no reconocido/);
+    expect(EstadosPagoPremio.validarParaGuardar('APROBADO')).toBe('APROBADO');
+    expect(EstadosPagoPremio.validarParaGuardar('ACEPTADO')).toBe('ACEPTADO');
+    expect(() => EstadosPagoPremio.validarParaGuardar('REALIZADO')).toThrow(/Estado no reconocido/);
   });
 });

--- a/public/billetera.html
+++ b/public/billetera.html
@@ -540,7 +540,8 @@
               <select id="filtro-estado">
                 <option value="">ESTADO</option>
                 <option value="PENDIENTE">Pendiente</option>
-                <option value="REALIZADO">Realizado</option>
+                <option value="APROBADO">Aprobado</option>
+                <option value="ACEPTADO">Aceptado</option>
                 <option value="ANULADO">Anulado</option>
               </select>
             </th>
@@ -1922,7 +1923,7 @@
         return window.EstadosPagoPremio.normalizarLectura(valor, (valor||'').toString().trim().toUpperCase());
       }
       const texto=(valor||'').toString().trim().toUpperCase();
-      return texto==='APROBADO'?'REALIZADO':texto;
+      return texto==='REALIZADO'?'APROBADO':texto;
     }
 
     function normalizarTransaccionParaTabla(id,data){
@@ -2066,7 +2067,8 @@
         const f=formatearFecha(t.estado==='PENDIENTE'?t.fechasolicitud:t.fechagestion);
         if(fecha && f!==fecha) return;
         if(estado && normalizarEstadoPremioTransaccion(t.estado)!==normalizarEstadoPremioTransaccion(estado)) return;
-        const estadoColor=t.estado==='PENDIENTE'?'orange':t.estado==='ANULADO'?'red':t.estado==='REALIZADO'?'green':'black';
+        const estadoNormalizado=normalizarEstadoPremioTransaccion(t.estado);
+        const estadoColor=estadoNormalizado==='PENDIENTE'?'orange':estadoNormalizado==='ANULADO'?'red':(estadoNormalizado==='APROBADO' || estadoNormalizado==='ACEPTADO')?'green':'black';
         const tr=document.createElement('tr');
         const montoFmt=parseFloat(t.Monto).toFixed(2).replace(/\.00$/, '').replace(/(\.\d)0$/, '$1');
         const tipoTrans=(t.tipotrans||'').toLowerCase();

--- a/public/js/estadoPagoPremio.js
+++ b/public/js/estadoPagoPremio.js
@@ -8,12 +8,13 @@
 })(typeof globalThis !== 'undefined' ? globalThis : this, function crearEstadoPagoPremio(){
   const ESTADOS_CANONICOS = Object.freeze({
     PENDIENTE: 'PENDIENTE',
-    REALIZADO: 'REALIZADO',
+    APROBADO: 'APROBADO',
+    ACEPTADO: 'ACEPTADO',
     ARCHIVADO: 'ARCHIVADO'
   });
 
   const ALIAS_LECTURA = Object.freeze({
-    APROBADO: ESTADOS_CANONICOS.REALIZADO
+    REALIZADO: ESTADOS_CANONICOS.APROBADO
   });
 
   function normalizarTexto(valor){
@@ -47,7 +48,8 @@
   }
 
   function estaFinalizado(valor){
-    return normalizarLectura(valor) === ESTADOS_CANONICOS.REALIZADO;
+    const estado = normalizarLectura(valor);
+    return estado === ESTADOS_CANONICOS.APROBADO || estado === ESTADOS_CANONICOS.ACEPTADO;
   }
 
   return Object.freeze({

--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -16,11 +16,7 @@
       etiqueta: 'Colaborador',
       items: [
         { clave: 'recargasPendientes', titulo: 'Notificación Recargas Pendientes', descripcion: 'Se repite cada 10 minutos si hay recargas por gestionar.' },
-        { clave: 'retirosPendientes', titulo: 'Notificación Retiros Pendientes', descripcion: 'Se repite cada 10 minutos si hay retiros por gestionar.' },
-        { clave: 'mensajeRecargaAprobada', titulo: 'Redacción de mensajes RECARGA APROBADA', descripcion: '✅ Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Recarga', color: '#0b6b27' },
-        { clave: 'mensajeRetiroAprobado', titulo: 'Redacción de mensajes RETIRO APROBADO', descripcion: '✅ Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Retiro', color: '#8b0000' },
-        { clave: 'mensajeRecargaAnulada', titulo: 'Redacción de mensajes RECARGA ANULADA', descripcion: '🚫 Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Recarga Anulada', color: '#0a8800' },
-        { clave: 'mensajeRetiroAnulado', titulo: 'Redacción de mensajes RETIRO ANULADO', descripcion: '🚫 Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Retiro Anulado', color: '#d32f2f' }
+        { clave: 'retirosPendientes', titulo: 'Notificación Retiros Pendientes', descripcion: 'Se repite cada 10 minutos si hay retiros por gestionar.' }
       ]
     },
     Administrador: {
@@ -31,11 +27,7 @@
         { clave: 'selladoSorteo', titulo: 'Notificación Sellado Sorteo', descripcion: 'Cuando llega la hora de sellado de un sorteo.' },
         { clave: 'juegoEnVivoSorteo', titulo: 'Notificación Juego en vivo Sorteo', descripcion: 'Cuando llega la hora de inicio de un sorteo.' },
         { clave: 'gestionPagos', titulo: 'Notificación Gestión Pagos', descripcion: 'Aviso único si hay gestiones de pagos pendientes.' },
-        { clave: 'topeReintentosAcreditacion', titulo: 'Notificación TOPE_REINTENTOS', descripcion: 'Te avisa cuando existan acreditaciones técnicas bloqueadas por tope de reintentos.' },
-        { clave: 'mensajeRecargaAprobada', titulo: 'Redacción de mensajes RECARGA APROBADA', descripcion: '✅ Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Recarga', color: '#0b6b27' },
-        { clave: 'mensajeRetiroAprobado', titulo: 'Redacción de mensajes RETIRO APROBADO', descripcion: '✅ Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Retiro', color: '#8b0000' },
-        { clave: 'mensajeRecargaAnulada', titulo: 'Redacción de mensajes RECARGA ANULADA', descripcion: '🚫 Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Recarga Anulada', color: '#0a8800' },
-        { clave: 'mensajeRetiroAnulado', titulo: 'Redacción de mensajes RETIRO ANULADO', descripcion: '🚫 Permite activar la redacción automatica de mensajes WhatsApp para enviar al jugador una notificacion de Retiro Anulado', color: '#d32f2f' }
+        { clave: 'topeReintentosAcreditacion', titulo: 'Notificación TOPE_REINTENTOS', descripcion: 'Te avisa cuando existan acreditaciones técnicas bloqueadas por tope de reintentos.' }
       ]
     }
   };
@@ -72,7 +64,7 @@
     if(window.EstadosPagoPremio && typeof window.EstadosPagoPremio.normalizarLectura === 'function'){
       return window.EstadosPagoPremio.normalizarLectura(estado);
     }
-    return estadoNormalizado(estado) === 'APROBADO' ? 'REALIZADO' : estadoNormalizado(estado);
+    return estadoNormalizado(estado) === 'REALIZADO' ? 'APROBADO' : estadoNormalizado(estado);
   }
 
   function historialVacio(){
@@ -175,8 +167,6 @@
   const CLAVES_RENOMBRADAS = {
     estatusDeposito: 'estatusRecarga',
     depositosPendientes: 'recargasPendientes',
-    mensajeDepositoAprobado: 'mensajeRecargaAprobada',
-    mensajeDepositoAnulado: 'mensajeRecargaAnulada'
   };
 
   const TIPOS_RECARGA = new Set(['recarga','deposito','depósito']);

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -186,17 +186,6 @@
     const datosRec = [];
     const datosRet = [];
     let unsubscribeTransacciones = null;
-    const MAPEO_PREFERENCIAS_WHATSAPP={
-      recarga:{
-        APROBADO:'mensajeRecargaAprobada',
-        ANULADO:'mensajeRecargaAnulada'
-      },
-      retiro:{
-        APROBADO:'mensajeRetiroAprobado',
-        ANULADO:'mensajeRetiroAnulado'
-      }
-    };
-
     function volverConFallback(){
       const role=(window.currentRole||'').trim();
       if(role && typeof redirectByRole==='function'){
@@ -366,11 +355,11 @@
       if(window.EstadosPagoPremio && typeof window.EstadosPagoPremio.normalizarLectura==='function'){
         return window.EstadosPagoPremio.normalizarLectura(texto, texto || 'PENDIENTE');
       }
-      return texto==='APROBADO'?'REALIZADO':texto;
+      return texto==='REALIZADO'?'APROBADO':texto;
     }
     function estadoEsAprobado(valor){
       const estado=estadoNormalizadoComparable(valor);
-      return estado==='REALIZADO' || estado==='APROBADO' || estado==='ACEPTADO';
+      return estado==='APROBADO' || estado==='ACEPTADO';
     }
     function estadoColor(e){
       if((e||'').toString().toUpperCase()==='ACEPTADO') return '#fff';
@@ -610,98 +599,24 @@
       return Number.isFinite(numero)?numero:defecto;
     }
 
-    const cacheWhatsapp=new Map();
-    const MENSAJES_WHATSAPP_RESULTADOS_DEFAULT={
-      mensajeRecargaAprobada:'✅ *RECARGA APROBADA* Tu recarga por <monto> Créditos en <app> ha sido aprobada.',
-      mensajeRecargaAnulada:'🚫 *RECARGA ANULADA* Tu recarga por <monto> Créditos en <app> fue anulada. Motivo: <motivo>.',
-      mensajeRetiroAprobado:'✅ *RETIRO APROBADO* Tu retiro por <monto> Créditos en <app> ha sido aprobado. Referencia: <referencia>. Total transferidos: <totalTransferido>.',
-      mensajeRetiroAnulado:'🚫 *RETIRO ANULADO* Tu retiro por <monto> Créditos en <app> fue anulado. Motivo: <motivo>.'
-    };
-    let mensajesWhatsappResultados={...MENSAJES_WHATSAPP_RESULTADOS_DEFAULT};
-    let mensajesWhatsappResultadosCargados=false;
-    let suscripcionMensajesWhatsappResultados=null;
+    const MENSAJES_RESULTADOS_INTERNOS = Object.freeze({
+      recarga: {
+        APROBADO: '✅ Tu recarga por <monto> Créditos en <app> ha sido aprobada.',
+        ANULADO: '🚫 Tu recarga por <monto> Créditos en <app> fue anulada. Motivo: <motivo>.'
+      },
+      retiro: {
+        APROBADO: '✅ Tu retiro por <monto> Créditos en <app> ha sido aprobado. Referencia: <referencia>. Total transferido: <totalTransferido>.',
+        ANULADO: '🚫 Tu retiro por <monto> Créditos en <app> fue anulado. Motivo: <motivo>.'
+      }
+    });
 
-    function actualizarMensajesWhatsappResultadosDesdeData(data={}){
-      const grupo=data.mensajesWhatsapp||{};
-      mensajesWhatsappResultados={
-        ...MENSAJES_WHATSAPP_RESULTADOS_DEFAULT,
-        mensajeRecargaAprobada:grupo.mensajeRecargaAprobada||data.mensajeRecargaAprobada||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRecargaAprobada,
-        mensajeRecargaAnulada:grupo.mensajeRecargaAnulada||data.mensajeRecargaAnulada||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRecargaAnulada,
-        mensajeRetiroAprobado:grupo.mensajeRetiroAprobado||data.mensajeRetiroAprobado||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRetiroAprobado,
-        mensajeRetiroAnulado:grupo.mensajeRetiroAnulado||data.mensajeRetiroAnulado||MENSAJES_WHATSAPP_RESULTADOS_DEFAULT.mensajeRetiroAnulado
-      };
-      mensajesWhatsappResultadosCargados=true;
-    }
-
-    function iniciarSuscripcionMensajesWhatsappResultados(){
-      if(suscripcionMensajesWhatsappResultados) return;
-      suscripcionMensajesWhatsappResultados=db.collection('Variablesglobales').doc('Parametros').onSnapshot(snap=>{
-        const data=snap.exists?(snap.data()||{}):{};
-        actualizarMensajesWhatsappResultadosDesdeData(data);
-      },err=>{
-        console.error('No se pudo sincronizar la configuración de mensajes de resultado WhatsApp en tiempo real',err);
-      });
-    }
-    function normalizarNumeroWhatsapp(valor){
-      const texto=(valor||'').toString();
-      let limpio=texto.replace(/[^0-9+]/g,'');
-      if(!limpio) return '';
-      if(limpio.startsWith('+')){
-        limpio='+'+limpio.slice(1).replace(/\+/g,'');
-      }else{
-        limpio=limpio.replace(/\+/g,'');
-      }
-      return limpio;
-    }
-    function construirEnlaceWhatsapp(numero,mensaje){
-      const normalizado=normalizarNumeroWhatsapp(numero);
-      if(!normalizado) return '';
-      const destino=normalizado.startsWith('+')?normalizado.slice(1):normalizado;
-      const texto=encodeURIComponent((mensaje||'').toString());
-      return `https://wa.me/${destino}${texto?`?text=${texto}`:''}`;
-    }
-    async function obtenerNumeroWhatsappDestino(idBilletera){
-      if(!idBilletera) return '';
-      if(cacheWhatsapp.has(idBilletera)) return cacheWhatsapp.get(idBilletera);
-      let numero='';
-      try{
-        const billeteraDoc=await db.collection('Billetera').doc(idBilletera).get();
-        if(billeteraDoc.exists){
-          const data=billeteraDoc.data()||{};
-          numero=data.numeroWhatsapp||data.numero_whatsapp||data.whatsapp||data.celular||data.numerocel||data.telefono||data.Telefono||'';
-        }
-        if(!numero){
-          const userDoc=await db.collection('users').doc(idBilletera).get();
-          if(userDoc.exists){
-            const data=userDoc.data()||{};
-            numero=data.telefono||data.Telefono||data.celular||data.whatsapp||data.phoneNumber||'';
-          }
-        }
-      }catch(err){
-        console.error('No se pudo obtener el número de WhatsApp',err);
-      }
-      const normalizado=normalizarNumeroWhatsapp(numero);
-      cacheWhatsapp.set(idBilletera,normalizado);
-      return normalizado;
-    }
-    async function cargarPlantillasWhatsappResultados(){
-      iniciarSuscripcionMensajesWhatsappResultados();
-      if(mensajesWhatsappResultadosCargados) return mensajesWhatsappResultados;
-      try{
-        const snap=await db.collection('Variablesglobales').doc('Parametros').get();
-        const data=snap.exists?(snap.data()||{}):{};
-        actualizarMensajesWhatsappResultadosDesdeData(data);
-      }catch(err){
-        console.error('No se pudo cargar la configuración de mensajes de resultado WhatsApp',err);
-      }
-      return mensajesWhatsappResultados;
-    }
     function aplicarPlantillaMensaje(plantilla,valores){
       return (plantilla||'').replace(/<([a-zA-Z0-9_]+)>/g,(_,clave)=>{
         const valor=valores[clave];
         return valor===undefined || valor===null ? '' : String(valor);
       }).trim();
     }
+
     async function construirMensajeResultado(transaccion,estadoFinal,nota){
       const tipo=normalizarTipoOperacion(transaccion);
       const montoSolicitadoNum=toNumberSafe(transaccion.MontoSolicitado??transaccion.Monto,transaccion.Monto);
@@ -710,48 +625,16 @@
       const montoSolicitado=formatearEnteroSeguro(montoSolicitadoNum);
       const montoTransferido=`${formatearEnteroSeguro(montoTransferidoNum)} Créditos`;
       const referenciaTexto=(transaccion.referencia||'').toString().trim();
-      const plantillas=await cargarPlantillasWhatsappResultados();
       const valoresBase={
         monto:montoSolicitado,
         app:'BingOnline',
         motivo:(nota||'No especificado').toString().trim(),
         referencia:referenciaTexto||'pendiente',
-        totalTransferido:montoTransferido,
-        comisionBancaria:'',
-        comisionGestion:'',
-        usuario:transaccion.IDbilletera||''
+        totalTransferido:montoTransferido
       };
-
-      if(estadoFinal==='APROBADO'){
-        if(tipo==='recarga'){
-          return aplicarPlantillaMensaje(plantillas.mensajeRecargaAprobada,valoresBase);
-        }
-        return aplicarPlantillaMensaje(plantillas.mensajeRetiroAprobado,valoresBase);
-      }
-      if(tipo==='recarga'){
-        return aplicarPlantillaMensaje(plantillas.mensajeRecargaAnulada,valoresBase);
-      }
-      return aplicarPlantillaMensaje(plantillas.mensajeRetiroAnulado,valoresBase);
-    }
-    async function notificarWhatsappTransacciones(){
-      return;
-    }
-
-    async function permitirRedaccionWhatsapp(transaccion,estadoFinal){
-      const claveEstado=(estadoFinal||'').toUpperCase();
-      const tipo=normalizarTipoOperacion(transaccion);
-      const clavePreferencia=(MAPEO_PREFERENCIAS_WHATSAPP[tipo]||{})[claveEstado];
-      if(!clavePreferencia) return false;
-      if(!window.notificationCenter || typeof window.notificationCenter.cuandoListo!=='function') return false;
-      try{
-        await window.notificationCenter.cuandoListo();
-      }catch(err){
-        console.warn('No se pudo sincronizar preferencias de notificaciones',err);
-        return false;
-      }
-      const config=window.notificationCenter.obtenerConfiguracion();
-      if(!config || !config.global || !config.preferencias) return false;
-      return Boolean(config.preferencias[clavePreferencia]);
+      const plantillasTipo=MENSAJES_RESULTADOS_INTERNOS[tipo]||MENSAJES_RESULTADOS_INTERNOS.recarga;
+      const plantilla=plantillasTipo[estadoFinal]||plantillasTipo.ANULADO;
+      return aplicarPlantillaMensaje(plantilla,valoresBase);
     }
 
     async function actualizar(ids,estado,nota,ref,condicion){


### PR DESCRIPTION
### Motivation
- Homogeneizar la gestión de estados en la billetera para usar `APROBADO` y `ACEPTADO` como estados finales en el flujo administrativo en lugar de depender de `REALIZADO` como canónico. 
- Eliminar la lógica que redacta/enlaza mensajes de WhatsApp desde la interfaz de gestión para evitar que la gestión envíe mensajes automáticos a los jugadores, sin tocar la lógica de mensajería que los jugadores usan para comunicarse con la app.

### Description
- Se reemplazó el conjunto canónico de estados en `public/js/estadoPagoPremio.js` para declarar `APROBADO` y `ACEPTADO` como estados válidos y tratar `REALIZADO` como alias de lectura a `APROBADO` y además considerar `APROBADO` y `ACEPTADO` como finalizados.
- Se actualizó la UI y la normalización en `public/billetera.html` y `public/transacciones.html` para mostrar/filtrar por `APROBADO` y `ACEPTADO` y ajustar la colorización y validaciones en tablas y filtros.
- Se removió la lógica de redacción/plantillas y resolución de números WhatsApp desde la gestión (suscripciones a plantillas, mapeos de preferencias y funciones de envío), y en su lugar se dejó generación de mensajes internos simples para la notificación interna (`notificacionInterna`) que verá el jugador en la app.
- Se limpiaron las opciones relacionadas con la redacción automática de WhatsApp en `public/js/notificationCenter.js` para roles de gestión y se adaptaron funciones de normalización en ese archivo.
- Se actualizaron y ajustaron pruebas en `__tests__/estadoPagoPremio-normalizacion.test.js` para reflejar la nueva normalización y validación de estados.

### Testing
- Se ejecutó la suite de pruebas con `npm test -- --runInBand` y todos los tests pasaron: 11 suites, 35 tests totales en verde.
- La prueba unitaria modificada `__tests__/estadoPagoPremio-normalizacion.test.js` pasó correctamente bajo la nueva lógica de estados.
- Cobertura y scripts de test existentes no mostraron regresiones en los archivos ejecutados por las suites automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e3e3ed8888326a6b701ef937fcb4d)