### PR TITLE
fix(premios): corrige flujo de porcentajes y carga Firebase en sorteos

### DIFF
--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -308,6 +308,31 @@
   let formaSeleccionadaId=null;
   let premioInicialBase=0;
   let totalPremiosBase=0;
+  let porcentajePremioConfigurado=0;
+
+  function normalizarPorcentaje(valor){
+    const numero=Number(valor);
+    if(!Number.isFinite(numero)) return 0;
+    if(numero<0) return 0;
+    if(numero>100) return 100;
+    return numero;
+  }
+
+  async function cargarPorcentajePremioDesdeParametros(){
+    if(!db){
+      porcentajePremioConfigurado=0;
+      return porcentajePremioConfigurado;
+    }
+    try{
+      const doc=await db.collection('Variablesglobales').doc('Parametros').get();
+      const data=doc.exists?(doc.data()||{}):{};
+      porcentajePremioConfigurado=normalizarPorcentaje(data.porcentajepremio);
+    }catch(error){
+      console.error('No se pudo cargar el porcentaje premio desde parámetros',error);
+      porcentajePremioConfigurado=0;
+    }
+    return porcentajePremioConfigurado;
+  }
 
   function mostrarConfirmacion(mensaje){
     const modal=document.getElementById('confirm-modal');
@@ -506,15 +531,18 @@
     setCookie(cookieKey,JSON.stringify(data));
   }
 
-firebase.auth().onAuthStateChanged(u=>{
-    if(u){
+  async function iniciarSesionYEstadoLocal(){
+    await initFirebase();
+    auth.onAuthStateChanged(async u=>{
+      if(!u) return;
       cookieKey='editarsorteo_'+sorteoId+'_'+u.email.replace(/[^\w]/g,'_');
+      await cargarPorcentajePremioDesdeParametros();
       cargarDatos().then(()=>{
         loadState();
         setupSaveListeners();
       });
-    }
-  });
+    });
+  }
 
   function formatearHora(hora){
     if(!hora) return '';
@@ -710,6 +738,10 @@ firebase.auth().onAuthStateChanged(u=>{
   async function cargarFormasModal(idx){
     const grid=document.getElementById('formas-grid');
     if(!grid) return;
+    if(!db){
+      grid.innerHTML='<div class="formas-empty">Firebase aún no está listo. Reintenta en unos segundos.</div>';
+      return;
+    }
     grid.innerHTML='<div class="formas-empty">Cargando...</div>';
     formasModalDatos=[];
     formaSeleccionadaId=null;
@@ -979,8 +1011,21 @@ firebase.auth().onAuthStateChanged(u=>{
     return data.url;
   }
 
-  crearFormas();
-  actualizarTotales();
+  async function iniciarPaginaEditarSorteo(){
+    try{
+      await initFirebase();
+      await cargarPorcentajePremioDesdeParametros();
+    }catch(error){
+      console.error('No se pudo inicializar Firebase en Editar Sorteo',error);
+      alert('No se pudo inicializar la conexión con Firebase. Recarga la página e intenta nuevamente.');
+      return;
+    }
+    crearFormas();
+    actualizarTotales();
+    iniciarSesionYEstadoLocal().catch(err=>console.error('No se pudo iniciar el estado local de sesión',err));
+  }
+
+  iniciarPaginaEditarSorteo();
 
   document.getElementById('cerrar-formas-modal').addEventListener('click',cerrarFormasModal);
   document.getElementById('formas-modal').addEventListener('click',e=>{if(e.target.id==='formas-modal') cerrarFormasModal();});
@@ -1143,7 +1188,8 @@ firebase.auth().onAuthStateChanged(u=>{
     try{
       const premioInicialFinal=premioInicialVal??0;
       const totalPremiosNuevo=Math.max(0,totalPremiosBase-premioInicialBase+premioInicialFinal);
-      const updateData={nombre,tipo,fecha,hora,horacierre:cierre,valorCarton:valor,estado,condicion,totalPremios:totalPremiosNuevo};
+      const porcentajePremioFinal=normalizarPorcentaje(porcentajePremioConfigurado);
+      const updateData={nombre,tipo,fecha,hora,horacierre:cierre,valorCarton:valor,estado,condicion,totalPremios:totalPremiosNuevo,porcentajepremio:porcentajePremioFinal};
       if(premioInicialVal!==null){
         updateData.premioInicial=premioInicialVal;
       }else{

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -3921,8 +3921,19 @@ function toggleForma(idx){
     const valor=toNumberSafe(sorteoData.valorCarton,0);
     const maxGratis=toNumberSafe(sorteoData.maxcartongratis,0);
     const vars=await db.collection('Variablesglobales').doc('Parametros').get();
+    const varsData=vars.data()||{};
     const porcentaje=toNumberSafe(vars.data()?.porcentaje,0);
     const porcentajesu=toNumberSafe(vars.data()?.porcentajesu,0);
+    const cuentasEspecialesRaw=Array.isArray(varsData.cuentasFondosEspeciales)
+      ? varsData.cuentasFondosEspeciales
+      : (Array.isArray(varsData.cuentasEspecialesFondos) ? varsData.cuentasEspecialesFondos : []);
+    const porcentajeCuentasActivas=cuentasEspecialesRaw
+      .filter(cuenta=>Boolean(cuenta?.activa))
+      .reduce((acc,cuenta)=>acc+toNumberSafe(cuenta?.porcentaje,0),0);
+    const porcentajePremioConfigurado=toNumberSafe(
+      sorteoData?.porcentajepremio,
+      toNumberSafe(varsData.porcentajepremio,0)
+    );
     let jugarGratis=false;
     const gratisJugandoJugador=gratisUsadosJugador;
     if(gratis>0 && (maxGratis<=0 || gratisJugandoJugador<maxGratis)){
@@ -3970,11 +3981,18 @@ function toggleForma(idx){
         if(!Number.isFinite(valorCartonActual) || valorCartonActual<0){
           throw new Error('VALOR_CARTON_INVALIDO');
         }
-        const porcentajeTx=toNumberSafe(porcentaje,0);
-        const porcentajeSuTx=toNumberSafe(porcentajesu,0);
+        const porcentajeTx=Math.max(0,toNumberSafe(porcentaje,0));
+        const porcentajeSuTx=Math.max(0,toNumberSafe(porcentajesu,0));
+        const porcentajePremioBase=Math.max(0,toNumberSafe(
+          sorteoDataTx?.porcentajepremio,
+          porcentajePremioConfigurado
+        ));
+        const porcentajePremioTx=porcentajePremioBase>0
+          ? porcentajePremioBase
+          : Math.max(0,100-porcentajeTx-porcentajeSuTx-porcentajeCuentasActivas);
         const porcentajeValTx=valorCartonActual*porcentajeTx/100;
         const porcentajeSuValTx=valorCartonActual*porcentajeSuTx/100;
-        const paraPremioTx=valorCartonActual-porcentajeValTx-porcentajeSuValTx;
+        const paraPremioTx=valorCartonActual*porcentajePremioTx/100;
         const creditosActual=toNumberSafe(billeteraSnap.data()?.creditos,0);
         const creditosTransitoActual=Math.max(0,toNumberSafe(billeteraSnap.data()?.creditostransito,0));
         const gratisActual=toNumberSafe(billeteraSnap.data()?.CartonesGratis,0);

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -306,6 +306,31 @@
   let modalFormaIdx=null;
   let formasModalDatos=[];
   let formaSeleccionadaId=null;
+  let porcentajePremioConfigurado=0;
+
+  function normalizarPorcentaje(valor){
+    const numero=Number(valor);
+    if(!Number.isFinite(numero)) return 0;
+    if(numero<0) return 0;
+    if(numero>100) return 100;
+    return numero;
+  }
+
+  async function cargarPorcentajePremioDesdeParametros(){
+    if(!db){
+      porcentajePremioConfigurado=0;
+      return porcentajePremioConfigurado;
+    }
+    try{
+      const doc=await db.collection('Variablesglobales').doc('Parametros').get();
+      const data=doc.exists?(doc.data()||{}):{};
+      porcentajePremioConfigurado=normalizarPorcentaje(data.porcentajepremio);
+    }catch(error){
+      console.error('No se pudo cargar el porcentaje premio desde parámetros',error);
+      porcentajePremioConfigurado=0;
+    }
+    return porcentajePremioConfigurado;
+  }
 
   function mostrarConfirmacion(mensaje){
     const modal=document.getElementById('confirm-modal');
@@ -484,13 +509,16 @@
     if(btn) btn.click();
   }
 
-  firebase.auth().onAuthStateChanged(u=>{
-    if(u){
+  async function iniciarSesionYEstadoLocal(){
+    await initFirebase();
+    auth.onAuthStateChanged(async u=>{
+      if(!u) return;
       cookieKey='nuevosorteo_'+u.email.replace(/[^\w]/g,'_');
+      await cargarPorcentajePremioDesdeParametros();
       loadState();
       setupSaveListeners();
-    }
-  });
+    });
+  }
 
   function formatearHora(hora){
     if(!hora) return '';
@@ -686,6 +714,10 @@
   async function cargarFormasModal(idx){
     const grid=document.getElementById('formas-grid');
     if(!grid) return;
+    if(!db){
+      grid.innerHTML='<div class="formas-empty">Firebase aún no está listo. Reintenta en unos segundos.</div>';
+      return;
+    }
     grid.innerHTML='<div class="formas-empty">Cargando...</div>';
     formasModalDatos=[];
     formaSeleccionadaId=null;
@@ -955,8 +987,21 @@
     return data.url;
   }
 
-  crearFormas();
-  actualizarTotales();
+  async function iniciarPaginaNuevoSorteo(){
+    try{
+      await initFirebase();
+      await cargarPorcentajePremioDesdeParametros();
+    }catch(error){
+      console.error('No se pudo inicializar Firebase en Nuevo Sorteo',error);
+      alert('No se pudo inicializar la conexión con Firebase. Recarga la página e intenta nuevamente.');
+      return;
+    }
+    crearFormas();
+    actualizarTotales();
+    iniciarSesionYEstadoLocal().catch(err=>console.error('No se pudo iniciar el estado local de sesión',err));
+  }
+
+  iniciarPaginaNuevoSorteo();
 
   document.getElementById('cerrar-formas-modal').addEventListener('click',cerrarFormasModal);
   document.getElementById('formas-modal').addEventListener('click',e=>{if(e.target.id==='formas-modal') cerrarFormasModal();});
@@ -1118,6 +1163,7 @@
     if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
       const premioInicialFinal=premioInicialVal??0;
+      const porcentajePremioFinal=normalizarPorcentaje(porcentajePremioConfigurado);
       const sorteoData={
         nombre,
         tipo,
@@ -1128,7 +1174,8 @@
         valorCarton:valor,
         estado,
         condicion,
-        totalPremios:premioInicialFinal
+        totalPremios:premioInicialFinal,
+        porcentajepremio:porcentajePremioFinal
       };
       if(premioInicialVal!==null){
         sorteoData.premioInicial=premioInicialVal;

--- a/public/parametros.html
+++ b/public/parametros.html
@@ -211,6 +211,9 @@
       align-items: center;
       gap: 4px;
     }
+    .fondos-fields-bottom-extra {
+      margin-top: 4px;
+    }
     .fondos-fields-bottom .field label {
       font-weight: 700;
       text-align: left;
@@ -309,7 +312,7 @@
     }
     @media (max-width: 768px) {
       #parametros-form {
-        width: 95%;
+        width: min(95vw, 560px);
       }
       .form-row {
         flex-direction: column;
@@ -349,8 +352,9 @@
         gap: 8px;
       }
       .fondos-fields-bottom .field {
-        width: 100%;
-        justify-content: space-between;
+        width: auto;
+        min-width: 260px;
+        justify-content: flex-start;
       }
       .icon-btn-group {
         width: 100%;
@@ -372,12 +376,12 @@
       .fondos-controls,
       .fondos-fields {
         flex-direction: column;
-        align-items: stretch;
+        align-items: flex-start;
       }
       .fondos-field,
       .fondos-field input[type="text"],
       .fondos-field input[type="number"] {
-        width: 100%;
+        width: min(100%, 420px);
         min-width: 0;
       }
       .fondos-checkbox {
@@ -486,16 +490,6 @@
       </div>
       <div class="fondos-controls">
         <div class="fondos-fields">
-          <div class="fondos-fields-top">
-            <div class="fondos-field">
-              <label for="fondo-nombre">Nombre cuenta</label>
-              <input type="text" id="fondo-nombre" placeholder="Nombre de cuenta">
-            </div>
-            <div class="fondos-field">
-              <label for="fondo-porcentaje">Porcentaje</label>
-              <input type="number" id="fondo-porcentaje" placeholder="0" step="0.01">
-            </div>
-          </div>
           <div class="fondos-fields-bottom">
             <div class="field">
               <label for="porcentaje">Porcentaje Agencia:</label>
@@ -507,6 +501,23 @@
               <input type="number" id="porcentajesu" placeholder="0" />
               <span class="percent">%</span>
             </div>
+            <div class="field">
+              <label for="porcentajepremio">Porcentaje premio:</label>
+              <input type="number" id="porcentajepremio" placeholder="0" step="0.01" />
+              <span class="percent">%</span>
+            </div>
+          </div>
+          <div class="fondos-fields-top fondos-fields-bottom-extra">
+            <div class="fondos-field">
+              <label for="fondo-nombre">Nombre cuenta</label>
+              <input type="text" id="fondo-nombre" placeholder="Nombre de cuenta">
+            </div>
+            <div class="fondos-field">
+              <label for="fondo-porcentaje">Porcentaje</label>
+              <input type="number" id="fondo-porcentaje" placeholder="0" step="0.01">
+            </div>
+          </div>
+          <div class="fondos-fields-bottom">
             <label class="fondos-field fondos-checkbox">
               <input type="checkbox" id="fondo-activa">
               Activa
@@ -514,9 +525,9 @@
           </div>
         </div>
         <div class="icon-btn-group">
-          <button type="button" id="fondo-nuevo-btn" class="icon-btn" title="Nuevo">☀️</button>
+          <button type="button" id="fondo-nuevo-btn" class="icon-btn" title="Nuevo" aria-label="Nuevo" style="color:#0a7a26;">➕</button>
           <button type="button" id="fondo-editar-btn" class="icon-btn" title="Editar" disabled>✏️</button>
-          <button type="button" id="fondo-eliminar-btn" class="icon-btn" title="Eliminar" disabled>🗑️</button>
+          <button type="button" id="fondo-eliminar-btn" class="icon-btn" title="Eliminar" disabled style="color:#c0392b;">➖</button>
         </div>
       </div>
       <div class="fondos-table-wrap">
@@ -619,6 +630,7 @@
       if(data.Pais){ document.getElementById('pais').value = data.Pais; }
       document.getElementById('porcentaje').value = data.porcentaje || '';
       document.getElementById('porcentajesu').value = data.porcentajesu || '';
+      document.getElementById('porcentajepremio').value = data.porcentajepremio || '';
       document.getElementById('porcentajeretiro').value = data.porcentajeretiro || '';
       document.getElementById('porcentajeadministra').value = data.porcentajeadministra || '';
       const cuentasFondosRaw = Array.isArray(data.cuentasFondosEspeciales)
@@ -647,10 +659,11 @@
     function calcularPorcentajeTotalFondos(){
       const porcentajeAgencia = obtenerValorNumericoSeguro(document.getElementById('porcentaje')?.value);
       const porcentajeSuperadmin = obtenerValorNumericoSeguro(document.getElementById('porcentajesu')?.value);
+      const porcentajePremio = obtenerValorNumericoSeguro(document.getElementById('porcentajepremio')?.value);
       const porcentajeCuentasActivas = cuentasEspecialesFondos
         .filter(cuenta => cuenta && cuenta.activa)
         .reduce((acumulado, cuenta) => acumulado + obtenerValorNumericoSeguro(cuenta.porcentaje), 0);
-      return porcentajeAgencia + porcentajeSuperadmin + porcentajeCuentasActivas;
+      return porcentajeAgencia + porcentajeSuperadmin + porcentajePremio + porcentajeCuentasActivas;
     }
     function actualizarResumenPorcentajesFondos(){
       const total = calcularPorcentajeTotalFondos();
@@ -811,6 +824,7 @@
         ZonaHoraria: document.getElementById('pais').selectedOptions[0]?.dataset.timezone || '',
         porcentaje: parseFloat(document.getElementById('porcentaje').value)||0,
         porcentajesu: parseFloat(document.getElementById('porcentajesu').value)||0,
+        porcentajepremio: parseFloat(document.getElementById('porcentajepremio').value)||0,
         porcentajeretiro: parseFloat(document.getElementById('porcentajeretiro').value)||0,
         porcentajeadministra: parseFloat(document.getElementById('porcentajeadministra').value)||0,
         cuentasFondosEspeciales: cuentasNormalizadas,
@@ -821,7 +835,7 @@
       alert('Parámetros guardados');
       toggleEdicion(true);
     });
-    ['porcentaje','porcentajesu'].forEach(idCampo=>{
+    ['porcentaje','porcentajesu','porcentajepremio'].forEach(idCampo=>{
       const campo = document.getElementById(idCampo);
       if(campo){
         campo.addEventListener('input', actualizarResumenPorcentajesFondos);


### PR DESCRIPTION
### Motivation
- Corregir la experiencia móvil y reordenar campos en la ventana de Parámetros para evitar estiramiento y ubicar "Nombre cuenta"/"Porcentaje" debajo de los porcentajes principales.
- Añadir un campo explícito `Porcentaje premio` para definir la porción destinada a premios y que el contador dinámico lo tome en cuenta.
- Evitar el fallo intermitente al crear/editar sorteos por inicialización incompleta de Firebase al cargar la sección de formas y garantizar que la lógica de reparto de premios use el nuevo porcentaje.

### Description
- Se añadió el campo `porcentajepremio` en `public/parametros.html` con cambios de layout móvil, reordenamiento de campos, y reemplazo de íconos (nuevo: ➕ verde, eliminar: ➖ rojo); el valor se persiste en `Variablesglobales/Parametros` al guardar.
- En `public/nuevosorteo.html` y `public/editarsorte.html` se endureció la inicialización: ahora se espera `initFirebase()` antes de operar con `db/auth`, se carga `porcentajepremio` desde Parámetros y se incluye en el documento `sorteos` al crear/actualizar.
- En `public/jugarcartones.html` se adaptó la lógica de transacción para calcular el monto que se suma a `totalPremios` usando `porcentajepremio` (si existe) y con un fallback heredado que calcula el remanente (100% menos otros porcentajes y cuentas especiales activas) cuando no esté definido, manteniendo compatibilidad con sorteos previos.
- Se añadieron comprobaciones defensivas al cargar el modal de formas para mostrar un mensaje amigable si `db`/Firebase aún no está listo y así evitar fallos visibles en la UI.

### Testing
- Ejecutado `npm test` en el repo; resultado: PASS (11 suites, 35 tests, todas las pruebas pasaron).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4cde6d8c08326b26a44d8d922459b)