### PR TITLE
Refactoriza installPrompt con API reutilizable en vistas clave

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -195,5 +195,12 @@
   });
   </script>
   <script src="js/installPrompt.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      if (typeof window.initInstallPrompt === 'function') {
+        window.initInstallPrompt({ containerId: 'install-prompt-index', mode: 'banner' });
+      }
+    });
+  </script>
 </body>
 </html>

--- a/public/js/installPrompt.js
+++ b/public/js/installPrompt.js
@@ -4,12 +4,8 @@
     installed: 'installPromptInstalled',
     accepted: 'installPromptAccepted'
   };
-
   const DISMISS_DAYS = 7;
-  let deferredPrompt = null;
-  let ctaContainer = null;
-  let modal = null;
-  let iosHint = null;
+  const STYLE_ID = 'bo-install-prompt-style';
 
   function isStandalone() {
     return Boolean(
@@ -39,156 +35,168 @@
     localStorage.setItem(STORAGE_KEYS.dismissedUntil, String(until));
   }
 
-  function createUi() {
-    if (ctaContainer) return;
-
+  function ensureStyles() {
+    if (document.getElementById(STYLE_ID)) return;
     const style = document.createElement('style');
+    style.id = STYLE_ID;
     style.textContent = `
-      .install-cta-wrap{position:fixed;right:16px;bottom:16px;z-index:9999;display:none}
-      .install-cta-btn{padding:10px 14px;border:none;border-radius:999px;background:#7a00cc;color:#fff;font-weight:700;cursor:pointer;box-shadow:0 8px 24px rgba(0,0,0,.2)}
-      .install-modal-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:none;align-items:center;justify-content:center;z-index:10000}
-      .install-modal{width:min(92vw,420px);background:#fff;border-radius:12px;padding:16px;text-align:left;box-shadow:0 12px 40px rgba(0,0,0,.28)}
-      .install-modal h3{margin:0 0 8px 0;font-size:1.1rem}
-      .install-modal p{margin:0 0 14px 0;font-size:.95rem;line-height:1.4;color:#222}
-      .install-modal-actions{display:flex;justify-content:flex-end;gap:8px}
-      .install-modal-actions button{border:none;border-radius:8px;padding:8px 12px;cursor:pointer}
-      .install-close{background:#ececec;color:#222}
-      .install-confirm{background:#7a00cc;color:#fff}
-      .install-ios-hint{position:fixed;left:16px;right:16px;bottom:16px;z-index:9999;background:#fff;border:1px solid #ddd;border-radius:10px;padding:12px 14px;box-shadow:0 8px 24px rgba(0,0,0,.18);display:none}
-      .install-ios-hint strong{display:block;margin-bottom:6px}
-      .install-ios-hint button{margin-top:8px;border:none;border-radius:8px;padding:6px 10px;background:#ececec;cursor:pointer}
+      .bo-install-prompt{position:fixed;right:16px;bottom:16px;z-index:9800;display:none;font-family:'Poppins',sans-serif}
+      .bo-install-prompt__banner{display:flex;align-items:center;gap:8px;background:#fff;color:#1f2937;border:1px solid #e5e7eb;border-radius:999px;padding:8px 10px;box-shadow:0 8px 24px rgba(0,0,0,.18)}
+      .bo-install-prompt__banner button{border:none;border-radius:999px;padding:7px 12px;cursor:pointer;font-weight:600}
+      .bo-install-prompt__banner .bo-install-open{background:#7a00cc;color:#fff}
+      .bo-install-prompt__banner .bo-install-dismiss{background:#ececec;color:#222}
+      .bo-install-prompt__backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45);display:none;align-items:center;justify-content:center;z-index:10000}
+      .bo-install-prompt__modal{width:min(92vw,420px);background:#fff;border-radius:12px;padding:16px;box-shadow:0 12px 40px rgba(0,0,0,.28)}
+      .bo-install-prompt__modal h3{margin:0 0 8px 0;font-size:1.1rem}
+      .bo-install-prompt__modal p{margin:0 0 14px 0;font-size:.95rem;line-height:1.4;color:#222}
+      .bo-install-prompt__actions{display:flex;justify-content:flex-end;gap:8px}
+      .bo-install-prompt__actions button{border:none;border-radius:8px;padding:8px 12px;cursor:pointer}
+      .bo-install-prompt__actions .bo-install-close{background:#ececec;color:#222}
+      .bo-install-prompt__actions .bo-install-confirm{background:#7a00cc;color:#fff}
+      .bo-install-prompt__ios{position:fixed;left:16px;right:16px;bottom:16px;z-index:9800;background:#fff;border:1px solid #ddd;border-radius:10px;padding:12px 14px;box-shadow:0 8px 24px rgba(0,0,0,.18);display:none;font-family:'Poppins',sans-serif}
+      .bo-install-prompt__ios strong{display:block;margin-bottom:6px}
+      .bo-install-prompt__ios button{margin-top:8px;border:none;border-radius:8px;padding:6px 10px;background:#ececec;cursor:pointer}
     `;
     document.head.appendChild(style);
+  }
 
-    ctaContainer = document.createElement('div');
-    ctaContainer.className = 'install-cta-wrap';
-    ctaContainer.innerHTML = '<button class="install-cta-btn" type="button">Instalar app</button>';
-    document.body.appendChild(ctaContainer);
+  function initInstallPrompt(options) {
+    const settings = {
+      containerId: options?.containerId || 'install-prompt-root',
+      mode: options?.mode === 'modal' ? 'modal' : 'banner'
+    };
 
-    modal = document.createElement('div');
-    modal.className = 'install-modal-backdrop';
+    let deferredPrompt = null;
+    let root = document.getElementById(settings.containerId);
+    if (!root) {
+      root = document.createElement('div');
+      root.id = settings.containerId;
+      document.body.appendChild(root);
+    }
+
+    ensureStyles();
+
+    const bannerWrap = document.createElement('div');
+    bannerWrap.className = 'bo-install-prompt';
+    bannerWrap.innerHTML = `
+      <div class="bo-install-prompt__banner">
+        <span>Instala la app</span>
+        <button type="button" class="bo-install-open">Instalar</button>
+        <button type="button" class="bo-install-dismiss">Ahora no</button>
+      </div>
+    `;
+
+    const modal = document.createElement('div');
+    modal.className = 'bo-install-prompt__backdrop';
     modal.innerHTML = `
-      <div class="install-modal" role="dialog" aria-modal="true" aria-label="Instalar aplicación">
+      <div class="bo-install-prompt__modal" role="dialog" aria-modal="true" aria-label="Instalar aplicación">
         <h3>Instalar app</h3>
         <p>Instala Bingo Online para abrir más rápido y usar una experiencia similar a una app.</p>
-        <div class="install-modal-actions">
-          <button class="install-close" type="button">Ahora no</button>
-          <button class="install-confirm" type="button">Instalar</button>
+        <div class="bo-install-prompt__actions">
+          <button class="bo-install-close" type="button">Ahora no</button>
+          <button class="bo-install-confirm" type="button">Instalar</button>
         </div>
       </div>
     `;
-    document.body.appendChild(modal);
 
-    iosHint = document.createElement('div');
-    iosHint.className = 'install-ios-hint';
+    const iosHint = document.createElement('div');
+    iosHint.className = 'bo-install-prompt__ios';
     iosHint.innerHTML = `
       <strong>Instalar app en iPhone/iPad</strong>
       <div>Abre el menú <em>Compartir</em> y luego toca <em>Añadir a pantalla de inicio</em>.</div>
       <button type="button">Entendido</button>
     `;
-    document.body.appendChild(iosHint);
 
-    ctaContainer.querySelector('button').addEventListener('click', function () {
+    root.replaceChildren(bannerWrap, modal, iosHint);
+
+    function hasPriorityOverlay() {
+      return Boolean(document.querySelector('.global-dialog-overlay[style*="display: flex"], .modal-whatsapp.activa, .modal-referidos.activa, #tutorial-overlay.activo'));
+    }
+
+    function hideAll() {
+      bannerWrap.style.display = 'none';
+      modal.style.display = 'none';
+      iosHint.style.display = 'none';
+    }
+
+    function showEntry() {
+      if (hasPriorityOverlay()) return;
+      if (settings.mode === 'modal') {
+        modal.style.display = 'flex';
+      } else {
+        bannerWrap.style.display = 'block';
+      }
+    }
+
+    if (isStandalone() || shouldPausePrompt()) {
+      hideAll();
+      return { destroy: hideAll };
+    }
+
+    if (isIosSafari()) {
+      if (!hasPriorityOverlay()) {
+        iosHint.style.display = 'block';
+      }
+      iosHint.querySelector('button').addEventListener('click', function () {
+        markDismissed();
+        iosHint.style.display = 'none';
+      });
+    }
+
+    bannerWrap.querySelector('.bo-install-open').addEventListener('click', function () {
       if (!deferredPrompt) return;
       modal.style.display = 'flex';
     });
 
-    modal.querySelector('.install-close').addEventListener('click', function () {
-      modal.style.display = 'none';
+    bannerWrap.querySelector('.bo-install-dismiss').addEventListener('click', function () {
       markDismissed();
-      hideCta();
+      hideAll();
+    });
+
+    modal.querySelector('.bo-install-close').addEventListener('click', function () {
+      markDismissed();
+      hideAll();
     });
 
     modal.addEventListener('click', function (event) {
       if (event.target === modal) {
-        modal.style.display = 'none';
         markDismissed();
-        hideCta();
+        hideAll();
       }
     });
 
-    modal.querySelector('.install-confirm').addEventListener('click', async function () {
+    modal.querySelector('.bo-install-confirm').addEventListener('click', async function () {
       if (!deferredPrompt) return;
-
       modal.style.display = 'none';
       deferredPrompt.prompt();
-
       const choiceResult = await deferredPrompt.userChoice;
-      console.info('Resultado userChoice PWA:', choiceResult.outcome);
-
       if (choiceResult.outcome === 'accepted') {
         localStorage.setItem(STORAGE_KEYS.accepted, '1');
-        hideCta();
       } else {
         markDismissed();
-        hideCta();
       }
-
+      hideAll();
       deferredPrompt = null;
     });
-
-    iosHint.querySelector('button').addEventListener('click', function () {
-      markDismissed();
-      iosHint.style.display = 'none';
-    });
-  }
-
-  function showCta() {
-    if (ctaContainer) {
-      ctaContainer.style.display = 'block';
-    }
-  }
-
-  function hideCta() {
-    if (ctaContainer) {
-      ctaContainer.style.display = 'none';
-    }
-  }
-
-  function showIosHint() {
-    if (iosHint) {
-      iosHint.style.display = 'block';
-    }
-  }
-
-  function hideAllInstallUi() {
-    hideCta();
-    if (modal) modal.style.display = 'none';
-    if (iosHint) iosHint.style.display = 'none';
-  }
-
-  function init() {
-    createUi();
-
-    if (isStandalone()) {
-      hideAllInstallUi();
-      return;
-    }
-
-    if (shouldPausePrompt()) {
-      hideAllInstallUi();
-      return;
-    }
-
-    if (isIosSafari()) {
-      showIosHint();
-    }
 
     window.addEventListener('beforeinstallprompt', function (event) {
       event.preventDefault();
       deferredPrompt = event;
-      showCta();
+      showEntry();
     });
 
     window.addEventListener('appinstalled', function () {
       localStorage.setItem(STORAGE_KEYS.installed, '1');
-      hideAllInstallUi();
+      hideAll();
     });
+
+    return {
+      destroy() {
+        hideAll();
+        root.replaceChildren();
+      }
+    };
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
-  }
+  window.initInstallPrompt = initInstallPrompt;
 })();

--- a/public/player.html
+++ b/public/player.html
@@ -2513,5 +2513,12 @@
 })();
 </script>
   <script src="js/installPrompt.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      if (typeof window.initInstallPrompt === 'function') {
+        window.initInstallPrompt({ containerId: 'install-prompt-player', mode: 'banner' });
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Introducir un componente UI liviano y reutilizable para sugerir la instalación PWA sin replicar lógica en todas las páginas. 
- Evitar que el prompt interfiera con flujos existentenes (tutoriales, modales de notificación o redirecciones de auth). 
- Exponer una API simple para permitir futuras integraciones por pantalla con `containerId` y `mode` configurables. 

### Description
- Se reescribió `public/js/installPrompt.js` para exponer `window.initInstallPrompt({ containerId, mode })` como API global y retornando un objeto con `destroy()` para limpiar la UI. 
- El componente soporta modo `banner` y cuadro de confirmación `modal`, muestra un hint específico para iOS y persiste estado en `localStorage` con las claves `installPromptDismissedUntil`, `installPromptInstalled` y `installPromptAccepted`. 
- Se añadió detección de overlays prioritarios (`.global-dialog-overlay`, `.modal-whatsapp.activa`, `.modal-referidos.activa`, `#tutorial-overlay.activo`) para evitar mostrar el prompt mientras hay modales/tutoriales activos. 
- El módulo se inicializa únicamente en las vistas de alta frecuencia `public/index.html` y `public/player.html` con contenedores dedicados (`install-prompt-index`, `install-prompt-player`) para evitar duplicados. 

### Testing
- Ejecuté `npm test -- --runInBand` y todos los suites automatizados pasaron (11 suites, 35 tests) ✅. 
- Levanté un servidor local `python3 -m http.server 4173` y validé visualmente con un script Playwright que disparó `beforeinstallprompt` y generó una captura del banner (artefacto generado) ✅. 
- Las páginas afectadas probadas en el servidor local cargaron correctamente `installPrompt.js` y no mostraron interferencias con los modales/tutorias durante la validación visual ✅.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0d1d23fc48326bfac93d730bc6b24)