### PR TITLE
Agregar carpeta public/sonidos para audios estáticos

### DIFF
--- a/public/sonidos/README.md
+++ b/public/sonidos/README.md
@@ -1,0 +1,7 @@
+# Carpeta de sonidos
+
+Esta carpeta es el lugar recomendado para guardar los archivos de audio (`.mp3`, `.ogg`, etc.) de la aplicación web, porque todo lo que está dentro de `public/` se publica como recurso estático.
+
+Ejemplos de rutas:
+- `/sonidos/intro.mp3`
+- `/sonidos/efectos/click.ogg`


### PR DESCRIPTION
### Motivation
- Centralizar los archivos de audio en `public/sonidos` para servirlos como recursos estáticos accesibles desde rutas como `/sonidos/*.mp3` y facilitar su gestión desde el manifiesto de audio.

### Description
- Se creó la carpeta `public/sonidos` y se añadieron `public/sonidos/.gitkeep` para versionarla y `public/sonidos/README.md` con una breve guía de uso y ejemplos de rutas y formatos (`.mp3`, `.ogg`).

### Testing
- Se verificó el contenido del README con `nl -ba public/sonidos/README.md` y se comprobó el estado del árbol de trabajo con `git status --short`, ambos comandos finalizaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73ad400008326b2304aaf06ce76bf)