### PR TITLE
Asegura desbloqueo real del AudioContext en reproducción de música y SFX

### DIFF
--- a/public/js/audioControls.js
+++ b/public/js/audioControls.js
@@ -280,21 +280,46 @@
       promptGlobalAudio.hide();
     }
 
+    function registrarEstadoBloqueado() {
+      if (statusEl) {
+        statusEl.textContent = '⚠️ Audio bloqueado por el navegador';
+      }
+    }
+
     async function desbloquearAudioYMusica({ fadeInMs = 0 } = {}) {
       await window.audioManager.init();
+
+      let contextoListo = false;
+      try {
+        if (typeof window.audioManager.ensureRunningContext === 'function') {
+          contextoListo = await window.audioManager.ensureRunningContext();
+        } else {
+          contextoListo = await window.audioManager.probeAutoplayState();
+        }
+      } catch (_) {
+        contextoListo = false;
+      }
+
+      if (!contextoListo || window.audioManager.isAutoplayBlocked?.()) {
+        registrarEstadoBloqueado();
+        mostrarPromptAudio();
+        return false;
+      }
+
       aplicarGanancias();
       if (!estado.muted && (musicDescriptor || musicSrc)) {
         await window.audioManager.playMusic(musicTrackId, { fadeInMs });
       }
       guardarConsentimientoAudio();
       ocultarPromptAudio();
+      return true;
     }
 
     async function intentarReproducirMusica(desdePrompt = false) {
       if (estado.muted || (!musicDescriptor && !musicSrc)) return;
       try {
-        await desbloquearAudioYMusica();
-        if (window.audioManager.isAutoplayBlocked?.()) {
+        const desbloqueado = await desbloquearAudioYMusica();
+        if (!desbloqueado || window.audioManager.isAutoplayBlocked?.()) {
           mostrarPromptAudio();
           return;
         }
@@ -356,8 +381,13 @@
 
     const manejarPrimerGesto = async () => {
       try {
-        await desbloquearAudioYMusica({ fadeInMs: 900 });
-      } catch (_) {}
+        const desbloqueado = await desbloquearAudioYMusica({ fadeInMs: 900 });
+        if (!desbloqueado) {
+          registrarEstadoBloqueado();
+        }
+      } catch (_) {
+        registrarEstadoBloqueado();
+      }
     };
 
     ['pointerdown', 'keydown'].forEach((evento) => {
@@ -365,7 +395,10 @@
     });
 
     promptGlobalAudio.setEnableHandler(async () => {
-      await desbloquearAudioYMusica({ fadeInMs: 900 });
+      const desbloqueado = await desbloquearAudioYMusica({ fadeInMs: 900 });
+      if (!desbloqueado) {
+        registrarEstadoBloqueado();
+      }
     });
 
     persistirYRefrescar();

--- a/public/js/audioManager.js
+++ b/public/js/audioManager.js
@@ -240,18 +240,11 @@
     }
 
     async probeAutoplayState() {
-      await this.init();
       let blocked = false;
 
-      if (this.audioContext.state !== 'running') {
-        try {
-          await this.audioContext.resume();
-        } catch (_) {
-          blocked = true;
-        }
-      }
-
-      if (this.audioContext.state !== 'running') {
+      try {
+        await this.ensureRunningContext();
+      } catch (_) {
         blocked = true;
       }
 
@@ -273,6 +266,31 @@
 
       this.autoplayBlocked = blocked;
       return !blocked;
+    }
+
+    createBlockedAudioError() {
+      const error = new Error('El contexto de audio sigue bloqueado tras intentar reanudarlo.');
+      error.code = 'AUDIO_CONTEXT_BLOCKED';
+      return error;
+    }
+
+    async ensureRunningContext() {
+      await this.init();
+
+      if (this.audioContext.state !== 'running') {
+        try {
+          await this.audioContext.resume();
+        } catch (_) {}
+      }
+
+      const running = this.audioContext.state === 'running';
+      this.autoplayBlocked = !running;
+
+      if (!running) {
+        throw this.createBlockedAudioError();
+      }
+
+      return true;
     }
 
     isAutoplayBlocked() {
@@ -370,7 +388,7 @@
       const sourceDescriptor = this.musicTracks.get(trackId);
       if (!sourceDescriptor) return;
 
-      await this.init();
+      await this.ensureRunningContext();
       const buffer = await this.loadBufferBySource(sourceDescriptor);
       if (!buffer) return;
 
@@ -400,6 +418,7 @@
         this.musicGain.gain.linearRampToValueAtTime(targetGain, now + fadeInMs / 1000);
       }
 
+      await this.ensureRunningContext();
       source.start(0);
       this.currentMusicSource = source;
     }
@@ -410,7 +429,7 @@
       if (!eventConfig) return;
       if (this.activeSfxNodes.size >= this.maxSfxConcurrency) return;
 
-      await this.init();
+      await this.ensureRunningContext();
       const buffer = await this.loadBufferBySource(eventConfig.source);
       if (!buffer) return;
 
@@ -431,6 +450,7 @@
         sourceGain.disconnect();
       };
 
+      await this.ensureRunningContext();
       source.start(0);
 
       if (eventConfig.critical || this.isCriticalEvent(eventName)) {


### PR DESCRIPTION
### Motivation
- Evitar fallos silenciosos al reproducir música o SFX cuando el `AudioContext` permanece en estado suspendido por políticas de autoplay del navegador. 
- Proveer feedback claro en la UI cuando el navegador mantiene el audio bloqueado para que el usuario pueda actuar.

### Description
- Se agregó `ensureRunningContext()` en `public/js/audioManager.js` que ejecuta `init()`, intenta `audioContext.resume()`, actualiza `autoplayBlocked` y lanza un error controlado con código `AUDIO_CONTEXT_BLOCKED` si no queda en `running`.
- `probeAutoplayState()` ahora reutiliza `ensureRunningContext()` y conserva la prueba con un buffer silencioso para validar el estado de autoplay sin duplicar lógica.
- `playMusic()` y `playSfx()` en `public/js/audioManager.js` invocan `ensureRunningContext()` antes de `loadBufferBySource` y de `source.start(0)` para garantizar que el contexto esté activo al cargar y arrancar audio.
- En `public/js/audioControls.js` `desbloquearAudioYMusica()` llama a `ensureRunningContext()` (con fallback a `probeAutoplayState()`), retorna `false` si sigue bloqueado, muestra el prompt de activación y registra estado bloqueado en la UI con el texto `⚠️ Audio bloqueado por el navegador`; además se adaptaron los manejadores de gesto inicial y del prompt para usar este flujo.

### Testing
- Ejecutado `node --check public/js/audioManager.js` y la comprobación de sintaxis devolvió éxito.
- Ejecutado `node --check public/js/audioControls.js` y la comprobación de sintaxis devolvió éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b832f21d348326977cf19bb0e9b527)