### PR TITLE
Fix notification switches panel from disappearing

### DIFF
--- a/public/js/notificationPanelSetup.js
+++ b/public/js/notificationPanelSetup.js
@@ -377,14 +377,14 @@
         return;
       }
       if (!window.notificationCenter){
-        panel.style.display = 'none';
+        panel.style.display = 'block';
         return;
       }
       panel.style.display = 'block';
       gruposDisponibles = window.notificationCenter.obtenerGruposUI(rol || 'Jugador');
       gruposDisponibles = Array.isArray(gruposDisponibles) ? gruposDisponibles.slice() : [];
       if (!gruposDisponibles.length){
-        panel.style.display = 'none';
+        panel.style.display = 'block';
         return;
       }
       try{
@@ -406,11 +406,11 @@
     function actualizarPanel(config){
       if (!panel) return;
       if (!config){
-        panel.style.display = 'none';
+        panel.style.display = 'block';
         return;
       }
       if (!Array.isArray(gruposDisponibles) || !gruposDisponibles.length){
-        panel.style.display = 'none';
+        panel.style.display = 'block';
         return;
       }
       panel.style.display = 'block';

--- a/public/perfil.html
+++ b/public/perfil.html
@@ -898,11 +898,11 @@
   function actualizarPanelNotificaciones(config,grupos){
     if(!notificacionesPanel) return;
     if(!config){
-      notificacionesPanel.style.display='none';
+      notificacionesPanel.style.display='block';
       return;
     }
     if(!Array.isArray(grupos) || !grupos.length){
-      notificacionesPanel.style.display='none';
+      notificacionesPanel.style.display='block';
       return;
     }
     notificacionesPanel.style.display='block';
@@ -932,14 +932,14 @@
   async function inicializarNotificacionesPerfil(role){
     if(!notificacionesPanel) return;
     if(!window.notificationCenter){
-      notificacionesPanel.style.display='none';
+      notificacionesPanel.style.display='block';
       return;
     }
     notificacionesPanel.style.display='block';
     const grupos=window.notificationCenter.obtenerGruposUI(role||'Jugador');
     gruposNotificacionesDisponibles=Array.isArray(grupos)?grupos.slice():[];
     if(!Array.isArray(grupos) || !grupos.length){
-      notificacionesPanel.style.display='none';
+      notificacionesPanel.style.display='block';
       return;
     }
     try{


### PR DESCRIPTION
## Resumen
Se corrigió el comportamiento de la sección de notificaciones que hacía que los switches desaparecieran después de unos segundos.

## Cambios realizados
- `public/js/notificationPanelSetup.js`
  - Ajusté la lógica de inicialización y actualización del panel para no ocultar el contenedor completo (`display: none`) cuando:
    - `window.notificationCenter` no está disponible temporalmente.
    - no hay grupos disponibles aún.
    - la configuración todavía no está lista.
  - Ahora el panel permanece visible (`display: block`) mientras se completa la carga, evitando el efecto de “parpadeo y desaparición”.

- `public/perfil.html`
  - Apliqué el mismo criterio en la implementación de notificaciones del perfil de usuario para mantener consistencia.
  - Se evita ocultar por completo el panel ante estados transitorios de carga.

## Impacto esperado
- Los usuarios vuelven a ver la sección de switches de notificaciones de forma estable.
- Se elimina la desaparición completa del módulo durante tiempos de inicialización o estados intermedios.

## Validación
- Revisión estática del flujo de visibilidad del panel en inicialización y actualización de estado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699face42f708326a3e4f69bd9bf845c)