### PR TITLE
Evitar sobrescribir el rol al guardar perfil de colaborador

### DIFF
--- a/public/configcollab.html
+++ b/public/configcollab.html
@@ -590,7 +590,6 @@
       const baseDatos={
         email:user.email,
         photoURL:user.photoURL||'',
-        role:'Colaborador',
         celular:valores.celular,
         numerocel:valores.celular
       };


### PR DESCRIPTION
### Motivation
- Al guardar/editar el perfil desde la pantalla de colaborador se estaba forzando `role: 'Colaborador'` provocando que usuarios con roles superiores (p. ej. `Superadmin`) se degradaran accidentalmente; la intención es que guardar perfil solo actualice datos personales y nunca cambie el rol.

### Description
- Se eliminó la asignación `role: 'Colaborador'` en el objeto de guardado dentro de `public/configcollab.html` para que las escrituras a Firestore no sobreescriban el rol existente y solo se actualicen los campos personales (`email`, `photoURL`, `celular`, `numerocel` y los cambios detectados), usando `set(..., { merge:true })` para preservar el rol actual.

### Testing
- Ejecutado el test unitario `npm test -- --runTestsByPath __tests__/auth-role-utils.test.js` y pasó correctamente (todos los tests en ese archivo: PASS).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10ea5227c83268c5149c59420dcec)