### PR TITLE
Corregir cierre involuntario del panel de notificaciones en perfil

### DIFF
--- a/public/js/notificationPanelSetup.js
+++ b/public/js/notificationPanelSetup.js
@@ -422,9 +422,6 @@
           globalInput.checked = globalActivo;
           globalInput.dataset.manual = 'false';
           globalInicializado = true;
-        }else if (!globalActivo && globalInput.checked){
-          globalInput.checked = false;
-          globalInput.dataset.manual = 'false';
         }
         actualizarIndicadoresGlobal();
       }


### PR DESCRIPTION
### Motivation
- Se corrige un comportamiento en que, al cambiar cualquier switch de notificaciones en `perfil.html` (por ejemplo con rol `Jugador`), la sección de notificaciones se colapsaba automáticamente en lugar de mantenerse desplegada según el switch del usuario.

### Description
- Se ajustó la lógica en `public/js/notificationPanelSetup.js` eliminando la rama que forzaba desmarcar el `globalInput` cuando la configuración persistida reportaba `global = false` dentro de `actualizarPanel(config)`, de modo que ahora se respeta el estado manual del switch y el panel no se cierra al togglear opciones individuales.

### Testing
- Se verificó la sintaxis del script con `node --check public/js/notificationPanelSetup.js` y la comprobación final pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10ac14fb483269ec32ece1296105e)