### PR TITLE
Mejorar service worker con app-shell precache y fallback de navegación

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -122,6 +122,7 @@
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script src="js/timezone.js"></script>
+  <script src="js/serviceWorkerRegistration.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', async () => {
       if(typeof firebase === 'undefined'){

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,19 +1,46 @@
-const CACHE_VERSION = 'bingo-audio-v1';
+const CACHE_VERSION = 'v2';
+const APP_SHELL_CACHE = `bingo-app-shell-${CACHE_VERSION}`;
 const AUDIO_CACHE = `bingo-audio-runtime-${CACHE_VERSION}`;
 
+const APP_SHELL_URLS = [
+  '/',
+  '/index.html',
+  '/css/desktopFrame.css',
+  '/img/Logo-BingOnline-nuevo500p.png',
+  '/img/apple-touch-icon.png',
+  '/img/android-chrome-192x192.png',
+  '/img/android-chrome-512x512.png',
+  '/img/favicon.ico',
+  '/img/favicon-16x16.ico',
+  '/img/favicon-32x32.ico',
+];
+
 self.addEventListener('install', (event) => {
-  event.waitUntil(self.skipWaiting());
+  event.waitUntil(
+    caches
+      .open(APP_SHELL_CACHE)
+      .then((cache) => cache.addAll(APP_SHELL_URLS))
+      .catch(() => undefined)
+      .then(() => self.skipWaiting()),
+  );
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(
-        keys
-          .filter((key) => key.startsWith('bingo-audio-runtime-') && key !== AUDIO_CACHE)
-          .map((key) => caches.delete(key)),
-      ),
-    ).then(() => self.clients.claim()),
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter(
+              (key) =>
+                (key.startsWith('bingo-app-shell-') && key !== APP_SHELL_CACHE) ||
+                (key.startsWith('bingo-audio-runtime-') && key !== AUDIO_CACHE),
+            )
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
   );
 });
 
@@ -25,6 +52,25 @@ function isAudioRequest(request) {
 
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .then(async (networkResponse) => {
+          if (networkResponse && networkResponse.ok) {
+            const cache = await caches.open(APP_SHELL_CACHE);
+            cache.put(event.request, networkResponse.clone());
+          }
+          return networkResponse;
+        })
+        .catch(async () => {
+          const cache = await caches.open(APP_SHELL_CACHE);
+          return (await cache.match(event.request)) || (await cache.match('/index.html'));
+        }),
+    );
+    return;
+  }
+
   if (!isAudioRequest(event.request)) return;
 
   event.respondWith(


### PR DESCRIPTION
### Motivation
- Asegurar control temprano del service worker en la página principal y añadir una estrategia mínima de navegación offline sin afectar la caché de audio existente.
- Separar cachés por propósito y versionarlos para permitir limpieza segura de versiones antiguas.

### Description
- Agrega la carga de `js/serviceWorkerRegistration.js` en `public/index.html` para registrar el SW de forma temprana (igual que en `player.html` y `juegoactivo.html`).
- Reescribe `public/sw.js` para introducir dos cachés versionados: `bingo-app-shell-{version}` para recursos críticos y `bingo-audio-runtime-{version}` para audio, manteniendo la lógica de cacheo de audio existente.
- Añade un precache mínimo (`/`, `/index.html`, CSS principal, logo e iconos) durante el `install` en el app-shell.
- Implementa una estrategia `network-first` para solicitudes de navegación (`request.mode === 'navigate'`) con fallback a la versión cacheada de la página (incluye `/index.html`).
- Limpia versiones antiguas de ambos tipos de caché durante el `activate` sin tocar la lógica de audio en `fetch`.

### Testing
- Se validó la sintaxis de `public/sw.js` con `node --check public/sw.js` y no se reportaron errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0cf06ad7c8326a5750178e8d04ac4)