### PR TITLE
Ajusta visibilidad del botón de bingo manual según cantados

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4801,8 +4801,11 @@
     }
     const key = obtenerClaveManualUsuarioActual();
     const candidatos = Array.isArray(manualBingoEstado?.candidatos) ? manualBingoEstado.candidatos : [];
+    const cantados = new Set(Array.isArray(manualBingoEstado?.cantados) ? manualBingoEstado.cantados : []);
     const esCandidato = candidatos.some(item=>normalizarClaveManual(item?.key || item?.userId || item?.email || item?.alias || item?.cartonId) === key);
-    if(esCandidato){
+    const yaCantado = key ? cantados.has(key) : false;
+    const mostrarBoton = usuarioPendienteConfirmacionManual() && esCandidato && !yaCantado;
+    if(mostrarBoton){
       manualBingoOverlayEl.style.display = 'flex';
       cerrarModalSegundoLugar();
       cerrarModalSinPremio();


### PR DESCRIPTION
### Motivation
- Evitar que un jugador candidato vea el overlay/botón de bingo manual si ya registró su canto en `manualBingoEstado.cantados`. 
- Alinear la regla de visibilidad del botón con la lógica que pausa mensajes mediante `usuarioPendienteConfirmacionManual()`.

### Description
- En `actualizarUiManualBingo()` se construye `cantados` como `Set` a partir de `manualBingoEstado.cantados` para búsquedas rápidas. 
- Se añadió el cálculo de `yaCantado` y la variable `mostrarBoton` condicionada a `usuarioPendienteConfirmacionManual() && esCandidato && !yaCantado`. 
- Si `mostrarBoton` es falso se llama a `ocultarBotonManualBingo()` para ocultar el overlay y evitar mostrar el botón.

### Testing
- Ejecuté `git diff -- public/juegoactivo.html` para revisar el diff aplicado y la salida coincide con el cambio esperado. 
- Inspeccioné las líneas relevantes con `nl -ba public/juegoactivo.html | sed -n '4792,4822p'` para confirmar que `cantados`, `yaCantado` y la condición `mostrarBoton` están presentes y correctas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3bc5537f4832694004c96ab9fb3dc)