### PR TITLE
Restringe acceso a Parámetros al correo desarrollador y oculta detalles de errores de registro

### DIFF
--- a/public/parametros.html
+++ b/public/parametros.html
@@ -212,27 +212,12 @@
   <script src="js/notificationCenter.js"></script>
   <script>
     ensureAuth('Superadmin');
-
-    const CLAIM_GESTION_PARAMETROS = 'canManageGlobalParams';
     const EMAIL_PERMITIDO_PARAMETROS = 'jhoseph.q@gmail.com';
     const camposContrasenaLegacy = ['contrasenasu','contrasenaSu','contrasenaSU','Contrasenasu','ContrasenaSu','ContrasenaSU'];
 
-    function tienePermisoDedicadoParametros(claims){
-      return claims?.[CLAIM_GESTION_PARAMETROS] === true;
-    }
-
-    async function validarAutorizacionFuerteSuperadmin(){
-      const verificacion = await verificarRolFuerte('Superadmin', { forceRefresh: true });
-      if(!verificacion.ok){
-        throw new Error('CLAIMS_SUPERADMIN_NO_VIGENTES');
-      }
-      const emailActual = String(verificacion.user?.email || '').trim().toLowerCase();
-      if(emailActual !== EMAIL_PERMITIDO_PARAMETROS || !tienePermisoDedicadoParametros(verificacion.claims)){
-        throw new Error('CLAIM_PARAMETROS_NO_AUTORIZADO');
-      }
-      if(!tieneReautenticacionReciente({ maxAgeMs: 10 * 60 * 1000 })){
-        throw new Error('REAUTENTICACION_REQUERIDA_DESDE_MENU_SUPERADMIN');
-      }
+    function usuarioPuedeGestionarParametros(user){
+      const emailActual = String(user?.email || '').trim().toLowerCase();
+      return emailActual === EMAIL_PERMITIDO_PARAMETROS;
     }
 
     async function migrarContrasenaLegacyParametros(){
@@ -366,20 +351,18 @@
           auth.onAuthStateChanged(async usuario=>{
             if(!usuario || parametrosYaInicializados) return;
             try{
-              await validarAutorizacionFuerteSuperadmin();
+              if(!usuarioPuedeGestionarParametros(usuario)){
+                throw new Error('USUARIO_NO_AUTORIZADO_PARAMETROS');
+              }
               await iniciarParametros();
               parametrosYaInicializados=true;
             }catch(err){
               parametrosYaInicializados=false;
               console.error('Fallo al cargar parámetros tras autenticar',err);
-              if(err && err.message === 'REAUTENTICACION_REQUERIDA_DESDE_MENU_SUPERADMIN'){
-                alert('Para abrir Parámetros Globales, vuelve al menú Superadmin y toca tu nombre para validar el acceso una sola vez.');
-              }else if(err && err.message === 'CLAIMS_SUPERADMIN_NO_VIGENTES'){
-                alert('Tus claims de Superadmin no están vigentes, cierre y abra sesión.');
-              }else if(err && err.message === 'CLAIM_PARAMETROS_NO_AUTORIZADO'){
-                alert('Esta cuenta no tiene el claim dedicado para gestionar parámetros globales.');
+              if(err && err.message === 'USUARIO_NO_AUTORIZADO_PARAMETROS'){
+                alert('Esta cuenta no está autorizada para acceder a Parámetros.');
               }else{
-                alert('Tu sesión no cumple la autorización fuerte de Superadmin para acceder a Parámetros.');
+                alert('No fue posible cargar Parámetros en este momento.');
               }
               window.location.href='super.html';
             }

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -652,7 +652,9 @@
         window.location.href='player.html';
       }catch(err){
         limpiarRegistroPendiente();
-        if(err?.message!=='telefono_invalido'){ setFieldMessage('confirmacion','No se pudo completar el registro. Revisa tus datos.'); }
+        if(err?.message!=='telefono_invalido'){
+          setFieldMessage('confirmacion','Hubo un error al intentar completar el registro de tu cuenta. Inténtalo nuevamente.');
+        }
       }finally{
         registroEnProceso = false;
       }
@@ -705,7 +707,7 @@
       try{ await initFirebase(); }
       catch(err){
         console.error('No se pudo inicializar Firebase en registrarse.html', err);
-        alert('No se pudo preparar el registro. Intenta nuevamente.');
+        alert('Hubo un error al intentar preparar el registro de tu cuenta. Inténtalo nuevamente.');
         window.location.href='index.html';
         return;
       }

--- a/public/super.html
+++ b/public/super.html
@@ -142,49 +142,6 @@
   <script>
   ensureAuth('Superadmin');
   const EMAIL_PERMITIDO_PARAMETROS = 'jhoseph.q@gmail.com';
-  const CLAIM_GESTION_PARAMETROS = 'canManageGlobalParams';
-  const CAMPO_PASSW_PARAMETROS = 'passw';
-  const PASSW_RESTAURADA_DEFAULT = 'Lib3lula14$';
-
-  function tienePermisoDedicadoParametros(claims){
-    return claims?.[CLAIM_GESTION_PARAMETROS] === true;
-  }
-
-  async function solicitarClaveMenuOculto(user){
-    const emailActual = String(user?.email || '').trim().toLowerCase();
-    if(emailActual !== EMAIL_PERMITIDO_PARAMETROS){
-      alert('Esta cuenta no está autorizada para abrir el menú oculto de Parámetros.');
-      return false;
-    }
-
-    const refParametros = db.collection('Variablesglobales').doc('Parametros');
-    const docParametros = await refParametros.get();
-    if(!docParametros.exists){
-      alert('No se encontró el documento Variablesglobales/Parametros.');
-      return false;
-    }
-
-    const dataParametros = docParametros.data() || {};
-    const passwGuardada = typeof dataParametros[CAMPO_PASSW_PARAMETROS] === 'string'
-      ? dataParametros[CAMPO_PASSW_PARAMETROS]
-      : '';
-
-    if(!passwGuardada){
-      await refParametros.set({ [CAMPO_PASSW_PARAMETROS]: PASSW_RESTAURADA_DEFAULT }, { merge: true });
-    }
-
-    const passwEsperada = passwGuardada || PASSW_RESTAURADA_DEFAULT;
-    const passwIngresada = prompt('Ingresa la contraseña del menú oculto:');
-    if(passwIngresada === null){
-      return false;
-    }
-    if(passwIngresada !== passwEsperada){
-      alert('Contraseña incorrecta.');
-      return false;
-    }
-
-    return true;
-  }
 
   async function intentarAbrirParametros(){
     const user = auth.currentUser;
@@ -194,27 +151,9 @@
       return;
     }
 
-    try{
-      const verificacion = await verificarRolFuerte('Superadmin', { forceRefresh: true });
-      if(!verificacion.ok){
-        alert('No tienes claims de Superadmin vigentes. Vuelve a iniciar sesión o contacta al administrador del sistema.');
-        window.location.href='super.html';
-        return;
-      }
-      if(!tienePermisoDedicadoParametros(verificacion.claims)){
-        alert('Tu sesión no tiene el permiso dedicado para gestionar parámetros globales.');
-        window.location.href='super.html';
-        return;
-      }
-
-      await reautenticarConPopup();
-      const autorizado = await solicitarClaveMenuOculto(user);
-      if(!autorizado){
-        return;
-      }
-    }catch(error){
-      console.error('No fue posible completar la autorización fuerte para Parámetros', error);
-      alert('No fue posible completar la reautenticación de Firebase. Intenta nuevamente.');
+    const emailActual = String(user.email || '').trim().toLowerCase();
+    if(emailActual !== EMAIL_PERMITIDO_PARAMETROS){
+      alert('Esta cuenta no está autorizada para abrir Parámetros.');
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Evitar el uso de `custom claims`, reautenticación y contraseña como vía para abrir `parametros.html` y simplificar el control de acceso a un único usuario autorizado.
- Garantizar que solo la cuenta autorizada del desarrollador pueda acceder y modificar parámetros globales.
- Ocultar mensajes de error técnicos en el flujo de registro para no exponer detalles internos como mensajes de Firebase.

### Description
- Cambiada la lógica en `public/super.html` para que al hacer click en el nombre/email se redirija a `parametros.html` únicamente si `auth.currentUser.email` es exactamente `jhoseph.q@gmail.com`, eliminando las comprobaciones por claims, reautenticación y prompt de contraseña.
- Reforzada la carga en `public/parametros.html` para permitir iniciar y mostrar la UI únicamente cuando el usuario autenticado tenga ese mismo correo (se reemplazó la validación por claims por una comprobación de email y se simplificaron los mensajes de error y flujos de retorno a `super.html`).
- Modificados mensajes en `public/registrarse.html` para que los errores mostrados al usuario sean genéricos y no expongan detalles de Firebase u otros sistemas (se reemplazaron mensajes de `alert`/`setFieldMessage` específicos por textos como `Hubo un error al intentar completar el registro de tu cuenta.`).
- Eliminados fragmentos de código relacionados con el `claim` dedicado y el prompt/contraseña legacy para el menú de parámetros, y limpiados los flujos de control asociados.

### Testing
- Ejecutados tests unitarios con Jest en `__tests__/auth.test.js` y `__tests__/registro.test.js` usando `npm test -- --runTestsByPath __tests__/auth.test.js __tests__/registro.test.js --coverage=false`, y ambos suites pasaron correctamente.
- Ejecuté también la misma selección de tests con la configuración de coverage habilitada; los tests pasaron pero la ejecución falló en la verificación de umbrales globales de cobertura (esto es una política del repositorio, no un fallo funcional de los cambios).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7278508388326bc2818b467f7d124)