### PR TITLE
Normalizar roles en el centro de notificaciones para restaurar secciones

### DIFF
--- a/public/js/notificationCenter.js
+++ b/public/js/notificationCenter.js
@@ -32,6 +32,25 @@
     }
   };
 
+  const ROLES_CANONICOS = {
+    jugador: 'Jugador',
+    usuario: 'Jugador',
+    player: 'Jugador',
+    colaborador: 'Colaborador',
+    collaborator: 'Colaborador',
+    administrador: 'Administrador',
+    admin: 'Administrador',
+    superadmin: 'Superadmin'
+  };
+
+  function normalizarRol(role){
+    if(!role) return 'Jugador';
+    const limpio = role.toString().trim();
+    if(!limpio) return 'Jugador';
+    const canonico = ROLES_CANONICOS[limpio.toLowerCase()];
+    return canonico || limpio;
+  }
+
   const INTERVALOS_REPETICION = {
     recargasPendientes: 600000,
     retirosPendientes: 600000,
@@ -75,17 +94,18 @@
   }
 
   function clavesPorRol(role){
+    const rol = normalizarRol(role);
     const claves = new Set();
-    if(role === 'Superadmin'){
+    if(rol === 'Superadmin'){
       Object.values(GRUPOS_NOTIFICACIONES).forEach(grupo => grupo.items.forEach(item => claves.add(item.clave)));
       return Array.from(claves);
     }
-    if(role === 'Colaborador'){
+    if(rol === 'Colaborador'){
       GRUPOS_NOTIFICACIONES.Colaborador.items.forEach(item => claves.add(item.clave));
       GRUPOS_NOTIFICACIONES.Jugador.items.forEach(item => claves.add(item.clave));
       return Array.from(claves);
     }
-    if(role === 'Administrador'){
+    if(rol === 'Administrador'){
       GRUPOS_NOTIFICACIONES.Administrador.items.forEach(item => claves.add(item.clave));
       GRUPOS_NOTIFICACIONES.Colaborador.items.forEach(item => claves.add(item.clave));
       GRUPOS_NOTIFICACIONES.Jugador.items.forEach(item => claves.add(item.clave));
@@ -354,12 +374,13 @@
         this.desvincularUsuario();
         return;
       }
-      const mismo = this.usuario && this.usuario.email === user.email && this.rol === role;
+      const rolNormalizado = normalizarRol(role);
+      const mismo = this.usuario && this.usuario.email === user.email && this.rol === rolNormalizado;
       if(mismo) return this.cuandoListo();
       this.desvincularUsuario();
       this.resetReady(true);
       this.usuario = user;
-      this.rol = role;
+      this.rol = rolNormalizado;
       try{
         if(typeof initFirebase === 'function'){
           await initFirebase();
@@ -636,13 +657,14 @@
     }
 
     obtenerGruposUI(role){
-      if(role === 'Superadmin'){
+      const rol = normalizarRol(role);
+      if(rol === 'Superadmin'){
         return [GRUPOS_NOTIFICACIONES.Colaborador, GRUPOS_NOTIFICACIONES.Jugador, GRUPOS_NOTIFICACIONES.Administrador].filter(Boolean);
       }
-      if(role === 'Colaborador'){
+      if(rol === 'Colaborador'){
         return [GRUPOS_NOTIFICACIONES.Colaborador, GRUPOS_NOTIFICACIONES.Jugador].filter(Boolean);
       }
-      if(role === 'Administrador'){
+      if(rol === 'Administrador'){
         return [GRUPOS_NOTIFICACIONES.Administrador, GRUPOS_NOTIFICACIONES.Colaborador, GRUPOS_NOTIFICACIONES.Jugador].filter(Boolean);
       }
       return [GRUPOS_NOTIFICACIONES.Jugador];


### PR DESCRIPTION
### Motivation
- La UI de notificaciones no mostraba secciones porque la lógica comparaba roles de forma estricta y los roles venían con variantes (minusculas, alias como `usuario` o `admin`).
- Se requiere una normalización central para mapear variantes de rol a nombres canónicos y asegurar que se calculen las claves y grupos de notificaciones correctos.

### Description
- Se agregó el mapa `ROLES_CANONICOS` y la función `normalizarRol` para convertir alias y variaciones de mayúsculas/minúsculas a roles canónicos (`Jugador`, `Colaborador`, `Administrador`, `Superadmin`).
- `clavesPorRol` ahora usa el rol normalizado para determinar las claves de notificación disponibles.
- `vincularUsuario` normaliza y guarda el rol del usuario antes de comparar y cargar la configuración.
- `obtenerGruposUI` usa el rol normalizado para construir los grupos que se renderizan en la UI.

### Testing
- Ejecuté `npm test -- --runInBand` y todos los tests pasaron: 11 suites, 35 tests en verde.
- Las suites unitarias relevantes (`auth-role-utils` y demás) mostraron cobertura y no reportaron fallos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb2e5dedc83268ec53eca596c1229)