### PR TITLE
Corregir flujo MANUAL de canto y persistir recordatorio de modo

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -1897,6 +1897,7 @@
   let modoRecordatorioMostrado = false;
   let manualCantoUnsub = null;
   let manualCantoActivo = null;
+  const MODO_RECORDATORIO_STORAGE_PREFIX = 'cantarsorteos_modo_recordatorio_v1_';
   let infoTiempoSorteo = {
     fecha: null,
     fechaCierre: null,
@@ -2419,7 +2420,10 @@
     });
   }
   if(modoRecordatorioAceptarBtn){
-    modoRecordatorioAceptarBtn.addEventListener('click', cerrarModalRecordatorioModo);
+    modoRecordatorioAceptarBtn.addEventListener('click', ()=>{
+      marcarRecordatorioModoMostrado();
+      cerrarModalRecordatorioModo();
+    });
   }
   if(modoRecordatorioModalEl){
     modoRecordatorioModalEl.addEventListener('click', evento=>{
@@ -2923,6 +2927,27 @@
     if(!modoRecordatorioModalEl) return;
     modoRecordatorioModalEl.classList.add('activa');
     modoRecordatorioModalEl.setAttribute('aria-hidden', 'false');
+  }
+
+  function obtenerClaveRecordatorioModo(){
+    const id = sanitizarId(currentSorteoId || currentSorteoData?.id || 'general');
+    return `${MODO_RECORDATORIO_STORAGE_PREFIX}${id || 'general'}`;
+  }
+
+  function marcarRecordatorioModoMostrado(){
+    try {
+      localStorage.setItem(obtenerClaveRecordatorioModo(), '1');
+    } catch (error) {
+      console.warn('No se pudo persistir el recordatorio de modo.', error);
+    }
+  }
+
+  function yaSeMostroRecordatorioModo(){
+    try {
+      return localStorage.getItem(obtenerClaveRecordatorioModo()) === '1';
+    } catch (error) {
+      return false;
+    }
   }
 
   function cerrarModalRecordatorioModo(){
@@ -4497,10 +4522,54 @@
   async function cerrarCantoManualActual(){
     if(!currentSorteoId || !manualCantoActivo?.activo) return;
     try {
+      const candidatos = Array.isArray(manualCantoActivo?.candidatos) ? manualCantoActivo.candidatos : [];
+      const cantados = Array.isArray(manualCantoActivo?.cantados) ? manualCantoActivo.cantados : [];
+      const cantadosSet = new Set(cantados);
+      const confirmados = [];
+      const noConfirmados = [];
+      candidatos.forEach(item=>{
+        const key = normalizarClaveManual(item?.key || item?.userId || item?.email || item?.alias || item?.cartonId);
+        if(!key) return;
+        if(cantadosSet.has(key)){
+          confirmados.push(key);
+        }else{
+          noConfirmados.push(key);
+        }
+      });
+      const ganadoresPorForma = {};
+      const formasPorUsuario = {};
+      cartonesGanadoresPorForma.forEach((registro, indice)=>{
+        const idxNumero = Number(indice);
+        if(!Number.isFinite(idxNumero)) return;
+        const ganadores = Array.isArray(registro?.cartones) ? registro.cartones : [];
+        let totalConfirmadosForma = 0;
+        ganadores.forEach(carton=>{
+          const key = normalizarClaveManual(carton?.userId || carton?.usuarioId || carton?.email || carton?.gmail || carton?.alias || carton?.id);
+          if(!key || !cantadosSet.has(key)) return;
+          totalConfirmadosForma += 1;
+          if(!formasPorUsuario[key]) formasPorUsuario[key] = [];
+          formasPorUsuario[key].push({
+            idx: idxNumero,
+            nombre: (registro?.forma?.nombre || '').toString().trim(),
+            cartonId: carton?.id || '',
+            cartonNum: carton?.cartonNum ?? carton?.Ncarton ?? null
+          });
+        });
+        if(totalConfirmadosForma > 0){
+          ganadoresPorForma[String(idxNumero)] = totalConfirmadosForma;
+        }
+      });
       await db.collection('manualBingoCantos').doc(currentSorteoId).set({
         activo: false,
         cerrarSolicitadoPor: adminActual?.email || '',
-        cerradoEn: firebase.firestore.FieldValue.serverTimestamp()
+        cerradoEn: firebase.firestore.FieldValue.serverTimestamp(),
+        resultado: {
+          cantoNumero: manualCantoActivo?.cantoNumero ?? null,
+          confirmados,
+          noConfirmados,
+          ganadoresPorForma,
+          formasPorUsuario
+        }
       }, { merge: true });
       cerrarModalNuevosGanadores();
     } catch (error) {
@@ -4518,6 +4587,7 @@
       cantoNumero,
       candidatos,
       cantados: [],
+      resultado: null,
       actualizadoEn: firebase.firestore.FieldValue.serverTimestamp()
     };
     try {
@@ -5516,7 +5586,7 @@
     if(obtenerEstadoActualNormalizado() !== 'jugando'){
       modoRecordatorioMostrado = false;
     }
-    if(obtenerEstadoActualNormalizado() === 'jugando' && !modoRecordatorioMostrado){
+    if(obtenerEstadoActualNormalizado() === 'jugando' && !modoRecordatorioMostrado && !yaSeMostroRecordatorioModo()){
       modoRecordatorioMostrado = true;
       abrirModalRecordatorioModo();
     }

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4653,6 +4653,7 @@
   let manualBingoBtnEl = null;
   let manualBingoPerdioEl = null;
   let ultimoCantoPerdidoMostrado = null;
+  let manualResultadosProcesados = new Set();
 
   function normalizarClaveManual(valor){
     return (valor || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '_');
@@ -4660,6 +4661,19 @@
 
   function esModoManualActivo(){
     return (activeSorteo?.modoJuego || '').toString().trim().toLowerCase() === 'manual';
+  }
+
+  function obtenerResumenResultadoManual(){
+    const resultado = manualBingoEstado?.resultado;
+    if(!resultado || typeof resultado !== 'object') return null;
+    return resultado;
+  }
+
+  function usuarioConfirmoManual(resultado = obtenerResumenResultadoManual()) {
+    if(!resultado) return false;
+    const key = normalizarClaveManual(usuarioActual?.uid || usuarioActual?.email || '');
+    const confirmados = new Set(Array.isArray(resultado?.confirmados) ? resultado.confirmados : []);
+    return key ? confirmados.has(key) : false;
   }
 
   function asegurarUiManualBingo(){
@@ -4728,6 +4742,41 @@
     }
   }
 
+  function procesarResultadoCantoManualCerrado(previo, actual){
+    if(!previo?.activo || actual?.activo) return;
+    const resultado = obtenerResumenResultadoManual();
+    const cantoNumero = Number(resultado?.cantoNumero ?? previo?.cantoNumero);
+    if(Number.isFinite(cantoNumero) && manualResultadosProcesados.has(cantoNumero)) return;
+    const key = normalizarClaveManual(usuarioActual?.uid || usuarioActual?.email || '');
+    const candidatos = new Set((Array.isArray(previo?.candidatos) ? previo.candidatos : []).map(item=>normalizarClaveManual(item?.key || item?.userId || item?.email || item?.alias)).filter(Boolean));
+    if(!key || !candidatos.has(key)) return;
+    const confirmados = new Set(Array.isArray(resultado?.confirmados) ? resultado.confirmados : (Array.isArray(previo?.cantados) ? previo.cantados : []));
+    if(confirmados.has(key)){
+      const detallesConfirmados = Array.isArray(resultado?.formasPorUsuario?.[key]) ? resultado.formasPorUsuario[key] : [];
+      if(detallesConfirmados.length && modalCelebracionEl && !celebracionModalActiva){
+        const detalles = detallesConfirmados.map(item=>{
+          const idx = Number(item?.idx);
+          const forma = formasActivas.find(f=>Number(f.idx)===idx) || { idx, nombre: item?.nombre || '' };
+          const totalGanadores = obtenerTotalGanadoresForma(forma);
+          return {
+            idx,
+            nombre: forma?.nombre || item?.nombre || '',
+            creditos: obtenerCreditosPorGanador(forma, totalGanadores),
+            cartonesGratis: obtenerCartonesGratisPorGanador(forma, totalGanadores),
+            color: obtenerColorParaForma(idx),
+            cartonLabel: item?.cartonNum ? `Cartón #${item.cartonNum}` : ''
+          };
+        });
+        mostrarModalCelebracionGanador(detalles, false);
+      }
+    }else{
+      mostrarModalSinPremio();
+    }
+    if(Number.isFinite(cantoNumero)){
+      manualResultadosProcesados.add(cantoNumero);
+    }
+  }
+
   function suscribirManualBingo(){
     if(manualBingoUnsub){ manualBingoUnsub(); manualBingoUnsub = null; }
     if(!activeSorteoId) return;
@@ -4735,6 +4784,7 @@
       const previo = manualBingoEstado;
       manualBingoEstado = doc.exists ? (doc.data() || null) : null;
       if(previo?.activo && !manualBingoEstado?.activo){
+        procesarResultadoCantoManualCerrado(previo, manualBingoEstado);
         const key = normalizarClaveManual(usuarioActual?.uid || usuarioActual?.email || '');
         const cantados = new Set(Array.isArray(previo?.cantados) ? previo.cantados : []);
         if(!cantados.has(key) && ultimoCantoPerdidoMostrado !== previo?.cantoNumero){
@@ -8904,6 +8954,14 @@
     const directo=normalizarCantidadGanadores(totalGanadoresAlterno);
     if(directo) return directo;
     const idx=Number(forma?.idx);
+    if(Number.isInteger(idx) && esModoManualActivo()){
+      const resultadoManual = obtenerResumenResultadoManual();
+      const mapaManual = resultadoManual?.ganadoresPorForma;
+      if(mapaManual && Object.prototype.hasOwnProperty.call(mapaManual, String(idx))){
+        const confirmados = normalizarCantidadGanadores(mapaManual[String(idx)]);
+        if(confirmados) return confirmados;
+      }
+    }
     if(Number.isInteger(idx) && cartonesGanadoresPorForma instanceof Map){
       const registro=cartonesGanadoresPorForma.get(idx);
       if(registro){
@@ -9002,6 +9060,9 @@
   function obtenerCartonesGratisPorGanador(forma,totalGanadores){
     const totalCartones=obtenerCartonesGratisForma(forma);
     if(totalCartones<=0) return 0;
+    if(esModoManualActivo()){
+      return totalCartones;
+    }
     let ganadoresNumero=Number(totalGanadores);
     if(!Number.isFinite(ganadoresNumero)){
       ganadoresNumero=1;
@@ -9555,6 +9616,15 @@
   function gestionarCelebracionesNuevosGanadores(cartones, esSimulacion=false){
     if(!Array.isArray(cartones) || !cartones.length){
       return;
+    }
+    if(esModoManualActivo() && !esSimulacion){
+      const resultadoManual = obtenerResumenResultadoManual();
+      if(!resultadoManual || manualBingoEstado?.activo){
+        return;
+      }
+      if(!usuarioConfirmoManual(resultadoManual)){
+        return;
+      }
     }
     if(esSimulacion && !cartonesRealesCargados){
       return;


### PR DESCRIPTION
### Motivation

- Evitar acreditación automática de ganadores durante la modalidad MANUAL y respetar el flujo: aparición de botón BINGO -> confirmación por jugador -> cierre de canto -> reparto según confirmados. 
- Hacer que el recordatorio sobre cambiar a MANUAL/AUTOMÁTICO se muestre solo una vez por sorteo tras ser aceptado. 
- Mantener sin cambios el comportamiento de la modalidad AUTOMÁTICA.

### Description

- Se centraliza y persiste el resultado del cierre de un canto manual en `manualBingoCantos.resultado` con los arrays `confirmados` y `noConfirmados`, el conteo `ganadoresPorForma` y el detalle `formasPorUsuario` para usarlo en la liquidación posterior (archivo modificado: `public/cantarsorteos.html`).
- Al iniciar un nuevo canto manual ahora se limpia `resultado` previo para evitar reutilizar datos antiguos (modificación en `public/cantarsorteos.html`).
- Se añadió persistencia por sorteo del recordatorio modo (clave en `localStorage` con prefijo `cantarsorteos_modo_recordatorio_v1_`) y se marca cuando el usuario acepta para que no vuelva a mostrarse aunque se recargue la ventana (modificación en `public/cantarsorteos.html`).
- En `public/juegoactivo.html` se integra el procesamiento del cierre de canto manual: cuando el documento `manualBingoCantos` pasa de `activo:true` a `activo:false` se procesa `resultado` y solo entonces se muestran celebraciones, papelillos o el mensaje de "sin premio" dependiendo de si el usuario confirmó, evitando premiaciones prematuras mientras el canto está activo.
- Ajustes en la lógica de reparto en modo MANUAL: `obtenerTotalGanadoresForma` toma en cuenta `ganadoresPorForma` confirmados y `obtenerCartonesGratisPorGanador` entrega los cartones gratis completos por ganador en modo MANUAL (no se dividen), mientras que en AUTOMÁTICO se preserva la lógica anterior de división.
- Cambios mínimos de integración y UI: control del overlay/botón BINGO, gestión de suscripciones a `manualBingoCantos`, y marca de canto procesado para evitar dobles notificaciones (archivos modificados: `public/cantarsorteos.html`, `public/juegoactivo.html`).

### Testing

- Ejecuté las pruebas automatizadas con `npm test -- --runInBand` y todas las suites pasaron (11 suites, 35 tests en verde).
- Validación automática de la UI local mediante un servidor estático y captura con script Playwright que navegó a `public/cantarsorteos.html` y generó un screenshot exitoso.
- Se realizaron commits y se creó el PR con estos cambios; los tests automatizados no mostraron fallos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3a4240f1c832696695b86f2e8ef56)