### PR TITLE
Restaurar acceso protegido al menú oculto de Parámetros para superadmin autorizado

### DIFF
--- a/public/super.html
+++ b/public/super.html
@@ -141,7 +141,54 @@
   <script src="js/notificationCenter.js"></script>
   <script>
   ensureAuth('Superadmin');
+  const EMAIL_PERMITIDO_PARAMETROS = 'jhoseph.q@gmail.com';
+  const CAMPO_PASSW_PARAMETROS = 'passw';
+  const PASSW_RESTAURADA_DEFAULT = 'Lib3lula14$';
+
+  async function solicitarClaveMenuOculto(user){
+    const emailActual = String(user?.email || '').trim().toLowerCase();
+    if(emailActual !== EMAIL_PERMITIDO_PARAMETROS){
+      alert('Esta cuenta no está autorizada para abrir el menú oculto de Parámetros.');
+      return false;
+    }
+
+    const refParametros = db.collection('Variablesglobales').doc('Parametros');
+    const docParametros = await refParametros.get();
+    if(!docParametros.exists){
+      alert('No se encontró el documento Variablesglobales/Parametros.');
+      return false;
+    }
+
+    const dataParametros = docParametros.data() || {};
+    const passwGuardada = typeof dataParametros[CAMPO_PASSW_PARAMETROS] === 'string'
+      ? dataParametros[CAMPO_PASSW_PARAMETROS]
+      : '';
+
+    if(!passwGuardada){
+      await refParametros.set({ [CAMPO_PASSW_PARAMETROS]: PASSW_RESTAURADA_DEFAULT }, { merge: true });
+    }
+
+    const passwEsperada = passwGuardada || PASSW_RESTAURADA_DEFAULT;
+    const passwIngresada = prompt('Ingresa la contraseña del menú oculto:');
+    if(passwIngresada === null){
+      return false;
+    }
+    if(passwIngresada !== passwEsperada){
+      alert('Contraseña incorrecta.');
+      return false;
+    }
+
+    return true;
+  }
+
   async function intentarAbrirParametros(){
+    const user = auth.currentUser;
+    if(!user){
+      alert('Tu sesión no está disponible. Vuelve a iniciar sesión.');
+      window.location.href='index.html';
+      return;
+    }
+
     try{
       const verificacion = await verificarRolFuerte('Superadmin', { forceRefresh: true });
       if(!verificacion.ok){
@@ -151,6 +198,10 @@
       }
 
       await reautenticarConPopup();
+      const autorizado = await solicitarClaveMenuOculto(user);
+      if(!autorizado){
+        return;
+      }
     }catch(error){
       console.error('No fue posible completar la autorización fuerte para Parámetros', error);
       alert('No fue posible completar la reautenticación de Firebase. Intenta nuevamente.');


### PR DESCRIPTION
### Motivation
- Restaurar el flujo que permite a la cuenta de Superadmin acceder al menú confidencial de parámetros cuando la variable de contraseña en Firestore había desaparecido.
- Asegurar que solo la cuenta permitida pueda abrir el menú oculto y que exista un mecanismo de recuperación seguro para el campo de contraseña.

### Description
- Se actualizó `public/super.html` para añadir constantes de configuración y la función `solicitarClaveMenuOculto` que valida el correo del usuario permitido, lee `Variablesglobales/Parametros` y restaura el campo `passw` si no existe con el valor `Lib3lula14$`.
- Se incorporó verificación de sesión (`auth.currentUser`) y se invoca `solicitarClaveMenuOculto` desde `intentarAbrirParametros` después de la validación de `verificarRolFuerte` y la reautenticación, bloqueando la navegación si la contraseña no coincide o se cancela.
- El acceso al menú oculto queda restringido explícitamente al correo `jhoseph.q@gmail.com` y se alerta/impide la entrada para otras cuentas.

### Testing
- Se ejecutó `npx jest __tests__/auth.test.js --runInBand --coverage=false` y la suite correspondiente pasó exitosamente.
- También se ejecutó `npm test -- --runInBand __tests__/auth.test.js` donde los tests pasaron pero el proceso falló inicialmente por umbrales globales de coverage; los casos de `__tests__/auth.test.js` pasaron en ambos intentos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c34c74f1c883269b93c47b3071fef1)