### PR TITLE
Sincroniza initUsers con Firebase Auth y custom claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,16 @@ Este segundo script poblará la colección `Bancos` con los bancos iniciales.
 
 Debe disponer de un archivo `serviceAccountKey.json` con las credenciales de Firebase o definir la variable `GOOGLE_APPLICATION_CREDENTIALS` apuntando al archivo de claves.
 
-Este script creará las entradas en la colección `users` y actualizará los roles en caso de que ya existan.
+Este script crea/actualiza las entradas en la colección `users` y, en la misma ejecución, sincroniza Firebase Auth:
+
+- verifica cada correo con `getUserByEmail`
+- si el usuario no existe en Auth, lo crea automáticamente (o reporta claramente el error)
+- aplica `setCustomUserClaims` para cuentas **Superadmin** con:
+  - `role: 'Superadmin'`
+  - `roles: ['Superadmin']`
+  - `admin: true`
+
+De esta forma, la inicialización de usuarios especiales deja perfil (`users/{email}`) + *custom claims* sincronizados en una sola corrida.
 
 ## Subida de imágenes
 

--- a/initUsers.js
+++ b/initUsers.js
@@ -1,6 +1,14 @@
 const admin = require('firebase-admin');
 const fs = require('fs');
 
+const DEFAULT_CLAIMS_BY_ROLE = {
+  Superadmin: {
+    role: 'Superadmin',
+    roles: ['Superadmin'],
+    admin: true,
+  },
+};
+
 let credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS || './serviceAccountKey.json';
 if (!fs.existsSync(credentialsPath)) {
   console.error('Service account credentials not found at', credentialsPath);
@@ -12,10 +20,30 @@ admin.initializeApp({
 });
 
 const db = admin.firestore();
+const auth = admin.auth();
 
-async function createUser(email, role) {
+async function ensureAuthUser(email) {
+  try {
+    const userRecord = await auth.getUserByEmail(email);
+    console.log(`[Auth] Usuario encontrado: ${email} (uid=${userRecord.uid})`);
+    return userRecord;
+  } catch (error) {
+    if (error && error.code === 'auth/user-not-found') {
+      const created = await auth.createUser({ email });
+      console.log(`[Auth] Usuario no existía y fue creado: ${email} (uid=${created.uid})`);
+      return created;
+    }
+
+    const details = error?.message || error;
+    console.error(`[Auth] No se pudo verificar/crear el usuario ${email}:`, details);
+    throw error;
+  }
+}
+
+async function syncSpecialUser(email, role) {
   const ref = db.collection('users').doc(email);
   const doc = await ref.get();
+
   if (!doc.exists) {
     await ref.set({
       email,
@@ -23,21 +51,29 @@ async function createUser(email, role) {
       role,
       aceptoNotificaciones: 'NO',
     });
-    console.log(`Created user ${email} with role ${role}`);
+    console.log(`[Firestore] Creado users/${email} con role=${role}`);
+  } else if (doc.data().role !== role) {
+    await ref.update({ role });
+    console.log(`[Firestore] Actualizado users/${email}.role a ${role}`);
   } else {
-    if (doc.data().role !== role) {
-      await ref.update({ role });
-      console.log(`Updated role for ${email} to ${role}`);
-    } else {
-      console.log(`User ${email} already exists`);
-    }
+    console.log(`[Firestore] users/${email}.role ya estaba en ${role}`);
+  }
+
+  const authUser = await ensureAuthUser(email);
+  const claims = DEFAULT_CLAIMS_BY_ROLE[role];
+
+  if (claims) {
+    await auth.setCustomUserClaims(authUser.uid, claims);
+    console.log(`[Claims] Aplicado claim para ${email}: ${JSON.stringify(claims)}`);
+  } else {
+    console.log(`[Claims] Sin cambios para ${email}: no hay claims definidos para role=${role}`);
   }
 }
 
 async function main() {
-  await createUser('jhoseph.q@gmail.com', 'Superadmin');
-  await createUser('cyz513@gmail.com', 'Superadmin');
-  await createUser('hexaservice.co@gmail.com', 'Colaborador');
+  await syncSpecialUser('jhoseph.q@gmail.com', 'Superadmin');
+  await syncSpecialUser('cyz513@gmail.com', 'Superadmin');
+  await syncSpecialUser('hexaservice.co@gmail.com', 'Colaborador');
 }
 
 main().then(() => process.exit(0)).catch(err => {


### PR DESCRIPTION
### Motivation
- Garantizar que la inicialización de usuarios especiales deje en sincronía el perfil en Firestore (`users/{email}`) y los *custom claims* en Firebase Auth en una sola ejecución.
- Asegurar que cuentas con rol `Superadmin` reciban los claims necesarios para privilegios administrativos.
- Manejar claramente el caso en que un usuario no exista en Auth creando la cuenta o reportando el error. 
- Añadir logs explícitos para facilitar auditoría y depuración del proceso de inicialización.

### Description
- Se añadió `DEFAULT_CLAIMS_BY_ROLE` con el objeto de claims para `Superadmin`: `{ role: 'Superadmin', roles: ['Superadmin'], admin: true }`.
- Se implementó `ensureAuthUser(email)` que usa `auth.getUserByEmail` y crea el usuario con `auth.createUser` si no existe, con logs claros de cada paso.
- Se reemplazó la función previa por `syncSpecialUser(email, role)` que crea/actualiza `users/{email}` en Firestore y luego sincroniza/establece los *custom claims* mediante `auth.setCustomUserClaims` cuando aplica.
- Se actualizó `README.md` documentando el comportamiento: el script ahora verifica/crea usuarios en Auth y aplica los claims de `Superadmin`, dejando perfil + claims sincronizados en una sola corrida.

### Testing
- Se validó sintácticamente el script con `node --check initUsers.js` y la comprobación finalizó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c35111fee88326a52a69bdb43a5029)