### PR TITLE
fix(auth): permitir reintento de inicialización Firebase tras fallo transitorio

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -100,7 +100,15 @@ async function initFirebase(){
     appleProvider.addScope('name');
     await auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL);
     return app;
-  })();
+  })().catch(error=>{
+    app = null;
+    auth = null;
+    db = null;
+    provider = null;
+    appleProvider = null;
+    firebaseInitPromise = null;
+    throw error;
+  });
 
   return firebaseInitPromise;
 }


### PR DESCRIPTION
### Motivation
- El flujo de creación de sorteos quedaba bloqueado porque una falla transitoria en `initFirebase()` dejaba la promesa interna en estado rechazado impidiendo cargar las `formas` en `nuevosorteo.html` tras los cambios de cuentas especiales.

### Description
- Se actualizó `initFirebase()` en `public/js/auth.js` para, en caso de error, limpiar el estado interno (`app`, `auth`, `db`, `provider`, `appleProvider`, `firebaseInitPromise`) y volver a lanzar el error para permitir nuevos intentos de inicialización sin dejar la aplicación en un estado irrecuperable.

### Testing
- Ejecuté `npm test` y todas las pruebas automatizadas pasaron correctamente (`11 suites, 35 tests` PASS), lo que confirma que la modificación no rompe los tests existentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4db8c13588326aa971e1ee7b049ab)