### PR TITLE
Eliminar TOPE_REINTENTOS y corregir flujo de aceptación de transacciones

### DIFF
--- a/public/js/internalTransactionNotifier.js
+++ b/public/js/internalTransactionNotifier.js
@@ -55,8 +55,14 @@
       const identidades=this.obtenerIdentidadesUsuario();
       let pendiente=null;
       for(const identidad of identidades){
-        const snap=await this.buscarPendientePorIdentidad(identidad);
+        const snap=await this.buscarPendientePorIdentidad(identidad,'IDbilletera');
         if(!snap.empty){ pendiente=snap.docs[0]; break; }
+      }
+      if(!pendiente){
+        for(const identidad of identidades){
+          const snap=await this.buscarPendientePorIdentidad(identidad,'idBilleteraInterna');
+          if(!snap.empty){ pendiente=snap.docs[0]; break; }
+        }
       }
       if(!pendiente) return;
       this.actual=this.normalizarDoc(pendiente);
@@ -76,11 +82,11 @@
       return Array.from(new Set(normalizadas));
     }
 
-    async buscarPendientePorIdentidad(identidad){
+    async buscarPendientePorIdentidad(identidad,campoIdentidad){
       const ref=db.collection('transacciones');
       try{
         return await ref
-          .where('IDbilletera','==',identidad)
+          .where(campoIdentidad,'==',identidad)
           .where('notificacionInterna.pendienteMostrar','==',true)
           .limit(1)
           .get();
@@ -94,7 +100,7 @@
         }
         console.warn('Consulta de notificación interna requiere índice compuesto. Usando búsqueda alternativa por identidad.');
         try{
-          const respaldo=await ref.where('IDbilletera','==',identidad).limit(25).get();
+          const respaldo=await ref.where(campoIdentidad,'==',identidad).limit(25).get();
           const pendiente=respaldo.docs.find(doc=>{
             const data=doc.data()||{};
             return Boolean(data.notificacionInterna && data.notificacionInterna.pendienteMostrar===true);
@@ -110,7 +116,26 @@
     normalizarDoc(doc){
       const data=doc.data()||{};
       const interna=data.notificacionInterna||{};
-      return {id:doc.id,mensaje:interna.mensaje||'Tienes una actualización en tu transacción.',estadoObjetivo:(interna.estadoObjetivo||'').toString().toUpperCase()};
+      return {
+        id:doc.id,
+        mensaje:interna.mensaje||'Tienes una actualización en tu transacción.',
+        estadoObjetivo:(interna.estadoObjetivo||'').toString().toUpperCase(),
+        tipotrans:(data.tipotrans||'').toString().toLowerCase(),
+        billeteraId:((data.idBilleteraInterna||data.IDbilletera)||'').toString(),
+        monto:Number(data.Monto)||0,
+        montoSolicitado:Number(data.MontoSolicitado ?? data.Monto)||0
+      };
+    }
+
+    normalizarTipoOperacion(tipo){
+      const limpio=(tipo||'').toString().trim().toLowerCase();
+      if(limpio==='deposito' || limpio==='depósito') return 'recarga';
+      return limpio;
+    }
+
+    toNumberSafe(valor,defecto=0){
+      const numero=parseFloat(valor);
+      return Number.isFinite(numero)?numero:defecto;
     }
 
     mostrar(notificacion){
@@ -133,7 +158,31 @@
         if(!snap.exists) return;
         const data=snap.data()||{};
         const estadoActual=(data.estado||'').toString().toUpperCase();
+        if(estadoActual==='ACEPTADO') return;
         const interna=data.notificacionInterna||{};
+        const tipo=this.normalizarTipoOperacion(data.tipotrans||this.actual.tipotrans);
+        const billeteraId=((data.idBilleteraInterna||data.IDbilletera||this.actual.billeteraId)||'').toString();
+        const monto=this.toNumberSafe(data.Monto,0);
+        const montoSolicitado=this.toNumberSafe((data.MontoSolicitado ?? data.Monto),monto);
+
+        if(estadoActual==='APROBADO' && billeteraId){
+          const billeteraRef=db.collection('Billetera').doc(billeteraId);
+          const billeteraSnap=await tx.get(billeteraRef);
+          const billeteraData=billeteraSnap.exists?(billeteraSnap.data()||{}):{};
+          const creditosActual=this.toNumberSafe(billeteraData.creditos,0);
+          const transitoActual=Math.max(0,this.toNumberSafe(billeteraData.creditostransito,0));
+          const payload={};
+          if(tipo==='recarga'){
+            payload.creditos=creditosActual+monto;
+          }else if(tipo==='retiro'){
+            payload.creditos=Math.max(0,creditosActual-montoSolicitado);
+            payload.creditostransito=Math.max(0,transitoActual-montoSolicitado);
+          }
+          if(Object.keys(payload).length){
+            tx.set(billeteraRef,payload,{merge:true});
+          }
+        }
+
         const payload={
           mensajeLeido:true,
           notificacionInterna:{

--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -26,8 +26,7 @@
         { clave: 'retirosPendientes', titulo: 'Notificación Retiros Pendientes', descripcion: 'Se repite cada 10 minutos si hay retiros por gestionar.' },
         { clave: 'selladoSorteo', titulo: 'Notificación Sellado Sorteo', descripcion: 'Cuando llega la hora de sellado de un sorteo.' },
         { clave: 'juegoEnVivoSorteo', titulo: 'Notificación Juego en vivo Sorteo', descripcion: 'Cuando llega la hora de inicio de un sorteo.' },
-        { clave: 'gestionPagos', titulo: 'Notificación Gestión Pagos', descripcion: 'Aviso único si hay gestiones de pagos pendientes.' },
-        { clave: 'topeReintentosAcreditacion', titulo: 'Notificación TOPE_REINTENTOS', descripcion: 'Te avisa cuando existan acreditaciones técnicas bloqueadas por tope de reintentos.' }
+        { clave: 'gestionPagos', titulo: 'Notificación Gestión Pagos', descripcion: 'Aviso único si hay gestiones de pagos pendientes.' }
       ]
     }
   };
@@ -35,8 +34,7 @@
   const INTERVALOS_REPETICION = {
     recargasPendientes: 600000,
     retirosPendientes: 600000,
-    gestionPagos: 600000,
-    topeReintentosAcreditacion: 600000
+    gestionPagos: 600000
   };
 
   const HISTORIAL_FABRICAS = {
@@ -47,7 +45,6 @@
     recargasPendientes: () => ({ ultimoEnvio: 0 }),
     retirosPendientes: () => ({ ultimoEnvio: 0 }),
     gestionPagos: () => ({ ultimoEnvio: 0 }),
-    topeReintentosAcreditacion: () => ({ ultimoEnvio: 0 }),
     selladoSorteo: () => ({ ids: {} }),
     juegoEnVivoSorteo: () => ({ ids: {} })
   };
@@ -214,8 +211,7 @@
         pendientes: {
           recargasPendientes: new Set(),
           retirosPendientes: new Set(),
-          gestionPagos: 0,
-          topeReintentosAcreditacion: 0
+          gestionPagos: 0
         },
         resumenPagos: { premios: 0, pagos: 0 },
         verificadorSorteos: null
@@ -399,8 +395,7 @@
         pendientes: {
           recargasPendientes: new Set(),
           retirosPendientes: new Set(),
-          gestionPagos: 0,
-          topeReintentosAcreditacion: 0
+          gestionPagos: 0
         },
         resumenPagos: { premios: 0, pagos: 0 },
         verificadorSorteos: null
@@ -832,17 +827,6 @@
       }catch(err){
         console.error('No se pudieron observar las gestiones de pagos', err);
       }
-      try{
-        const unsubTope = db.collection('AcreditacionesPendientes')
-          .where('estado','==','TOPE_REINTENTOS')
-          .onSnapshot(snapshot => {
-            this.cache.pendientes.topeReintentosAcreditacion = snapshot.size;
-            this.gestionarTopeReintentos();
-          }, err => console.error('Error escuchando TOPE_REINTENTOS de acreditaciones', err));
-        this.desuscriptores.push(unsubTope);
-      }catch(err){
-        console.error('No se pudieron observar acreditaciones en TOPE_REINTENTOS', err);
-      }
       this.iniciarVerificacionSorteos();
     }
 
@@ -992,7 +976,6 @@
 
     obtenerConteoPendiente(clave){
       if(clave === 'gestionPagos') return this.cache.pendientes.gestionPagos || 0;
-      if(clave === 'topeReintentosAcreditacion') return this.cache.pendientes.topeReintentosAcreditacion || 0;
       const conjunto = this.cache.pendientes[clave];
       return conjunto ? conjunto.size : 0;
     }
@@ -1033,22 +1016,6 @@
           historial.ultimoEnvio = 0;
           this.programarGuardadoHistorial();
         }
-      }
-    }
-
-    gestionarTopeReintentos(){
-      const total = this.cache.pendientes.topeReintentosAcreditacion || 0;
-      const historial = this.config.historial.topeReintentosAcreditacion;
-      if(total > 0){
-        const mensaje = `Hay ${total} acreditación(es) en TOPE_REINTENTOS. Ingresa a Centro de Pagos para reencolar.`;
-        if(historial && historial.ultimoEnvio === 0 && this.puedeNotificar('topeReintentosAcreditacion')){
-          historial.ultimoEnvio = Date.now();
-          this.programarGuardadoHistorial();
-          this.emitirNotificacion('topeReintentosAcreditacion', mensaje, 'Acreditaciones bloqueadas');
-        }
-      }else if(historial){
-        historial.ultimoEnvio = 0;
-        this.programarGuardadoHistorial();
       }
     }
 

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -692,32 +692,15 @@
         const esRetiro=tipo==='retiro';
         const esRecarga=tipo==='recarga';
 
-        if(billeteraId && ((estado==='APROBADO' && (esRecarga||esRetiro)) || (estado==='ANULADO' && esRetiro))){
+        if(billeteraId && estado==='ANULADO' && esRetiro){
           const billeteraRef=db.collection('Billetera').doc(billeteraId);
           await db.runTransaction(async t=>{
             const bdoc=await t.get(billeteraRef);
             const billeteraData=bdoc.exists?(bdoc.data()||{}):{};
-            let creditosActual=toNumberSafe(billeteraData.creditos,0);
-            let transitoActual=Math.max(0,toNumberSafe(billeteraData.creditostransito,0));
             const montoTransaccion=toNumberSafe((data.MontoSolicitado ?? data.Monto),0);
-            const payload={};
-            if(estado==='APROBADO'){
-              if(esRecarga){
-                creditosActual+=toNumberSafe(data.Monto,0);
-                payload.creditos=creditosActual;
-              }else if(esRetiro){
-                creditosActual=Math.max(0,creditosActual-montoTransaccion);
-                transitoActual=Math.max(0,transitoActual-montoTransaccion);
-                payload.creditos=creditosActual;
-                payload.creditostransito=transitoActual;
-              }
-            }else if(estado==='ANULADO' && esRetiro){
-              transitoActual=Math.max(0,transitoActual-montoTransaccion);
-              payload.creditostransito=transitoActual;
-            }
-            if(Object.keys(payload).length>0){
-              t.set(billeteraRef,payload,{merge:true});
-            }
+            const transitoActual=Math.max(0,toNumberSafe(billeteraData.creditostransito,0));
+            const payload={ creditostransito: Math.max(0,transitoActual-montoTransaccion) };
+            t.set(billeteraRef,payload,{merge:true});
           });
         }
 


### PR DESCRIPTION
### Motivation
- Eliminar la notificación `TOPE_REINTENTOS` porque ya no se usará en la aplicación y evitar la lógica asociada que escucha esa colección en Firestore. 
- Resolver por qué la ventana persistente de aceptación no se muestra al jugador tras la aprobación por parte de un gestor, y asegurar que la aceptación del jugador actualice correctamente la billetera y el estado a `ACEPTADO`.

### Description
- Eliminé la opción `topeReintentosAcreditacion` del catálogo de notificaciones y removí su historial, intervalo y el monitor que observaba `AcreditacionesPendientes` en `public/js/notificationCenter.js`.
- Modifiqué `public/js/internalTransactionNotifier.js` para buscar transacciones pendientes tanto por `IDbilletera` como por `idBilleteraInterna`, evitando que el modal no aparezca en cuentas con identidad interna; además agregué normalizaciones y utilidades (`normalizarTipoOperacion`, `toNumberSafe`).
- Moví la aplicación de créditos/devolución de `creditostransito` fuera del momento de `APROBADO` y la ejecuté en la transacción que ocurre cuando el jugador presiona `Aceptar` en el modal (si el estado era `APROBADO` la transacción pasa a `ACEPTADO` y la billetera se actualiza en consecuencia) dentro de `public/js/internalTransactionNotifier.js`.
- Ajusté `public/transacciones.html` para que la gestión sólo libere `creditostransito` al anular retiros (`ANULADO`) y que no aplique cambios de crédito al marcar `APROBADO`, preservando el flujo de aceptación por parte del jugador.

### Testing
- Ejecuté `npm test -- --runInBand` y todas las suites unitarias automáticas pasaron correctamente (Test Suites: 11 passed, Tests: 35 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4a4b79b48326a8b0e40837358371)