### PR TITLE
Corregir flujo de sorteo manual y añadir 'Segundos para cierre Cantos' en configuración

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -4529,12 +4529,17 @@
       if(doc.exists){
         const data = doc.data() || {};
         const candidatos = [
+          data.segundosCierreCantos,
+          data.segundosParaCierreCantos,
+          data.cierreCantosSegundos,
           data.duracionCantoManualSegundos,
           data.tiempoCantoManualSegundos,
           data.manualBingoDuracionSegundos
         ];
-        const detectado = candidatos.find(valor=>Number.isFinite(Number(valor)) && Number(valor) > 0);
-        duracionCantoManualSegundos = detectado ? Math.max(5, Math.floor(Number(detectado))) : DURACION_CANTO_MANUAL_SEGUNDOS_FALLBACK;
+        const detectado = candidatos.find(valor=>Number.isFinite(Number(valor)) && Number(valor) >= 0);
+        duracionCantoManualSegundos = detectado !== undefined
+          ? Math.max(0, Math.floor(Number(detectado)))
+          : DURACION_CANTO_MANUAL_SEGUNDOS_FALLBACK;
         return;
       }
     } catch (error) {
@@ -4545,16 +4550,24 @@
 
   function actualizarContadorManualCanto(payload = manualCantoActivo){
     if(!nuevosGanadoresContadorEl) return;
+    const duracionSegundos = Math.max(0, Math.floor(Number(payload?.duracionSegundos) || 0));
+    const sinExpiracionAutomatica = duracionSegundos === 0;
     const abiertoMs = resolverMillisFechaFirestore(payload?.abiertoEn);
-    const duracionMs = Math.max(1000, Math.floor(Number(payload?.duracionSegundos) || duracionCantoManualSegundos) * 1000);
-    const expiraMs = resolverMillisFechaFirestore(payload?.expiraEn) || (Number.isFinite(abiertoMs) ? (abiertoMs + duracionMs) : null);
+    const duracionMs = duracionSegundos > 0 ? (duracionSegundos * 1000) : null;
+    const expiraMs = resolverMillisFechaFirestore(payload?.expiraEn)
+      || ((Number.isFinite(abiertoMs) && Number.isFinite(duracionMs)) ? (abiertoMs + duracionMs) : null);
     if(!payload?.activo){
       nuevosGanadoresContadorEl.textContent = '';
       nuevosGanadoresContadorEl.classList.remove('expirado');
       return;
     }
+    if(sinExpiracionAutomatica){
+      nuevosGanadoresContadorEl.textContent = 'Cierre manual: esperando confirmaciones del administrador.';
+      nuevosGanadoresContadorEl.classList.remove('expirado');
+      return;
+    }
     if(!expiraMs){
-      nuevosGanadoresContadorEl.textContent = `Tiempo manual: ${duracionCantoManualSegundos}s`;
+      nuevosGanadoresContadorEl.textContent = `Tiempo manual: ${duracionSegundos}s`;
       nuevosGanadoresContadorEl.classList.remove('expirado');
       return;
     }
@@ -4584,8 +4597,10 @@
 
   function manualCantoEstaExpirado(payload = manualCantoActivo){
     if(!payload?.activo) return false;
+    const duracionSegundos = Math.max(0, Math.floor(Number(payload?.duracionSegundos) || 0));
+    if(duracionSegundos === 0) return false;
     const abiertoMs = resolverMillisFechaFirestore(payload?.abiertoEn);
-    const duracionMs = Math.max(1000, Math.floor(Number(payload?.duracionSegundos) || duracionCantoManualSegundos) * 1000);
+    const duracionMs = duracionSegundos * 1000;
     const expiraMs = resolverMillisFechaFirestore(payload?.expiraEn) || (Number.isFinite(abiertoMs) ? (abiertoMs + duracionMs) : null);
     return Number.isFinite(expiraMs) && expiraMs <= Date.now();
   }
@@ -4640,14 +4655,8 @@
   function renderResumenDiagnosticoManual(payload = {}){
     if(!nuevosGanadoresDiagnosticoEl) return;
     const resumen = obtenerResumenDiagnosticoManual(payload);
-    nuevosGanadoresDiagnosticoEl.textContent = [
-      `Sorteo: ${resumen.sorteoId}`,
-      `Canto: ${resumen.cantoNumero ?? '-'}`,
-      `Estado: ${resumen.estado}`,
-      `Candidatos: ${resumen.cantidadCandidatos}`,
-      `Confirmados: ${resumen.cantidadConfirmados}`,
-      `Duración(ms): ${Number.isFinite(resumen.duracionMs) ? resumen.duracionMs : '-'}`
-    ].join(' · ');
+    const pendientes = Math.max(0, Number(resumen.cantidadCandidatos || 0) - Number(resumen.cantidadConfirmados || 0));
+    nuevosGanadoresDiagnosticoEl.textContent = `Confirmados: ${resumen.cantidadConfirmados} · Pendientes: ${pendientes}`;
   }
 
   async function registrarEventoManualBingo({
@@ -4947,6 +4956,7 @@
           return;
         }
         aperturaRealizada = true;
+        const tieneCierreAutomatico = duracionCantoManualSegundos > 0;
         transaction.set(docRef, {
           sorteoId: currentSorteoId,
           activo: true,
@@ -4956,7 +4966,7 @@
           cantados: [],
           resultado: null,
           abiertoEn: firebase.firestore.FieldValue.serverTimestamp(),
-          expiraEn: firebase.firestore.Timestamp.fromMillis(Date.now() + (duracionCantoManualSegundos * 1000)),
+          expiraEn: tieneCierreAutomatico ? firebase.firestore.Timestamp.fromMillis(Date.now() + (duracionCantoManualSegundos * 1000)) : null,
           duracionSegundos: duracionCantoManualSegundos,
           actualizadoEn: firebase.firestore.FieldValue.serverTimestamp()
         }, { merge: true });

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -767,6 +767,43 @@
     .live-link-actions button:hover {
       transform: scale(1.02);
     }
+
+    .cierre-cantos-row {
+      margin-top: 10px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .cierre-cantos-input {
+      width: 74px;
+      min-height: 34px;
+      border-radius: 8px;
+      border: 1px solid #6b7280;
+      padding: 6px 8px;
+      box-sizing: border-box;
+      font-family: Calibri, Arial, sans-serif;
+      font-size: 0.82rem;
+      color: #374151;
+      background: #f9fafb;
+    }
+    .cierre-cantos-input:focus {
+      outline: 2px solid rgba(107,114,128,0.35);
+    }
+    .cierre-cantos-btn {
+      font-family: Calibri, Arial, sans-serif;
+      font-size: 0.8rem;
+      padding: 6px 14px;
+      border-radius: 6px;
+      border: 1px solid #6b7280;
+      background: #9ca3af;
+      color: #ffffff;
+      cursor: pointer;
+      transition: transform 0.2s ease;
+    }
+    .cierre-cantos-btn:hover {
+      transform: scale(1.02);
+    }
     @media (orientation: portrait) {
       #asignacion-usuarios-section {
         margin: 4px 0;
@@ -1200,6 +1237,12 @@
     <div class="whatsapp-actions">
       <button type="button" id="guardar-link-whatsapp">Guardar</button>
     </div>
+
+    <label for="segundos-cierre-cantos">Segundos para cierre Cantos</label>
+    <div class="cierre-cantos-row">
+      <input type="text" id="segundos-cierre-cantos" class="cierre-cantos-input" inputmode="numeric" pattern="[0-9]*" maxlength="4" placeholder="0">
+      <button type="button" id="guardar-segundos-cierre-cantos" class="cierre-cantos-btn">Guardar</button>
+    </div>
     <div class="publicidad-bloque" aria-labelledby="publicidad-sorteos-titulo">
       <p id="publicidad-sorteos-titulo" class="publicidad-titulo">Links de publicidad en Sorteos</p>
       <div class="publicidad-campos">
@@ -1451,6 +1494,8 @@
     const etiquetaNumeroWhatsapp=document.getElementById('numero-whatsapp-label');
     const campoLinkWhatsapp=document.getElementById('link-whatsapp');
     const botonGuardarLink=document.getElementById('guardar-link-whatsapp');
+    const campoSegundosCierreCantos=document.getElementById('segundos-cierre-cantos');
+    const botonGuardarSegundosCierreCantos=document.getElementById('guardar-segundos-cierre-cantos');
     const campoLinkPublicidadSorteos=document.getElementById('link-publicidad-sorteos');
     const campoLinkPublicidadSorteosDos=document.getElementById('link-publicidad-sorteos-2');
     const botonGuardarLinksPublicidad=document.getElementById('guardar-links-publicidad-sorteos');
@@ -1818,6 +1863,10 @@
           if(linkGuardado){
             campoLinkWhatsapp.value=linkGuardado;
           }
+          const segundosCierre = Number(data.segundosCierreCantos ?? data.segundosParaCierreCantos ?? data.cierreCantosSegundos ?? data.duracionCantoManualSegundos ?? data.tiempoCantoManualSegundos ?? data.manualBingoDuracionSegundos ?? 0);
+          if(campoSegundosCierreCantos){
+            campoSegundosCierreCantos.value = Number.isFinite(segundosCierre) && segundosCierre >= 0 ? String(Math.floor(segundosCierre)) : '0';
+          }
           const linkPublicidadPrimario=(data.linkPublicidadSorteos1??data.linkPublicidadSorteos??data.linkpublicidadsorteos??data.linkPublicidad??'').toString();
           const linkPublicidadSecundario=(data.linkPublicidadSorteos2??data.linkpublicidadsorteos2??data.linkPublicidad2??'').toString();
           if(linkPublicidadPrimario){
@@ -1907,7 +1956,41 @@
       botonGuardarNumeros.addEventListener('click',guardarListadoWhatsapp);
     }
 
-    botonGuardarLink.addEventListener('click',async ()=>{
+
+    if(campoSegundosCierreCantos){
+      campoSegundosCierreCantos.addEventListener('input',()=>{
+        campoSegundosCierreCantos.value=(campoSegundosCierreCantos.value||'').replace(/\D/g,'').slice(0,4);
+      });
+    }
+    if(botonGuardarSegundosCierreCantos){
+      botonGuardarSegundosCierreCantos.addEventListener('click',async ()=>{
+        const valorLimpio=(campoSegundosCierreCantos?.value||'').replace(/\D/g,'');
+        const segundos=valorLimpio===''?0:Math.max(0,Math.floor(Number(valorLimpio)||0));
+        const confirmar=await confirm('¿Deseas guardar los segundos para cierre de cantos? Si guardas 0, el cierre será manual.');
+        if(!confirmar) return;
+        try {
+          await db.collection('Variablesglobales').doc('Parametros').set({
+            segundosCierreCantos:segundos,
+            segundosParaCierreCantos:segundos,
+            cierreCantosSegundos:segundos,
+            duracionCantoManualSegundos:segundos,
+            tiempoCantoManualSegundos:segundos,
+            manualBingoDuracionSegundos:segundos
+          },{merge:true});
+          if(campoSegundosCierreCantos){
+            campoSegundosCierreCantos.value=String(segundos);
+          }
+          alert(segundos===0
+            ? 'Configuración guardada. El cierre de cantos será manual.'
+            : 'Configuración guardada correctamente.');
+        } catch(err){
+          console.error('No se pudo guardar los segundos para cierre de cantos',err);
+          alert('Ocurrió un error al guardar los segundos de cierre de cantos. Inténtalo nuevamente.');
+        }
+      });
+    }
+
+        botonGuardarLink.addEventListener('click',async ()=>{
       const valor=campoLinkWhatsapp.value.trim();
       if(!valor){
         alert('El campo link de WhatsApp no puede estar vacío');

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4654,8 +4654,10 @@
   let manualBingoPerdioEl = null;
   let manualBingoContadorEl = null;
   let manualBingoContadorIntervalo = null;
+  let manualConfirmacionLocalPendiente = false;
   let ultimoCantoPerdidoMostrado = null;
   let manualResultadosProcesados = new Set();
+  let manualCelebracionesMostradas = new Set();
 
   function normalizarClaveManual(valor){
     return (valor || '').toString().trim().toLowerCase().replace(/[^a-z0-9]+/g, '_');
@@ -4691,13 +4693,23 @@
 
   function actualizarContadorManualBingo(){
     if(!manualBingoContadorEl) return;
-    if(!manualBingoEstado?.activo || !esModoManualActivo()){
+    if(!manualBingoEstado?.activo || !esModoManualActivo() || manualConfirmacionLocalPendiente){
+      manualBingoContadorEl.style.display = 'none';
+      manualBingoContadorEl.textContent = '';
+      return;
+    }
+    if(!usuarioPendienteConfirmacionManual()){
       manualBingoContadorEl.style.display = 'none';
       manualBingoContadorEl.textContent = '';
       return;
     }
     const abiertoMs = resolverMillisDesdeFirestore(manualBingoEstado?.abiertoEn);
-    const duracionSegundos = Math.max(1, Math.floor(Number(manualBingoEstado?.duracionSegundos) || 20));
+    const duracionSegundos = Math.max(0, Math.floor(Number(manualBingoEstado?.duracionSegundos) || 0));
+    if(duracionSegundos === 0){
+      manualBingoContadorEl.textContent = '⏳ Canto manual activo · esperando cierre del administrador';
+      manualBingoContadorEl.style.display = 'block';
+      return;
+    }
     const expiraMs = resolverMillisDesdeFirestore(manualBingoEstado?.expiraEn) || (Number.isFinite(abiertoMs) ? (abiertoMs + (duracionSegundos * 1000)) : null);
     if(!expiraMs){
       manualBingoContadorEl.textContent = `⏳ Canto manual activo · ${duracionSegundos}s`;
@@ -4738,7 +4750,7 @@
   function usuarioConfirmoManual(resultado = obtenerResumenResultadoManual()) {
     if(!resultado) return false;
     const key = obtenerClaveManualUsuarioActual();
-    const confirmados = new Set(Array.isArray(resultado?.confirmados) ? resultado.confirmados : []);
+    const confirmados = new Set((Array.isArray(resultado?.confirmados) ? resultado.confirmados : []).map(normalizarClaveManual).filter(Boolean));
     return key ? confirmados.has(key) : false;
   }
 
@@ -4749,7 +4761,7 @@
     const candidatos = Array.isArray(manualBingoEstado?.candidatos) ? manualBingoEstado.candidatos : [];
     const esCandidato = candidatos.some(item=>normalizarClaveManual(item?.key || item?.userId || item?.email || item?.alias || item?.cartonId) === key);
     if(!esCandidato) return false;
-    const cantados = new Set(Array.isArray(manualBingoEstado?.cantados) ? manualBingoEstado.cantados : []);
+    const cantados = new Set((Array.isArray(manualBingoEstado?.cantados) ? manualBingoEstado.cantados : []).map(normalizarClaveManual).filter(Boolean));
     return !cantados.has(key);
   }
 
@@ -4774,9 +4786,9 @@
     });
     const salida = [];
     unicos.forEach((item, cantoNumero)=>{
-      const confirmados = new Set(Array.isArray(item?.confirmados) ? item.confirmados : []);
-      const candidatos = new Set(Array.isArray(item?.candidatos) ? item.candidatos : []);
-      const noConfirmados = new Set(Array.isArray(item?.noConfirmados) ? item.noConfirmados : []);
+      const confirmados = new Set((Array.isArray(item?.confirmados) ? item.confirmados : []).map(normalizarClaveManual).filter(Boolean));
+      const candidatos = new Set((Array.isArray(item?.candidatos) ? item.candidatos : []).map(normalizarClaveManual).filter(Boolean));
+      const noConfirmados = new Set((Array.isArray(item?.noConfirmados) ? item.noConfirmados : []).map(normalizarClaveManual).filter(Boolean));
       const participa = confirmados.has(key) || noConfirmados.has(key) || candidatos.has(key);
       if(!participa) return;
       salida.push({
@@ -4800,7 +4812,7 @@
   }
 
   function debePausarMensajesPorManual(){
-    return usuarioPendienteConfirmacionManual();
+    return usuarioPendienteConfirmacionManual() || usuarioConfirmoManual();
   }
 
   function asegurarUiManualBingo(){
@@ -4863,7 +4875,7 @@
         actualizadoEn: firebase.firestore.FieldValue.serverTimestamp()
       }, { merge: true });
       const candidatos = Array.isArray(manualBingoEstado?.candidatos) ? manualBingoEstado.candidatos : [];
-      const cantados = Array.isArray(manualBingoEstado?.cantados) ? manualBingoEstado.cantados : [];
+      const cantados = (Array.isArray(manualBingoEstado?.cantados) ? manualBingoEstado.cantados : []).map(normalizarClaveManual).filter(Boolean);
       const abiertosMs = manualBingoEstado?.abiertoEn?.toMillis ? manualBingoEstado.abiertoEn.toMillis() : null;
       await registrarEventoManualBingoJugador({
         eventType: 'player_confirmed',
@@ -4872,6 +4884,8 @@
         cantidadCandidatos: candidatos.length,
         cantidadConfirmados: cantados.length + 1
       });
+      manualConfirmacionLocalPendiente = true;
+      actualizarContadorManualBingo();
       setTimeout(()=>{
         ocultarBotonManualBingo();
         manualBingoBtnEl.src = 'img/boton-bingo.png';
@@ -4905,7 +4919,7 @@
     }
     const key = obtenerClaveManualUsuarioActual();
     const candidatos = Array.isArray(manualBingoEstado?.candidatos) ? manualBingoEstado.candidatos : [];
-    const cantados = new Set(Array.isArray(manualBingoEstado?.cantados) ? manualBingoEstado.cantados : []);
+    const cantados = new Set((Array.isArray(manualBingoEstado?.cantados) ? manualBingoEstado.cantados : []).map(normalizarClaveManual).filter(Boolean));
     const esCandidato = candidatos.some(item=>normalizarClaveManual(item?.key || item?.userId || item?.email || item?.alias || item?.cartonId) === key);
     const yaCantado = key ? cantados.has(key) : false;
     const mostrarBoton = usuarioPendienteConfirmacionManual() && esCandidato && !yaCantado;
@@ -4930,7 +4944,7 @@
     const key = normalizarClaveManual(usuarioActual?.uid || usuarioActual?.email || '');
     const candidatos = new Set((Array.isArray(previo?.candidatos) ? previo.candidatos : []).map(item=>normalizarClaveManual(item?.key || item?.userId || item?.email || item?.alias)).filter(Boolean));
     if(!key || !candidatos.has(key)) return;
-    const confirmados = new Set(Array.isArray(resultado?.confirmados) ? resultado.confirmados : (Array.isArray(previo?.cantados) ? previo.cantados : []));
+    const confirmados = new Set((Array.isArray(resultado?.confirmados) ? resultado.confirmados : (Array.isArray(previo?.cantados) ? previo.cantados : [])).map(normalizarClaveManual).filter(Boolean));
     if(confirmados.has(key)){
       const detallesConfirmados = Array.isArray(resultado?.formasPorUsuario?.[key]) ? resultado.formasPorUsuario[key] : [];
       if(detallesConfirmados.length && modalCelebracionEl && !celebracionModalActiva){
@@ -4966,11 +4980,16 @@
       if(previo?.activo && !manualBingoEstado?.activo){
         procesarResultadoCantoManualCerrado(previo, manualBingoEstado);
         const key = normalizarClaveManual(usuarioActual?.uid || usuarioActual?.email || '');
-        const cantados = new Set(Array.isArray(previo?.cantados) ? previo.cantados : []);
+        const cantados = new Set((Array.isArray(previo?.cantados) ? previo.cantados : []).map(normalizarClaveManual).filter(Boolean));
         if(!cantados.has(key) && ultimoCantoPerdidoMostrado !== previo?.cantoNumero){
           ultimoCantoPerdidoMostrado = previo?.cantoNumero;
           mostrarAvisoBingoPerdido(previo?.cantoNumero);
         }
+      }
+      const keyActual = normalizarClaveManual(usuarioActual?.uid || usuarioActual?.email || '');
+      const cantadosActuales = new Set((Array.isArray(manualBingoEstado?.cantados) ? manualBingoEstado.cantados : []).map(normalizarClaveManual).filter(Boolean));
+      if(!manualBingoEstado?.activo || (keyActual && cantadosActuales.has(keyActual))){
+        manualConfirmacionLocalPendiente = false;
       }
       actualizarUiManualBingo();
     }, err=>console.error('Error escuchando manualBingoCantos', err));
@@ -9842,7 +9861,11 @@
         }
       });
       if(detallesManual.length){
-        mostrarModalCelebracionGanador(detallesManual, false);
+        const llaveHistorial = detallesManual.map(item=>`${item.perdido?'p':'g'}-${item.idx}-${item.cartonLabel || ''}-${item.nombre || ''}`).join('|');
+        if(!manualCelebracionesMostradas.has(llaveHistorial)){
+          manualCelebracionesMostradas.add(llaveHistorial);
+          mostrarModalCelebracionGanador(detallesManual, false);
+        }
       }
       return;
     }
@@ -11186,6 +11209,9 @@
       suscribirSimulacionSorteo(null);
       if(manualBingoUnsub){ manualBingoUnsub(); manualBingoUnsub = null; }
       manualBingoEstado = null;
+      manualConfirmacionLocalPendiente = false;
+      manualResultadosProcesados.clear();
+      manualCelebracionesMostradas.clear();
       ocultarBotonManualBingo();
       if(sorteoManualSeleccionadoId && activeSorteoId===sorteoManualSeleccionadoId && activeSorteo){
         actualizarHeader();
@@ -11224,6 +11250,9 @@
     if(cambio){
       reiniciarAlertaFormasSinGanadores();
       reiniciarNotificacionesPremios();
+      manualConfirmacionLocalPendiente = false;
+      manualResultadosProcesados.clear();
+      manualCelebracionesMostradas.clear();
       todasFormasConGanadores=false;
       indiceUltimoGanador=null;
       cantosComplementariosActivos=false;


### PR DESCRIPTION
### Motivation
- Evitar que jugadores vean ventanas de papelillos, contadores o mensajes de transparencia cuando no son candidatos pendientes en la modalidad MANUAL; el contador y UI deben mostrarse solo a jugadores que deben confirmar BINGO.
- Permitir al administrador configurar el comportamiento del cierre automático de cantos mediante un campo que defina segundos (incluyendo la opción 0 para cierre manual).
- Corregir inconsistencias de identificación de usuarios (claves) para evitar notificaciones/celebraciones repetidas o erróneas.

### Description
- Añadí soporte para un nuevo parámetro configurable "Segundos para cierre Cantos" en la pantalla de Configuraciones con input numérico y botón gris, lectura/guardado en `Variablesglobales/Parametros` (claves compatibles: `segundosCierreCantos`, `segundosParaCierreCantos`, `cierreCantosSegundos` y aliases legacy). (archivo: `public/configuraciones.html`).
- Modifiqué la lógica del canto manual para que: el contador de jugador (overlay BINGO) solo se muestre si el usuario es candidato pendiente; al confirmar con BINGO el contador se oculta y se marca un estado local para evitar reapariciones; si el parámetro de segundos es `0` no se establece expiración automática (espera cierre manual), si >0 se usa contador regresivo y cierre automático por expiración. (archivo: `public/cantarsorteos.html` y `public/juegoactivo.html`).
- Normalicé las claves de usuario en candidatos/confirmados/noConfirmados/historial usando `normalizarClaveManual` para evitar falsos positivos de identidad y actualicé deduplicación para evitar reabrir modal de celebración (papelillos) en el mismo estado repetidas veces. (archivo: `public/juegoactivo.html`).
- Simplifiqué el texto diagnóstico mostrado al administrador en la ventana de nuevos ganadores para mostrar solo Confirmados y Pendientes en lugar de datos internos/ID del sorteo. (archivo: `public/cantarsorteos.html`).

### Testing
- Ejecuté la suite de pruebas con Jest: `npm test -- --runInBand` y todas las pruebas pasaron (11 suites, 35 tests, status: PASS).
- Probé la UI estática del formulario de Configuraciones iniciando un servidor local y generando captura (`http.server` + Playwright) para verificar presencia y estilos del nuevo campo; la captura se produjo correctamente.
- Validé manualmente la escucha/actualización de estados de `manualBingoCantos` e interacciones del jugador (confirmación BINGO, ocultado de contador y bloqueo de repeticiones) mediante ejecución local del frontend.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f693a1cc832691a6e03039d7ef6a)