### PR TITLE
feat(sorteos): habilita acceso PDF para jugadores por fases

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -6125,7 +6125,16 @@
           const d = doc.data() || {};
           const condicionRaw = (d?.condicion || '').toString().trim().toUpperCase();
           if(condicionRaw === 'ARCHIVADO') return;
-          const registro = { id: doc.id, ...d, pdf: d.pdf || 'no', cantos: [], formas: [] };
+          const registro = {
+            id: doc.id,
+            ...d,
+            pdf: d.pdf || 'no',
+            pdfresul: d.pdfresul || 'no',
+            accesoPdfJuegoJugadores: d.accesoPdfJuegoJugadores || 'no',
+            accesoPdfResultadosJugadores: d.accesoPdfResultadosJugadores || 'no',
+            cantos: [],
+            formas: []
+          };
           registro.pagosCentroAprobados = d.pagosCentroAprobados;
           registro.condicion = condicionRaw || 'VISIBLE';
           registro.nombre = registro.nombre || 'Sorteo';
@@ -6149,8 +6158,13 @@
         sorteos = Array.from(registrosMap.values());
         if(pendientesPdf.length){
           Promise.allSettled(pendientesPdf.map(id=>
-            db.collection('sorteos').doc(id).set({ pdf: 'no' }, { merge: true })
-          )).catch(err=>console.error('Error asegurando pdf en sorteos', err));
+            db.collection('sorteos').doc(id).set({
+              pdf: 'no',
+              pdfresul: 'no',
+              accesoPdfJuegoJugadores: 'no',
+              accesoPdfResultadosJugadores: 'no'
+            }, { merge: true })
+          )).catch(err=>console.error('Error asegurando estados PDF en sorteos', err));
         }
         const idsSorteos = Array.from(registrosMap.keys());
         const cargasDetalles = [];
@@ -6583,31 +6597,29 @@
 
     const estadoActual = obtenerEstadoActualNormalizado();
     if(estadoActual === 'finalizado'){
-      let estadoPdfResultado = (currentSorteoData.pdfresul || '').toString().trim().toLowerCase();
-      if(estadoPdfResultado !== 'si'){
-        try {
-          const docFinal = await db.collection('sorteos').doc(currentSorteoId).get();
-          if(docFinal.exists){
-            const datosFinal = docFinal.data() || {};
-            estadoPdfResultado = (datosFinal.pdfresul || '').toString().trim().toLowerCase() || estadoPdfResultado;
-            currentSorteoData.pdfresul = estadoPdfResultado;
-            const indiceSorteo = sorteos.findIndex(s=>s && s.id === currentSorteoId);
-            if(indiceSorteo >= 0){
-              sorteos[indiceSorteo] = { ...sorteos[indiceSorteo], pdfresul: estadoPdfResultado };
-            }
-          }
-        } catch (errFinal) {
-          console.warn('No se pudo actualizar el estado del PDF de resultados', errFinal);
-        }
+      const confirmar = await preguntarAccionEstado('¿Deseas habilitar el acceso a PDF Resultados a los Jugadores?');
+      if(!confirmar) return;
+      try {
+        const timestamp = firebase.firestore.FieldValue.serverTimestamp();
+        const payload = {
+          accesoPdfResultadosJugadores: 'si',
+          pdfresul: 'si',
+          accesoPdfResultadosJugadoresEn: timestamp
+        };
+        await Promise.all([
+          db.collection('sorteos').doc(currentSorteoId).set(payload, { merge: true }),
+          db.collection('cantarsorteos').doc(currentSorteoId).set(payload, { merge: true })
+        ]);
+        currentSorteoData.accesoPdfResultadosJugadores = 'si';
+        currentSorteoData.pdfresul = 'si';
+        mensajeEl.textContent = 'Acceso a PDF de resultados habilitado para jugadores.';
+        actualizarBotones();
+        actualizarAnimaciones();
+        mostrarDatos();
+      } catch (errFinal) {
+        console.error('No se pudo habilitar el acceso a PDF de resultados', errFinal);
+        alert('Ocurrió un error habilitando el acceso al PDF de resultados.');
       }
-
-      if(estadoPdfResultado === 'no' || !estadoPdfResultado){
-        abrirPdfResultados();
-        return;
-      }
-
-      alert('El sorteo ya está finalizado y se confirmó la descarga del PDF de resultados.');
-      abrirPdfResultados();
       return;
     }
 
@@ -6624,20 +6636,25 @@
       }
       const datos = docRef.data() || {};
       const { estado: pdfEstadoNormalizado } = sincronizarDatosPdf(datos);
-
-      if(pdfEstadoNormalizado === 'no'){
-        try {
-          const destinoUrl = new URL('pdfsorteo.html', window.location.href);
-          destinoUrl.searchParams.set('s', currentSorteoId);
-          window.location.assign(destinoUrl.toString());
-        } catch (err) {
-          const fallback = `pdfsorteo.html?s=${encodeURIComponent(currentSorteoId)}`;
-          window.location.href = fallback;
-        }
+      if(pdfEstadoNormalizado === 'si'){
+        mostrarAvisoSimple('El acceso al PDF de juego ya estaba habilitado para jugadores.', 'PDF habilitado');
         return;
       }
-
-      alert('Ya se ha confirmado la descarga del archivo PDF de sellado de este sorteo');
+      const confirmar = await preguntarAccionEstado('¿Deseas habilitar el acceso a PDF de juego a los Jugadores?');
+      if(!confirmar) return;
+      const timestamp = firebase.firestore.FieldValue.serverTimestamp();
+      const payload = {
+        pdf: 'si',
+        accesoPdfJuegoJugadores: 'si',
+        accesoPdfJuegoJugadoresEn: timestamp,
+        pdfActualizadoEn: timestamp
+      };
+      await Promise.all([
+        db.collection('sorteos').doc(currentSorteoId).set(payload, { merge: true }),
+        db.collection('cantarsorteos').doc(currentSorteoId).set(payload, { merge: true })
+      ]);
+      sincronizarDatosPdf({ ...datos, ...payload });
+      mensajeEl.textContent = 'Acceso a PDF de juego habilitado para jugadores.';
     } catch (error) {
       console.error('Error consultando el estado del PDF', error);
       alert('Ocurrió un error al consultar el estado del documento PDF.');
@@ -6655,10 +6672,11 @@
     try {
       const destinoUrl = new URL('pdfsorteo.html', window.location.href);
       destinoUrl.searchParams.set('s', currentSorteoId);
+      destinoUrl.searchParams.set('modo', 'admin');
       window.location.assign(destinoUrl.toString());
     } catch (error) {
       console.error('No se pudo abrir la ventana de PDF del sorteo', error);
-      const fallback = `pdfsorteo.html?s=${encodeURIComponent(currentSorteoId)}`;
+      const fallback = `pdfsorteo.html?s=${encodeURIComponent(currentSorteoId)}&modo=admin`;
       try {
         window.location.assign(fallback);
       } catch (fallbackError) {
@@ -6782,31 +6800,7 @@
     const estadoActual = obtenerEstadoActualNormalizado();
     if(estadoActual === 'finalizado'){
       forzarVisibilidadResultado(true);
-      let estadoPdfResultado = (currentSorteoData.pdfresul || '').toString().trim().toLowerCase();
-      if(estadoPdfResultado !== 'si'){
-        try {
-          await asegurarDbListo();
-          const docFinal = await db.collection('sorteos').doc(currentSorteoId).get();
-          if(docFinal.exists){
-            const datosFinal = docFinal.data() || {};
-            estadoPdfResultado = (datosFinal.pdfresul || '').toString().trim().toLowerCase() || estadoPdfResultado;
-            currentSorteoData.pdfresul = estadoPdfResultado;
-            const indiceSorteo = sorteos.findIndex(s=>s && s.id === currentSorteoId);
-            if(indiceSorteo >= 0){
-              sorteos[indiceSorteo] = { ...sorteos[indiceSorteo], pdfresul: estadoPdfResultado };
-            }
-          }
-        } catch (errFinal) {
-          console.warn('No se pudo actualizar el estado del PDF de resultados al reintentar la descarga', errFinal);
-        }
-      }
-
-      if(estadoPdfResultado !== 'si'){
-        mostrarAvisoSimple('El sorteo ya se encuentra finalizado. Se abrirá el PDF de resultados para que confirmes su descarga.', 'PDF pendiente');
-        abrirPdfResultados();
-      } else {
-        alert('El sorteo ya finalizó.');
-      }
+      alert('El sorteo ya finalizó.');
       return;
     }
     if(estadoActual !== 'jugando'){
@@ -6837,9 +6831,10 @@
     try {
       const destinoUrl = new URL('pdfresultados.html', window.location.href);
       destinoUrl.searchParams.set('s', currentSorteoId);
+      destinoUrl.searchParams.set('modo', 'admin');
       window.location.assign(destinoUrl.toString());
     } catch (error) {
-      const fallback = `pdfresultados.html?s=${encodeURIComponent(currentSorteoId)}`;
+      const fallback = `pdfresultados.html?s=${encodeURIComponent(currentSorteoId)}&modo=admin`;
       try {
         window.location.assign(fallback);
       } catch (fallbackError) {
@@ -6862,11 +6857,38 @@
     }
     const estadoPdfResultado = (currentSorteoData.pdfresul || '').toString().trim().toLowerCase();
     if(estadoPdfResultado === 'si'){
-      mostrarAvisoSimple('El PDF de resultados confirmado se abre desde el icono flotante del botón.', 'PDF disponible');
+      mostrarAvisoSimple('El acceso al PDF de resultados ya fue habilitado para jugadores.', 'PDF habilitado');
       return;
     }
-    mostrarAvisoSimple('Se abrirá el PDF de resultados para que confirmes su descarga.', 'PDF pendiente');
-    abrirPdfResultados();
+    preguntarAccionEstado('¿Deseas habilitar el acceso a PDF Resultados a los Jugadores?')
+      .then(async confirmar=>{
+        if(!confirmar) return;
+        try{
+          const timestamp = firebase.firestore.FieldValue.serverTimestamp();
+          const payload = {
+            pdfresul: 'si',
+            accesoPdfResultadosJugadores: 'si',
+            accesoPdfResultadosJugadoresEn: timestamp
+          };
+          await Promise.all([
+            db.collection('sorteos').doc(currentSorteoId).set(payload, { merge: true }),
+            db.collection('cantarsorteos').doc(currentSorteoId).set(payload, { merge: true })
+          ]);
+          currentSorteoData.pdfresul = 'si';
+          currentSorteoData.accesoPdfResultadosJugadores = 'si';
+          const indiceSorteo = sorteos.findIndex(s=>s && s.id === currentSorteoId);
+          if(indiceSorteo >= 0){
+            sorteos[indiceSorteo] = { ...sorteos[indiceSorteo], ...payload };
+          }
+          mensajeEl.textContent = 'Acceso a PDF de resultados habilitado para jugadores.';
+          actualizarBotones();
+          actualizarAnimaciones();
+          mostrarDatos();
+        }catch(err){
+          console.error('No se pudo habilitar el acceso a PDF de resultados', err);
+          alert('No fue posible habilitar el acceso al PDF de resultados.');
+        }
+      });
   }
 
   function manejarClickPdfResultadosAlmacenado(evento){

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1790,6 +1790,53 @@
           gap: calc(clamp(6px, 2vw, 14px) * var(--panel-botones-escala-limitada, 1));
           justify-items: center;
       }
+      .panel-pdf-jugadores {
+          width: 100%;
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: center;
+          gap: clamp(6px, 1vw, 10px);
+      }
+      .pdf-acceso-btn {
+          display: inline-flex;
+          align-items: center;
+          gap: clamp(4px, 0.8vw, 8px);
+          padding: clamp(5px, 0.8vw, 8px) clamp(8px, 1.3vw, 12px);
+          border-radius: 999px;
+          border: 1px solid rgba(46,125,50,0.25);
+          background: #eceff1;
+          color: #546e7a;
+          font-size: clamp(0.58rem, 1.2vw, 0.74rem);
+          font-weight: 700;
+          letter-spacing: .2px;
+          cursor: not-allowed;
+          opacity: .75;
+      }
+      .pdf-acceso-btn .estado-luz {
+          width: clamp(7px, 0.9vw, 9px);
+          height: clamp(7px, 0.9vw, 9px);
+          border-radius: 50%;
+          background: #90a4ae;
+          box-shadow: 0 0 0 rgba(76,175,80,0);
+          flex: 0 0 auto;
+      }
+      .pdf-acceso-btn.habilitado {
+          background: linear-gradient(135deg, #e8f5e9, #f1f8e9);
+          border-color: rgba(46,125,50,0.6);
+          color: #1b5e20;
+          cursor: pointer;
+          opacity: 1;
+      }
+      .pdf-acceso-btn.habilitado .estado-luz {
+          background: #00c853;
+          box-shadow: 0 0 0 0 rgba(0,200,83,.65);
+          animation: parpadeoPdfAcceso 1.15s infinite;
+      }
+      @keyframes parpadeoPdfAcceso {
+          0% { opacity: 1; box-shadow: 0 0 0 0 rgba(0,200,83,.6); }
+          70% { opacity: .55; box-shadow: 0 0 0 8px rgba(0,200,83,0); }
+          100% { opacity: 1; box-shadow: 0 0 0 0 rgba(0,200,83,0); }
+      }
       .panel-botones-formas__mensaje {
           width: 100%;
           min-height: clamp(28px, 3vw, 40px);
@@ -4311,6 +4358,16 @@
         </div>
         <div class="panel-columna-derecha__rejilla panel-columna-derecha__modales">
           <div id="panel-botones-formas" role="region" aria-label="Ganadores por forma"></div>
+          <div id="panel-pdf-jugadores" class="panel-pdf-jugadores" role="group" aria-label="Accesos PDF para jugadores">
+            <button id="btn-pdf-cartones" type="button" class="pdf-acceso-btn" disabled>
+              <span class="estado-luz" aria-hidden="true"></span>
+              <span>Cartones sellados</span>
+            </button>
+            <button id="btn-pdf-resultados" type="button" class="pdf-acceso-btn" disabled>
+              <span class="estado-luz" aria-hidden="true"></span>
+              <span>Cartones ganadores</span>
+            </button>
+          </div>
         </div>
       </div>
     </section>
@@ -4687,6 +4744,9 @@
   const panelSuperiorEl = document.getElementById('panel-superior');
   const cantosPanelEl = document.getElementById('cantos-panel');
   const panelBotonesFormasEl = document.getElementById('panel-botones-formas');
+  const panelPdfJugadoresEl = document.getElementById('panel-pdf-jugadores');
+  const btnPdfCartonesEl = document.getElementById('btn-pdf-cartones');
+  const btnPdfResultadosEl = document.getElementById('btn-pdf-resultados');
   const formasMensajeEl = document.getElementById('formas-mensaje');
   const misCartonesSectionEl = document.getElementById('mis-cartones-section');
   const complementariosAvisoEl = document.getElementById('complementarios-aviso');
@@ -9493,6 +9553,7 @@
       }
       alternarVisibilidadEncabezadoSorteo(false);
       actualizarTituloFinalizadoBtn();
+      actualizarBotonesPdfJugadores();
       return;
     }
     if(!activeSorteo){
@@ -9504,6 +9565,7 @@
         sorteoDetallesEl.innerHTML='';
       }
       actualizarTituloFinalizadoBtn();
+      actualizarBotonesPdfJugadores();
       return;
     }
     alternarVisibilidadEncabezadoSorteo(true);
@@ -9555,6 +9617,45 @@
       sorteoDetallesEl.innerHTML=partes.join(' ');
     }
     actualizarTituloFinalizadoBtn();
+    actualizarBotonesPdfJugadores();
+  }
+
+  function estadoBanderaSi(valor){
+    return (valor || '').toString().trim().toLowerCase() === 'si';
+  }
+
+  function abrirVentanaPdfJugador(tipo){
+    if(!activeSorteoId) return;
+    const destino = tipo === 'resultados' ? 'pdfresultados.html' : 'pdfsorteo.html';
+    try{
+      const url = new URL(destino, window.location.href);
+      url.searchParams.set('s', activeSorteoId);
+      url.searchParams.set('modo', 'jugador');
+      window.location.assign(url.toString());
+    }catch(error){
+      window.location.href = `${destino}?s=${encodeURIComponent(activeSorteoId)}&modo=jugador`;
+    }
+  }
+
+  function actualizarBotonesPdfJugadores(){
+    if(!panelPdfJugadoresEl || !btnPdfCartonesEl || !btnPdfResultadosEl) return;
+    const haySorteo = !!(activeSorteoId && activeSorteo);
+    panelPdfJugadoresEl.style.display = haySorteo ? 'flex' : 'none';
+    if(!haySorteo){
+      [btnPdfCartonesEl, btnPdfResultadosEl].forEach(btn=>{
+        btn.disabled = true;
+        btn.classList.remove('habilitado');
+      });
+      return;
+    }
+    const estadoSorteo = (activeSorteo?.estado || '').toString().trim().toLowerCase();
+    const esFinalizado = estadoSorteo === 'finalizado';
+    const habilitadoJuego = esFinalizado || estadoBanderaSi(activeSorteo?.accesoPdfJuegoJugadores) || estadoBanderaSi(activeSorteo?.pdf);
+    const habilitadoResultados = esFinalizado || estadoBanderaSi(activeSorteo?.accesoPdfResultadosJugadores) || estadoBanderaSi(activeSorteo?.pdfresul);
+    btnPdfCartonesEl.disabled = !habilitadoJuego;
+    btnPdfResultadosEl.disabled = !habilitadoResultados;
+    btnPdfCartonesEl.classList.toggle('habilitado', habilitadoJuego);
+    btnPdfResultadosEl.classList.toggle('habilitado', habilitadoResultados);
   }
 
   function renderCantos(){
@@ -10505,6 +10606,18 @@
   }
   if(seleccionarFinalizadoBtn){
     seleccionarFinalizadoBtn.addEventListener('click',abrirModalSorteosFinalizados);
+  }
+  if(btnPdfCartonesEl){
+    btnPdfCartonesEl.addEventListener('click', ()=>{
+      if(btnPdfCartonesEl.disabled) return;
+      abrirVentanaPdfJugador('juego');
+    });
+  }
+  if(btnPdfResultadosEl){
+    btnPdfResultadosEl.addEventListener('click', ()=>{
+      if(btnPdfResultadosEl.disabled) return;
+      abrirVentanaPdfJugador('resultados');
+    });
   }
   if(jugarOtroSorteoBtn){
     jugarOtroSorteoBtn.addEventListener('click',()=>{
@@ -11623,10 +11736,15 @@
       unsubscribeSorteos();
       unsubscribeSorteos=null;
     }
-    unsubscribeSorteos=db.collection('sorteos').where('estado','==','Jugando').onSnapshot(snapshot=>{
+    unsubscribeSorteos=db.collection('sorteos').where('estado','in',['Jugando','Sellado']).onSnapshot(snapshot=>{
       const lista=[];
       snapshot.forEach(doc=>{
         const data=doc.data()||{};
+        const estadoSorteo = (data.estado || '').toString().toLowerCase();
+        const pdfJuegoHabilitado = estadoBanderaSi(data.accesoPdfJuegoJugadores) || estadoBanderaSi(data.pdf);
+        if(estadoSorteo === 'sellado' && !pdfJuegoHabilitado){
+          return;
+        }
         lista.push({id:doc.id,...data});
       });
       lista.sort((a,b)=>{

--- a/public/pdfresultados.html
+++ b/public/pdfresultados.html
@@ -101,16 +101,6 @@
       background: linear-gradient(#008c3a, #66d17a);
       display: none;
     }
-    #pdf-listo-btn {
-      position: relative;
-      display: none;
-      background: linear-gradient(#b85c00, #ffaf40);
-      overflow: visible;
-    }
-    #pdf-listo-btn.pdf-disponible {
-      box-shadow: 0 0 18px rgba(255, 214, 102, 0.6);
-      transform: translateY(-2px);
-    }
     .orientacion-modal {
       position: fixed;
       inset: 0;
@@ -1324,7 +1314,6 @@
   <div id="acciones-fixed">
     <button id="generar-resultados-btn">Resultados</button>
     <button id="generar-pdf-btn">Generar PDF</button>
-    <button id="pdf-listo-btn">PDF LISTO</button>
   </div>
   <div id="orientacion-modal" class="orientacion-modal" role="dialog" aria-modal="true" aria-labelledby="orientacion-modal-titulo" aria-hidden="true">
     <div class="orientacion-modal-contenido">
@@ -1400,11 +1389,12 @@
   <script src="js/notificationCenter.js"></script>
   <script src="js/estadoPagoPremio.js"></script>
   <script>
-  ensureAuth('Administrador');
+  ensureAuth();
 
   const params = new URLSearchParams(window.location.search);
   const sorteoId = params.get('s');
-  const COMPAT_ORQUESTAR_PAGOS_AL_CONFIRMAR_PDF = false;
+  const modoVista = (params.get('modo') || '').toString().trim().toLowerCase();
+  const vistaJugador = modoVista === 'jugador';
   if(!sorteoId){
     alert('No se indicó un sorteo.');
     window.location.href = 'cantarsorteos.html';
@@ -1413,7 +1403,6 @@
   const salirBtn = document.getElementById('salir-btn');
   const generarResultadosBtn = document.getElementById('generar-resultados-btn');
   const pdfBtn = document.getElementById('generar-pdf-btn');
-  const pdfListoBtn = document.getElementById('pdf-listo-btn');
   const loadingOverlay = document.getElementById('loading-overlay');
   const loadingText = document.getElementById('loading-text');
   const nombreEl = document.getElementById('nombre-sorteo');
@@ -2375,11 +2364,10 @@
     return `#${hexCanal(mezcla(r))}${hexCanal(mezcla(g))}${hexCanal(mezcla(b))}`;
   }
 
-  salirBtn.addEventListener('click', ()=>{ window.location.href = 'cantarsorteos.html'; });
+  salirBtn.addEventListener('click', ()=>{ window.location.href = vistaJugador ? 'juegoactivo.html' : 'cantarsorteos.html'; });
   if(generarResultadosBtn){ generarResultadosBtn.disabled = true; }
   if(generarResultadosBtn){ generarResultadosBtn.addEventListener('click', manejarGenerarResultados); }
   if(pdfBtn){ pdfBtn.addEventListener('click', generarPDF); }
-  if(pdfListoBtn){ pdfListoBtn.addEventListener('click', confirmarPdfListo); }
   if(orientacionAceptarBtn){ orientacionAceptarBtn.addEventListener('click', ocultarModalOrientacion); }
   if(orientacionModal){
     orientacionModal.addEventListener('click', (event)=>{
@@ -2464,30 +2452,11 @@
 
   function mostrarMensajeCartonesPendientes(){
     if(!cartonesGrid) return;
-    cartonesGrid.innerHTML = '<div class="cartones-placeholder">Haz clic en "Resultados" para calcular y mostrar los cartones del sorteo.</div>';
+    cartonesGrid.innerHTML = vistaJugador
+      ? '<div class="cartones-placeholder">Cargando resultados del sorteo...</div>'
+      : '<div class="cartones-placeholder">Haz clic en "Resultados" para calcular y mostrar los cartones del sorteo.</div>';
   }
 
-  function actualizarBotonPdfListoSegunEstado(opciones = {}){
-    if(!pdfListoBtn) return;
-    const estado = (sorteoData?.pdfresul || '').toString().toLowerCase();
-    const forzarMostrar = opciones.forzarMostrar === true;
-    const mostrar = forzarMostrar || estado === 'si';
-    pdfListoBtn.style.display = mostrar ? 'block' : 'none';
-    if(estado === 'si' && !forzarMostrar){
-      pdfListoBtn.textContent = 'PDF confirmado';
-      pdfListoBtn.disabled = true;
-      pdfListoBtn.classList.add('pdf-disponible');
-      return;
-    }
-    pdfListoBtn.textContent = 'PDF LISTO';
-    const disabled = typeof opciones.disabled === 'boolean' ? opciones.disabled : true;
-    pdfListoBtn.disabled = disabled;
-    const marcarDisponible = opciones.disponible === true;
-    pdfListoBtn.classList.toggle('pdf-disponible', marcarDisponible);
-    if(!marcarDisponible && estado !== 'si'){
-      pdfListoBtn.classList.remove('pdf-disponible');
-    }
-  }
 
   function formatearFechaParaMostrar(fecha){
     if(!fecha) return '-';
@@ -2880,7 +2849,6 @@
 
   function renderCartones(){
     cartonesGrid.innerHTML = '';
-    actualizarBotonPdfListoSegunEstado();
     if(!cartonesMapa.size){
       cartonesGrid.innerHTML = '<div class="cartones-placeholder">No hay cartones generados para este sorteo.</div>';
       return;
@@ -3054,6 +3022,14 @@
         return;
       }
       sorteoData = sorteoDoc.data();
+      const estadoSorteo = (sorteoData.estado || '').toString().trim().toLowerCase();
+      const accesoResultadosHabilitado = estadoSorteo === 'finalizado'
+        || ['si', 'true'].includes((sorteoData.accesoPdfResultadosJugadores || sorteoData.pdfresul || '').toString().trim().toLowerCase());
+      if(vistaJugador && !accesoResultadosHabilitado){
+        alert('El acceso al PDF de resultados aún no ha sido habilitado para jugadores.');
+        window.location.href = 'juegoactivo.html';
+        return;
+      }
       const nombreBase = sorteoData.nombre || 'Sorteo';
       const tituloResultado = `RESULTADO ${nombreBase}`.trim();
       nombreEl.textContent = tituloResultado;
@@ -3115,7 +3091,12 @@
       renderFormas();
       mostrarMensajeCartonesPendientes();
       if(generarResultadosBtn){ generarResultadosBtn.disabled = false; }
-      actualizarBotonPdfListoSegunEstado();
+      if(generarResultadosBtn){
+        generarResultadosBtn.style.display = vistaJugador ? 'none' : 'block';
+      }
+      if(vistaJugador){
+        await cargarCartones();
+      }
     } catch (err) {
       console.error('Error cargando datos', err);
       alert('Ocurrió un error cargando la información del sorteo.');
@@ -3158,10 +3139,6 @@
       if(pdfBtn){
         pdfBtn.style.display = cartonesCargados ? 'block' : 'none';
         pdfBtn.disabled = !cartonesCargados;
-      }
-      if(pdfListoBtn){
-        pdfListoBtn.style.display = 'none';
-        pdfListoBtn.classList.remove('pdf-disponible');
       }
       if(generarResultadosBtn){ generarResultadosBtn.textContent = cartonesCargados ? 'Regenerar resultados' : 'Resultados'; }
     } catch (err) {
@@ -3223,23 +3200,12 @@
 
     try {
       await ensureFirebaseReady();
-      try {
-        await Promise.all([
-          db.collection('sorteos').doc(sorteoId).set({ pdfresul: 'no' }, { merge: true }),
-          db.collection('cantarsorteos').doc(sorteoId).set({ pdfresul: 'no' }, { merge: true })
-        ]);
-        if(sorteoData){
-          sorteoData.pdfresul = 'no';
-        }
-      } catch (errActualizar) {
-        console.error('No se pudo reiniciar el estado pdfresul', errActualizar);
-      }
+      if(generarResultadosBtn){ generarResultadosBtn.style.display = vistaJugador ? 'none' : 'block'; }
       if(generarResultadosBtn){ generarResultadosBtn.disabled = true; }
       if(pdfBtn){
         pdfBtn.disabled = true;
         pdfBtn.textContent = 'Generando PDF...';
       }
-      actualizarBotonPdfListoSegunEstado({ forzarMostrar: true, disabled: true });
       mostrarLoading('Generando PDF para descargar, por favor espera');
 
       if(debeForzarPaisaje){
@@ -3398,12 +3364,10 @@
       }
 
       pdf.save(nombreArchivo);
-      actualizarBotonPdfListoSegunEstado({ forzarMostrar: true, disponible: true, disabled: false });
-      alert('El PDF del sorteo ha sido generado. Descárgalo y luego confirma con "PDF LISTO".');
+      alert('El PDF del sorteo ha sido generado. Descárgalo.');
     } catch (err) {
       console.error('Error generando el PDF', err);
       alert('No se pudo generar el PDF del sorteo. Intenta nuevamente.');
-      actualizarBotonPdfListoSegunEstado();
     } finally {
       restaurarCartones();
       restaurarFormas();
@@ -3422,59 +3386,6 @@
         generarResultadosBtn.disabled = false;
         generarResultadosBtn.textContent = textoOriginalCartones || generarResultadosBtn.textContent;
       }
-      ocultarLoading();
-    }
-  }
-
-  async function confirmarPdfListo(){
-    if(!sorteoId){ return; }
-    const confirmar = await window.confirm('¿Confirmas que el PDF fue descargado correctamente?');
-    if(!confirmar) return;
-    try {
-      await ensureFirebaseReady();
-      if(pdfListoBtn){ pdfListoBtn.disabled = true; }
-      mostrarLoading('Actualizando el estado del PDF, por favor espera');
-      const timestamp = firebase.firestore.FieldValue.serverTimestamp();
-      const eliminar = firebase.firestore.FieldValue.delete();
-      const payload = {
-        pdf: 'si',
-        pdfActualizadoEn: timestamp,
-        pdfUrl: eliminar,
-        pdfStoragePath: eliminar,
-        pdfresul: 'si'
-      };
-      await Promise.all([
-        db.collection('sorteos').doc(sorteoId).set(payload, { merge: true }),
-        db.collection('cantarsorteos').doc(sorteoId).set(payload, { merge: true })
-      ]);
-      if(sorteoData){
-        sorteoData.pdfresul = 'si';
-      }
-      if(COMPAT_ORQUESTAR_PAGOS_AL_CONFIRMAR_PDF){
-        const resultadoOrquestacion = await orquestarCierreSorteoPdfListo();
-        if(sorteoData){
-          sorteoData.solicitudesPagosGeneradas = true;
-          sorteoData.pagosCentroAprobados = false;
-        }
-        const mensajeCorte = resultadoOrquestacion.corteYaEjecutado
-          ? 'El corte de premios ya estaba ejecutado, no se reprocesaron solicitudes.'
-          : `Premios consolidados: ${resultadoOrquestacion.ganadores}.`;
-        alert(
-          `El sorteo se marcó como PDF listo y se ejecutó la orquestación de pagos.\n`+
-          `${mensajeCorte}\n`+
-          `Solicitudes administrativas creadas: ${resultadoOrquestacion.administrativos}.\n`+
-          `Solicitudes de colaboradores creadas: ${resultadoOrquestacion.colaboradores}.\n`+
-          `Los pagos quedan en estado PENDIENTE hasta ser procesados/aprobados en Centro de Pagos.`
-        );
-      } else {
-        alert('El sorteo se marcó como PDF listo. La generación de premios/pagos se realiza manualmente desde Centro de Pagos.');
-      }
-      window.location.href = 'cantarsorteos.html';
-    } catch (err) {
-      console.error('Error actualizando el estado del PDF', err);
-      alert('No se pudo actualizar el estado del PDF. Intenta nuevamente.');
-      if(pdfListoBtn){ pdfListoBtn.disabled = false; }
-    } finally {
       ocultarLoading();
     }
   }

--- a/public/pdfsorteo.html
+++ b/public/pdfsorteo.html
@@ -98,10 +98,6 @@
       background: linear-gradient(#008c3a, #66d17a);
       display: none;
     }
-    #pdf-listo-btn {
-      background: linear-gradient(#b85c00, #ffaf40);
-      display: none;
-    }
     .orientacion-modal {
       position: fixed;
       inset: 0;
@@ -1058,7 +1054,6 @@
   <div id="acciones-fixed">
     <button id="generar-cartones-btn">Generar cartones</button>
     <button id="generar-pdf-btn">Generar PDF</button>
-    <button id="pdf-listo-btn">PDF listo</button>
   </div>
   <div id="orientacion-modal" class="orientacion-modal" role="dialog" aria-modal="true" aria-labelledby="orientacion-modal-titulo" aria-hidden="true">
     <div class="orientacion-modal-contenido">
@@ -1125,10 +1120,12 @@
   <script src="js/auth.js"></script>
   <script src="js/notificationCenter.js"></script>
   <script>
-  ensureAuth('Administrador');
+  ensureAuth();
 
   const params = new URLSearchParams(window.location.search);
   const sorteoId = params.get('s');
+  const modoVista = (params.get('modo') || '').toString().trim().toLowerCase();
+  const vistaJugador = modoVista === 'jugador';
   if(!sorteoId){
     alert('No se indicó un sorteo.');
     window.location.href = 'cantarsorteos.html';
@@ -1137,7 +1134,6 @@
   const salirBtn = document.getElementById('salir-btn');
   const generarCartonesBtn = document.getElementById('generar-cartones-btn');
   const pdfBtn = document.getElementById('generar-pdf-btn');
-  const pdfListoBtn = document.getElementById('pdf-listo-btn');
   const loadingOverlay = document.getElementById('loading-overlay');
   const loadingText = document.getElementById('loading-text');
   const nombreEl = document.getElementById('nombre-sorteo');
@@ -1225,11 +1221,10 @@
     return `#${hexCanal(mezcla(r))}${hexCanal(mezcla(g))}${hexCanal(mezcla(b))}`;
   }
 
-  salirBtn.addEventListener('click', ()=>{ window.location.href = 'cantarsorteos.html'; });
+  salirBtn.addEventListener('click', ()=>{ window.location.href = vistaJugador ? 'juegoactivo.html' : 'cantarsorteos.html'; });
   if(generarCartonesBtn){ generarCartonesBtn.disabled = true; }
   if(generarCartonesBtn){ generarCartonesBtn.addEventListener('click', manejarGenerarCartones); }
   if(pdfBtn){ pdfBtn.addEventListener('click', generarPDF); }
-  if(pdfListoBtn){ pdfListoBtn.addEventListener('click', confirmarPdfListo); }
   if(orientacionAceptarBtn){ orientacionAceptarBtn.addEventListener('click', ocultarModalOrientacion); }
   if(orientacionModal){
     orientacionModal.addEventListener('click', (event)=>{
@@ -1300,7 +1295,9 @@
 
   function mostrarMensajeCartonesPendientes(){
     if(!cartonesGrid) return;
-    cartonesGrid.innerHTML = '<div class="cartones-placeholder">Haz clic en "Generar cartones" para cargar los cartones del sorteo.</div>';
+    cartonesGrid.innerHTML = vistaJugador
+      ? '<div class="cartones-placeholder">Cargando cartones del sorteo...</div>'
+      : '<div class="cartones-placeholder">Haz clic en "Generar cartones" para cargar los cartones del sorteo.</div>';
   }
 
   function formatearFechaParaMostrar(fecha){
@@ -1603,7 +1600,6 @@
 
   function renderCartones(){
     cartonesGrid.innerHTML = '';
-    pdfListoBtn.style.display = 'none';
     if(!cartonesData.length){
       cartonesGrid.innerHTML = '<div class="cartones-placeholder">No se encontraron cartones generados para este sorteo.</div>';
       return;
@@ -1760,6 +1756,12 @@
         return;
       }
       sorteoData = sorteoDoc.data();
+      const accesoJuegoHabilitado = ['si', 'true'].includes((sorteoData.accesoPdfJuegoJugadores || sorteoData.pdf || '').toString().trim().toLowerCase());
+      if(vistaJugador && !accesoJuegoHabilitado){
+        alert('El acceso al PDF de cartones aún no ha sido habilitado para jugadores.');
+        window.location.href = 'juegoactivo.html';
+        return;
+      }
       nombreEl.textContent = sorteoData.nombre || 'Sorteo';
       tipoTituloEl.textContent = sorteoData.tipo ? sorteoData.tipo : '';
       datoFechaEl.textContent = formatearFechaParaMostrar(sorteoData.fecha || '');
@@ -1777,6 +1779,12 @@
       renderFormas();
       mostrarMensajeCartonesPendientes();
       if(generarCartonesBtn){ generarCartonesBtn.disabled = false; }
+      if(generarCartonesBtn){
+        generarCartonesBtn.style.display = vistaJugador ? 'none' : 'block';
+      }
+      if(vistaJugador){
+        await cargarCartones();
+      }
     } catch (err) {
       console.error('Error cargando datos', err);
       alert('Ocurrió un error cargando la información del sorteo.');
@@ -1830,9 +1838,6 @@
     if(!window.html2canvas || !jsPDFLib){
       alert('Dependencias para generar PDF no disponibles');
       return;
-    }
-    if(pdfListoBtn){
-      pdfListoBtn.style.display = 'none';
     }
     const nombreArchivo = `${construirNombreArchivo()}.pdf`;
     if(!primeraPaginaEl){
@@ -2003,8 +2008,7 @@
       }
 
       pdf.save(nombreArchivo);
-      if(pdfListoBtn){ pdfListoBtn.style.display = 'block'; pdfListoBtn.disabled = false; }
-      alert('El PDF del sorteo ha sido generado. Descárgalo y luego confirma con "PDF listo".');
+      alert('El PDF del sorteo ha sido generado. Descárgalo.');
     } catch (err) {
       console.error('Error generando el PDF', err);
       alert('No se pudo generar el PDF del sorteo. Intenta nuevamente.');
@@ -2023,37 +2027,6 @@
         generarCartonesBtn.disabled = false;
         generarCartonesBtn.textContent = textoOriginalCartones || generarCartonesBtn.textContent;
       }
-      ocultarLoading();
-    }
-  }
-
-  async function confirmarPdfListo(){
-    if(!sorteoId){ return; }
-    const confirmar = await window.confirm('¿Confirmas que el PDF fue descargado correctamente?');
-    if(!confirmar) return;
-    try {
-      await ensureFirebaseReady();
-      if(pdfListoBtn){ pdfListoBtn.disabled = true; }
-      mostrarLoading('Actualizando el estado del PDF, por favor espera');
-      const timestamp = firebase.firestore.FieldValue.serverTimestamp();
-      const eliminar = firebase.firestore.FieldValue.delete();
-      const payload = {
-        pdf: 'si',
-        pdfActualizadoEn: timestamp,
-        pdfUrl: eliminar,
-        pdfStoragePath: eliminar
-      };
-      await Promise.all([
-        db.collection('sorteos').doc(sorteoId).set(payload, { merge: true }),
-        db.collection('cantarsorteos').doc(sorteoId).set(payload, { merge: true })
-      ]);
-      alert('El sorteo se marcó como PDF listo.');
-      window.location.href = 'cantarsorteos.html';
-    } catch (err) {
-      console.error('Error actualizando el estado del PDF', err);
-      alert('No se pudo actualizar el estado del PDF. Intenta nuevamente.');
-      if(pdfListoBtn){ pdfListoBtn.disabled = false; }
-    } finally {
       ocultarLoading();
     }
   }


### PR DESCRIPTION
## Resumen de cambios
- `public/cantarsorteos.html`
  - El botón **PDF** en estado Sellado ahora **habilita acceso para jugadores** (con confirmación) en lugar de redirigir.
  - El botón **PDF resultados** en estado Finalizado ahora **habilita acceso para jugadores** (con confirmación) en lugar de redirigir.
  - Se persisten flags nuevos en Firestore: `accesoPdfJuegoJugadores` y `accesoPdfResultadosJugadores` (más timestamp de habilitación).
  - Los íconos flotantes de ambos botones siguen redirigiendo a `pdfsorteo.html` y `pdfresultados.html` (modo admin) para mantener el flujo de operador.
  - Se adaptó la carga inicial para inicializar flags PDF faltantes en sorteos históricos.

- `public/juegoactivo.html`
  - Se agregaron dos botones pequeños para jugadores en una sola línea bajo el panel de formas:
    - **Cartones sellados**
    - **Cartones ganadores**
  - Estado visual:
    - Deshabilitado: gris/inactivo.
    - Habilitado: color activo + luz verde parpadeante.
  - Ambos botones navegan a ventanas PDF en `modo=jugador`.
  - El listener de sorteos ahora observa `Jugando` y `Sellado`; en `Sellado` se muestra el sorteo si ya se habilitó PDF de juego (cumple el requisito de visibilidad previa a Jugando).
  - En sorteos Finalizados consultados manualmente se habilitan ambos accesos.

- `public/pdfsorteo.html`
  - `ensureAuth('Administrador')` -> `ensureAuth()` para permitir acceso de jugadores autenticados.
  - Se eliminó el botón **PDF listo** y su lógica de confirmación.
  - Soporte de `modo=jugador`:
    - Oculta botón “Generar cartones”.
    - Al entrar, genera automáticamente datos/cartones.
    - Solo se usa “Generar PDF” para descarga.
  - Validación de acceso: en modo jugador bloquea acceso si aún no está habilitado.
  - Botón salir redirige a `juegoactivo.html` en modo jugador.

- `public/pdfresultados.html`
  - `ensureAuth('Administrador')` -> `ensureAuth()` para permitir acceso de jugadores autenticados.
  - Se eliminó el botón **PDF LISTO** y toda su lógica de confirmación/orquestación asociada.
  - Soporte de `modo=jugador`:
    - Oculta botón “Resultados”.
    - Al entrar, calcula/carga resultados automáticamente.
    - Solo usa “Generar PDF” para descarga.
  - Validación de acceso en modo jugador según flag habilitado (o estado Finalizado).
  - Botón salir redirige a `juegoactivo.html` en modo jugador.

## Motivación y problema que resuelve
Se necesitaba cambiar el flujo para que:
1. El cantante habilite accesos PDF por fase desde `cantarsorteos` (sin redirección directa).
2. El jugador vea botones de acceso en `juegoactivo` y descargue PDFs bajo demanda.
3. En modo jugador, las ventanas PDF se preparen automáticamente y muestren solo la acción de descarga.
4. Mantener acceso del cantante vía íconos flotantes para abrir directamente las ventanas PDF.

## Riesgos / impacto
- **UI/UX**: cambio de comportamiento esperado de botones PDF en `cantarsorteos`.
- **Datos Firestore**: se agregan/consumen nuevas banderas (`accesoPdfJuegoJugadores`, `accesoPdfResultadosJugadores`).
- **Flujo de estados**: `juegoactivo` ahora puede mostrar sorteo en `Sellado` cuando se habilita PDF de juego.

## Plan de rollback
1. Revertir commit `8dca917`.
2. Desplegar nuevamente frontend estático.
3. (Opcional) ignorar flags nuevas en lecturas antiguas; no se eliminaron campos críticos existentes.

## Evidencia de pruebas
- `npm test -- --runInBand` ✅ PASS (11 suites, 35 tests)

## Checklist de seguridad
- [x] No se agregaron secretos ni credenciales hardcodeadas.
- [x] No se modificaron `firestore.rules` ni `storage.rules`.
- [x] No se alteraron flujos sensibles de autenticación backend.

## Notas para reviewer
- Revisar especialmente la compatibilidad visual de los nuevos botones PDF en `juegoactivo` para móviles y desktop.
- Validar manualmente los 4 recorridos clave:
  1) Cantante habilita PDF juego en Sellado.
  2) Jugador entra por `juegoactivo` a `pdfsorteo` en modo jugador.
  3) Cantante habilita PDF resultados en Finalizado.
  4) Jugador entra por `juegoactivo` a `pdfresultados` en modo jugador.

## Notas para deploy
- No requiere migraciones ni cambios de backend.
- Confirmar que el cliente tenga permisos de lectura sobre documentos de sorteo y colecciones usadas por ventanas PDF (como ya ocurre en flujo actual).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f4f634b48326be659f0fcaea2f13)