### PR TITLE
fix(centropagos): filtra selector por sorteos finalizados

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -767,14 +767,14 @@
       if(docSorteo.exists){
         const data = docSorteo.data() || {};
         const nombre = (data.nombre || data.nombreSorteo || '').toString().trim();
-        if(nombre){ sorteosNombreCache.set(id, nombre); }
+        if(nombre && cpEstadoFinalizado(data)){ sorteosNombreCache.set(id, nombre); }
         return data;
       }
       const docCantar = await db.collection('cantarsorteos').doc(id).get();
       if(docCantar.exists){
         const data = docCantar.data() || {};
         const nombre = (data.nombre || data.nombreSorteo || '').toString().trim();
-        if(nombre){ sorteosNombreCache.set(id, nombre); }
+        if(nombre && cpEstadoFinalizado(data)){ sorteosNombreCache.set(id, nombre); }
         return data;
       }
       return null;
@@ -783,12 +783,16 @@
     function cpResolverNombreSorteo({ sorteoId = '', sorteoNombre = '' } = {}){
       const nombreDirecto = (sorteoNombre || '').toString().trim();
       if(nombreDirecto){
-        if(sorteoId){ sorteosNombreCache.set(sorteoId, nombreDirecto); }
+        if(sorteoId && sorteosNombreCache.has(sorteoId)){ sorteosNombreCache.set(sorteoId, nombreDirecto); }
         return nombreDirecto;
       }
       const id = (sorteoId || '').toString().trim();
       if(!id) return '';
       return (sorteosNombreCache.get(id) || '').toString().trim();
+    }
+
+    function cpEstadoFinalizado(data = {}){
+      return (data.estado || data.estadoactual || '').toString().trim().toLowerCase() === 'finalizado';
     }
 
     async function cpCargarSelectorSorteos(){
@@ -798,8 +802,11 @@
         await ensureFirebaseListo();
         const snap = await dbRef().collection('sorteos').limit(150).get();
         const lista = [];
+        sorteosNombreCache.clear();
         snap.forEach(doc=>{
           const data = doc.data() || {};
+          const estado = (data.estado || data.estadoactual || '').toString().trim().toLowerCase();
+          if(estado !== 'finalizado' || !cpEstadoFinalizado(data)) return;
           const nombre = (data.nombre || data.nombreSorteo || '').toString().trim();
           const fechaInfo = normalizarFecha(data.fecha || data.fechasorteo || data.fechaSorteo || data.createdAt);
           const etiqueta = `${nombre || 'Sorteo'} - ${fechaInfo.mostrar !== '-' ? fechaInfo.mostrar : 'Sin fecha'}`;
@@ -810,7 +817,16 @@
         selector.innerHTML = '<option value="">Selecciona un sorteo</option>' +
           lista.map(item=>`<option value="${escapeHtml(item.id)}">${escapeHtml(item.etiqueta)}</option>`).join('');
         if(sorteoIdDesdeQuery){
-          selector.value = sorteoIdDesdeQuery;
+          if(sorteosNombreCache.has(sorteoIdDesdeQuery)){
+            selector.setCustomValidity('');
+            selector.value = sorteoIdDesdeQuery;
+          } else {
+            selector.value = '';
+            selector.setCustomValidity('El sorteo indicado no está finalizado o no existe.');
+            selector.reportValidity();
+          }
+        } else {
+          selector.setCustomValidity('');
         }
       } catch (err) {
         console.warn('No se pudo cargar el selector de sorteos', err);


### PR DESCRIPTION
### Motivation
- Evitar que en el Centro de Pagos se muestren o se preseleccionen sorteos que no hayan finalizado, ya que eso permitía iniciar flujos (generación/consulta de pagos) sobre sorteos en estados no deseados. 
- El cambio normaliza y valida el campo de estado (`estado` / `estadoactual`) para aplicar el filtro de manera consistente. 
- Riesgo bajo: cambio localizado en la lógica del selector de frontend y caché auxiliar; plan de rollback: revertir el cambio en `public/centropagos.html` y redeploy del frontend si fuese necesario. 

### Description
- Se añadió la función auxiliar `cpEstadoFinalizado(data)` que normaliza `data.estado || data.estadoactual` y verifica si es `finalizado`.
- En `cpCargarSelectorSorteos()` se normaliza el estado con `(data.estado || data.estadoactual || '').toString().trim().toLowerCase()` y se descartan los documentos cuyo estado no sea `finalizado` antes de crear la lista mostrada.
- Se limpia `sorteosNombreCache` antes de repoblarla y ahora solo se almacenan nombres de sorteos que resultaron finalizados tras el filtro; además se ajustó `cpResolverDataSorteo()` para solo agregar al cache cuando el sorteo está finalizado.
- Si `sorteoIdDesdeQuery` viene en la URL y no corresponde a un sorteo finalizado, el `selector.value` se limpia y se muestra un mensaje de validación (`setCustomValidity` + `reportValidity`); si es finalizado se selecciona normalmente.
- Se mantiene el ordenamiento por `etiqueta` usando `localeCompare`, pero ahora se aplica sobre la lista ya filtrada de sorteos finalizados.

### Testing
- Comando ejecutado: `npm test`.
- Resultado: PASS — se ejecutaron 11 suites y 35 pruebas, todas PASSED (informes de consola mostraron mensajes esperados del entorno de pruebas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e426fef7d4832691e9b0fc40621c8e)