### PR TITLE
fix(pwa): desactiva flujo de copia de URL en navegadores

### DIFF
--- a/public/js/serviceWorkerRegistration.js
+++ b/public/js/serviceWorkerRegistration.js
@@ -1,6 +1,12 @@
 (function () {
   if (!('serviceWorker' in navigator)) return;
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(() => {});
+
+  window.addEventListener('load', async () => {
+    try {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map((registration) => registration.unregister()));
+    } catch (_) {
+      // Intencionalmente silencioso para no afectar el flujo principal de la app.
+    }
   });
 })();

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,7 +3,7 @@
   "short_name": "Bingo",
   "start_url": "/index.html",
   "scope": "/",
-  "display": "standalone",
+  "display": "browser",
   "background_color": "#ffffff",
   "theme_color": "#7a00cc",
   "icons": [


### PR DESCRIPTION
### Motivation
- El modo PWA/standalone y el Service Worker estaban provocando en algunos navegadores (p. ej. Android/Brave) el aviso para “copiar la URL” que se había intentado usar para notificaciones, flujo que ya no se utilizará y debe eliminarse sin tocar la lógica de negocio.

### Description
- Se modificó `public/js/serviceWorkerRegistration.js` para dejar de registrar `/sw.js` y, en su lugar, desregistrar cualquier Service Worker existente al cargar la página; además se cambió `public/manifest.webmanifest` de `"display": "standalone"` a `"display": "browser"` para evitar la ejecución en modo app instalada; cambios pequeños, focalizados y reversibles (restaurar registro del SW y `display: "standalone"` si se requiere volver atrás).

### Testing
- Se ejecutó `npm test` y todos los tests automatizados pasaron (comando: `npm test` → RESULTADO: PASS, 11 suites, 35 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2e5c7eb7c83269a6d787ed57c8eb9)