### PR TITLE
Reforzar audio con fallback local y síntesis WebAudio

### DIFF
--- a/public/js/audioManager.js
+++ b/public/js/audioManager.js
@@ -133,6 +133,7 @@
       if (typeof source === 'string') {
         return {
           urls: [source],
+          generator: null,
           preferredFormats: ['mp3', 'ogg', 'wav'],
           normalizationGain: 1,
           category: 'sfx',
@@ -145,6 +146,7 @@
         if (manifestNode) {
           return {
             urls: this.resolveSources(manifestNode),
+            generator: manifestNode.generator || null,
             preferredFormats: manifestNode.preferredFormats || ['mp3', 'ogg', 'wav'],
             license: manifestNode.license || null,
             attribution: manifestNode.attribution || null,
@@ -164,6 +166,7 @@
       const urls = this.resolveSources(source);
       return {
         urls,
+        generator: source.generator || null,
         preferredFormats: source.preferredFormats || ['mp3', 'ogg', 'wav'],
         license: source.license || null,
         attribution: source.attribution || null,
@@ -335,7 +338,108 @@
         }
       }
 
+      if (descriptor.generator) {
+        const generated = this.createGeneratedBuffer(descriptor.generator, descriptor.category);
+        if (generated) {
+          if (urls[0]) {
+            this.buffers.set(urls[0], generated);
+          }
+          return generated;
+        }
+      }
+
       return null;
+    }
+
+    createGeneratedBuffer(generatorConfig = {}, category = 'sfx') {
+      if (!this.audioContext) return null;
+
+      const sampleRate = this.audioContext.sampleRate || 44100;
+      const kind = String(generatorConfig.kind || '').toLowerCase();
+
+      if (kind === 'pulse') {
+        const duration = Number.isFinite(generatorConfig.durationSec)
+          ? Math.max(0.05, generatorConfig.durationSec)
+          : 0.24;
+        const frequency = Number.isFinite(generatorConfig.frequency)
+          ? Math.max(80, generatorConfig.frequency)
+          : 880;
+        const gain = Number.isFinite(generatorConfig.gain)
+          ? clamp(generatorConfig.gain, 0.03, 1)
+          : 0.25;
+        const attack = Number.isFinite(generatorConfig.attackSec)
+          ? Math.max(0.001, generatorConfig.attackSec)
+          : 0.005;
+        const release = Number.isFinite(generatorConfig.releaseSec)
+          ? Math.max(0.01, generatorConfig.releaseSec)
+          : 0.14;
+        const waveform = generatorConfig.waveform || 'sine';
+        return this.generatePulseBuffer({ sampleRate, duration, frequency, gain, attack, release, waveform });
+      }
+
+      if (kind === 'ambient-loop' || category === 'music') {
+        const duration = Number.isFinite(generatorConfig.durationSec)
+          ? Math.max(1.5, generatorConfig.durationSec)
+          : 6;
+        return this.generateAmbientLoopBuffer({
+          sampleRate,
+          duration,
+          rootFrequency: Number.isFinite(generatorConfig.rootFrequency) ? generatorConfig.rootFrequency : 196,
+          gain: Number.isFinite(generatorConfig.gain) ? clamp(generatorConfig.gain, 0.02, 0.35) : 0.12,
+        });
+      }
+
+      return null;
+    }
+
+    generatePulseBuffer({ sampleRate, duration, frequency, gain, attack, release, waveform }) {
+      const totalSamples = Math.max(1, Math.floor(sampleRate * duration));
+      const buffer = this.audioContext.createBuffer(1, totalSamples, sampleRate);
+      const channel = buffer.getChannelData(0);
+      const sustainStart = attack;
+      const releaseStart = Math.max(sustainStart, duration - release);
+
+      for (let i = 0; i < totalSamples; i += 1) {
+        const t = i / sampleRate;
+        const phase = 2 * Math.PI * frequency * t;
+        let base = Math.sin(phase);
+        if (waveform === 'triangle') {
+          base = (2 / Math.PI) * Math.asin(Math.sin(phase));
+        }
+        if (waveform === 'square') {
+          base = Math.sign(Math.sin(phase));
+        }
+
+        let env = 1;
+        if (t < sustainStart) {
+          env = t / sustainStart;
+        } else if (t >= releaseStart) {
+          env = Math.max(0, (duration - t) / Math.max(0.001, release));
+        }
+
+        channel[i] = base * env * gain;
+      }
+
+      return buffer;
+    }
+
+    generateAmbientLoopBuffer({ sampleRate, duration, rootFrequency, gain }) {
+      const totalSamples = Math.max(1, Math.floor(sampleRate * duration));
+      const buffer = this.audioContext.createBuffer(1, totalSamples, sampleRate);
+      const channel = buffer.getChannelData(0);
+      const harmonic = rootFrequency * 1.5;
+      const shimmer = rootFrequency * 2;
+
+      for (let i = 0; i < totalSamples; i += 1) {
+        const t = i / sampleRate;
+        const fade = Math.sin(Math.PI * (i / totalSamples));
+        const bed = Math.sin(2 * Math.PI * rootFrequency * t) * 0.65;
+        const layer = Math.sin(2 * Math.PI * harmonic * t + Math.sin(t * 0.5) * 0.3) * 0.25;
+        const sparkle = Math.sin(2 * Math.PI * shimmer * t + Math.sin(t * 0.17) * 0.5) * 0.1;
+        channel[i] = (bed + layer + sparkle) * gain * fade;
+      }
+
+      return buffer;
     }
 
     async preloadCriticalSfx() {

--- a/public/js/audioManifest.js
+++ b/public/js/audioManifest.js
@@ -2,7 +2,7 @@
   const manifest = {
     manifestVersion: '2026.02.18-v2',
     globalAudioPolicy: {
-      preferredFormats: ['mp3', 'ogg'],
+      preferredFormats: ['wav', 'mp3', 'ogg'],
       musicPreload: 'deferred',
       criticalSfxPreload: 'on-game-enter',
       maxSfxBytes: 122880,
@@ -12,7 +12,7 @@
     music: {
       backgroundMain: {
         category: 'music',
-        preferredFormats: ['mp3', 'ogg'],
+        preferredFormats: ['wav', 'mp3', 'ogg'],
         preload: 'deferred',
         maxBytes: 1048576,
         normalizationGain: 0.92,
@@ -28,17 +28,28 @@
             kind: 'fallback',
           },
         ],
+        generator: {
+          kind: 'ambient-loop',
+          durationSec: 6,
+          rootFrequency: 196,
+          gain: 0.11,
+        },
         license: 'Mixkit Free Sound Effects License / Pixabay Content License',
-        attribution: 'Mixkit (principal) y Pixabay (respaldo)',
+        attribution: 'Mixkit (principal), Pixabay (respaldo) y sintetizador local (último respaldo)',
       },
     },
     sfx: {
       drawNumber: {
         category: 'sfx',
-        preferredFormats: ['mp3', 'ogg'],
+        preferredFormats: ['wav', 'mp3', 'ogg'],
         maxBytes: 122880,
         normalizationGain: 0.95,
         sources: [
+          {
+            format: 'wav',
+            url: '/sonidos/1.wav',
+            kind: 'local-primary',
+          },
           {
             format: 'mp3',
             url: 'https://assets.mixkit.co/sfx/preview/mixkit-select-click-1109.mp3',
@@ -50,15 +61,27 @@
             kind: 'fallback',
           },
         ],
+        generator: {
+          kind: 'pulse',
+          frequency: 880,
+          durationSec: 0.16,
+          gain: 0.22,
+          waveform: 'triangle',
+        },
         license: 'Mixkit Free Sound Effects License / Pixabay Content License',
-        attribution: 'Mixkit (principal) y Pixabay (respaldo)',
+        attribution: 'Sonido local / Mixkit / Pixabay + sintetizador local',
       },
       markCell: {
         category: 'sfx',
-        preferredFormats: ['mp3', 'ogg'],
+        preferredFormats: ['wav', 'mp3', 'ogg'],
         maxBytes: 122880,
         normalizationGain: 0.9,
         sources: [
+          {
+            format: 'wav',
+            url: '/sonidos/2.wav',
+            kind: 'local-primary',
+          },
           {
             format: 'mp3',
             url: 'https://assets.mixkit.co/sfx/preview/mixkit-modern-technology-select-3124.mp3',
@@ -70,15 +93,27 @@
             kind: 'fallback',
           },
         ],
+        generator: {
+          kind: 'pulse',
+          frequency: 660,
+          durationSec: 0.14,
+          gain: 0.22,
+          waveform: 'sine',
+        },
         license: 'Mixkit Free Sound Effects License / Pixabay Content License',
-        attribution: 'Mixkit (principal) y Pixabay (respaldo)',
+        attribution: 'Sonido local / Mixkit / Pixabay + sintetizador local',
       },
       openModal: {
         category: 'sfx',
-        preferredFormats: ['mp3', 'ogg'],
+        preferredFormats: ['wav', 'mp3', 'ogg'],
         maxBytes: 122880,
         normalizationGain: 0.88,
         sources: [
+          {
+            format: 'wav',
+            url: '/sonidos/3.wav',
+            kind: 'local-primary',
+          },
           {
             format: 'mp3',
             url: 'https://assets.mixkit.co/sfx/preview/mixkit-software-interface-start-2574.mp3',
@@ -90,16 +125,28 @@
             kind: 'fallback',
           },
         ],
+        generator: {
+          kind: 'pulse',
+          frequency: 740,
+          durationSec: 0.13,
+          gain: 0.2,
+          waveform: 'square',
+        },
         license: 'Mixkit Free Sound Effects License / Pixabay Content License',
-        attribution: 'Mixkit (principal) y Pixabay (respaldo)',
+        attribution: 'Sonido local / Mixkit / Pixabay + sintetizador local',
       },
       win: {
         category: 'sfx',
-        preferredFormats: ['mp3', 'ogg'],
+        preferredFormats: ['wav', 'mp3', 'ogg'],
         preloadCritical: true,
         maxBytes: 122880,
         normalizationGain: 0.86,
         sources: [
+          {
+            format: 'wav',
+            url: '/sonidos/4.wav',
+            kind: 'local-primary',
+          },
           {
             format: 'mp3',
             url: 'https://assets.mixkit.co/sfx/preview/mixkit-winning-chimes-2015.mp3',
@@ -111,8 +158,15 @@
             kind: 'fallback',
           },
         ],
+        generator: {
+          kind: 'pulse',
+          frequency: 523.25,
+          durationSec: 0.25,
+          gain: 0.26,
+          waveform: 'triangle',
+        },
         license: 'Mixkit Free Sound Effects License / Pixabay Content License',
-        attribution: 'Mixkit (principal) y Pixabay (respaldo)',
+        attribution: 'Sonido local / Mixkit / Pixabay + sintetizador local',
       },
     },
   };


### PR DESCRIPTION
### Motivation
- Detecté que el sistema de audio dependía fuertemente de fuentes remotas (CDN/CORS), lo que podía dejar la app sin sonido si las descargas fallaban o la reproducción automática estaba bloqueada. 
- El objetivo fue garantizar salida sonora sin agregar archivos binarios al PR, ofreciendo alternativas locales y generativas en tiempo de ejecución.

### Description
- Añadí soporte en `AudioManager` para un nuevo campo `generator` en los descriptores y lo integré en `normalizeSourceDescriptor` para leerlo desde manifiesto o fuente. 
- Implementé fallback en `loadBufferBySource` que, tras intentar las URLs locales/remotas, invoca `createGeneratedBuffer` para producir un `AudioBuffer` por síntesis si las descargas/decodificaciones fallan. 
- Añadí generación en tiempo real con `createGeneratedBuffer`, `generatePulseBuffer` (SFX cortos configurables: frecuencia, envelop, waveform) y `generateAmbientLoopBuffer` (loop de música de respaldo). 
- Actualicé `public/js/audioManifest.js` para priorizar fuentes locales `/sonidos/*.wav`, ampliar `preferredFormats` y añadir configuraciones `generator` para música y SFX clave como último respaldo, sin eliminar las fuentes remotas.

### Testing
- Ejecuté los tests automatizados con `npm test -- --runInBand` y todos pasaron (11 suites, 35 tests). 
- Las suites mostraron salida exitosa y cobertura relevante sin introducir errores en las pruebas existentes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f68a91a08326b8a8836787278bd3)