### PR TITLE
Corrige acreditación de recargas aprobadas desde solicitudes

### DIFF
--- a/public/js/internalTransactionNotifier.js
+++ b/public/js/internalTransactionNotifier.js
@@ -173,7 +173,9 @@
           const transitoActual=Math.max(0,this.toNumberSafe(billeteraData.creditostransito,0));
           const payload={};
           if(tipo==='recarga'){
-            payload.creditos=creditosActual+monto;
+            if(data.acreditacionAplicada!==true){
+              payload.creditos=creditosActual+monto;
+            }
           }else if(tipo==='retiro'){
             payload.creditos=Math.max(0,creditosActual-montoSolicitado);
             payload.creditostransito=Math.max(0,transitoActual-montoSolicitado);

--- a/public/transacciones.html
+++ b/public/transacciones.html
@@ -704,6 +704,18 @@
           });
         }
 
+        if(billeteraId && estado==='APROBADO' && esRecarga && !estadoEsAprobado(data.estado)){
+          const billeteraRef=db.collection('Billetera').doc(billeteraId);
+          await db.runTransaction(async t=>{
+            const bdoc=await t.get(billeteraRef);
+            const billeteraData=bdoc.exists?(bdoc.data()||{}):{};
+            const montoTransaccion=toNumberSafe((data.Monto ?? data.MontoSolicitado),0);
+            const creditosActual=toNumberSafe(billeteraData.creditos,0);
+            t.set(billeteraRef,{ creditos: creditosActual+montoTransaccion },{merge:true});
+          });
+          upd.acreditacionAplicada=true;
+        }
+
         if(estado==='APROBADO' || estado==='ANULADO'){
           const mensajeInterno=await construirMensajeResultado({...data, referencia:ref||data.referencia||''},estado,nota);
           upd.notificacionInterna={


### PR DESCRIPTION
## Resumen
- se actualiza el flujo de aprobación en `public/transacciones.html` para que, al aprobar una recarga, se acrediten los créditos en `Billetera` dentro de una transacción de Firestore.
- se marca la transacción con `acreditacionAplicada: true` al completar esa acreditación.
- se ajusta `public/js/internalTransactionNotifier.js` para evitar una doble recarga al aceptar la notificación interna cuando `acreditacionAplicada` ya está en `true`.

## Problema que resuelve
Las recargas solicitadas quedaban en estado **APROBADO** en la tabla de transacciones, pero el saldo de créditos no se reflejaba en la billetera del jugador.

## Impacto esperado
- Al aprobar una solicitud de recarga desde la gestión de transacciones, el saldo se actualiza inmediatamente en la billetera.
- Se mantiene compatibilidad con el flujo de notificación interna sin duplicar créditos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b065b260ac83269b0bf3a9e5b27fd0)