### PR TITLE
fix(sorteos): habilitar PDF resultados al finalizar y ajustes UI juegoactivo

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -6884,10 +6884,7 @@
       mensajeEl.textContent = 'El sorteo fue finalizado correctamente.';
       finalizarBtn.classList.remove('attention');
       forzarVisibilidadResultado(true);
-      const habilitarPdfJugadores = await preguntarAccionEstado('¿Deseas habilitar el acceso a PDF Resultados a los Jugadores?');
-      if(habilitarPdfJugadores){
-        await habilitarAccesoPdfResultadosJugadores();
-      }
+      await habilitarAccesoPdfResultadosJugadores();
       mostrarAvisoSimple('Sorteo finalizado. Puedes abrir PDF resultados cuando quieras con el ícono flotante.', 'Finalizado');
     } catch (err) {
       console.error('Error finalizando sorteo', err);

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1801,7 +1801,7 @@
           display: inline-flex;
           align-items: center;
           gap: clamp(4px, 0.8vw, 8px);
-          padding: clamp(5px, 0.8vw, 8px) clamp(8px, 1.3vw, 12px);
+          padding: clamp(3px, 0.6vw, 6px) clamp(8px, 1.3vw, 12px);
           border-radius: 12px;
           border: 1px solid rgba(46,125,50,0.25);
           background: #eceff1;
@@ -1811,7 +1811,7 @@
           letter-spacing: .2px;
           line-height: 1.05;
           text-align: center;
-          min-height: 48px;
+          min-height: 40px;
           cursor: not-allowed;
           opacity: .75;
       }
@@ -1929,8 +1929,13 @@
           opacity: 1;
           background: rgba(255,255,255,0.96);
           box-shadow: 0 6px 18px rgba(0,0,0,0.16);
-          padding: 6px 18px;
+          padding: 0 clamp(10px, 2vw, 16px);
           border: 1px solid rgba(0,0,0,0.08);
+          min-height: var(--panel-forma-altura);
+          height: var(--panel-forma-altura);
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
       }
       .panel-botones-formas__grid > .carton-forma-accion {
           width: auto;
@@ -2179,9 +2184,11 @@
           justify-content: center;
           align-items: center;
           display: inline-flex;
-          flex-direction: column;
-          padding-top: clamp(1px, 0.2vw, 2px);
-          padding-bottom: clamp(1px, 0.2vw, 2px);
+          flex-direction: row;
+          flex-wrap: nowrap;
+          gap: clamp(4px, 1.2vw, 10px);
+          padding-top: 0;
+          padding-bottom: 0;
       }
       .carton-forma-leyenda--panel:not(.visible) {
           display: none;
@@ -2190,18 +2197,19 @@
           opacity: 1;
       }
       .carton-forma-leyenda__titulo {
-          display: block;
+          display: inline;
           color: #000000;
-          font-size: clamp(0.52rem, 2vw, 0.7rem);
-          line-height: 0.95;
+          font-size: clamp(0.52rem, 1.8vw, 0.68rem);
+          line-height: 1;
           letter-spacing: 0.7px;
       }
       .carton-forma-leyenda__forma {
-          display: block;
+          display: inline;
           color: inherit;
-          font-size: clamp(0.48rem, 1.9vw, 0.64rem);
-          line-height: 0.95;
-          word-break: break-word;
+          font-size: clamp(0.52rem, 1.8vw, 0.68rem);
+          line-height: 1;
+          word-break: normal;
+          white-space: nowrap;
           text-align: center;
       }
       body.simulacion-cartones-activa .carton-visual,
@@ -4286,7 +4294,7 @@
   <button id="whatsapp-flotante" class="whatsapp-flotante" type="button" aria-label="Abrir grupo de WhatsApp">
     <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/WhatsApp_icon.png/598px-WhatsApp_icon.png" alt="">
   </button>
-  <button id="live-stream-toggle" class="live-stream-toggle" type="button" aria-label="Mostrar transmisión en vivo">LIVE</button>
+  <button id="live-stream-toggle" class="live-stream-toggle" type="button" aria-label="Mostrar transmisión en vivo" hidden aria-hidden="true" style="display:none;">LIVE</button>
   <div id="live-stream-window" class="live-stream-window" aria-hidden="true" role="dialog" aria-label="Transmisión en vivo">
     <div id="live-stream-handle" class="live-stream-header">
       <span class="live-stream-titulo">Transmisión en vivo</span>
@@ -4862,7 +4870,7 @@
   let liveStreamLinkValor = '';
   let liveStreamLinkCargado = false;
   let liveStreamLinkPromesa = null;
-  let liveStreamHabilitado = true;
+  let liveStreamHabilitado = false;
   let liveStreamVisible = false;
   let liveStreamDragState = {activo:false, offsetX:0, offsetY:0, pointerId:null};
   let liveStreamTieneTransmision = false;
@@ -8776,7 +8784,7 @@
           info.leyenda.innerHTML='';
           const titulo=document.createElement('span');
           titulo.className='carton-forma-leyenda__titulo';
-          titulo.textContent=modoSimulacionCartones?'HUBIESES GANADO CON':'GANASTE CON';
+          titulo.textContent='FORMA GANADORA';
           const nombre=document.createElement('span');
           nombre.className='carton-forma-leyenda__forma';
           nombre.textContent=etiqueta;


### PR DESCRIPTION
### Motivation
- Automatizar el flujo de cierre de sorteos para que, al marcar un sorteo como `Finalizado`, se habilite inmediatamente el PDF de resultados para jugadores sin pasos adicionales.
- Mejorar la presentación visual en `juegoactivo` para que la etiqueta de victoria sea más clara y ocupe una sola línea, y armonizar alturas entre elementos relacionados.
- Reducir la altura de los botones de acceso a PDF para que se vean más angostos y ocultar el botón `LIVE` cuando la configuración global de transmisión esté apagada.

### Description
- En `public/cantarsorteos.html` se modificó `finalizarSorteo()` para invocar directamente `habilitarAccesoPdfResultadosJugadores()` tras actualizar el estado a `Finalizado`, eliminando la confirmación adicional de habilitación de PDF.
- En `public/juegoactivo.html` se cambió el texto de la leyenda del cartón principal a `FORMA GANADORA` y se ajustaron estilos para mostrar la leyenda en una misma línea, usando la variable `--panel-forma-altura` para igualar la altura al panel de "ganancias totales".
- Se redujo la altura/espaciado de los botones `Cartones sellados` y `Cartones ganadores` ajustando `padding` y `min-height` (aprox. 48px → 40px) para conseguir ~8px menos de alto.
- El botón `LIVE` ahora se inicia oculto (`hidden`, `display:none`) y la variable `liveStreamHabilitado` se inicializa en `false`, de modo que solo se muestra cuando la lectura de `Variablesglobales/Parametros` permita habilitarlo.
- Archivos modificados: `public/cantarsorteos.html`, `public/juegoactivo.html`.

### Testing
- Ejecutado: `npm test` y todas las suites pasaron: 11 suites, 35 tests — PASS.
- Resultado de tests: `PASS` (sin fallos en tests unitarios automatizados).
- Nota: se recomienda validación manual en staging para verificar visualmente: 1) finalizar sorteo y confirmar PDF habilitado; 2) comprobar rótulo "FORMA GANADORA" en diversas resoluciones; 3) confirmar que `LIVE` no aparece si transmisión en vivo está deshabilitada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f968a3a883269383a8af39c8e1ca)