### PR TITLE
Support second-place free cards, improve player key handling, and small UI fixes

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -1457,6 +1457,64 @@
       return 0;
     }
 
+    function cpObtenerCartonesGratisSegundoForma(forma){
+      if(!forma) return 0;
+      const candidatos = [
+        forma?.cartonesGratis2,
+        forma?.cartonesgratis2,
+        forma?.cartones_gratis2,
+        forma?.cartonesGratisSegundo,
+        forma?.cartonesGratisSegundoLugar,
+        forma?.premioCartonesGratis2,
+        forma?.premioCartonesGratisSegundo,
+        forma?.premioCartonesGratisSegundoLugar
+      ];
+      for(const candidato of candidatos){
+        const numero = Number(candidato);
+        if(Number.isFinite(numero)){
+          return Math.max(0, Math.round(numero));
+        }
+      }
+      return 0;
+    }
+
+    function cpConstruirClaveJugador(carton){
+      const claveUsuario = (carton?.userId || carton?.usuarioId || '').toString().trim();
+      const correoCarton = cpNormalizarEmail(carton?.gmail || carton?.email || carton?.IDbilletera || '');
+      const aliasCarton = (carton?.alias || carton?.aliasCarton || '').toString();
+      return claveUsuario || (correoCarton ? `correo::${correoCarton}` : `alias::${aliasCarton.toLowerCase()}`);
+    }
+
+    function cpObtenerCartonesSegundoLugar(ctx, forma, pasoGanador){
+      const posiciones = cpObtenerPosicionesForma(forma);
+      if(!posiciones.length || posiciones.length <= 1) return [];
+      const pasoLimite = Number(pasoGanador);
+      if(!Number.isFinite(pasoLimite) || pasoLimite < 0) return [];
+      const resultado = [];
+      ctx.cartonesMapa.forEach(carton=>{
+        let faltantes = 0;
+        let validas = 0;
+        for(const pos of posiciones){
+          const valor = carton.valorPorPos.get(`${pos.r}-${pos.c}`);
+          if(valor === undefined){
+            faltantes = 2;
+            break;
+          }
+          const paso = ctx.cantosIndiceMap.get(valor);
+          if(paso === undefined || paso > pasoLimite){
+            faltantes += 1;
+            if(faltantes > 1) break;
+          }else{
+            validas += 1;
+          }
+        }
+        if(faltantes === 1 && validas > 0){
+          resultado.push(carton);
+        }
+      });
+      return resultado;
+    }
+
     function cpObtenerCartonesGratisPorGanador(forma,totalGanadores){
       const totalCartones = cpObtenerCartonesGratisForma(forma);
       if(totalCartones <= 0) return 0;
@@ -1579,10 +1637,9 @@
         const creditosPorGanador = cantidad > 0 ? Math.floor(totalCreditos / cantidad) : 0;
         const gratisPorGanador = cpObtenerCartonesGratisPorGanador(forma, cantidad);
         ganadores.forEach(carton=>{
-          const claveUsuario = (carton?.userId || carton?.usuarioId || '').toString().trim();
-          const correoCarton = (carton?.gmail || carton?.email || carton?.IDbilletera || '').toString().trim();
+          const clave = cpConstruirClaveJugador(carton);
+          const correoCarton = cpNormalizarEmail(carton?.gmail || carton?.email || carton?.IDbilletera || '');
           const aliasCarton = (carton?.alias || carton?.aliasCarton || '').toString();
-          const clave = claveUsuario || (correoCarton ? `correo::${correoCarton.toLowerCase()}` : `alias::${aliasCarton.toLowerCase()}`);
           if(!jugadoresMapa.has(clave)){
             jugadoresMapa.set(clave, {
               userId: carton?.userId || carton?.usuarioId || '',
@@ -1590,6 +1647,7 @@
               alias: aliasCarton,
               creditos: 0,
               cartonesGratis: 0,
+              cartonesGratisSegundoLugar: 0,
               formas: [],
               cartonesIds: new Set()
             });
@@ -1608,6 +1666,22 @@
             cartonesGratis: gratisPorGanador
           });
         });
+
+        const cartonesGratisSegundo = cpObtenerCartonesGratisSegundoForma(forma);
+        if(cartonesGratisSegundo > 0){
+          const pasoGanador = Number(registro?.paso);
+          const segundos = cpObtenerCartonesSegundoLugar(ctx, forma, pasoGanador);
+          const clavesSegundoOtorgadas = new Set();
+          segundos.forEach(cartonSegundo=>{
+            const claveSegundo = cpConstruirClaveJugador(cartonSegundo);
+            if(!claveSegundo || clavesSegundoOtorgadas.has(claveSegundo)) return;
+            clavesSegundoOtorgadas.add(claveSegundo);
+            const jugador = jugadoresMapa.get(claveSegundo);
+            if(!jugador) return;
+            jugador.cartonesGratis += cartonesGratisSegundo;
+            jugador.cartonesGratisSegundoLugar = (Number(jugador.cartonesGratisSegundoLugar) || 0) + cartonesGratisSegundo;
+          });
+        }
       });
 
       const agregados = new Map();

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4292,7 +4292,7 @@
 <body>
   <button id="volver-btn" class="menu-btn back-btn" aria-label="Volver" data-compact-back="true">&#9664;</button>
   <button id="whatsapp-flotante" class="whatsapp-flotante" type="button" aria-label="Abrir grupo de WhatsApp">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/WhatsApp_icon.png/598px-WhatsApp_icon.png" alt="">
+    <img src="img/whatsapp-icon.png" alt="">
   </button>
   <button id="live-stream-toggle" class="live-stream-toggle" type="button" aria-label="Mostrar transmisión en vivo" hidden aria-hidden="true" style="display:none;">LIVE</button>
   <div id="live-stream-window" class="live-stream-window" aria-hidden="true" role="dialog" aria-label="Transmisión en vivo">
@@ -8784,7 +8784,7 @@
           info.leyenda.innerHTML='';
           const titulo=document.createElement('span');
           titulo.className='carton-forma-leyenda__titulo';
-          titulo.textContent='FORMA GANADORA';
+          titulo.textContent='GANADOR:';
           const nombre=document.createElement('span');
           nombre.className='carton-forma-leyenda__forma';
           nombre.textContent=etiqueta;


### PR DESCRIPTION
### Motivation

- Add support for awarding free cards to second-place players and make player identification more robust when aggregating winners.
- Replace an external WhatsApp icon hotlink with a local asset and adjust the winner label text for clarity.

### Description

- Added `cpObtenerCartonesGratisSegundoForma` to read second-place free-card counts from multiple possible form properties.
- Added `cpConstruirClaveJugador` to centralize construction of a player key using `userId`, normalized email via `cpNormalizarEmail`, or alias as fallbacks.
- Added `cpObtenerCartonesSegundoLugar` to select cartons that finished exactly one missing position away from a given winning step for second-place awarding.
- Integrated the new functions into `cpObtenerGanadoresAgrupados` so second-place free cards are identified and added to player aggregates and a new `cartonesGratisSegundoLugar` field is tracked.
- Replaced the external WhatsApp icon URL with a local `img/whatsapp-icon.png` asset in `juegoactivo.html` and changed the carton winner legend text from `FORMA GANADORA` to `GANADOR:`.

### Testing

- No new automated tests were added for this PR, and existing project checks were run locally via `npm run lint` and `npm test`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4044f6620832689c9302d77409ba7)