### PR TITLE
fix(centropagos): filtra premios y pagos por sorteo seleccionado

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -1992,6 +1992,10 @@
         if(idx >= 0) pagosAdminActivos[idx] = registro;
         else pagosAdminActivos.push(registro);
       });
+      const sorteoActivo = cpObtenerSorteoIdObjetivo();
+      if(sorteoActivo && sorteoActivo !== sorteoId){
+        return;
+      }
       renderPremios();
       renderPagos();
     }
@@ -2374,8 +2378,16 @@
       tbody.innerHTML = filas;
     }
 
+    function cpCoincideSorteoSeleccionado(item){
+      const sorteoObjetivo = cpObtenerSorteoIdObjetivo();
+      if(!sorteoObjetivo) return true;
+      return (item?.sorteoId || '') === sorteoObjetivo;
+    }
+
     function aplicarFiltrosPremios(origen){
+      const sorteoObjetivo = cpObtenerSorteoIdObjetivo();
       return origen.filter(item=>{
+        if(sorteoObjetivo && item.sorteoId !== sorteoObjetivo) return false;
         const jugador = `${item.gmail || ''} ${item.alias || ''} ${item.nombre || ''}`.toLowerCase();
         if(filtrosPremios.jugador && !jugador.includes(filtrosPremios.jugador)) return false;
         if(filtrosPremios.fecha && !(item.fechaMostrar || '').toLowerCase().includes(filtrosPremios.fecha)) return false;
@@ -2385,7 +2397,9 @@
     }
 
     function aplicarFiltrosPagos(origen){
+      const sorteoObjetivo = cpObtenerSorteoIdObjetivo();
       return origen.filter(item=>{
+        if(sorteoObjetivo && item.sorteoId !== sorteoObjetivo) return false;
         const jugador = `${item.gmail || ''} ${item.alias || ''} ${item.nombre || ''}`.toLowerCase();
         if(filtrosPagos.jugador && !jugador.includes(filtrosPagos.jugador)) return false;
         if(filtrosPagos.fecha && !(item.fechaMostrar || '').toLowerCase().includes(filtrosPagos.fecha)) return false;
@@ -2418,7 +2432,7 @@
     function renderPremios(){
       const lista = mostrarPremiosArchivo ? aplicarFiltrosPremios(premiosArchivados) : aplicarFiltrosPremios(premiosActivos);
       renderTabla(lista, 'tabla-premios', { mostrarArchivo: mostrarPremiosArchivo, tipo: 'premios' });
-      actualizarBadge('premios', premiosActivos.filter(item=>item.estado === 'PENDIENTE').length);
+      actualizarBadge('premios', premiosActivos.filter(item=>item.estado === 'PENDIENTE' && cpCoincideSorteoSeleccionado(item)).length);
       actualizarEstadoBotones();
       reconciliarIndicadorPagos().catch(err=>console.warn('No se pudo actualizar el indicador tras renderizar premios', err));
     }
@@ -2426,7 +2440,7 @@
     function renderPagos(){
       const lista = mostrarPagosArchivo ? aplicarFiltrosPagos(pagosAdminArchivados) : aplicarFiltrosPagos(pagosAdminActivos);
       renderTabla(lista, 'tabla-pagos', { mostrarArchivo: mostrarPagosArchivo, tipo: 'pagos' });
-      actualizarBadge('pagos', pagosAdminActivos.filter(item=>item.estado === 'PENDIENTE').length);
+      actualizarBadge('pagos', pagosAdminActivos.filter(item=>item.estado === 'PENDIENTE' && cpCoincideSorteoSeleccionado(item)).length);
       actualizarEstadoBotones();
       reconciliarIndicadorPagos().catch(err=>console.warn('No se pudo actualizar el indicador tras renderizar pagos', err));
     }
@@ -2900,6 +2914,12 @@
     }
     function configurarBotones(){
       const selectorSorteo = document.getElementById('cp-sorteo-selector');
+      if(selectorSorteo){
+        selectorSorteo.addEventListener('change', ()=>{
+          renderPremios();
+          renderPagos();
+        });
+      }
       const botonGenerarSolicitudes = document.getElementById('cp-generar-solicitudes');
       if(botonGenerarSolicitudes){
         botonGenerarSolicitudes.addEventListener('click', async()=>{


### PR DESCRIPTION
### Motivation
- Evitar que la vista del centro de pagos mezcle registros de sorteos distintos cuando hay un sorteo seleccionado en `#cp-sorteo-selector` para reducir errores operativos al procesar/archivar pagos y premios.
- Mantener la cache y snapshots globales existentes para minimizar el alcance del cambio y evitar reescribir la arquitectura de suscripciones en esta PR.
- Aplicar un filtro visual por `sorteoId` lo antes posible en el flujo de render para que badges y conteos reflejen solo el sorteo activo.

### Description
- Se añadió el helper `cpCoincideSorteoSeleccionado(item)` y se usa para comprobar si un registro pertenece al sorteo actualmente seleccionado obtenido con `cpObtenerSorteoIdObjetivo()`.
- Se incorporó el filtro por sorteo al inicio de `aplicarFiltrosPremios(origen)` y `aplicarFiltrosPagos(origen)` para excluir registros cuyo `item.sorteoId` no coincida cuando hay sorteo objetivo.
- Se actualizó el cálculo de badges en `renderPremios()` y `renderPagos()` para contar solo elementos pendientes que coincidan con el sorteo seleccionado con `cpCoincideSorteoSeleccionado`.
- Se añadió un `change` listener en `#cp-sorteo-selector` que invoca `renderPremios()` y `renderPagos()` al cambiar la selección, y se agregó en `cpRecargarTablasTrasGeneracion(sorteoId)` una protección que evita re-render si el selector está apuntando a otro sorteo, evitando mezcla visual tras la generación de solicitudes.
- Cambios realizados únicamente en `public/centropagos.html` en la rama `fix/filtrar-centropagos-por-sorteo` con commit message `fix(centropagos): filtra premios y pagos por sorteo seleccionado`.

### Testing
- Ejecuté `npm test` y todos los suites pasaron: `11 suites, 35 tests` (PASS), tiempo total ~3.4s; por tanto las pruebas automatizadas no reportaron regresiones.
- No se ejecutaron scripts de generación adicionales (`generate:firebase-config` / `generate:loterias-manifest`) porque el cambio es frontend estático y no afecta esos flujos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42aaf07b0832683057a41bd4e89ce)