### PR TITLE
fix(parametros): mejora responsive móvil y usabilidad de 'Cuentas especiales de fondos'

### DIFF
--- a/public/parametros.html
+++ b/public/parametros.html
@@ -184,6 +184,11 @@
       gap: 6px;
       margin-bottom: 8px;
     }
+    .fondos-checkbox input[type="checkbox"],
+    .fondos-table input[type="checkbox"] {
+      width: 20px;
+      height: 20px;
+    }
     .icon-btn-group {
       display: flex;
       gap: 8px;
@@ -224,6 +229,13 @@
     .fondos-table td:last-child {
       text-align: center;
     }
+    .fondos-table th:nth-child(3),
+    .fondos-table td:nth-child(3),
+    .fondos-table th:nth-child(4),
+    .fondos-table td:nth-child(4) {
+      min-width: 95px;
+      font-weight: 600;
+    }
     @media (max-width: 768px) {
       #parametros-form {
         width: 95%;
@@ -254,6 +266,68 @@
       }
       .icon-btn-group {
         width: 100%;
+      }
+    }
+    @media (max-width: 768px) and (orientation: portrait) {
+      body {
+        padding-top: 72px;
+      }
+      #volver-btn {
+        width: auto;
+        min-height: 44px;
+        padding: 0 12px;
+        z-index: 1000;
+      }
+      h2 {
+        margin-top: 10px !important;
+      }
+      .fondos-controls,
+      .fondos-fields {
+        flex-direction: column;
+        align-items: stretch;
+      }
+      .fondos-field,
+      .fondos-field input[type="text"],
+      .fondos-field input[type="number"] {
+        width: 100%;
+        min-width: 0;
+      }
+      .fondos-checkbox {
+        min-height: 44px;
+        margin-bottom: 0;
+      }
+      .fondos-checkbox input[type="checkbox"],
+      .fondos-table input[type="checkbox"] {
+        width: 24px;
+        height: 24px;
+      }
+      .icon-btn-group {
+        display: flex;
+        flex-wrap: nowrap;
+        justify-content: space-between;
+        align-items: center;
+        gap: 6px;
+        padding: 6px;
+        border: 1px solid #d9d9d9;
+        border-radius: 8px;
+        background: #f7f7f7;
+      }
+      .icon-btn {
+        flex: 1;
+        min-width: 44px;
+        min-height: 44px;
+      }
+      .fondos-table-wrap {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+      .fondos-table th,
+      .fondos-table td {
+        font-size: 0.82rem;
+      }
+      .fondos-table td:last-child {
+        min-width: 44px;
+        min-height: 44px;
       }
     }
   </style>


### PR DESCRIPTION
### Motivation
- Mejorar la usabilidad en móviles (≤768px) y en orientación vertical de la sección "Cuentas especiales de fondos" evitando controles apretados y problemas de interacción táctil.
- Evitar solapamientos con el botón "#volver-btn" y mantener la legibilidad de columnas clave como porcentaje/estado sin tocar la lógica ni contratos de datos.
- Cambio localizado y de bajo riesgo que no debe afectar autenticación, reglas de Firestore ni comportamiento JS existente.

### Description
- Se añadieron reglas CSS en `public/parametros.html` para `@media (max-width: 768px)` y `@media (max-width: 768px) and (orientation: portrait)` para adaptar el layout en móvil vertical.
- Controles de alta/edición se apilan en columna (`.fondos-controls`, `.fondos-fields`) y los campos ocupan 100% de ancho para facilitar edición táctil.
- Botones de icono pasan a una barra compacta con distribución uniforme y tamaño táctil mínimo (`.icon-btn` min 44px), y los checkboxes se escalan a tamaños táctiles mayores en móvil.
- La tabla quedó dentro de un contenedor con `overflow-x: auto` y `-webkit-overflow-scrolling: touch`, y se fijaron anchos mínimos para columnas de porcentaje/estado para preservar legibilidad.
- Ajuste del `padding-top` del `body` y del tamaño/posición de `#volver-btn` para evitar solapamientos en pantallas pequeñas.

### Testing
- Ejecutado `npm test` en el entorno de desarrollo: resultado PASS (11 suites, 35 tests) con salida: `Test Suites: 11 passed, 11 total; Tests: 35 passed`.
- No se ejecutaron pruebas visuales automatizadas porque el entorno no dispone de un renderer/browsershot; se recomienda comprobación manual en viewport móvil (≤768px, portrait) antes de merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4356fbc208326834d5d5a179eea5d)