### PR TITLE
feat(pwa): mostrar instalación solo tras registro exitoso

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -2516,7 +2516,12 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       if (typeof window.initInstallPrompt === 'function') {
-        window.initInstallPrompt({ containerId: 'install-prompt-player', mode: 'banner' });
+        const postRegistroInstallPromptKey = 'bo_show_install_prompt_after_signup';
+        const mostrarPromptPostRegistro = sessionStorage.getItem(postRegistroInstallPromptKey) === '1';
+        if (mostrarPromptPostRegistro) {
+          sessionStorage.removeItem(postRegistroInstallPromptKey);
+          window.initInstallPrompt({ containerId: 'install-prompt-player', mode: 'banner' });
+        }
       }
     });
   </script>

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -471,6 +471,7 @@
     const selectCodigoPais=document.getElementById('codigo-pais');
     poblarSelectCodigos(selectCodigoPais);
     const REGISTRO_PENDIENTE_KEY = 'registroPendienteBingoOnline';
+    const POST_REGISTRO_INSTALL_PROMPT_KEY = 'bo_show_install_prompt_after_signup';
     let registroEnProceso = false;
     let loginEnProceso = false;
     let pasoActual = 1;
@@ -676,6 +677,7 @@
         }
         limpiarRegistroPendiente();
         trackEvent('registro_exito',{email:user.email});
+        sessionStorage.setItem(POST_REGISTRO_INSTALL_PROMPT_KEY, '1');
         window.location.href='player.html';
       }catch(err){
         limpiarRegistroPendiente();


### PR DESCRIPTION
### Motivation
- Mostrar el CTA de "Instalar" únicamente justo después de que un usuario complete el registro para mejorar el onboarding y evitar que el prompt aparezca en momentos no deseados.

### Description
- Se añadió la bandera de sesión `bo_show_install_prompt_after_signup` en `public/registrarse.html` para marcar registro exitoso y disparar el CTA en la siguiente vista.
- Se actualizó `public/player.html` para leer la bandera de `sessionStorage`, inicializar `initInstallPrompt` solo si la bandera está presente y luego eliminarla para evitar repeticiones.
- No se cambió la implementación existente de `installPrompt.js`, por lo que se conserva compatibilidad con Android/PC (`beforeinstallprompt`) y iOS (instrucciones de "Añadir a pantalla de inicio").

### Testing
- Ejecuté `npm test` y todos los tests pasaron: `11 suites, 35 tests` en verde (comando `npm test` → PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2e8e00c288326a35f79e0c1773989)