### PR TITLE
Mover botón de cierre al borde superior derecho del modal de seguimiento de canto

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -795,6 +795,7 @@
       box-sizing: border-box;
       background: rgba(8,16,32,0.82);
       z-index: 1700;
+      position: relative;
     }
     .modal.modal-nuevos-ganadores.activa {
       display: flex;
@@ -849,6 +850,29 @@
       display: flex;
       flex-direction: column;
       gap: 14px;
+    }
+    #nuevos-ganadores-cerrar {
+      position: absolute;
+      top: max(8px, env(safe-area-inset-top));
+      right: max(8px, env(safe-area-inset-right));
+      width: 42px;
+      height: 42px;
+      border: none;
+      border-radius: 999px;
+      background: rgba(255,255,255,0.95);
+      color: #243b6a;
+      font-size: 1.4rem;
+      line-height: 1;
+      cursor: pointer;
+      box-shadow: 0 8px 18px rgba(0,0,0,0.28);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 2;
+    }
+    #nuevos-ganadores-cerrar:hover {
+      transform: scale(1.05);
+      background: #fff;
     }
     #nuevos-ganadores-titulo {
       font-family: 'Bangers', cursive;
@@ -1733,8 +1757,8 @@
     </div>
   </div>
   <div id="nuevos-ganadores-modal" class="modal modal-nuevos-ganadores" role="dialog" aria-modal="true" aria-labelledby="nuevos-ganadores-titulo" aria-hidden="true">
+    <button id="nuevos-ganadores-cerrar" class="modal-cerrar" type="button" aria-label="Ocultar">✖</button>
     <div class="modal-contenido" role="document">
-      <button id="nuevos-ganadores-cerrar" class="modal-cerrar" type="button" aria-label="Ocultar">✖</button>
       <h2 id="nuevos-ganadores-titulo">SEGUIMIENTO DE CANTO MANUAL</h2>
       <div id="nuevos-ganadores-resumen"></div>
       <div id="nuevos-ganadores-contador" aria-live="polite"></div>


### PR DESCRIPTION
### Motivation
- Ajustar la posición de la “X” de cierre en el modal de seguimiento de canto manual para que quede en la esquina superior derecha del contenedor del modal y no dentro del contenido, mejorando la usabilidad sin afectar otros modales.

### Description
- Modifiqué `public/cantarsorteos.html` para sacar el botón de cierre `#nuevos-ganadores-cerrar` fuera de `.modal-contenido` y colocarlo como hijo directo de `#nuevos-ganadores-modal`.
- Añadí `position: relative;` al selector de la ventana del modal y estilos nuevos para `#nuevos-ganadores-cerrar` (posicionamiento absoluto, tamaño, fondo, hover y `z-index`) para fijar la X en la esquina superior derecha.
- Mantuvé intacto el contenido interno del modal (`.modal-contenido`) y no toqué otros modales ni su comportamiento funcional.

### Testing
- Revisé el diff del archivo modificado con `git diff -- public/cantarsorteos.html` y verifiqué que los cambios se limiten a `public/cantarsorteos.html` (éxito).
- Levanté un servidor local con `python -m http.server 4173` y confirmé que la página `public/cantarsorteos.html` se sirve correctamente (éxito).
- Ejecuté un script con Playwright que abre la página, fuerza la apertura del modal y genera una captura de pantalla para validar visualmente la nueva posición de la `✖` (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e8e7967083269185e2b8b41fbb08)