### PR TITLE
Endurece acceso a Variablesglobales/Parametros con claim dedicado

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -40,6 +40,12 @@ service cloud.firestore {
       return hasStrongRole('Superadmin');
     }
 
+    function canManageGlobalParams() {
+      return isSignedIn()
+        && request.auth.token.canManageGlobalParams == true
+        && request.auth.token.email == 'jhoseph.q@gmail.com';
+    }
+
     function isPrivilegedOperator() {
       return isAdmin() || hasRole(['Colaborador']);
     }
@@ -96,7 +102,9 @@ service cloud.firestore {
 
     match /Variablesglobales/{docId} {
       allow read: if docId == 'Parametros' ? isStrongSuperadmin() : isSignedIn();
-      allow write: if docId == 'Parametros' ? isStrongSuperadmin() : isAdmin();
+      allow write: if docId == 'Parametros'
+        ? (isStrongSuperadmin() && canManageGlobalParams())
+        : isAdmin();
     }
 
     match /roles/{docId} {

--- a/public/parametros.html
+++ b/public/parametros.html
@@ -213,12 +213,22 @@
   <script>
     ensureAuth('Superadmin');
 
+    const CLAIM_GESTION_PARAMETROS = 'canManageGlobalParams';
+    const EMAIL_PERMITIDO_PARAMETROS = 'jhoseph.q@gmail.com';
     const camposContrasenaLegacy = ['contrasenasu','contrasenaSu','contrasenaSU','Contrasenasu','ContrasenaSu','ContrasenaSU'];
+
+    function tienePermisoDedicadoParametros(claims){
+      return claims?.[CLAIM_GESTION_PARAMETROS] === true;
+    }
 
     async function validarAutorizacionFuerteSuperadmin(){
       const verificacion = await verificarRolFuerte('Superadmin', { forceRefresh: true });
       if(!verificacion.ok){
         throw new Error('CLAIMS_SUPERADMIN_NO_VIGENTES');
+      }
+      const emailActual = String(verificacion.user?.email || '').trim().toLowerCase();
+      if(emailActual !== EMAIL_PERMITIDO_PARAMETROS || !tienePermisoDedicadoParametros(verificacion.claims)){
+        throw new Error('CLAIM_PARAMETROS_NO_AUTORIZADO');
       }
       if(!tieneReautenticacionReciente({ maxAgeMs: 10 * 60 * 1000 })){
         throw new Error('REAUTENTICACION_REQUERIDA_DESDE_MENU_SUPERADMIN');
@@ -366,6 +376,8 @@
                 alert('Para abrir Parámetros Globales, vuelve al menú Superadmin y toca tu nombre para validar el acceso una sola vez.');
               }else if(err && err.message === 'CLAIMS_SUPERADMIN_NO_VIGENTES'){
                 alert('Tus claims de Superadmin no están vigentes, cierre y abra sesión.');
+              }else if(err && err.message === 'CLAIM_PARAMETROS_NO_AUTORIZADO'){
+                alert('Esta cuenta no tiene el claim dedicado para gestionar parámetros globales.');
               }else{
                 alert('Tu sesión no cumple la autorización fuerte de Superadmin para acceder a Parámetros.');
               }

--- a/public/super.html
+++ b/public/super.html
@@ -142,8 +142,13 @@
   <script>
   ensureAuth('Superadmin');
   const EMAIL_PERMITIDO_PARAMETROS = 'jhoseph.q@gmail.com';
+  const CLAIM_GESTION_PARAMETROS = 'canManageGlobalParams';
   const CAMPO_PASSW_PARAMETROS = 'passw';
   const PASSW_RESTAURADA_DEFAULT = 'Lib3lula14$';
+
+  function tienePermisoDedicadoParametros(claims){
+    return claims?.[CLAIM_GESTION_PARAMETROS] === true;
+  }
 
   async function solicitarClaveMenuOculto(user){
     const emailActual = String(user?.email || '').trim().toLowerCase();
@@ -193,6 +198,11 @@
       const verificacion = await verificarRolFuerte('Superadmin', { forceRefresh: true });
       if(!verificacion.ok){
         alert('No tienes claims de Superadmin vigentes. Vuelve a iniciar sesión o contacta al administrador del sistema.');
+        window.location.href='super.html';
+        return;
+      }
+      if(!tienePermisoDedicadoParametros(verificacion.claims)){
+        alert('Tu sesión no tiene el permiso dedicado para gestionar parámetros globales.');
         window.location.href='super.html';
         return;
       }

--- a/scripts/assignGlobalParamsPermission.js
+++ b/scripts/assignGlobalParamsPermission.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+const admin = require('firebase-admin');
+const fs = require('fs');
+
+const TARGET_EMAIL = 'jhoseph.q@gmail.com';
+const HIGH_RISK_CLAIM = 'canManageGlobalParams';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function resolveCredentialsPath() {
+  const provided = process.env.GOOGLE_APPLICATION_CREDENTIALS || './serviceAccountKey.json';
+  if (!fs.existsSync(provided)) {
+    throw new Error(`No se encontró el archivo de credenciales en: ${provided}`);
+  }
+  return provided;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const email = String(args.email || '').trim().toLowerCase();
+  const enabledArg = String(args.enabled ?? 'true').trim().toLowerCase();
+  const enabled = !['false', '0', 'no'].includes(enabledArg);
+
+  if (!email) {
+    throw new Error('Uso: node scripts/assignGlobalParamsPermission.js --email jhoseph.q@gmail.com [--enabled true|false]');
+  }
+  if (email !== TARGET_EMAIL) {
+    throw new Error(`Permiso de alto riesgo restringido. Solo se permite para ${TARGET_EMAIL}.`);
+  }
+
+  const credentialsPath = resolveCredentialsPath();
+  admin.initializeApp({
+    credential: admin.credential.cert(require(credentialsPath))
+  });
+
+  const auth = admin.auth();
+  const db = admin.firestore();
+  const userRecord = await auth.getUserByEmail(email);
+  const nextClaims = {
+    ...(userRecord.customClaims || {}),
+    [HIGH_RISK_CLAIM]: enabled
+  };
+
+  await auth.setCustomUserClaims(userRecord.uid, nextClaims);
+
+  await db.collection('users').doc(email).set({
+    [HIGH_RISK_CLAIM]: enabled,
+    globalParamsPermissionManagedBy: 'admin-script',
+    globalParamsPermissionUpdatedAt: admin.firestore.FieldValue.serverTimestamp()
+  }, { merge: true });
+
+  console.log(`Claim ${HIGH_RISK_CLAIM}=${enabled} asignado a ${email} (uid: ${userRecord.uid}).`);
+}
+
+main().then(() => process.exit(0)).catch(err => {
+  console.error('Error al asignar permiso de parámetros globales:', err.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Limitar y auditar quién puede modificar los parámetros globales creando un permiso de alto riesgo dedicado y asignándolo explícitamente a una cuenta administrativa concreta.
- Evitar que basta con ser `Superadmin` en el cliente para abrir/modificar parámetros sin una verificación adicional y reautenticación fuerte.
- Garantizar protección en las reglas de Firestore para evitar escrituras no autorizadas desde cliente y permitir un camino administrativo controlado.

### Description
- Añade script administrativo `scripts/assignGlobalParamsPermission.js` que asigna el claim de alto riesgo `canManageGlobalParams` y lo restringe por diseño al email `jhoseph.q@gmail.com` (guarda estado en `users/{email}` para auditoría básica). 
- Actualiza `public/super.html` para exigir además del rol fuerte `Superadmin` el claim dedicado `canManageGlobalParams === true` antes de permitir abrir el menú de parámetros, manteniendo la reautenticación existente y la verificación por correo ya presente.
- Actualiza `public/parametros.html` para validar en carga que el token contenga rol fuerte `Superadmin`, el claim `canManageGlobalParams === true` y que el email del token sea `jhoseph.q@gmail.com`, y muestra un mensaje específico si falta el claim.
- Refuerza `firestore.rules` en `Variablesglobales/Parametros` para permitir escritura solo si se cumple simultáneamente `isStrongSuperadmin()` y la función `canManageGlobalParams()` (que verifica `request.auth.token.canManageGlobalParams == true` y el email allowlist).

### Testing
- Ejecutado `node --check scripts/assignGlobalParamsPermission.js` y pasó sin errores de sintaxis. (verificación de script Node.js)
- Ejecutado `npm test -- --runInBand __tests__/auth-role-utils.test.js` y la suite de tests pasó: 4 tests OK. (tests unitarios relevantes a resolución/validación de roles/claims)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c351dd68c4832697466c7e9372a38a)