### PR TITLE
CentroPagos: usar APROBADO/ACEPTADO en lugar de REALIZADO

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -563,7 +563,8 @@
               <select id="filtro-premios-estado">
                 <option value="">Estado</option>
                 <option value="PENDIENTE">PENDIENTE</option>
-                <option value="REALIZADO">REALIZADO</option>
+                <option value="APROBADO">APROBADO</option>
+                <option value="ACEPTADO">ACEPTADO</option>
                 <option value="ARCHIVADO">ARCHIVADO</option>
               </select>
             </th>
@@ -608,7 +609,8 @@
               <select id="filtro-pagos-estado">
                 <option value="">Estado</option>
                 <option value="PENDIENTE">PENDIENTE</option>
-                <option value="REALIZADO">REALIZADO</option>
+                <option value="APROBADO">APROBADO</option>
+                <option value="ACEPTADO">ACEPTADO</option>
                 <option value="ARCHIVADO">ARCHIVADO</option>
               </select>
             </th>
@@ -2073,8 +2075,9 @@
 
     function obtenerEtiquetaEstado(valorEstado){
       const estado = normalizarEstado(valorEstado);
-      if(estado === 'REALIZADO') return 'REALIZADO';
       if(estado === 'PENDIENTE') return 'PENDIENTE';
+      if(estado === 'APROBADO') return 'APROBADO';
+      if(estado === 'ACEPTADO') return 'ACEPTADO';
       if(estado === 'ARCHIVADO') return 'ARCHIVADO';
       return estado;
     }
@@ -2200,7 +2203,10 @@
       }
       const filas = lista.map((item, indice)=>{
       const numero = indice + 1;
-      const estadoClase = item.estado === 'REALIZADO' ? 'estado-aprobado' : (item.estado === 'PENDIENTE' ? 'estado-pendiente' : 'estado-archivado');
+      const estadoNormalizado = normalizarEstado(item.estado);
+      const estadoClase = (estadoNormalizado === 'APROBADO' || estadoNormalizado === 'ACEPTADO')
+        ? 'estado-aprobado'
+        : (estadoNormalizado === 'PENDIENTE' ? 'estado-pendiente' : 'estado-archivado');
       const rolNormalizado = normalizarTipoUsuario(item.tipo || item.estado || '');
       const estadoHtml = tipo === 'colaboradores'
         ? construirRolBadgeHtml(rolNormalizado)
@@ -2481,7 +2487,7 @@
         }, { merge: true });
 
         tx.set(premioRef, {
-          estado: validarEstadoGuardado('REALIZADO', `PremiosSorteos:${enRegistro.id}`),
+          estado: validarEstadoGuardado('APROBADO', `PremiosSorteos:${enRegistro.id}`),
           idBilletera: billeteraId,
           fechaGestion: fechaServidor(),
           horaGestion: horaServidor(),
@@ -2514,7 +2520,7 @@
           tipotrans: (enRegistro.tipotrans || 'pago').toString().toLowerCase(),
           origen: (enRegistro.origen || 'pagos_administracion').toString().toLowerCase(),
           Monto: monto,
-          estado: validarEstadoGuardado('REALIZADO', 'TransaccionPagoAdministracion'),
+          estado: validarEstadoGuardado('APROBADO', 'TransaccionPagoAdministracion'),
           IDbilletera: enRegistro.billetera,
           fechasolicitud: '',
           horasolicitud: '',
@@ -2619,7 +2625,7 @@
             const estadoActual = normalizarEstado(data.estado);
             if(window.EstadosPagoPremio.estaFinalizado(estadoActual)) return;
             tx.update(ref, {
-              estado: validarEstadoGuardado('REALIZADO', `PagosAdministracion:${id}`),
+              estado: validarEstadoGuardado('APROBADO', `PagosAdministracion:${id}`),
               fechaGestion: fechaServidor(),
               horaGestion: horaServidor(),
               gestionadoPor: authInstance().currentUser?.email || '',

--- a/scripts/reconciliarPremiosPendientes.js
+++ b/scripts/reconciliarPremiosPendientes.js
@@ -28,7 +28,14 @@ function resolveCredentialsPath() {
 }
 
 function normalizarEstado(estado) {
-  return (estado || '').toString().trim().toUpperCase();
+  const texto = (estado || '').toString().trim().toUpperCase();
+  if (texto === 'REALIZADO') return 'APROBADO';
+  return texto;
+}
+
+function estadoFinalizado(estado) {
+  const normalizado = normalizarEstado(estado);
+  return normalizado === 'APROBADO' || normalizado === 'ACEPTADO';
 }
 
 async function main() {
@@ -66,10 +73,10 @@ async function main() {
   premiosSnap.forEach(doc => {
     const data = doc.data() || {};
     const estado = normalizarEstado(data.estado);
-    if (estado === 'REALIZADO' || estado === 'ARCHIVADO') return;
+    if (estadoFinalizado(estado) || estado === 'ARCHIVADO') return;
     const eventoGanadorId = (data.eventoGanadorId || doc.id || '').toString();
     const match = pendientesPorEvento.get(eventoGanadorId);
-    if (!match || match.estado === 'REALIZADO') {
+    if (!match || estadoFinalizado(match.estado)) {
       huerfanos.push({
         premioId: doc.id,
         eventoGanadorId,


### PR DESCRIPTION
### Motivation
- Unificar la secuencia de estados a `PENDIENTE → APROBADO → ACEPTADO` para evitar errores durante el procesamiento y las transferencias al manejar registros históricos y nuevos.

### Description
- Actualicé los selectores de filtro en la UI de **PREMIOS JUGADORES** y **PAGOS ADMINISTRACIÓN** para reemplazar la opción `REALIZADO` por `APROBADO` y añadir `ACEPTADO` (`public/centropagos.html`).
- Cambié el render y la etiqueta de estado para que `APROBADO` y `ACEPTADO` se muestren como estados aprobados en las tablas y quité la dependencia visual de `REALIZADO` (`public/centropagos.html`).
- Modifiqué la lógica de persistencia al procesar aprobaciones para guardar `APROBADO` en registros de `PremiosSorteos`, `PagosAdministracion` y en las transacciones creadas, manteniendo la validación de estados canónicos (`public/centropagos.html`).
- Robustecí el script de reconciliación para normalizar `REALIZADO` → `APROBADO` y para considerar finalizados los estados `APROBADO` y `ACEPTADO`, evitando inconsistencias al detectar huérfanos (`scripts/reconciliarPremiosPendientes.js`).

### Testing
- Ejecuté `npm test` y todas las suites pasaron correctamente (11 suites, 35 tests OK).
- Ejecuté la suite específica de normalización (`estadoPagoPremio-normalizacion.test.js`) y pasó correctamente aunque la ejecución aislada mostró advertencia de umbral de cobertura por filtrado; los tests unitarios relevantes pasaron.
- Intenté generar una captura visual con Playwright para documentar el cambio UI, pero falló el lanzamiento de Chromium en este contenedor (SIGSEGV), por lo que no se pudo incluir screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e76369af083268ef3a4f28dd2273f)