### PR TITLE
feat(sorteos): mejora flujo de finalización, pagos y live en juego activo

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -1059,6 +1059,35 @@
       color: var(--texto-secundario);
       text-align: center;
     }
+    #modal-ganadores-preview {
+      display: none;
+      justify-content: center;
+      align-items: center;
+      padding: 8px 0 2px;
+      width: 100%;
+    }
+    #modal-ganadores-preview .carton-tabla--mini {
+      border: 2px solid rgba(0, 0, 0, 0.15);
+      border-collapse: collapse;
+      background: linear-gradient(160deg, rgba(255,255,255,0.95), rgba(237,247,255,0.95));
+      box-shadow: 0 8px 20px rgba(0,0,0,0.12);
+    }
+    #modal-ganadores-preview .carton-tabla--mini th,
+    #modal-ganadores-preview .carton-tabla--mini td {
+      width: 30px;
+      height: 30px;
+      min-width: 30px;
+      font-size: 0.85rem;
+    }
+    #modal-ganadores-preview .carton-tabla--mini td.celda-forma-estrella {
+      background: linear-gradient(145deg, var(--forma-color-suave, #6fa8dc), rgba(255,255,255,0.92));
+    }
+    #modal-ganadores-preview .carton-tabla--mini td.celda-forma-estrella .forma-estrella {
+      color: var(--forma-color-intenso, #0b5394);
+      font-size: 0.95rem;
+      text-shadow: 0 0 7px rgba(255,255,255,0.85);
+      line-height: 1;
+    }
     .ganador-card {
       background: linear-gradient(135deg, rgba(255,255,255,0.96), rgba(240,240,240,0.96));
       border-radius: 14px;
@@ -1754,6 +1783,7 @@
       <div id="modal-ganadores-subtitulo" class="mensaje"></div>
       <div id="modal-ganadores-lista"></div>
       <div id="modal-ganadores-sin" class="modal-mensaje"></div>
+      <div id="modal-ganadores-preview" aria-hidden="true"></div>
     </div>
   </div>
   <div id="nuevos-ganadores-modal" class="modal modal-nuevos-ganadores" role="dialog" aria-modal="true" aria-labelledby="nuevos-ganadores-titulo" aria-hidden="true">
@@ -1907,6 +1937,7 @@
   const modalGanadoresSubtituloEl = document.getElementById('modal-ganadores-subtitulo');
   const modalGanadoresListaEl = document.getElementById('modal-ganadores-lista');
   const modalGanadoresSinEl = document.getElementById('modal-ganadores-sin');
+  const modalGanadoresPreviewEl = document.getElementById('modal-ganadores-preview');
   const modalPremioFormaEl = document.getElementById('modal-premio-forma');
   const modalPremioFormaValorEl = document.getElementById('modal-premio-forma-valor');
   const modalPremioFormaLabelEl = document.getElementById('modal-premio-forma-label');
@@ -4326,6 +4357,7 @@
     const resaltarTodas = datosForma.resaltarTodas === true;
     info.celdas.forEach(celda=>{
       celda.classList.remove('celda-forma-activa', 'celda-forma-solo-borde', 'celda-forma-temporal', 'celda-cantada', 'celda-canto-penalizado');
+      celda.classList.remove('celda-forma-estrella');
       if(celda.dataset.cantada === '1'){
         celda.classList.add('celda-cantada');
       }else if(celda.dataset.cantada === 'p'){
@@ -4333,6 +4365,8 @@
       }
       celda.style.removeProperty('--forma-rgb');
       celda.style.removeProperty('--forma-rgb-vivo');
+      const estrellas = celda.querySelectorAll('.forma-estrella');
+      estrellas.forEach(node=>node.remove());
     });
     posiciones.forEach(pos=>{
       const clave = `${pos.r}-${pos.c}`;
@@ -4343,6 +4377,13 @@
       if(datosForma.soloBorde) celda.classList.add('celda-forma-solo-borde');
       celda.style.setProperty('--forma-rgb', rgbBase);
       celda.style.setProperty('--forma-rgb-vivo', rgbVivo);
+      if(datosForma.mostrarEstrellas){
+        celda.classList.add('celda-forma-estrella');
+        const estrella = document.createElement('span');
+        estrella.className = 'forma-estrella';
+        estrella.textContent = '★';
+        celda.appendChild(estrella);
+      }
     });
     if(info.leyenda){
       if(datosForma.mostrarLeyenda === false){
@@ -4449,9 +4490,33 @@
     actualizarModalPremioForma(forma);
     modalGanadoresListaEl.innerHTML = '';
     modalGanadoresSinEl.textContent = '';
+    if(modalGanadoresPreviewEl){
+      modalGanadoresPreviewEl.innerHTML = '';
+      modalGanadoresPreviewEl.style.display = 'none';
+      modalGanadoresPreviewEl.setAttribute('aria-hidden', 'true');
+    }
     const ganadores = registro?.cartones ? [...registro.cartones] : [];
     if(!ganadores.length){
       modalGanadoresSinEl.textContent = forma?.nombre ? 'Aún no hay cartones ganadores para esta forma.' : 'Esta forma no está configurada para el sorteo.';
+      if(forma?.nombre && modalGanadoresPreviewEl){
+        const colorForma = obtenerColorParaForma(forma?.idx || 1);
+        const tablaInfo = crearTablaCartonVisual({ id: 'forma-preview', posiciones: [] }, 'mini');
+        aplicarResumenCarton(tablaInfo);
+        aplicarFormaCarton(tablaInfo, {
+          posiciones: obtenerPosicionesNormalizadas(forma),
+          color: colorForma,
+          nombre: forma?.nombre,
+          indice: forma?.idx,
+          mostrarLeyenda: false,
+          resaltarTodas: true,
+          mostrarEstrellas: true
+        });
+        modalGanadoresPreviewEl.style.setProperty('--forma-color-suave', ajustarLuminosidad(colorForma, 0.35));
+        modalGanadoresPreviewEl.style.setProperty('--forma-color-intenso', obtenerColorOscurecido(colorForma, 0.7));
+        modalGanadoresPreviewEl.appendChild(tablaInfo.tabla);
+        modalGanadoresPreviewEl.style.display = 'flex';
+        modalGanadoresPreviewEl.setAttribute('aria-hidden', 'false');
+      }
     }else{
       ganadores.sort((a,b)=>{
         const pasoA = obtenerPasoFormaCarton(a.id, idxNumero);
@@ -6819,11 +6884,43 @@
       mensajeEl.textContent = 'El sorteo fue finalizado correctamente.';
       finalizarBtn.classList.remove('attention');
       forzarVisibilidadResultado(true);
-      abrirPdfResultados();
+      const habilitarPdfJugadores = await preguntarAccionEstado('¿Deseas habilitar el acceso a PDF Resultados a los Jugadores?');
+      if(habilitarPdfJugadores){
+        await habilitarAccesoPdfResultadosJugadores();
+      }
+      mostrarAvisoSimple('Sorteo finalizado. Puedes abrir PDF resultados cuando quieras con el ícono flotante.', 'Finalizado');
     } catch (err) {
       console.error('Error finalizando sorteo', err);
       alert('No fue posible finalizar el sorteo.');
     }
+  }
+
+  async function habilitarAccesoPdfResultadosJugadores(){
+    if(!currentSorteoId || !currentSorteoData) return;
+    const estadoPdfResultado = (currentSorteoData.pdfresul || '').toString().trim().toLowerCase();
+    if(estadoPdfResultado === 'si'){
+      return;
+    }
+    const timestamp = firebase.firestore.FieldValue.serverTimestamp();
+    const payload = {
+      pdfresul: 'si',
+      accesoPdfResultadosJugadores: 'si',
+      accesoPdfResultadosJugadoresEn: timestamp
+    };
+    await Promise.all([
+      db.collection('sorteos').doc(currentSorteoId).set(payload, { merge: true }),
+      db.collection('cantarsorteos').doc(currentSorteoId).set(payload, { merge: true })
+    ]);
+    currentSorteoData.pdfresul = 'si';
+    currentSorteoData.accesoPdfResultadosJugadores = 'si';
+    const indiceSorteo = sorteos.findIndex(s=>s && s.id === currentSorteoId);
+    if(indiceSorteo >= 0){
+      sorteos[indiceSorteo] = { ...sorteos[indiceSorteo], ...payload };
+    }
+    mensajeEl.textContent = 'Acceso a PDF de resultados habilitado para jugadores.';
+    actualizarBotones();
+    actualizarAnimaciones();
+    mostrarDatos();
   }
 
   function abrirPdfResultados(){
@@ -6864,26 +6961,7 @@
       .then(async confirmar=>{
         if(!confirmar) return;
         try{
-          const timestamp = firebase.firestore.FieldValue.serverTimestamp();
-          const payload = {
-            pdfresul: 'si',
-            accesoPdfResultadosJugadores: 'si',
-            accesoPdfResultadosJugadoresEn: timestamp
-          };
-          await Promise.all([
-            db.collection('sorteos').doc(currentSorteoId).set(payload, { merge: true }),
-            db.collection('cantarsorteos').doc(currentSorteoId).set(payload, { merge: true })
-          ]);
-          currentSorteoData.pdfresul = 'si';
-          currentSorteoData.accesoPdfResultadosJugadores = 'si';
-          const indiceSorteo = sorteos.findIndex(s=>s && s.id === currentSorteoId);
-          if(indiceSorteo >= 0){
-            sorteos[indiceSorteo] = { ...sorteos[indiceSorteo], ...payload };
-          }
-          mensajeEl.textContent = 'Acceso a PDF de resultados habilitado para jugadores.';
-          actualizarBotones();
-          actualizarAnimaciones();
-          mostrarDatos();
+          await habilitarAccesoPdfResultadosJugadores();
         }catch(err){
           console.error('No se pudo habilitar el acceso a PDF de resultados', err);
           alert('No fue posible habilitar el acceso al PDF de resultados.');

--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -912,6 +912,7 @@
         sorteoId,
         sorteoData: sorteoData || {},
         db: dbRef(),
+        parametrosData: null,
         formasData: [],
         cartonesMapa: new Map(),
         cartonesGanadoresPorForma: new Map(),
@@ -1232,13 +1233,40 @@
     }
 
     async function cpObtenerAdministrativosProcesados(ctx){
+      if(!ctx.parametrosData){
+        try{
+          const docParametros = await ctx.db.collection('Variablesglobales').doc('Parametros').get();
+          ctx.parametrosData = docParametros.exists ? (docParametros.data() || {}) : {};
+        }catch(err){
+          console.warn('No se pudieron cargar los parámetros globales para pagos administrativos', err);
+          ctx.parametrosData = {};
+        }
+      }
+      const valorCarton = Number(ctx.sorteoData?.valorCarton) || 0;
+      const cartonesPagados = Number(ctx.sorteoData?.cartonesjugando ?? ctx.sorteoData?.cartonesJugando ?? 0) || 0;
+      const premioInicial = Number(ctx.sorteoData?.premioInicial ?? 0) || 0;
+      const totalGeneradoPorPagados = Math.max(0, valorCarton) * Math.max(0, cartonesPagados);
+      const baseTotalSorteo = Math.max(0, premioInicial) + totalGeneradoPorPagados;
       const definiciones = [
-        { rolInterno: 'agencia', clavesMonto: ['totalporcentaje','totalPorcentaje','total_porcentaje'] },
-        { rolInterno: 'desarrollador', clavesMonto: ['totalporcentajesu','totalPorcentajeSu','total_porcentajesu'] }
+        {
+          rolInterno: 'agencia',
+          clavesMonto: ['totalporcentaje','totalPorcentaje','total_porcentaje'],
+          clavesPorcentaje: ['porcentaje']
+        },
+        {
+          rolInterno: 'desarrollador',
+          clavesMonto: ['totalporcentajesu','totalPorcentajeSu','total_porcentajesu'],
+          clavesPorcentaje: ['porcentajesu']
+        }
       ];
       const lista = [];
       for(const definicion of definiciones){
-        const monto = cpObtenerCampoNumeroFlexible(ctx.sorteoData || {}, definicion.clavesMonto);
+        const montoHistorico = cpObtenerCampoNumeroFlexible(ctx.sorteoData || {}, definicion.clavesMonto);
+        const porcentajeConfigurado = cpObtenerCampoNumeroFlexible(ctx.parametrosData || {}, definicion.clavesPorcentaje);
+        const montoCalculado = (baseTotalSorteo > 0 && porcentajeConfigurado > 0)
+          ? ((baseTotalSorteo * porcentajeConfigurado) / 100)
+          : 0;
+        const monto = montoCalculado > 0 ? montoCalculado : montoHistorico;
         const usuarios = await cpObtenerUsuariosPorRolInterno(ctx, definicion.rolInterno);
         usuarios.forEach(usuario=>{
           const email = cpNormalizarEmail(usuario.email || usuario.uid || '');

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -638,6 +638,26 @@
       text-shadow: none;
       margin-top: 12px;
     }
+    .live-toggle-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin-top: 14px;
+      padding: 8px 10px;
+      border-radius: 10px;
+      background: rgba(255, 122, 0, 0.08);
+      border: 1px solid rgba(255, 122, 0, 0.25);
+    }
+    .live-toggle-row .live-toggle-label {
+      margin: 0;
+      color: #ea580c;
+      font-size: 0.86rem;
+      font-weight: 700;
+    }
+    .live-link-content[hidden] {
+      display: none !important;
+    }
     .whatsapp-section label.publicidad-label {
       color: #1d4ed8;
     }
@@ -1257,10 +1277,19 @@
         <button type="button" id="guardar-links-publicidad-sorteos">Guardar links</button>
       </div>
     </div>
-    <label for="link-live-tiktok">Link de Live TikTok/YouTube/Facebook/Twitch</label>
-    <textarea id="link-live-tiktok" placeholder="https://www.tiktok.com/@cuenta/live, https://youtube.com/watch?v=..., https://www.facebook.com/tuPagina/videos/... o https://www.twitch.tv/tuCanal" spellcheck="false"></textarea>
-    <div class="live-link-actions">
-      <button type="button" id="guardar-link-live-tiktok">Guardar</button>
+    <div class="live-toggle-row">
+      <span class="live-toggle-label">Transmitir en vivo</span>
+      <label class="switch">
+        <input type="checkbox" id="toggle-transmitir-vivo">
+        <span class="slider"></span>
+      </label>
+    </div>
+    <div id="live-link-content" class="live-link-content" hidden>
+      <label for="link-live-tiktok">Link de Live TikTok/YouTube/Facebook/Twitch</label>
+      <textarea id="link-live-tiktok" placeholder="https://www.tiktok.com/@cuenta/live, https://youtube.com/watch?v=..., https://www.facebook.com/tuPagina/videos/... o https://www.twitch.tv/tuCanal" spellcheck="false"></textarea>
+      <div class="live-link-actions">
+        <button type="button" id="guardar-link-live-tiktok">Guardar</button>
+      </div>
     </div>
   </section>
   <div id="whatsapp-modal-overlay" class="whatsapp-modal-overlay" aria-hidden="true">
@@ -1499,6 +1528,8 @@
     const campoLinkPublicidadSorteos=document.getElementById('link-publicidad-sorteos');
     const campoLinkPublicidadSorteosDos=document.getElementById('link-publicidad-sorteos-2');
     const botonGuardarLinksPublicidad=document.getElementById('guardar-links-publicidad-sorteos');
+    const toggleTransmitirVivo=document.getElementById('toggle-transmitir-vivo');
+    const liveLinkContentEl=document.getElementById('live-link-content');
     const campoLinkLiveTiktok=document.getElementById('link-live-tiktok');
     const botonGuardarLinkLive=document.getElementById('guardar-link-live-tiktok');
     const modalOverlay=document.getElementById('whatsapp-modal-overlay');
@@ -1623,6 +1654,10 @@
     function actualizarVisualizacionMensajes(toggle,contenedor){
       if(!toggle || !contenedor) return;
       contenedor.style.display=toggle.checked?'flex':'none';
+    }
+    function actualizarVisualizacionLive(){
+      if(!liveLinkContentEl || !toggleTransmitirVivo) return;
+      liveLinkContentEl.hidden=!toggleTransmitirVivo.checked;
     }
     async function cargarMensajesEditables(){
       try{
@@ -1879,9 +1914,16 @@
           if(linkLiveGuardado){
             campoLinkLiveTiktok.value=linkLiveGuardado;
           }
+          const liveHabilitadoRaw=data.transmitirEnVivo ?? data.transmitirenvivo ?? data.liveHabilitado ?? data.livehabilitado;
+          const liveHabilitado=(String(liveHabilitadoRaw ?? 'si').toLowerCase()==='si') || liveHabilitadoRaw===true;
+          if(toggleTransmitirVivo){
+            toggleTransmitirVivo.checked=liveHabilitado;
+          }
         }
       } catch(err){
         console.error('No se pudieron obtener los datos de WhatsApp',err);
+      } finally {
+        actualizarVisualizacionLive();
       }
     }
 
@@ -2038,6 +2080,21 @@
     }
     if(toggleMensajesReferidos){
       toggleMensajesReferidos.addEventListener('change',()=>actualizarVisualizacionMensajes(toggleMensajesReferidos,mensajesReferidosContent));
+    }
+    if(toggleTransmitirVivo){
+      toggleTransmitirVivo.addEventListener('change',async ()=>{
+        actualizarVisualizacionLive();
+        const valor=toggleTransmitirVivo.checked?'si':'no';
+        try{
+          await db.collection('Variablesglobales').doc('Parametros').set({
+            transmitirEnVivo:valor,
+            liveHabilitado:valor
+          },{merge:true});
+        }catch(err){
+          console.error('No se pudo guardar el estado de transmisión en vivo',err);
+          alert('No fue posible guardar el estado de transmisión en vivo.');
+        }
+      });
     }
     botonGuardarLinkLive.addEventListener('click',async ()=>{
       const valor=campoLinkLiveTiktok.value.trim();

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1802,13 +1802,16 @@
           align-items: center;
           gap: clamp(4px, 0.8vw, 8px);
           padding: clamp(5px, 0.8vw, 8px) clamp(8px, 1.3vw, 12px);
-          border-radius: 999px;
+          border-radius: 12px;
           border: 1px solid rgba(46,125,50,0.25);
           background: #eceff1;
           color: #546e7a;
           font-size: clamp(0.58rem, 1.2vw, 0.74rem);
           font-weight: 700;
           letter-spacing: .2px;
+          line-height: 1.05;
+          text-align: center;
+          min-height: 48px;
           cursor: not-allowed;
           opacity: .75;
       }
@@ -2177,6 +2180,8 @@
           align-items: center;
           display: inline-flex;
           flex-direction: column;
+          padding-top: clamp(1px, 0.2vw, 2px);
+          padding-bottom: clamp(1px, 0.2vw, 2px);
       }
       .carton-forma-leyenda--panel:not(.visible) {
           display: none;
@@ -2188,14 +2193,14 @@
           display: block;
           color: #000000;
           font-size: clamp(0.52rem, 2vw, 0.7rem);
-          line-height: 1.05;
+          line-height: 0.95;
           letter-spacing: 0.7px;
       }
       .carton-forma-leyenda__forma {
           display: block;
           color: inherit;
           font-size: clamp(0.48rem, 1.9vw, 0.64rem);
-          line-height: 1.05;
+          line-height: 0.95;
           word-break: break-word;
           text-align: center;
       }
@@ -4361,11 +4366,11 @@
           <div id="panel-pdf-jugadores" class="panel-pdf-jugadores" role="group" aria-label="Accesos PDF para jugadores">
             <button id="btn-pdf-cartones" type="button" class="pdf-acceso-btn" disabled>
               <span class="estado-luz" aria-hidden="true"></span>
-              <span>Cartones sellados</span>
+              <span>Cartones<br>sellados</span>
             </button>
             <button id="btn-pdf-resultados" type="button" class="pdf-acceso-btn" disabled>
               <span class="estado-luz" aria-hidden="true"></span>
-              <span>Cartones ganadores</span>
+              <span>Cartones<br>ganadores</span>
             </button>
           </div>
         </div>
@@ -4857,6 +4862,7 @@
   let liveStreamLinkValor = '';
   let liveStreamLinkCargado = false;
   let liveStreamLinkPromesa = null;
+  let liveStreamHabilitado = true;
   let liveStreamVisible = false;
   let liveStreamDragState = {activo:false, offsetX:0, offsetY:0, pointerId:null};
   let liveStreamTieneTransmision = false;
@@ -4871,6 +4877,7 @@
   let liveStreamPlatform = 'otro';
   let liveStreamIconInterval = null;
   let liveStreamMostrarTexto = true;
+  let autoConsultaFinalizadoEnCurso = false;
   const LIVE_ICON_INTERVAL_MS = 3000;
   let ventanaEnFoco = document.visibilityState === 'visible' && document.hasFocus();
   let cantosRecientesSinAnimacion = false;
@@ -6020,6 +6027,8 @@
         const doc = await db.collection('Variablesglobales').doc('Parametros').get();
         if(doc.exists){
           const data = doc.data() || {};
+          const liveHabilitadoRaw = data.transmitirEnVivo ?? data.transmitirenvivo ?? data.liveHabilitado ?? data.livehabilitado;
+          liveStreamHabilitado = (String(liveHabilitadoRaw ?? 'si').toLowerCase() === 'si') || liveHabilitadoRaw === true;
           const enlace = (data.linkLiveTiktok ?? data.linklivetiktok ?? data.link_live_tiktok ?? '').toString().trim();
           if(enlace){
             liveStreamLinkValor = enlace;
@@ -6029,12 +6038,32 @@
         console.error('Error obteniendo el enlace de la transmisión en vivo', err);
       }
       liveStreamLinkCargado = true;
+      actualizarVisibilidadBotonLive();
       return liveStreamLinkValor;
     })();
     return liveStreamLinkPromesa;
   }
 
+  function actualizarVisibilidadBotonLive(){
+    if(!liveStreamToggleBtn) return;
+    if(liveStreamHabilitado){
+      liveStreamToggleBtn.hidden = false;
+      liveStreamToggleBtn.style.display = '';
+      liveStreamToggleBtn.setAttribute('aria-hidden', 'false');
+    }else{
+      liveStreamToggleBtn.hidden = true;
+      liveStreamToggleBtn.style.display = 'none';
+      liveStreamToggleBtn.setAttribute('aria-hidden', 'true');
+      if(liveStreamVisible){
+        ocultarLiveStream();
+      }
+    }
+  }
+
   function prepararLiveStream(){
+    if(!liveStreamHabilitado){
+      return;
+    }
     mostrarLiveStream();
     mostrarMensajeLive('Buscando transmisiones en vivo...');
     if(!liveStreamAudioHabilitado){
@@ -6514,11 +6543,13 @@
       .then(link=>{
         liveStreamTieneTransmision = typeof link === 'string' && !!link.trim();
         actualizarPlataformaLive(liveStreamTieneTransmision ? link : '');
+        actualizarVisibilidadBotonLive();
         actualizarBotonLiveAnimacion();
       })
       .catch(()=>{
         liveStreamTieneTransmision = false;
         actualizarPlataformaLive('');
+        actualizarVisibilidadBotonLive();
         actualizarBotonLiveAnimacion();
       });
   }
@@ -10747,6 +10778,7 @@
 
   if(liveStreamToggleBtn){
     liveStreamToggleBtn.addEventListener('click',()=>{
+      if(!liveStreamHabilitado) return;
       if(liveStreamVisible){
         ocultarLiveStream();
       }else{
@@ -11481,8 +11513,40 @@
     });
   }
 
+  async function intentarAutoConsultarSorteoFinalizado(sorteoId){
+    if(!sorteoId || autoConsultaFinalizadoEnCurso || sorteoManualSeleccionadoId){
+      return false;
+    }
+    autoConsultaFinalizadoEnCurso = true;
+    try{
+      const doc = await db.collection('sorteos').doc(sorteoId).get();
+      if(!doc.exists) return false;
+      const data = doc.data() || {};
+      const estado = (data.estado || '').toString().trim().toLowerCase();
+      const condicionTexto = (data.condicion ?? data['condición'] ?? '').toString().trim().toUpperCase();
+      if(estado !== 'finalizado' || (condicionTexto && condicionTexto !== 'VISIBLE')){
+        return false;
+      }
+      await seleccionarSorteoFinalizado({
+        id: sorteoId,
+        nombre: data.nombre || 'Sorteo',
+        fecha: data.fecha || '',
+        hora: data.hora || '',
+        tipo: data.tipo || '',
+        estado: data.estado || 'Finalizado'
+      });
+      return true;
+    }catch(err){
+      console.error('No se pudo autoseleccionar el sorteo finalizado', err);
+      return false;
+    }finally{
+      autoConsultaFinalizadoEnCurso = false;
+    }
+  }
+
   function seleccionarSorteo(activos){
     const lista=Array.isArray(activos)?activos:[];
+    const sorteoActivoPrevioId = activeSorteoId;
     haySorteoJugando=lista.length>0;
     if(haySorteoJugando || !sorteoManualSeleccionadoId){
       contadoresOcultosPorFinalizado=false;
@@ -11496,6 +11560,9 @@
     }
     actualizarSinSorteoUI();
     if(!lista.length){
+      if(sorteoActivoPrevioId && !sorteoManualSeleccionadoId){
+        intentarAutoConsultarSorteoFinalizado(sorteoActivoPrevioId);
+      }
       suscribirSimulacionSorteo(null);
       if(manualBingoUnsub){ manualBingoUnsub(); manualBingoUnsub = null; }
       manualBingoEstado = null;


### PR DESCRIPTION
### Motivation
- Evitar que al finalizar un sorteo el administrador sea forzado a abrir el PDF de resultados y permitirle habilitar el acceso a jugadores de forma opcional. 
- Mostrar correctamente la miniatura de la forma (con estrellas) cuando no hay ganadores, para mayor claridad en los modales. 
- Corregir el cálculo de pagos administrativos para que tome como base el total real del sorteo (incluyendo monto inicial + ventas de cartones pagados). 
- Permitir controlar la transmisión en vivo desde configuración y adaptar la UI de `juegoactivo` (navegación automática a sorteo finalizado y ajustes visuales solicitados).

### Description
- cantarsorteos.html: ya no redirige automáticamente a `pdfresultados.html` al finalizar; ahora pregunta al administrador si desea habilitar el acceso a PDF resultados para jugadores y persiste ese estado mediante un helper reutilizable (`habilitarAccesoPdfResultadosJugadores`). Se añadió preview de mini-cartón con estrellas en el modal de formas sin ganadores (estilos + render). (archivo: `public/cantarsorteos.html`).
- centropagos.html: el cálculo para pagos administrativos ahora usa como base `premioInicial + (cartonesPagados * valorCarton)` y prioriza porcentajes configurados globalmente en `Variablesglobales/Parametros` (`porcentaje`, `porcentajesu`) con fallback a los montos históricos guardados en el sorteo. Se añadió caching de `Parametros` por contexto. (archivo: `public/centropagos.html`).
- juegoactivo.html: añadido comportamiento para intentar auto-consultar un sorteo cuando el sorteo en curso pasa a `Finalizado` (el jugador ve la consulta automáticamente), ajustes visuales para reducir altura del bloque “GANASTE CON …” (line-height/paddings) y cambio en la presentación de los botones PDF para mostrar la etiqueta en dos líneas; integración con bandera de live para ocultar/mostrar el botón LIVE según la configuración. (archivo: `public/juegoactivo.html`).
- configuraciones.html: nuevo switch “Transmitir en vivo” que muestra/oculta el bloque de link de transmisión; persiste la bandera (`transmitirEnVivo` / `liveHabilitado`) en `Variablesglobales/Parametros` sin borrar el link existente. (archivo: `public/configuraciones.html`).

### Testing
- Comando ejecutado: `npm test` — Resultado: PASS (11 suites, 35 tests passed).
- Nota: las pruebas automatizadas unitarias pasaron y no se introdujeron cambios que afecten a los tests existentes; las verificaciones visuales (UI) deben validarse manualmente en un entorno de navegador tras deploy. If needed, recomiendo un smoke test manual en: `cantarsorteos.html`, `centropagos.html`, `juegoactivo.html` y `configuraciones.html` para validar los flujos UI (habilitar/deshabilitar live, finalizar sorteo y preview de formas sin ganadores, y cálculo administrativo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e39684b0288326be1acf59c0fc577e)