### PR TITLE
Add PR-driven Firestore mutation workflow and apply script for Bingoanimalito

### DIFF
--- a/.github/workflows/bingoanimalito-firebase-pr-sync.yml
+++ b/.github/workflows/bingoanimalito-firebase-pr-sync.yml
@@ -1,0 +1,75 @@
+name: Bingoanimalito Firestore Sync by PR
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+    paths:
+      - 'firebase/bingoanimalito/**.json'
+  workflow_dispatch:
+    inputs:
+      files:
+        description: 'Rutas JSON separadas por coma (opcional para ejecución manual)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  apply-mutations:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Detectar archivos JSON cambiados en el PR
+        id: changed
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.merge_commit_sha }}" | grep '^firebase/bingoanimalito/.*\.json$' | paste -sd, -)
+          echo "files=${FILES}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolver archivos a procesar
+        id: target
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            FILES="${{ inputs.files }}"
+          else
+            FILES="${{ steps.changed.outputs.files }}"
+          fi
+
+          if [ -z "${FILES}" ]; then
+            echo "No hay archivos JSON para procesar."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "files=${FILES}" >> "$GITHUB_OUTPUT"
+          echo "Archivos detectados: ${FILES}"
+
+      - name: Aplicar mutaciones en Firestore (Bingoanimalito)
+        if: steps.target.outputs.files != ''
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/firebase-sa.json
+          FIREBASE_SA_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGOANIMALITO }}
+        run: |
+          set -euo pipefail
+          if [ -z "${FIREBASE_SA_JSON}" ]; then
+            echo "::error::Falta el secreto FIREBASE_SERVICE_ACCOUNT_BINGOANIMALITO"
+            exit 1
+          fi
+          printf '%s' "${FIREBASE_SA_JSON}" > "${GOOGLE_APPLICATION_CREDENTIALS}"
+          node scripts/applyFirestoreMutations.js --files "${{ steps.target.outputs.files }}"

--- a/README.md
+++ b/README.md
@@ -135,6 +135,28 @@ Los flujos definidos en `.github/workflows/` generan `public/firebase-config.js`
 
 Cada secreto debe contener el valor correspondiente del proyecto de Firebase. Si utiliza otras herramientas de despliegue, replique el mismo proceso de copiado y reemplazo de marcadores antes de publicar los archivos.
 
+## Mutaciones de Firestore por Pull Request (Bingoanimalito)
+
+Para replicar el flujo de cambios auditables vía PR en una base de Firebase, este repositorio incluye:
+
+- Workflow: `.github/workflows/bingoanimalito-firebase-pr-sync.yml`
+- Script: `scripts/applyFirestoreMutations.js`
+- Carpeta de cambios: `firebase/bingoanimalito/`
+
+### Cómo usarlo
+
+1. Cree un archivo JSON dentro de `firebase/bingoanimalito/` con las mutaciones (`set`, `update`, `delete`).
+2. Abra un PR hacia `main`.
+3. Al hacer merge, el workflow detecta los archivos JSON modificados y ejecuta las mutaciones con Firebase Admin SDK.
+
+También puede ejecutarse manualmente con `workflow_dispatch` pasando `files` (coma-separado) o localmente:
+
+```bash
+npm run apply-firebase-mutations -- --files firebase/bingoanimalito/mi-cambio.json
+```
+
+> Requisito: configurar el secreto `FIREBASE_SERVICE_ACCOUNT_BINGOANIMALITO` en GitHub con la cuenta de servicio JSON.
+
 ## Directrices de desarrollo
 
 - Toda obtención o cálculo de fechas y horas debe realizarse empleando el huso horario definido para el despliegue del sistema.
@@ -150,7 +172,6 @@ Cada secreto debe contener el valor correspondiente del proyecto de Firebase. Si
 - El documento `Variablesglobales/Parametros` contiene configuración sensible y se trata como **confidencial**.
 - En `firestore.rules`, su lectura y escritura requieren privilegio fuerte de **Superadmin** (`isStrongSuperadmin()`).
 - La página `public/parametros.html` está diseñada para este mismo nivel de privilegio; usuarios autenticados sin rol fuerte de Superadmin deben recibir denegación de acceso al intentar leer ese documento.
-
 
 
 

--- a/firebase/bingoanimalito/README.md
+++ b/firebase/bingoanimalito/README.md
@@ -1,0 +1,46 @@
+# Mutaciones de Firestore para Bingoanimalito
+
+Esta carpeta define cambios de datos que se aplican automáticamente cuando un PR es **mergeado** a `main`.
+
+## Flujo
+
+1. Crear un archivo JSON en esta carpeta (ejemplo: `2026-03-27-actualizar-parametros.json`).
+2. Abrir PR y solicitar revisión.
+3. Al hacer merge, el workflow `.github/workflows/bingoanimalito-firebase-pr-sync.yml` aplica las mutaciones con Firebase Admin SDK.
+
+## Formato de archivo
+
+```json
+{
+  "author": "tu.usuario",
+  "ticket": "BA-123",
+  "mutations": [
+    {
+      "op": "set",
+      "path": "Variablesglobales/Parametros",
+      "merge": true,
+      "data": {
+        "Aplicacion": "Bingoanimalito",
+        "Pais": "VE"
+      }
+    },
+    {
+      "op": "update",
+      "path": "configuracion/general",
+      "data": {
+        "modo": "produccion"
+      }
+    },
+    {
+      "op": "delete",
+      "path": "temporal/documento-demo"
+    }
+  ]
+}
+```
+
+## Secretos requeridos en GitHub
+
+- `FIREBASE_SERVICE_ACCOUNT_BINGOANIMALITO`
+
+Debe contener el JSON completo de la cuenta de servicio con permisos de escritura en Firestore.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node uploadServer.js",
     "cron": "node cronActualizarEstadosSorteos.js",
     "assign-role": "node scripts/assignRoleClaims.js",
+    "apply-firebase-mutations": "node scripts/applyFirestoreMutations.js",
     "test:coverage": "jest --coverage",
     "reconciliar-premios": "node scripts/reconciliarPremiosPendientes.js"
   },

--- a/scripts/applyFirestoreMutations.js
+++ b/scripts/applyFirestoreMutations.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const admin = require('firebase-admin');
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const current = argv[i];
+    if (!current.startsWith('--')) continue;
+    const key = current.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      args[key] = next;
+      i += 1;
+    } else {
+      args[key] = 'true';
+    }
+  }
+  return args;
+}
+
+function loadMutationFile(filePath) {
+  const absPath = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`No existe el archivo de mutaciones: ${filePath}`);
+  }
+
+  const raw = fs.readFileSync(absPath, 'utf8');
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`JSON inválido en ${filePath}: ${error.message}`);
+  }
+
+  if (!Array.isArray(payload.mutations) || payload.mutations.length === 0) {
+    throw new Error(`El archivo ${filePath} debe incluir un arreglo "mutations" con al menos 1 elemento.`);
+  }
+
+  return payload;
+}
+
+function initializeFirebase() {
+  if (admin.apps.length > 0) return;
+  admin.initializeApp();
+}
+
+function validateMutation(mutation, index, sourceFile) {
+  if (!mutation || typeof mutation !== 'object') {
+    throw new Error(`[${sourceFile}] mutations[${index}] no es un objeto válido.`);
+  }
+
+  const { op, path: docPath } = mutation;
+  if (!docPath || typeof docPath !== 'string' || !docPath.includes('/')) {
+    throw new Error(`[${sourceFile}] mutations[${index}] requiere "path" con formato collection/document.`);
+  }
+
+  if (!['set', 'update', 'delete'].includes(op)) {
+    throw new Error(`[${sourceFile}] mutations[${index}] op inválido. Usa set, update o delete.`);
+  }
+
+  if ((op === 'set' || op === 'update') && (typeof mutation.data !== 'object' || mutation.data === null || Array.isArray(mutation.data))) {
+    throw new Error(`[${sourceFile}] mutations[${index}] requiere "data" objeto para op=${op}.`);
+  }
+}
+
+async function applyMutation(db, mutation) {
+  const ref = db.doc(mutation.path);
+  if (mutation.op === 'delete') {
+    await ref.delete();
+    return { op: 'delete', path: mutation.path };
+  }
+
+  if (mutation.op === 'set') {
+    const merge = mutation.merge !== false;
+    await ref.set(mutation.data, { merge });
+    return { op: 'set', path: mutation.path, merge };
+  }
+
+  await ref.update(mutation.data);
+  return { op: 'update', path: mutation.path };
+}
+
+async function run() {
+  const args = parseArgs(process.argv);
+  const filesArg = args.files || args.file;
+
+  if (!filesArg) {
+    throw new Error('Debes indicar --files con rutas separadas por coma.');
+  }
+
+  const files = filesArg
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  initializeFirebase();
+  const db = admin.firestore();
+
+  for (const filePath of files) {
+    const payload = loadMutationFile(filePath);
+    const author = payload.author || 'desconocido';
+    const ticket = payload.ticket || 'sin-ticket';
+    console.log(`Procesando ${filePath} (author=${author}, ticket=${ticket})`);
+
+    for (let i = 0; i < payload.mutations.length; i += 1) {
+      const mutation = payload.mutations[i];
+      validateMutation(mutation, i, filePath);
+      const result = await applyMutation(db, mutation);
+      console.log(`✔ ${result.op} ${result.path}`);
+    }
+  }
+}
+
+run().catch((error) => {
+  console.error(`Error aplicando mutaciones de Firestore: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Permitir aplicar mutaciones de Firestore de manera auditable mediante archivos JSON incluidos en PRs para el entorno Bingoanimalito.
- Soportar ejecución automática al hacer merge y ejecución manual (`workflow_dispatch`) con una lista de archivos para operaciones puntuales.

### Description

- Añade el workflow de GitHub Actions `/.github/workflows/bingoanimalito-firebase-pr-sync.yml` que detecta JSONs en `firebase/bingoanimalito/**.json`, extrae los archivos modificados y aplica mutaciones si el PR fue mergeado o si se ejecuta manualmente, usando el secreto `FIREBASE_SERVICE_ACCOUNT_BINGOANIMALITO`.
- Agrega el script `scripts/applyFirestoreMutations.js` que parsea los archivos JSON, valida cada mutación (`set`, `update`, `delete`), inicializa `firebase-admin` y aplica las operaciones sobre documentos de Firestore con logging y manejo de errores.
- Documenta el flujo y formato en `firebase/bingoanimalito/README.md` y actualiza `README.md` del repositorio con instrucciones de uso, requisitos de secreto y ejemplo de invocación local/CI.
- Añade el script npm `apply-firebase-mutations` en `package.json` para ejecutar localmente el aplicador de mutaciones.

### Testing

- No se ejecutaron pruebas automatizadas adicionales como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c556e87b648326962e8241834b202b)