### PR TITLE
Evita reiniciar cantos manuales activos y fusiona candidatos faltantes

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -4587,18 +4587,79 @@
   async function iniciarCantoManual(candidatos = []){
     if(!currentSorteoId || !candidatos.length) return;
     const cantoNumero = cantosOrdenados[cantosOrdenados.length - 1] || null;
-    const payload = {
-      sorteoId: currentSorteoId,
-      activo: true,
-      modo: 'manual',
-      cantoNumero,
-      candidatos,
-      cantados: [],
-      resultado: null,
-      actualizadoEn: firebase.firestore.FieldValue.serverTimestamp()
+    const docRef = db.collection('manualBingoCantos').doc(currentSorteoId);
+    const normalizadosEntrantes = new Map();
+    candidatos.forEach(item=>{
+      const key = normalizarClaveManual(item?.key || item?.userId || item?.email || item?.alias || item?.cartonId);
+      if(!key || normalizadosEntrantes.has(key)) return;
+      normalizadosEntrantes.set(key, {
+        ...item,
+        key
+      });
+    });
+    const mergearCandidatos = (existentes = [], entrantes = [])=>{
+      const combinados = new Map();
+      existentes.forEach(item=>{
+        const key = normalizarClaveManual(item?.key || item?.userId || item?.email || item?.alias || item?.cartonId);
+        if(!key || combinados.has(key)) return;
+        combinados.set(key, { ...item, key });
+      });
+      entrantes.forEach(item=>{
+        const key = normalizarClaveManual(item?.key || item?.userId || item?.email || item?.alias || item?.cartonId);
+        if(!key) return;
+        const previo = combinados.get(key) || {};
+        combinados.set(key, {
+          ...previo,
+          ...item,
+          key,
+          alias: item?.alias || previo?.alias || 'Jugador'
+        });
+      });
+      return Array.from(combinados.values());
     };
     try {
-      await db.collection('manualBingoCantos').doc(currentSorteoId).set(payload, { merge: true });
+      await db.runTransaction(async transaction=>{
+        const snapshot = await transaction.get(docRef);
+        const firestoreData = snapshot.exists ? (snapshot.data() || {}) : null;
+        const existeActivoFirestore = firestoreData?.activo === true;
+        const existeActivoLocal = manualCantoActivo?.activo === true;
+        const candidatosEntrantes = Array.from(normalizadosEntrantes.values());
+        if(existeActivoFirestore || existeActivoLocal){
+          const baseCandidatos = Array.isArray(firestoreData?.candidatos)
+            ? firestoreData.candidatos
+            : (Array.isArray(manualCantoActivo?.candidatos) ? manualCantoActivo.candidatos : []);
+          const candidatosFusionados = mergearCandidatos(baseCandidatos, candidatosEntrantes);
+          const cantoActivo = firestoreData?.cantoNumero ?? manualCantoActivo?.cantoNumero ?? null;
+          const mismoCanto = Number.isFinite(Number(cantoActivo)) && Number.isFinite(Number(cantoNumero))
+            ? Number(cantoActivo) === Number(cantoNumero)
+            : cantoActivo === cantoNumero;
+          console.info('Canto manual ya activo: se conserva estado y solo se fusionan candidatos faltantes.', {
+            sorteoId: currentSorteoId,
+            cantoNumeroSolicitado: cantoNumero,
+            cantoNumeroActivo: cantoActivo,
+            mismoCanto,
+            candidatosPrevios: baseCandidatos.length,
+            candidatosEntrantes: candidatosEntrantes.length,
+            candidatosFusionados: candidatosFusionados.length
+          });
+          transaction.set(docRef, {
+            sorteoId: currentSorteoId,
+            candidatos: candidatosFusionados,
+            actualizadoEn: firebase.firestore.FieldValue.serverTimestamp()
+          }, { merge: true });
+          return;
+        }
+        transaction.set(docRef, {
+          sorteoId: currentSorteoId,
+          activo: true,
+          modo: 'manual',
+          cantoNumero,
+          candidatos: candidatosEntrantes,
+          cantados: [],
+          resultado: null,
+          actualizadoEn: firebase.firestore.FieldValue.serverTimestamp()
+        }, { merge: true });
+      });
     } catch (error) {
       console.error('No se pudo iniciar el canto manual.', error);
     }


### PR DESCRIPTION
### Motivation
- Evitar que la apertura de un nuevo canto manual sobrescriba o reinicie el estado de un canto ya activo en Firestore, manteniendo `cantados`, `resultado` y `historialPorCanto` intactos y haciendo la operación idempotente.

### Description
- Refactoricé `iniciarCantoManual` para leer el documento `manualBingoCantos/{currentSorteoId}` dentro de una transacción y comprobar tanto el estado local (`manualCantoActivo?.activo`) como el de Firestore antes de crear un nuevo canto.
- Normalicé y deduplicé los candidatos entrantes y añadí una función `mergearCandidatos` que fusiona candidatos existentes y entrantes sin perder datos previos. 
- Si se detecta un canto manual activo, ahora solo se fusionan candidatos faltantes y no se resetean `cantados`, `resultado` ni `historialPorCanto`; además se registra con `console.info` un evento informativo con contexto.
- La operación quedó idempotente para el mismo `cantoNumero`, porque conserva el estado activo existente y limita la modificación a la fusión de candidatos.

### Testing
- Se aplicó y verificó el parche en `public/cantarsorteos.html` y se inspeccionó el diff resultante para confirmar las inserciones/ediciones esperadas.
- Se ejecutó la verificación de diferencias con `git diff --check` y no se reportaron errores en el cambio aplicado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3baa7d8048326a3d4117f427b258f)