### PR TITLE
fix(pagos): cambia placeholder de filtro jugador a usuario

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -602,7 +602,7 @@
         <thead>
           <tr class="filtros">
             <th>N°</th>
-            <th><input type="text" id="filtro-pagos-jugador" placeholder="Jugador"></th>
+            <th><input type="text" id="filtro-pagos-jugador" placeholder="Usuario"></th>
             <th>Créditos</th>
             <th><input type="text" id="filtro-pagos-fecha" placeholder="Fecha"></th>
             <th>


### PR DESCRIPTION
### Motivation
- Ajustar el copy del input de filtrado en la cabecera de `#tabla-pagos` para usar la terminología solicitada sin afectar la funcionalidad existente.

### Description
- Se modificó en `public/centropagos.html` únicamente el atributo `placeholder` del input de la columna de usuario de `"Jugador"` a `"Usuario"`, manteniendo `id="filtro-pagos-jugador"` para no romper listeners de `configurarFiltros()`.

### Testing
- Ejecutado `npm test` y todas las suites pasaron: 11 suites, 35 tests — PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42d4c3ac08326918a92ace3405108)