### PR TITLE
Soporta reproducción de cantos WAV en juego activo

### DIFF
--- a/public/js/audioManager.js
+++ b/public/js/audioManager.js
@@ -85,7 +85,7 @@
     resolveSources(node = {}) {
       const preferredFormats = Array.isArray(node.preferredFormats) && node.preferredFormats.length
         ? node.preferredFormats
-        : ['mp3', 'ogg'];
+        : ['mp3', 'ogg', 'wav'];
 
       const candidates = [];
       if (Array.isArray(node.sources)) {
@@ -133,7 +133,7 @@
       if (typeof source === 'string') {
         return {
           urls: [source],
-          preferredFormats: ['mp3', 'ogg'],
+          preferredFormats: ['mp3', 'ogg', 'wav'],
           normalizationGain: 1,
           category: 'sfx',
           maxBytes: this.defaultMaxSfxBytes,
@@ -145,7 +145,7 @@
         if (manifestNode) {
           return {
             urls: this.resolveSources(manifestNode),
-            preferredFormats: manifestNode.preferredFormats || ['mp3', 'ogg'],
+            preferredFormats: manifestNode.preferredFormats || ['mp3', 'ogg', 'wav'],
             license: manifestNode.license || null,
             attribution: manifestNode.attribution || null,
             normalizationGain: Number.isFinite(manifestNode.normalizationGain)
@@ -164,7 +164,7 @@
       const urls = this.resolveSources(source);
       return {
         urls,
-        preferredFormats: source.preferredFormats || ['mp3', 'ogg'],
+        preferredFormats: source.preferredFormats || ['mp3', 'ogg', 'wav'],
         license: source.license || null,
         attribution: source.attribution || null,
         normalizationGain: Number.isFinite(source.normalizationGain) ? clamp(source.normalizationGain, 0.1, 2) : 1,

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v2';
+const CACHE_VERSION = 'v3';
 const APP_SHELL_CACHE = `bingo-app-shell-${CACHE_VERSION}`;
 const AUDIO_CACHE = `bingo-audio-runtime-${CACHE_VERSION}`;
 
@@ -47,7 +47,7 @@ self.addEventListener('activate', (event) => {
 function isAudioRequest(request) {
   const url = new URL(request.url);
   if (request.destination === 'audio') return true;
-  return /\.(mp3|ogg)(\?|$)/i.test(url.pathname);
+  return /\.(mp3|ogg|wav)(\?|$)/i.test(url.pathname);
 }
 
 self.addEventListener('fetch', (event) => {


### PR DESCRIPTION
### Motivation
- El código de `juegoactivo` registra los cantos como `sonidos/{n}.wav` y algunos clientes no reproducían esos SFX porque el runtime y el service worker no consideraban `wav` como formato preferido/para cachear.
- Se necesita que los WAV sean tratados como formatos de primera clase para que `AudioManager` los seleccione y el service worker los sirva/cace correctamente.

### Description
- Añade `wav` a los `preferredFormats` por defecto en `AudioManager` para que la resolución de fuentes y normalización trate `.wav` como formato prioritario (`public/js/audioManager.js`).
- Actualiza la normalización de descriptores y los casos donde la fuente es una cadena para incluir `wav` como formato preferido por defecto (`public/js/audioManager.js`).
- Ajusta el Service Worker para detectar y cachear también solicitudes de audio `.wav` y aumenta la versión de caché a `v3` para forzar la renovación de clientes (`public/sw.js`).
- Archivos modificados: `public/js/audioManager.js`, `public/sw.js`.

### Testing
- Ejecutado `npm test -- --runInBand` y todos los tests unitarios pasaron con éxito (11 suites, 35 tests aprobados).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b74ae581748326ba0898a15c127a87)