### PR TITLE
fix(juegoactivo): prioriza cartones por aciertos activos

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -8586,6 +8586,37 @@
     return resultado;
   }
 
+  function obtenerCantosActivosSet(){
+    const activos=new Set();
+    if(!Array.isArray(cantosOrdenados) || !cantosOrdenados.length){
+      return activos;
+    }
+    cantosOrdenados.forEach(numero=>{
+      const normalizado=Number(numero);
+      if(Number.isFinite(normalizado) && esCantoGanador(normalizado)){
+        activos.add(normalizado);
+      }
+    });
+    return activos;
+  }
+
+  function contarAciertosCarton(carton, cantosActivosSet=obtenerCantosActivosSet()){
+    if(!carton || !(cantosActivosSet instanceof Set) || !cantosActivosSet.size){
+      return 0;
+    }
+    const valores=carton.valorPorPos instanceof Map
+      ? Array.from(carton.valorPorPos.values())
+      : [];
+    let aciertos=0;
+    valores.forEach(valor=>{
+      const numero=Number(valor);
+      if(Number.isFinite(numero) && cantosActivosSet.has(numero)){
+        aciertos++;
+      }
+    });
+    return aciertos;
+  }
+
   function actualizarEtiquetaMisCartones(){
     if(!misCartonesLabelEl) return;
     misCartonesLabelEl.textContent = modoSimulacionCartones
@@ -10286,11 +10317,13 @@
       return;
     }
     cartonesMensajeEl.textContent='';
+    const cantosActivosSet=obtenerCantosActivosSet();
     const decorados=lista.map(carton=>{
       const formasGanadas=mapaFormasActivo.get(carton.id)||[];
       const primerPaso=formasGanadas.length?Math.min(...formasGanadas.map(f=>f.paso)):Infinity;
       const resumenGanancias=obtenerResumenGananciasCarton(carton,5);
-      return {...carton, formasGanadas, primerPaso, resumenGanancias};
+      const totalAciertos=contarAciertosCarton(carton, cantosActivosSet);
+      return {...carton, formasGanadas, primerPaso, resumenGanancias, totalAciertos};
     });
     totalGananciasJugador=decorados.reduce((acum,carton)=>{
       const total=Number(carton?.resumenGanancias?.total)||0;
@@ -10302,6 +10335,9 @@
       const aGan=a.formasGanadas.length>0;
       const bGan=b.formasGanadas.length>0;
       if(aGan!==bGan) return aGan?-1:1;
+      const aciertosA=Number(a.totalAciertos)||0;
+      const aciertosB=Number(b.totalAciertos)||0;
+      if(aciertosA!==aciertosB) return aciertosB-aciertosA;
       if(aGan && bGan){
         if(a.primerPaso!==b.primerPaso) return a.primerPaso-b.primerPaso;
       }


### PR DESCRIPTION
### Motivation
- Mejorar la priorización visual de los cartones para que refleje el progreso real en función de los cantos válidos (evitando que cartones con menos aciertos aparezcan por encima de otros más avanzados). 
- Evitar contar como aciertos los cantos complementarios o penalizados usando la misma lógica oficial (`esCantoGanador`) para coherencia con el motor de cálculo de ganadores. 
- Unificar la lógica de conteo de aciertos para modo real y modo simulación para mantener comportamiento idéntico en ambas vistas. 

### Description
- Se modificó `public/juegoactivo.html` añadiendo `obtenerCantosActivosSet()` que obtiene el conjunto de cantos válidos usando `esCantoGanador()` y `contarAciertosCarton(carton, cantosActivosSet)` para contar aciertos por cartón. 
- En `renderCartonesJugador()` se calcula `totalAciertos` para cada cartón antes del ordenamiento y se extiende cada item decorado con esa propiedad. 
- Se ajustó el `sort` de cartones con los criterios solicitados: 1) ganadores primero (`formasGanadas.length > 0`), 2) `totalAciertos` descendente, 3) si ambos son ganadores `primerPaso` ascendente como desempate, 4) número de cartón ascendente. 
- El conteo de aciertos se reutiliza tanto en modo real como en modo simulación porque `renderCartonesJugador()` obtiene la lista adecuada (`obtenerCartonesJugadorActual()`) y aplica `contarAciertosCarton()` en ambos casos. 

### Testing
- Ejecuté las pruebas automáticas con `npm test` y todas las suites pasaron: `11 suites, 35 tests` con resultado `PASS`. 
- Las pruebas unitarias existentes no detectaron regresiones y la interfaz afectada es sólo frontend estático (`public/juegoactivo.html`). 
- No se modificaron reglas de Firestore/Storage ni se añadieron secretos en el cambio, por lo que las pruebas de backend/infra no fueron necesarias.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e432379b108326b4e067786965aed9)