### PR TITLE
Evitar sobrescritura de rol al guardar perfil y sincronizar notificaciones

### DIFF
--- a/public/perfil.html
+++ b/public/perfil.html
@@ -545,6 +545,7 @@
   let rolNotificacionesActual=null;
   let desuscribirSesionPerfil=null;
   let usuarioSesionActiva=null;
+  let rolPersistentePerfil='Jugador';
 
   function configurarPanelNotificacionesPerfil(rol){
     if(typeof setupNotificationPanel!=='function') return;
@@ -903,7 +904,6 @@
     const baseDatos={
       email:user.email,
       photoURL:user.photoURL||'',
-      role:'Jugador',
       celular:valores.celular,
       numerocel:valores.celular
     };
@@ -955,6 +955,10 @@
             if(doc.exists){
               const d=doc.data()||{};
               datosPerfil=d;
+              const rolDocumento=(d.role||d.rol||d.rolinterno||'').toString().trim();
+              if(rolDocumento){
+                rolPersistentePerfil=rolDocumento;
+              }
               const celularNormalizado=normalizarCelular(d.celular||d.numerocel||d.telefono||d.Telefono||d.whatsapp||'');
               valoresOriginales={
                 name:(d.name||'').toString().trim(),
@@ -969,6 +973,7 @@
               actualizarCamposCelularDesdeNumero(valoresOriginales.celular);
               tieneDatosGuardados=camposObligatoriosCompletos(valoresOriginales);
             }else{
+              rolPersistentePerfil='Jugador';
               valoresOriginales={name:'',apellido:'',alias:'',celular:'',numerocel:''};
               nombreInput.value='';
               apellidoInput.value='';
@@ -981,6 +986,10 @@
             mostrarMensajeValidacion('No se pudieron cargar los datos del perfil. Intenta nuevamente.');
           }
           const rolNotificaciones=(datosPerfil && (datosPerfil.role||datosPerfil.rol||datosPerfil.rolinterno))||window.currentRole||'Jugador';
+          if(window.notificationCenter && typeof window.notificationCenter.vincularUsuario==='function'){
+            try{ await window.notificationCenter.vincularUsuario(user, rolNotificaciones||rolPersistentePerfil||'Jugador'); }
+            catch(error){ console.error('No se pudo vincular el centro de notificaciones en perfil',error); }
+          }
           window.currentRole=rolNotificaciones;
           configurarPanelNotificacionesPerfil(rolNotificaciones);
           actualizarEstadoCamposObligatorios();


### PR DESCRIPTION
### Motivation
- Evitar que al guardar los datos desde `perfil.html` se sobrescriba el rol del usuario (p. ej. Superadmin → Jugador) porque el cambio de roles sólo debe gestionarse desde `gestionarusuarios.html`.
- Asegurar que los switches de notificaciones en la pantalla de perfil persistan y se recarguen correctamente igual que en la vista de configuraciones de Superadmin.

### Description
- Eliminé el campo `role: 'Jugador'` del payload que se escribe en Firestore al guardar el perfil para no sobreescribir el rol del documento existente. (archivo modificado: `public/perfil.html`).
- Añadí la variable `rolPersistentePerfil` y lógica que lee el rol almacenado en el documento (`d.role || d.rol || d.rolinterno`) para conservar referencia del rol persistente al cargar el perfil.
- Vinculé explícitamente el `notificationCenter` en el flujo de carga de `perfil.html` llamando a `window.notificationCenter.vincularUsuario(user, rol)` usando el rol leído para asegurar lectura/guardado de `notificationSettings` antes de montar el panel de notificaciones.

### Testing
- Ejecutado el conjunto de pruebas automatizadas con `npm test -- --runInBand`.
- Todos los tests pasaron: **11 suites aprobadas, 35 tests aprobados**; salida de Jest sin fallos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a106d769748326a41f2b30345f4554)