### PR TITLE
fix(jugarcartones): contextualiza carga azar y resalta celdas modificadas

### DIFF
--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -637,6 +637,8 @@
     .carton-center-info{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px;line-height:1;font-weight:bold;text-transform:none;}
     #carton-num-max{font-size:1.2rem;color:#006400;text-shadow:0 0 4px #fff,0 0 6px rgba(0,0,0,0.2);font-family:'Poppins',sans-serif;display:block;animation:wiggle 1s infinite;}
     .carton td.error{border:2px solid red;}
+    .carton td.azar-resaltado-verde{background:#1ca14c !important;color:#fff !important;text-shadow:none !important;transition:background-color .2s ease,color .2s ease;}
+    .carton td.azar-resaltado-azul{background:#1f4fbf !important;color:#fff !important;text-shadow:none !important;transition:background-color .2s ease,color .2s ease;}
     .carton-back{position:absolute;top:0;left:0;right:0;bottom:0;border-radius:10px;backface-visibility:hidden;transform:rotateY(180deg);background:linear-gradient(white,gray);display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:5px;overflow:hidden;}
     .carton-back img{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:80%;height:auto;opacity:0.15;object-fit:contain;pointer-events:none;z-index:0;}
     .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;z-index:1000;padding:12px;box-sizing:border-box;}
@@ -3525,8 +3527,30 @@ function toggleForma(idx){
     validateBoard();
   }
 
-  function cargarAzar(){
-    limpiarcarton();
+  function obtenerEstadoCartonAzar(){
+    const celdasNoFree=[...document.querySelectorAll('#bingo-board td:not(.free)')];
+    const total=celdasNoFree.length;
+    let llenas=0;
+    celdasNoFree.forEach(td=>{
+      if((td.dataset.value||'').toString().trim()!=='') llenas++;
+    });
+    if(llenas===0) return 'vacio';
+    if(llenas===total) return 'lleno';
+    return 'parcial';
+  }
+
+  function resaltarCeldasModificadas(celdas=[],modo='verde'){
+    if(!Array.isArray(celdas) || celdas.length===0) return;
+    const clase=modo==='azul'?'azar-resaltado-azul':'azar-resaltado-verde';
+    celdas.forEach(td=>{
+      td.classList.remove('azar-resaltado-verde','azar-resaltado-azul');
+      td.classList.add(clase);
+      setTimeout(()=>td.classList.remove(clase),2000);
+    });
+  }
+
+  function cargarAzar({reemplazoTotal=false}={}){
+    const celdasModificadas=[];
     for(let c=0;c<5;c++){
       const [start,end]=ranges[c];
       const nums=[];
@@ -3535,13 +3559,29 @@ function toggleForma(idx){
       for(let r=0;r<5;r++){
         if(r===2&&c===2) continue;
         const td=document.querySelector(`#bingo-board td[data-row="${r}"][data-col="${c}"]`);
+        const actual=(td.dataset.value||'').toString().trim();
+        if(!reemplazoTotal && actual!=='') continue;
         const val=nums.pop();
         td.dataset.value=val;
         td.textContent=val;
+        celdasModificadas.push(td);
       }
     }
+    resaltarCeldasModificadas(celdasModificadas,reemplazoTotal?'azul':'verde');
     validateBoard();
     saveToCookie();
+  }
+
+  async function manejarAzarContextual(){
+    const estado=obtenerEstadoCartonAzar();
+    let mensaje='¿Quieres cargar jugadas al azar?';
+    if(estado==='parcial'){
+      mensaje='¿Deseas elegir al azar los números restantes en el cartón?';
+    }else if(estado==='lleno'){
+      mensaje='¿Deseas cambiar todas las jugadas al azar en el cartón?';
+    }
+    if(!(await confirm(mensaje))) return;
+    cargarAzar({reemplazoTotal:estado==='lleno'});
   }
 
   async function actualizarDatosSorteo(){
@@ -4736,7 +4776,7 @@ document.getElementById('gratis-label').addEventListener('click',()=>{
   document.getElementById('premio-valor').addEventListener('click',mostrarPremiosModal);
   document.getElementById('premios-aceptar').addEventListener('click',()=>{document.getElementById('premios-modal').style.display='none';});
   document.getElementById('limpiar-btn').addEventListener('click',async()=>{if(await confirm('¿Deseas limpiar todas las jugadas del carton?')) limpiarcarton();});
-  document.getElementById('azar-btn').addEventListener('click',async()=>{if(await confirm('¿Quieres cargar jugadas al azar?')) cargarAzar();});
+  document.getElementById('azar-btn').addEventListener('click',manejarAzarContextual);
   document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='player.html';});
   document.getElementById('guardar-check').addEventListener('change',e=>{
     const show=e.target.checked;


### PR DESCRIPTION
### Motivation
- Evitar que el botón “Azar” siempre reemplace todo el cartón y prevenir acciones destructivas en cartones parcialmente completados.
- Mejorar la experiencia visual indicando claramente qué celdas fueron modificadas por la operación de azar.

### Description
- Se reemplaza el listener anterior de `#azar-btn` por la función `manejarAzarContextual()` que decide el comportamiento según el estado del cartón (`vacio`, `parcial`, `lleno`).
- Se agrega `obtenerEstadoCartonAzar()` para detectar si el cartón está `vacio`, `parcial` o `lleno` y ajustar el `confirm` con mensajes específicos por caso.
- Se modifica `cargarAzar` para aceptar `{reemplazoTotal}`: cuando es `false` solo completa celdas vacías (no limpia el cartón), y cuando es `true` reemplaza todas las jugadas; `validateBoard()` y `saveToCookie()` quedan intactos y se ejecutan al final como antes.
- Se añade el helper `resaltarCeldasModificadas(celdas, modo)` que usa `classList` + `setTimeout` para aplicar clases CSS temporales (`azar-resaltado-verde` / `azar-resaltado-azul`) por 2s, más las reglas CSS correspondientes para los colores y transición.

### Testing
- Ejecutado `npm test` y todas las suites pasaron: `PASS` (11 suites, 35 tests).
- Se verificó estáticamente que los cambios están limitados a `public/jugarcartones.html` y no tocan backend, Firestore ni reglas de seguridad.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4339975448326be25fe7be7ee5626)