### PR TITLE
fix(parametros): compacta layout y valida suma de porcentajes

### DIFF
--- a/public/parametros.html
+++ b/public/parametros.html
@@ -84,7 +84,7 @@
       max-width: 600px;
       display: none;
       flex-direction: column;
-      gap: 8px;
+      gap: 6px;
       font-family: Calibri, Arial, sans-serif;
       font-size: 0.9rem;
       align-items: center;
@@ -93,16 +93,17 @@
       display: flex;
       align-items: center;
       width: 100%;
+      gap: 8px;
     }
     .form-row label {
-      flex: 0 0 150px;
+      flex: 0 0 138px;
       font-weight: bold;
       text-align: right;
-      margin-right: 10px;
+      margin-right: 4px;
     }
     .form-row input {
       flex: 1;
-      padding: 5px;
+      padding: 4px 6px;
       border-radius: 5px;
       border: 1px solid #ccc;
       text-align: left;
@@ -114,17 +115,18 @@
     }
     .small-row {
       flex-wrap: wrap;
-      gap: 10px;
-      justify-content: center;
+      gap: 8px;
+      justify-content: space-between;
     }
     .small-row .field {
       display: flex;
       align-items: center;
+      gap: 4px;
     }
     .small-row .field label {
       flex: none;
       width: auto;
-      margin-right: 5px;
+      margin-right: 0;
       text-align: left;
     }
     .small-row .field input {
@@ -140,39 +142,101 @@
       width: 100%;
       border: 1px solid #d9d9d9;
       border-radius: 10px;
-      padding: 12px;
+      padding: 10px;
       box-sizing: border-box;
       background: rgba(255, 255, 255, 0.9);
     }
+    .fondos-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
     .fondos-especiales-section h3 {
-      margin: 0 0 10px;
+      margin: 0;
       font-size: 1.05rem;
       text-align: left;
+    }
+    .fondos-resumen {
+      text-align: right;
+      line-height: 1.15;
+    }
+    .fondos-resumen-principal {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      font-weight: 600;
+    }
+    .fondos-resumen-label {
+      font-weight: 700;
+    }
+    .fondos-resumen-valor {
+      font-weight: 700;
+    }
+    .fondos-resumen-estado {
+      margin-top: 2px;
+      font-size: 0.66rem;
+      font-weight: 700;
     }
     .fondos-controls {
       display: flex;
       align-items: flex-end;
-      gap: 10px;
+      gap: 8px;
       flex-wrap: wrap;
-      margin-bottom: 10px;
+      margin-bottom: 8px;
     }
     .fondos-fields {
       display: flex;
       align-items: flex-end;
-      gap: 10px;
+      gap: 8px;
       flex: 1;
       flex-wrap: wrap;
+    }
+    .fondos-fields-top {
+      display: grid;
+      grid-template-columns: minmax(180px, 1fr) minmax(120px, 140px);
+      gap: 8px;
+      width: 100%;
+    }
+    .fondos-fields-bottom {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      width: 100%;
+      flex-wrap: wrap;
+    }
+    .fondos-fields-bottom .field {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+    }
+    .fondos-fields-bottom .field label {
+      font-weight: 700;
+      text-align: left;
+    }
+    .fondos-fields-bottom .field input {
+      width: 72px;
+      padding: 4px 6px;
+      text-align: center;
+      border-radius: 5px;
+      border: 1px solid #ccc;
+      background: #fff;
+    }
+    .fondos-fields-bottom .field .percent {
+      font-weight: 700;
     }
     .fondos-field {
       display: flex;
       flex-direction: column;
       align-items: flex-start;
-      gap: 4px;
+      gap: 3px;
     }
     .fondos-field input[type="text"],
     .fondos-field input[type="number"] {
-      min-width: 150px;
-      padding: 5px;
+      width: 100%;
+      min-width: 120px;
+      padding: 4px 6px;
       border-radius: 5px;
       border: 1px solid #ccc;
       box-sizing: border-box;
@@ -191,7 +255,7 @@
     }
     .icon-btn-group {
       display: flex;
-      gap: 8px;
+      gap: 6px;
       flex-wrap: wrap;
     }
     .icon-btn {
@@ -221,7 +285,7 @@
     .fondos-table th,
     .fondos-table td {
       border: 1px solid #d8d8d8;
-      padding: 6px 8px;
+      padding: 5px 6px;
       text-align: left;
       white-space: nowrap;
     }
@@ -230,10 +294,17 @@
       text-align: center;
     }
     .fondos-table th:nth-child(3),
-    .fondos-table td:nth-child(3),
+    .fondos-table td:nth-child(3) {
+      width: 1%;
+      min-width: 42px;
+      text-align: center;
+      font-weight: 600;
+    }
     .fondos-table th:nth-child(4),
     .fondos-table td:nth-child(4) {
-      min-width: 95px;
+      width: 1%;
+      min-width: 62px;
+      text-align: center;
       font-weight: 600;
     }
     @media (max-width: 768px) {
@@ -263,6 +334,23 @@
       .fondos-controls {
         flex-direction: column;
         align-items: stretch;
+      }
+      .fondos-header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      .fondos-resumen {
+        text-align: left;
+      }
+      .fondos-fields-top {
+        grid-template-columns: 1fr;
+      }
+      .fondos-fields-bottom {
+        gap: 8px;
+      }
+      .fondos-fields-bottom .field {
+        width: 100%;
+        justify-content: space-between;
       }
       .icon-btn-group {
         width: 100%;
@@ -375,16 +463,6 @@
         <select id="pais"></select>
       </div>
       <div class="field">
-        <label for="porcentaje">Porcentaje Agencia:</label>
-        <input type="number" id="porcentaje" placeholder="0" />
-        <span class="percent">%</span>
-      </div>
-      <div class="field">
-        <label for="porcentajesu">Porcentaje Superadmin:</label>
-        <input type="number" id="porcentajesu" placeholder="0" />
-        <span class="percent">%</span>
-      </div>
-      <div class="field">
         <label for="porcentajeretiro">Porcentaje de Retiros:</label>
         <input type="number" id="porcentajeretiro" placeholder="0" step="0.01" />
         <span class="percent">%</span>
@@ -396,21 +474,44 @@
       </div>
     </div>
     <div class="fondos-especiales-section">
-      <h3>Cuentas especiales de fondos</h3>
+      <div class="fondos-header">
+        <h3>Cuentas especiales de fondos</h3>
+        <div class="fondos-resumen" aria-live="polite">
+          <div class="fondos-resumen-principal">
+            <span class="fondos-resumen-label">%</span>
+            <span id="fondos-total-porcentaje" class="fondos-resumen-valor">0.00</span>
+          </div>
+          <div id="fondos-total-estado" class="fondos-resumen-estado">Porcentaje válido</div>
+        </div>
+      </div>
       <div class="fondos-controls">
         <div class="fondos-fields">
-          <div class="fondos-field">
-            <label for="fondo-nombre">Nombre cuenta</label>
-            <input type="text" id="fondo-nombre" placeholder="Nombre de cuenta">
+          <div class="fondos-fields-top">
+            <div class="fondos-field">
+              <label for="fondo-nombre">Nombre cuenta</label>
+              <input type="text" id="fondo-nombre" placeholder="Nombre de cuenta">
+            </div>
+            <div class="fondos-field">
+              <label for="fondo-porcentaje">Porcentaje</label>
+              <input type="number" id="fondo-porcentaje" placeholder="0" step="0.01">
+            </div>
           </div>
-          <div class="fondos-field">
-            <label for="fondo-porcentaje">Porcentaje</label>
-            <input type="number" id="fondo-porcentaje" placeholder="0" step="0.01">
+          <div class="fondos-fields-bottom">
+            <div class="field">
+              <label for="porcentaje">Porcentaje Agencia:</label>
+              <input type="number" id="porcentaje" placeholder="0" />
+              <span class="percent">%</span>
+            </div>
+            <div class="field">
+              <label for="porcentajesu">Porcentaje Superadmin:</label>
+              <input type="number" id="porcentajesu" placeholder="0" />
+              <span class="percent">%</span>
+            </div>
+            <label class="fondos-field fondos-checkbox">
+              <input type="checkbox" id="fondo-activa">
+              Activa
+            </label>
           </div>
-          <label class="fondos-field fondos-checkbox">
-            <input type="checkbox" id="fondo-activa">
-            Activa
-          </label>
         </div>
         <div class="icon-btn-group">
           <button type="button" id="fondo-nuevo-btn" class="icon-btn" title="Nuevo">☀️</button>
@@ -424,7 +525,7 @@
             <tr>
               <th>N°</th>
               <th>Nombre cuenta</th>
-              <th>Porcentaje</th>
+              <th>%</th>
               <th>Estado</th>
               <th>Sel.</th>
             </tr>
@@ -535,8 +636,38 @@
       renderizarTablaFondos();
       limpiarFormularioFondos();
       actualizarEstadoAccionesFondos();
+      actualizarResumenPorcentajesFondos();
       /* Habilitar edición por defecto para permitir la selección inmediata del país */
       toggleEdicion(false);
+    }
+    function obtenerValorNumericoSeguro(valor){
+      const numero = Number.parseFloat(valor);
+      return Number.isFinite(numero) ? numero : 0;
+    }
+    function calcularPorcentajeTotalFondos(){
+      const porcentajeAgencia = obtenerValorNumericoSeguro(document.getElementById('porcentaje')?.value);
+      const porcentajeSuperadmin = obtenerValorNumericoSeguro(document.getElementById('porcentajesu')?.value);
+      const porcentajeCuentasActivas = cuentasEspecialesFondos
+        .filter(cuenta => cuenta && cuenta.activa)
+        .reduce((acumulado, cuenta) => acumulado + obtenerValorNumericoSeguro(cuenta.porcentaje), 0);
+      return porcentajeAgencia + porcentajeSuperadmin + porcentajeCuentasActivas;
+    }
+    function actualizarResumenPorcentajesFondos(){
+      const total = calcularPorcentajeTotalFondos();
+      const esValido = total >= 0 && total <= 100;
+      const elementoTotal = document.getElementById('fondos-total-porcentaje');
+      const elementoEstado = document.getElementById('fondos-total-estado');
+      if(!elementoTotal || !elementoEstado){
+        return { total, esValido };
+      }
+      elementoTotal.textContent = total.toFixed(2);
+      elementoTotal.style.color = esValido ? '#0a7a26' : '#c0392b';
+      elementoEstado.textContent = esValido ? 'Porcentaje válido' : 'Porcentaje excedido';
+      elementoEstado.style.color = esValido ? '#0a7a26' : '#c0392b';
+      return { total, esValido };
+    }
+    function mostrarErrorValidacionPorcentajes(total){
+      alert(`⚠️ No se pudo guardar.\n\nLa suma de porcentajes en "Cuentas especiales de fondos" es ${total.toFixed(2)}% y debe mantenerse entre 0% y 100%.\n\nAjusta Porcentaje Agencia, Porcentaje Superadmin o las cuentas activas antes de guardar.`);
     }
     function limpiarFormularioFondos(){
       document.getElementById('fondo-nombre').value = '';
@@ -558,6 +689,7 @@
         `;
         body.appendChild(tr);
       });
+      actualizarResumenPorcentajesFondos();
       body.querySelectorAll('input[name="fondo-seleccion"]').forEach(radio=>{
         radio.addEventListener('change', (event)=>{
           cuentaEspecialSeleccionadaId = event.target.dataset.cuentaId || null;
@@ -610,6 +742,7 @@
       renderizarTablaFondos();
       limpiarFormularioFondos();
       actualizarEstadoAccionesFondos();
+      actualizarResumenPorcentajesFondos();
     });
     document.getElementById('fondo-editar-btn').addEventListener('click', ()=>{
       const cuentaSeleccionada = obtenerCuentaSeleccionada();
@@ -626,6 +759,7 @@
       cuentaSeleccionada.updatedAt = new Date().toISOString();
       renderizarTablaFondos();
       actualizarEstadoAccionesFondos();
+      actualizarResumenPorcentajesFondos();
     });
     document.getElementById('fondo-eliminar-btn').addEventListener('click', ()=>{
       if(!cuentaEspecialSeleccionadaId){
@@ -636,6 +770,7 @@
       renderizarTablaFondos();
       limpiarFormularioFondos();
       actualizarEstadoAccionesFondos();
+      actualizarResumenPorcentajesFondos();
     });
     function toggleEdicion(disabled){
       document.querySelectorAll('#parametros-form input, #parametros-form select').forEach(inp=>inp.disabled = disabled);
@@ -651,6 +786,11 @@
     }
     document.getElementById('editar-btn').addEventListener('click', ()=>{ toggleEdicion(false); });
     document.getElementById('guardar-btn').addEventListener('click', async ()=>{
+      const estadoPorcentaje = actualizarResumenPorcentajesFondos();
+      if(!estadoPorcentaje.esValido){
+        mostrarErrorValidacionPorcentajes(estadoPorcentaje.total);
+        return;
+      }
       const timestampActualizacion = new Date().toISOString();
       const cuentasNormalizadas = cuentasEspecialesFondos.map(({id, nombre, porcentaje, activa, updatedAt})=>({
         id,
@@ -680,6 +820,12 @@
       await db.collection('Variablesglobales').doc('Parametros').set({ ...data, ...limpiezaLegacy },{merge:true});
       alert('Parámetros guardados');
       toggleEdicion(true);
+    });
+    ['porcentaje','porcentajesu'].forEach(idCampo=>{
+      const campo = document.getElementById(idCampo);
+      if(campo){
+        campo.addEventListener('input', actualizarResumenPorcentajesFondos);
+      }
     });
     document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='super.html';});
     async function iniciarParametros(){


### PR DESCRIPTION
### Motivation
- Reducir el espaciado y aumentar la densidad de la ventana `parametros.html` para una apariencia más profesional y eficiente.
- Mejorar la visibilidad en tiempo real de la suma de porcentajes asociados a fondos para evitar configuraciones inválidas.
- Evitar que el usuario guarde parámetros cuando la suma de porcentajes (Agencia + Superadmin + cuentas activas) exceda el 100% manteniendo la misma lógica de persistencia.

### Description
- Se compactó el layout y estilos en `public/parametros.html` (reducido gap/paddings, etiquetas más ajustadas y grid para campos de fondos) para agrupar controles en líneas y optimizar espacios. 
- Se reubicaron visualmente `Porcentaje Agencia` y `Porcentaje Superadmin` dentro de la sección "Cuentas especiales de fondos" sin cambiar sus `id` ni la estructura guardada en Firestore (`porcentaje`, `porcentajesu`).
- En la sección de fondos se colocó `Nombre cuenta` y `Porcentaje` en la misma línea (dos columnas) y se cambió el encabezado de la tabla de `Porcentaje` a `%` reduciendo el ancho de las columnas `%` y `Estado`. 
- Se añadió un indicador dinámico en la esquina superior derecha de la sección de fondos que muestra la suma (Agencia + Superadmin + cuentas activas), cambia a color verde/rojo según validez y muestra el texto `Porcentaje válido` / `Porcentaje excedido`, más la validación en el guardado que bloquea la operación si el total está fuera del rango 0–100. 
- Nuevas funciones JS añadidas en el mismo archivo: `obtenerValorNumericoSeguro`, `calcularPorcentajeTotalFondos`, `actualizarResumenPorcentajesFondos` y `mostrarErrorValidacionPorcentajes`, y se engancharon eventos para recomputar automáticamente al editar/crear/eliminar cuentas o al cambiar los campos globales.

### Testing
- Ejecuté las pruebas automatizadas con `npm test` y todas las suites pasaron: 11 suites / 35 tests (PASS).
- No se ejecutaron pruebas E2E visuales automáticas en este entorno; se recomienda revisión manual de la vista `public/parametros.html` en desktop y móvil tras desplegar para verificar alineaciones y comportamiento del guardado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e43ba5109883268dc076a987eedeff)