### PR TITLE
Unificar flujo de sesión en perfil y limpiar suscripciones de notificaciones

### DIFF
--- a/public/perfil.html
+++ b/public/perfil.html
@@ -543,6 +543,8 @@
   const mensajeValidacionEl=document.getElementById('perfil-mensaje');
   let panelNotificacionesPerfil=null;
   let rolNotificacionesActual=null;
+  let desuscribirSesionPerfil=null;
+  let usuarioSesionActiva=null;
 
   function configurarPanelNotificacionesPerfil(rol){
     if(typeof setupNotificationPanel!=='function') return;
@@ -558,15 +560,53 @@
     rolNotificacionesActual=rolNormalizado;
   }
 
+  function limpiarPanelNotificacionesPerfil(contexto){
+    if(panelNotificacionesPerfil && typeof panelNotificacionesPerfil.cleanup==='function'){
+      try{ panelNotificacionesPerfil.cleanup(); }
+      catch(error){ console.error(`No se pudo limpiar el panel de notificaciones${contexto?` (${contexto})`:''}`,error); }
+    }
+    panelNotificacionesPerfil=null;
+    rolNotificacionesActual=null;
+  }
+
   if(typeof hasWindow==='function' && hasWindow() && typeof window.addEventListener==='function'){
     window.addEventListener('beforeunload',()=>{
-      if(panelNotificacionesPerfil && typeof panelNotificacionesPerfil.cleanup==='function'){
-        try{ panelNotificacionesPerfil.cleanup(); }
-        catch(error){ console.error('No se pudo limpiar el panel de notificaciones al salir',error); }
+      limpiarPanelNotificacionesPerfil('al salir');
+      if(typeof desuscribirSesionPerfil==='function'){
+        try{ desuscribirSesionPerfil(); }
+        catch(error){ console.error('No se pudo desuscribir el listener de sesión al salir',error); }
       }
-      panelNotificacionesPerfil=null;
-      rolNotificacionesActual=null;
+      desuscribirSesionPerfil=null;
+      usuarioSesionActiva=null;
     });
+  }
+
+  function configurarSesionVisible(user){
+    const nombreVisible=(user.displayName&&user.displayName.trim())?user.displayName:(user.email||'');
+    const nameEl=document.getElementById('user-name');
+    if(nameEl) nameEl.textContent=nombreVisible;
+    const emailEl=document.getElementById('user-email');
+    if(emailEl) emailEl.textContent=user.email||'';
+    const picEl=document.getElementById('user-pic');
+    if(picEl){
+      if(typeof asignarFotoUsuario==='function'){
+        asignarFotoUsuario(picEl,user.photoURL||'');
+      }else if(user.photoURL){
+        picEl.src=user.photoURL;
+      }
+    }
+    const infoEl=document.getElementById('session-info');
+    if(infoEl) infoEl.style.display='flex';
+    const logoutEl=document.getElementById('logout-link');
+    if(logoutEl && !logoutEl.dataset.listenerPerfil){
+      logoutEl.addEventListener('click',e=>{
+        e.preventDefault();
+        limpiarPanelNotificacionesPerfil('al cerrar sesión');
+        usuarioSesionActiva=null;
+        logout();
+      });
+      logoutEl.dataset.listenerPerfil='true';
+    }
   }
 
   function poblarSelectCodigos(select){
@@ -901,9 +941,14 @@
 
   initFirebase()
     .then(()=>{
-      ensureAuth();
-      auth.onAuthStateChanged(async user=>{
+      desuscribirSesionPerfil=auth.onAuthStateChanged(async user=>{
         if(user){
+          if(usuarioSesionActiva===user.uid){
+            return;
+          }
+          limpiarPanelNotificacionesPerfil('cambio de usuario');
+          usuarioSesionActiva=user.uid;
+          configurarSesionVisible(user);
           let datosPerfil=null;
           try{
             const doc=await db.collection('users').doc(user.email).get();
@@ -936,16 +981,13 @@
             mostrarMensajeValidacion('No se pudieron cargar los datos del perfil. Intenta nuevamente.');
           }
           const rolNotificaciones=(datosPerfil && (datosPerfil.role||datosPerfil.rol||datosPerfil.rolinterno))||window.currentRole||'Jugador';
+          window.currentRole=rolNotificaciones;
           configurarPanelNotificacionesPerfil(rolNotificaciones);
           actualizarEstadoCamposObligatorios();
           evaluarCambios();
         } else {
-          if(panelNotificacionesPerfil && typeof panelNotificacionesPerfil.cleanup==='function'){
-            try{ panelNotificacionesPerfil.cleanup(); }
-            catch(error){ console.error('No se pudo limpiar el panel de notificaciones',error); }
-          }
-          panelNotificacionesPerfil=null;
-          rolNotificacionesActual=null;
+          limpiarPanelNotificacionesPerfil('sin sesión');
+          usuarioSesionActiva=null;
           window.location.href='index.html';
         }
       });


### PR DESCRIPTION
### Motivation
- Evitar listeners redundantes y race conditions derivados de usar `ensureAuth()` y un `auth.onAuthStateChanged` duplicado en `public/perfil.html`.
- Garantizar que la inicialización del panel de notificaciones ocurra solo una vez por sesión activa y después de resolver el rol del usuario.
- Asegurar que las suscripciones del panel se limpien al cerrar sesión, cambiar de usuario o al abandonar la página para evitar fugas de listeners.

### Description
- Reemplacé la llamada combinada a `ensureAuth()` + listener por un único `auth.onAuthStateChanged` almacenado en `desuscribirSesionPerfil` y eliminado la duplicidad local de inicialización.
- Añadí el guard `usuarioSesionActiva` (por `uid`) para evitar re-inicializar el panel cuando el mismo usuario ya está activo y así permitir que la inicialización ocurra solo una vez por sesión.
- Introduje `limpiarPanelNotificacionesPerfil(contexto)` para centralizar el `cleanup` del `panelNotificacionesPerfil` y llamarlo en `beforeunload`, al salir sin sesión y al cambiar de usuario.
- Agregué `configurarSesionVisible(user)` para exponer nombre/email/foto en la UI y registrar un `logout` handler único que también hace `cleanup` del panel; además se actualiza `window.currentRole` tras resolver el rol.

### Testing
- Ejecuté `rg` para verificar la presencia de los nuevos identificadores y la ausencia de la invocación redundante a `ensureAuth()` en `public/perfil.html` y el resultado fue el esperado.
- Revisé el diff con `git diff` para confirmar los cambios en `public/perfil.html` y que las rutas de cleanup y control de sesión se añadieron correctamente.
- Inspeccioné el archivo modificado con `nl`/visualización para validar la ubicación de las nuevas funciones y las llamadas a `limpiarPanelNotificacionesPerfil`, sin errores detectados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb97e32a483269ffb3970127a5ad9)