### PR TITLE
Agregar manifest PWA y metadatos móviles para instalación

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <link rel="manifest" href="/manifest.webmanifest">
   <link rel="apple-touch-icon" sizes="180x180" href="img/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="192x192" href="img/android-chrome-192x192.png">
   <link rel="icon" type="image/png" sizes="512x512" href="img/android-chrome-512x512.png">
@@ -10,6 +11,9 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#7a00cc">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-title" content="Bingo Online">
   <title>Login - Bingo Online</title>
   <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,21 @@
+{
+  "name": "Bingo Online",
+  "short_name": "Bingo",
+  "start_url": "/index.html",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#7a00cc",
+  "icons": [
+    {
+      "src": "/img/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/img/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/player.html
+++ b/public/player.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
+  <link rel="manifest" href="/manifest.webmanifest">
   <link rel="apple-touch-icon" sizes="180x180" href="img/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="192x192" href="img/android-chrome-192x192.png">
   <link rel="icon" type="image/png" sizes="512x512" href="img/android-chrome-512x512.png">
@@ -10,6 +11,9 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#7a00cc">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-title" content="Bingo Online">
   <title>Bingo Online</title>
   <!-- Fuentes -->
   <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">


### PR DESCRIPTION
### Motivation
- Habilitar que la aplicación sea instalable como PWA y ofrecer experiencia standalone en Android/Chrome y metadatos de soporte en iOS/Safari.
- Evitar que la app instalada arranque en rutas que requieran sesión activa configurando un `start_url` que lleve al flujo de login/inicio.
- Proveer los íconos necesarios y colores de tema para que el instalador muestre la app correctamente.

### Description
- Creé `public/manifest.webmanifest` con los campos `name`, `short_name`, `start_url`, `scope`, `display`, `background_color`, `theme_color` y los íconos PNG `192x192` y `512x512` apuntando a `/img/android-chrome-192x192.png` y `/img/android-chrome-512x512.png`.
- Añadí en `public/index.html` el enlace al manifest (`<link rel="manifest" href="/manifest.webmanifest">`) y las metaetiquetas móviles `theme-color`, `apple-mobile-web-app-capable` y `apple-mobile-web-app-title` manteniendo el `apple-touch-icon` existente.
- Apliqué las mismas adiciones de `manifest` y metaetiquetas en `public/player.html` para consistencia en las páginas de entrada de usuario.
- Configuré `start_url` como `/index.html` para que la app instalada abra en la pantalla de inicio/login y no en una ruta de sesión que pueda romper el flujo.

### Testing
- Validé que `public/manifest.webmanifest` sea JSON válido con `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('public/manifest.webmanifest','utf8')); console.log('manifest ok')"`, y la ejecución devolvió éxito.
- Verifiqué que los archivos modificados aparecen en el índice con `git status --short` y realicé el commit con `git commit`, ambos completados correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0cddb2b848326b68a7e9732ed2702)