### PR TITLE
Mejora la detección de autoplay y estados de audio bloqueado en la UI

### DIFF
--- a/public/js/audioControls.js
+++ b/public/js/audioControls.js
@@ -214,6 +214,7 @@
     });
 
     let estado = leerEstadoAudio();
+    let audioBloqueadoPorNavegador = false;
     let hideTimer = null;
     const promptGlobalAudio = obtenerPromptGlobalAudio();
 
@@ -239,7 +240,13 @@
       toggle.setAttribute('title', muted ? 'Activar sonido' : 'Silenciar sonido');
 
       if (statusEl) {
-        statusEl.textContent = muted ? '🔇 Audio silenciado' : '🔊 Audio activo';
+        if (muted) {
+          statusEl.textContent = '🔇 Audio silenciado por usuario';
+        } else if (audioBloqueadoPorNavegador) {
+          statusEl.textContent = '⚠️ Audio bloqueado por el navegador';
+        } else {
+          statusEl.textContent = '🔊 Audio activo';
+        }
       }
 
       masterInput.value = estado.masterVolume.toFixed(2);
@@ -281,31 +288,31 @@
     }
 
     function registrarEstadoBloqueado() {
-      if (statusEl) {
-        statusEl.textContent = '⚠️ Audio bloqueado por el navegador';
-      }
+      audioBloqueadoPorNavegador = true;
+      actualizarUI();
+    }
+
+    function registrarEstadoDesbloqueado() {
+      audioBloqueadoPorNavegador = false;
+      actualizarUI();
     }
 
     async function desbloquearAudioYMusica({ fadeInMs = 0 } = {}) {
-      await window.audioManager.init();
-
       let contextoListo = false;
       try {
-        if (typeof window.audioManager.ensureRunningContext === 'function') {
-          contextoListo = await window.audioManager.ensureRunningContext();
-        } else {
-          contextoListo = await window.audioManager.probeAutoplayState();
-        }
+        contextoListo = await window.audioManager.probeAutoplayState();
       } catch (_) {
         contextoListo = false;
       }
 
-      if (!contextoListo || window.audioManager.isAutoplayBlocked?.()) {
+      const contextoCorriendo = window.audioManager.audioContext?.state === 'running';
+      if (!contextoListo || !contextoCorriendo || window.audioManager.isAutoplayBlocked?.()) {
         registrarEstadoBloqueado();
         mostrarPromptAudio();
         return false;
       }
 
+      registrarEstadoDesbloqueado();
       aplicarGanancias();
       if (!estado.muted && (musicDescriptor || musicSrc)) {
         await window.audioManager.playMusic(musicTrackId, { fadeInMs });
@@ -395,25 +402,46 @@
     });
 
     promptGlobalAudio.setEnableHandler(async () => {
-      const desbloqueado = await desbloquearAudioYMusica({ fadeInMs: 900 });
-      if (!desbloqueado) {
-        registrarEstadoBloqueado();
+      let autoplayDisponible = false;
+      try {
+        autoplayDisponible = await window.audioManager.probeAutoplayState();
+      } catch (_) {
+        autoplayDisponible = false;
       }
+
+      const contextoCorriendo = window.audioManager.audioContext?.state === 'running';
+      if (!autoplayDisponible || !contextoCorriendo) {
+        registrarEstadoBloqueado();
+        mostrarPromptAudio();
+        return;
+      }
+
+      const desbloqueado = await desbloquearAudioYMusica({ fadeInMs: 900 });
+      if (!desbloqueado) registrarEstadoBloqueado();
     });
 
     persistirYRefrescar();
 
-    if (!estado.muted && usuarioHabilitoAudio()) {
-      intentarReproducirMusica();
-    } else {
-      window.audioManager.init().then(() => {
-        if (window.audioManager.isAutoplayBlocked?.()) {
-          mostrarPromptAudio();
-        }
-      }).catch(() => {
+    (async () => {
+      let autoplayDisponible = false;
+      try {
+        autoplayDisponible = await window.audioManager.probeAutoplayState();
+      } catch (_) {
+        autoplayDisponible = false;
+      }
+
+      const contextoCorriendo = window.audioManager.audioContext?.state === 'running';
+      if (!autoplayDisponible || !contextoCorriendo) {
+        registrarEstadoBloqueado();
         mostrarPromptAudio();
-      });
-    }
+        return;
+      }
+
+      registrarEstadoDesbloqueado();
+      if (!estado.muted && usuarioHabilitoAudio()) {
+        intentarReproducirMusica();
+      }
+    })();
 
     window.bingoAudioState = estado;
   }


### PR DESCRIPTION
### Motivation
- Asegurar que al arrancar los controles de audio se verifique realmente el estado de autoplay en lugar de asumir que `init()` es suficiente. 
- Evitar intentos automáticos de reproducción cuando el navegador bloquea el audio y proporcionar una UI que diferencie bloqueo por navegador frente a silencio por parte del usuario.

### Description
- En `initBingoAudioControl` se reemplazó la inicialización pasiva por una verificación real usando `await window.audioManager.probeAutoplayState()` y comprobación de `audioContext.state === 'running'` antes de intentar reproducir música automáticamente. 
- Cuando se detecta bloqueo se muestra el prompt global (`audio-control__prompt`) y se marca un flag interno `audioBloqueadoPorNavegador` para reflejar el estado en la UI. 
- El handler del botón del prompt vuelve a ejecutar `probeAutoplayState()` y solo continúa cuando el contexto de audio está en `running`, evitando reproducir si sigue bloqueado. 
- Se actualizó la vista de estado (`statusEl` / `audio-status-game`) para diferenciar claramente `🔇 Audio silenciado por usuario`, `⚠️ Audio bloqueado por el navegador` y `🔊 Audio activo`.

### Testing
- Ejecuté `node --check public/js/audioControls.js` y la verificación de sintaxis completó sin errores. (éxito)
- Levanté el servidor con `node uploadServer.js` para validación manual/visual y el proceso arrancó correctamente en `localhost:3000`. (éxito)
- Ejecuté un script de Playwright que navegó a `http://127.0.0.1:3000` y generó una captura (`artifacts/audio-controls-home.png`) para validar la UI del control de audio. (éxito)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8346263f88326937be34c0ecfdde9)