### PR TITLE
Ajusta layout de cartón destacado y reduce tamaño de bolitas en escritorio

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1420,7 +1420,9 @@
           overflow: visible;
           min-height: 0;
           --destacado-cell-size: clamp(42px, 8.8vw, 108px);
+          --destacado-cell-size-base: var(--destacado-cell-size);
           --carton-principal-padding: clamp(6px, 1.2vw, 12px);
+          --carton-destacado-factor: 1;
       }
       #carton-destacado.activo {
           display: flex;
@@ -1502,7 +1504,7 @@
           transform-style: preserve-3d;
           transform-origin: center center;
           transition: transform 0.6s ease;
-          border-radius: 18px;
+          border-radius: calc(18px * var(--carton-destacado-factor, 1));
           background: linear-gradient(160deg, #087f23 0%, #f7f55d 100%);
           box-shadow: 0 16px 32px rgba(0,0,0,0.35);
           cursor: pointer;
@@ -1538,17 +1540,17 @@
           align-items: stretch;
           justify-content: flex-start;
           backface-visibility: hidden;
-          border-radius: 14px;
+          border-radius: calc(14px * var(--carton-destacado-factor, 1));
           overflow: hidden;
           padding: 0;
           box-shadow: inset 0 0 10px rgba(0,0,0,0.2);
       }
       #carton-destacado .carton-front {
-          gap: clamp(0px, 0.6vw, 8px);
+          gap: calc(clamp(0px, 0.6vw, 8px) * var(--carton-destacado-factor, 1));
           align-items: stretch;
           justify-content: center;
           min-height: 0;
-          padding: clamp(4px, 1vw, 10px);
+          padding: calc(clamp(4px, 1vw, 10px) * var(--carton-destacado-factor, 1));
           box-sizing: border-box;
           background: linear-gradient(#ffffff, #dcdcdc);
       }
@@ -1558,11 +1560,11 @@
           grid-template-rows: auto 1fr;
           align-items: stretch;
           justify-items: center;
-          gap: clamp(0px, 0.4vw, 6px);
+          gap: calc(clamp(0px, 0.4vw, 6px) * var(--carton-destacado-factor, 1));
           flex: 1 1 auto;
           align-self: stretch;
           min-height: 0;
-          padding: var(--carton-principal-padding, clamp(6px, 1.2vw, 12px));
+          padding: calc(var(--carton-principal-padding, clamp(6px, 1.2vw, 12px)) * var(--carton-destacado-factor, 1));
           box-sizing: border-box;
           aspect-ratio: auto;
           position: relative;
@@ -1570,7 +1572,7 @@
               var(--destacado-cell-size),
               max(
                   clamp(28px, 8vw, 36px),
-                  calc((100% - (var(--carton-principal-padding) * 2)) / 5)
+                  calc((100% - (var(--carton-principal-padding) * 2 * var(--carton-destacado-factor, 1))) / 5)
               )
           );
       }
@@ -3379,6 +3381,7 @@
               --carton-contenido-ancho: clamp(360px, 31vw, 500px);
               --carton-principal-padding: clamp(8px, 1vw, 14px);
               --destacado-cell-size: clamp(52px, 5.6vw, 78px);
+              --destacado-cell-size-base: clamp(52px, 5.6vw, 78px);
               width: min(100%, calc(var(--carton-contenido-ancho) + (var(--carton-destacado-margen) * 2)));
               max-width: min(100%, calc(var(--carton-contenido-ancho) + (var(--carton-destacado-margen) * 2)));
               margin-inline: auto;
@@ -3432,8 +3435,8 @@
               margin-inline: auto;
           }
           .conducto-sphere {
-              --conducto-esfera-base: clamp(calc(var(--conducto-cell-size-real) * 0.78), 40px, calc(var(--conducto-cell-size-real) * 0.96));
-              --conducto-esfera-font-base: clamp(0.9rem, 1.4vw, 1.18rem);
+              --conducto-esfera-base: clamp(calc(var(--conducto-cell-size-real) * 0.72), 36px, calc(var(--conducto-cell-size-real) * 0.88));
+              --conducto-esfera-font-base: clamp(0.84rem, 1.24vw, 1.08rem);
           }
       }
       @media (max-width: 819px) {
@@ -3838,6 +3841,7 @@
               max-width: var(--carton-contenido-ancho, var(--carton-destacado-max-width));
               align-items: center;
               --destacado-cell-size: clamp(40px, 11vw, 108px);
+              --destacado-cell-size-base: clamp(40px, 11vw, 108px);
           }
           #carton-destacado .carton-box,
           #carton-destacado .carton-wrapper,
@@ -3859,16 +3863,16 @@
               align-self: stretch;
               width: 100%;
               max-width: var(--carton-contenido-ancho, 100%);
-              gap: clamp(0px, 0.6vw, 4px);
-              padding: clamp(4px, 1vw, 8px);
+              gap: calc(clamp(0px, 0.6vw, 4px) * var(--carton-destacado-factor, 1));
+              padding: calc(clamp(4px, 1vw, 8px) * var(--carton-destacado-factor, 1));
               grid-template-rows: min-content minmax(0, 1fr);
-              align-content: stretch;
+              align-content: center;
               justify-items: stretch;
               overflow: visible;
           }
           #carton-destacado .carton-front,
           #carton-destacado .carton-back {
-              min-height: var(--carton-contenido-alto, auto);
+              min-height: 0;
               overflow: visible;
               display: flex;
               flex-direction: column;
@@ -3876,8 +3880,8 @@
               justify-content: flex-start;
           }
           #carton-destacado .carton-front {
-              gap: clamp(0px, 0.6vw, 4px);
-              justify-content: flex-start;
+              gap: calc(clamp(0px, 0.6vw, 4px) * var(--carton-destacado-factor, 1));
+              justify-content: center;
           }
           #carton-destacado .carton-front .carton-visual > * {
               margin: 0;
@@ -4081,6 +4085,7 @@
               margin-inline: auto;
               width: 100%;
               max-width: var(--carton-contenido-ancho);
+              --destacado-cell-size-base: clamp(40px, 10.4vw, 100px);
           }
           #carton-destacado .carton-wrapper {
               --carton-wrapper-altura: var(--carton-contenido-alto);
@@ -4120,6 +4125,7 @@
           }
           #carton-destacado {
               --destacado-cell-size: clamp(40px, 10.4vw, 100px);
+              --destacado-cell-size-base: clamp(40px, 10.4vw, 100px);
           }
           #formas-mensaje {
               grid-area: mensaje;
@@ -4151,6 +4157,7 @@
             #carton-destacado {
                 --carton-contenido-ancho: clamp(380px, 30vw, 520px);
                 --destacado-cell-size: clamp(56px, 5.2vw, 82px);
+                --destacado-cell-size-base: clamp(56px, 5.2vw, 82px);
             }
             #carton-destacado .carton-tabla--principal thead th {
                 font-size: calc(var(--principal-cell-size, var(--cell-size)) * 0.94);
@@ -4192,6 +4199,7 @@
                 --carton-destacado-margen: clamp(12px, 1.2vw, 20px);
                 --carton-contenido-ancho: clamp(400px, 28vw, 540px);
                 --destacado-cell-size: clamp(60px, 4.8vw, 86px);
+                --destacado-cell-size-base: clamp(60px, 4.8vw, 86px);
             }
             #carton-destacado .carton-box,
             #carton-destacado .carton-wrapper {
@@ -4204,8 +4212,8 @@
                 font-size: calc(var(--principal-cell-size, var(--cell-size)) * 0.76);
             }
             .conducto-sphere {
-                --conducto-esfera-base: clamp(calc(var(--conducto-cell-size-real) * 0.84), 44px, calc(var(--conducto-cell-size-real) * 0.98));
-                --conducto-esfera-font-base: clamp(0.96rem, 1.2vw, 1.24rem);
+                --conducto-esfera-base: clamp(calc(var(--conducto-cell-size-real) * 0.72), 38px, calc(var(--conducto-cell-size-real) * 0.9));
+                --conducto-esfera-font-base: clamp(0.88rem, 1.08vw, 1.12rem);
             }
             .whatsapp-flotante {
                 right: var(--app-desktop-side-padding, 18px);
@@ -6587,8 +6595,17 @@
       elementosAltura.forEach(el=>el?.style?.removeProperty('--carton-contenido-alto'));
       const estilosCartonDestacado=cartonDestacadoContenedor?getComputedStyle(cartonDestacadoContenedor):null;
       const tamanoCeldaActual=estilosCartonDestacado?parseFloat(estilosCartonDestacado.getPropertyValue('--destacado-cell-size')):NaN;
+      const tamanoCeldaBase=estilosCartonDestacado?parseFloat(estilosCartonDestacado.getPropertyValue('--destacado-cell-size-base')):NaN;
       const rectContenedor=cartonDestacadoContenedor?cartonDestacadoContenedor.getBoundingClientRect():null;
       const anchoFrente=frente?frente.getBoundingClientRect().width:0;
+      if(cartonDestacadoContenedor){
+        if(!enModoRetrato && Number.isFinite(tamanoCeldaActual) && tamanoCeldaActual>0 && Number.isFinite(tamanoCeldaBase) && tamanoCeldaBase>0){
+          const factor=Math.max(0.78, Math.min(tamanoCeldaActual/tamanoCeldaBase, 1));
+          cartonDestacadoContenedor.style.setProperty('--carton-destacado-factor', factor.toFixed(3));
+        }else{
+          cartonDestacadoContenedor.style.removeProperty('--carton-destacado-factor');
+        }
+      }
       if(anchoFrente>0){
         const anchoFinal=Math.ceil(anchoFrente);
         const anchoValor=`${anchoFinal}px`;


### PR DESCRIPTION
### Motivation
- En vista escritorio/pantallas grandes el contenedor del `carton-destacado` y sus elementos anidados estaban sobredimensionados y las bolitas del conducto se veían demasiado grandes respecto a los márgenes, provocando problemas visuales; la vista móvil no debía modificarse. 

### Description
- Introduce la variable CSS `--carton-destacado-factor` y `--destacado-cell-size-base` y aplica ese factor a `border-radius`, `gap`, `padding` y al cálculo de `--principal-cell-size` para escalar proporcionalmente todos los contenedores anidados del cartón destacado en escritorio. 
- Ajusta reglas CSS en los distintos `@media` de escritorio/landscape para fijar un `destacado-cell-size` base por breakpoint sin afectar móvil y para evitar alturas mínimas que forzaban la expansión del contenedor. 
- Modifica la función `actualizarAlturaCartonWrapper` (JS inline) para calcular un factor de escala basado en el tamaño real de la celda (`--destacado-cell-size` vs `--destacado-cell-size-base`) y aplicar `--carton-destacado-factor` dinámicamente en pantallas no retrato. 
- Reduce ligeramente las variables que controlan el tamaño de las bolitas del conducto (`.conducto-sphere`) en puntos de ruptura de escritorio para que queden bien dentro de los márgenes azules, manteniendo las reglas móviles intactas. 
- Todos los cambios se limitaron al archivo `public/juegoactivo.html` y se diseñaron para no tocar la experiencia móvil. 

### Testing
- Ejecutado `npm test -- --runInBand` y todos los test suites pasaron (11 suites, 35 tests; `PASS`). 
- Verificado sintaxis del JavaScript inline con la extracción a `/tmp/juegoactivo-inline.js` y `node --check /tmp/juegoactivo-inline.js`, sin errores de sintaxis. 
- No se realizaron cambios que afecten otras rutas o funcionalidades fuera del layout; la vista móvil fue revisada para garantizar que no se modificó su comportamiento.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bca5926a2883268a038f3a2aacf14d)