### PR TITLE
Corregir visualización de ventana de cierre de canto en modo automático

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -4725,6 +4725,10 @@
 
   function mostrarModalNuevosGanadores(payload){
     if(!nuevosGanadoresModalEl || !nuevosGanadoresListaEl) return;
+    if(!esModoManual()){
+      cerrarModalNuevosGanadores();
+      return;
+    }
     manualCantoActivo = payload || null;
     if(payload && typeof payload === 'object'){
       manualCantoEstadoRemoto = payload;
@@ -4993,6 +4997,12 @@
     }
     if(!currentSorteoId) return;
     manualCantoUnsub = db.collection('manualBingoCantos').doc(currentSorteoId).onSnapshot(doc=>{
+      if(!esModoManual()){
+        manualCantoEstadoRemoto = doc.exists ? (doc.data() || { activo: false }) : { activo: false };
+        cerrarModalNuevosGanadores();
+        actualizarTablaEstado();
+        return;
+      }
       if(!doc.exists){
         manualCantoEstadoRemoto = { activo: false };
         cerrarModalNuevosGanadores();
@@ -5066,9 +5076,7 @@
     if(esPrimerProcesamiento || !nuevos.length) return;
     if(esModoManual()){
       iniciarCantoManual(Array.from(candidatosManual.values()));
-      return;
     }
-    mostrarModalNuevosGanadores({ candidatos: nuevos.map(item=>({ alias: `${item.nombre} (${item.total})`, key: `${item.nombre}-${item.total}` })), cantados: [] });
   }
 
   function buildPremioId({ sorteoId, formaIdx, cartonId, prefijo = '' } = {}){


### PR DESCRIPTION
## Resumen
- Ajusté la lógica en `public/cantarsorteos.html` para que la ventana/modal de seguimiento y cierre de canto manual solo se muestre cuando el sorteo está en **modo MANUAL**.
- Evité que en **modo AUTOMÁTICO** se abra o permanezca activa esa ventana.

## Cambios realizados
1. En `mostrarModalNuevosGanadores(payload)`:
   - Se agregó un guard clause con `esModoManual()`.
   - Si el modo no es manual, se cierra la ventana y se retorna.

2. En `suscribirCantoManual()`:
   - Al recibir snapshot, si el modo actual no es manual:
     - Se actualiza estado remoto básico.
     - Se cierra la ventana de nuevos ganadores/cierre de canto.
     - Se actualiza el estado de la tabla y se retorna sin renderizar modal.

3. En `revisarGanadoresNuevos(...)`:
   - Se eliminó el flujo que abría la ventana de nuevos ganadores en modo automático.
   - Se conserva la apertura/inicio de flujo manual únicamente bajo `esModoManual()`.

## Impacto esperado
- **Modo MANUAL:** mantiene el flujo de apertura/cierre de canto manual sin cambios funcionales relevantes.
- **Modo AUTOMÁTICO:** ya no muestra la ventana de cierre de canto manual, evitando interferencia con su flujo normal.

## Riesgo
- Bajo. Los cambios están encapsulados en validaciones de modo y no alteran estructura de datos ni contratos de Firestore.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b085fda7008326adc6721f8786efdb)