### PR TITLE
chore(revert): restaurar estado hasta PR #1138 (ae8bd9f)

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -602,7 +602,7 @@
         <thead>
           <tr class="filtros">
             <th>N°</th>
-            <th><input type="text" id="filtro-pagos-jugador" placeholder="Usuario"></th>
+            <th><input type="text" id="filtro-pagos-jugador" placeholder="Jugador"></th>
             <th>Créditos</th>
             <th><input type="text" id="filtro-pagos-fecha" placeholder="Fecha"></th>
             <th>
@@ -767,14 +767,14 @@
       if(docSorteo.exists){
         const data = docSorteo.data() || {};
         const nombre = (data.nombre || data.nombreSorteo || '').toString().trim();
-        if(nombre && cpEstadoFinalizado(data)){ sorteosNombreCache.set(id, nombre); }
+        if(nombre){ sorteosNombreCache.set(id, nombre); }
         return data;
       }
       const docCantar = await db.collection('cantarsorteos').doc(id).get();
       if(docCantar.exists){
         const data = docCantar.data() || {};
         const nombre = (data.nombre || data.nombreSorteo || '').toString().trim();
-        if(nombre && cpEstadoFinalizado(data)){ sorteosNombreCache.set(id, nombre); }
+        if(nombre){ sorteosNombreCache.set(id, nombre); }
         return data;
       }
       return null;
@@ -783,16 +783,12 @@
     function cpResolverNombreSorteo({ sorteoId = '', sorteoNombre = '' } = {}){
       const nombreDirecto = (sorteoNombre || '').toString().trim();
       if(nombreDirecto){
-        if(sorteoId && sorteosNombreCache.has(sorteoId)){ sorteosNombreCache.set(sorteoId, nombreDirecto); }
+        if(sorteoId){ sorteosNombreCache.set(sorteoId, nombreDirecto); }
         return nombreDirecto;
       }
       const id = (sorteoId || '').toString().trim();
       if(!id) return '';
       return (sorteosNombreCache.get(id) || '').toString().trim();
-    }
-
-    function cpEstadoFinalizado(data = {}){
-      return (data.estado || data.estadoactual || '').toString().trim().toLowerCase() === 'finalizado';
     }
 
     async function cpCargarSelectorSorteos(){
@@ -802,11 +798,8 @@
         await ensureFirebaseListo();
         const snap = await dbRef().collection('sorteos').limit(150).get();
         const lista = [];
-        sorteosNombreCache.clear();
         snap.forEach(doc=>{
           const data = doc.data() || {};
-          const estado = (data.estado || data.estadoactual || '').toString().trim().toLowerCase();
-          if(estado !== 'finalizado' || !cpEstadoFinalizado(data)) return;
           const nombre = (data.nombre || data.nombreSorteo || '').toString().trim();
           const fechaInfo = normalizarFecha(data.fecha || data.fechasorteo || data.fechaSorteo || data.createdAt);
           const etiqueta = `${nombre || 'Sorteo'} - ${fechaInfo.mostrar !== '-' ? fechaInfo.mostrar : 'Sin fecha'}`;
@@ -817,16 +810,7 @@
         selector.innerHTML = '<option value="">Selecciona un sorteo</option>' +
           lista.map(item=>`<option value="${escapeHtml(item.id)}">${escapeHtml(item.etiqueta)}</option>`).join('');
         if(sorteoIdDesdeQuery){
-          if(sorteosNombreCache.has(sorteoIdDesdeQuery)){
-            selector.setCustomValidity('');
-            selector.value = sorteoIdDesdeQuery;
-          } else {
-            selector.value = '';
-            selector.setCustomValidity('El sorteo indicado no está finalizado o no existe.');
-            selector.reportValidity();
-          }
-        } else {
-          selector.setCustomValidity('');
+          selector.value = sorteoIdDesdeQuery;
         }
       } catch (err) {
         console.warn('No se pudo cargar el selector de sorteos', err);
@@ -1203,12 +1187,6 @@
       return 0;
     }
 
-    function cpRedondearSeisDecimales(valor){
-      const numero = Number(valor);
-      if(!Number.isFinite(numero)) return 0;
-      return Math.round((numero + Number.EPSILON) * 1e6) / 1e6;
-    }
-
     async function cpObtenerUsuariosPorRolInterno(ctx, rolInterno){
       const resultados = [];
       const texto = (rolInterno || '').toString().trim();
@@ -1297,37 +1275,12 @@
             gmail: email,
             alias: usuario.alias || '',
             nombre: usuario.nombre || '',
-            creditos: cpRedondearSeisDecimales(Number.isFinite(monto) ? Number(monto) || 0 : 0),
+            creditos: Number.isFinite(monto) ? Number(monto) || 0 : 0,
             rolInterno: definicion.rolInterno,
             userIds: usuario.uid ? [usuario.uid] : []
           });
         });
       }
-
-      const cuentasEspecialesRaw = Array.isArray(ctx.parametrosData?.cuentasFondosEspeciales)
-        ? ctx.parametrosData.cuentasFondosEspeciales
-        : (Array.isArray(ctx.parametrosData?.cuentasEspecialesFondos) ? ctx.parametrosData.cuentasEspecialesFondos : []);
-      const cuentasEspecialesActivas = cuentasEspecialesRaw.filter(cuenta => Boolean(cuenta?.activa));
-      cuentasEspecialesActivas.forEach(cuenta=>{
-        const porcentajeCuenta = Number(cuenta?.porcentaje) || 0;
-        const montoCuenta = (baseTotalSorteo > 0 && porcentajeCuenta > 0)
-          ? ((baseTotalSorteo * porcentajeCuenta) / 100)
-          : 0;
-        const nombreCuenta = String(cuenta?.nombre || '').trim();
-        const cuentaId = String(cuenta?.id || '').trim();
-        const aliasCuenta = nombreCuenta || cuentaId || 'Fondo especial';
-        lista.push({
-          gmail: '',
-          alias: aliasCuenta,
-          nombre: aliasCuenta,
-          creditos: cpRedondearSeisDecimales(montoCuenta),
-          rolInterno: 'fondo_especial',
-          tipoRegistro: 'FONDO_ESPECIAL_SORTEO',
-          userIds: [],
-          cuentaEspecialId: cuentaId,
-          nombreCuentaEspecial: nombreCuenta
-        });
-      });
       return lista;
     }
 
@@ -1904,13 +1857,7 @@
 
       administrativos.forEach(administrativo=>{
         const email = cpNormalizarEmail(administrativo.gmail);
-        const cuentaEspecialId = String(administrativo.cuentaEspecialId || '').trim();
-        const nombreCuentaEspecial = String(administrativo.nombreCuentaEspecial || '').trim();
-        const esFondoEspecial = (administrativo.rolInterno || '').toString().toLowerCase() === 'fondo_especial';
-        const baseDocId = esFondoEspecial
-          ? `${ctx.sorteoId}_fondo_${cuentaEspecialId || administrativo.alias || 'especial'}`
-          : `${ctx.sorteoId}_admin_${administrativo.rolInterno || 'admin'}`;
-        const docId = cpConstruirIdSolicitud(baseDocId, email || administrativo.alias || cuentaEspecialId || 'admin');
+        const docId = cpConstruirIdSolicitud(`${ctx.sorteoId}_admin_${administrativo.rolInterno || 'admin'}`, email || administrativo.alias || 'admin');
         const payload = {
           sorteoId: ctx.sorteoId,
           sorteoNombre,
@@ -1924,11 +1871,9 @@
           fecha: timestamp,
           creadoEn: timestamp,
           actualizadoEn: timestamp,
-          tipoRegistro: administrativo.tipoRegistro || 'ADMINISTRATIVO_SORTEO',
+          tipoRegistro: 'ADMINISTRATIVO_SORTEO',
           rolInterno: administrativo.rolInterno || '',
           userIds: administrativo.userIds || [],
-          cuentaEspecialId,
-          nombreCuentaEspecial,
           generadoDesde: 'centropagos'
         };
         if(email){ payload.idBilletera = email; }
@@ -1956,10 +1901,7 @@
           alias: item.alias || '',
           nombre: item.nombre || '',
           rolInterno: item.rolInterno || '',
-          creditos: Number(item.creditos) || 0,
-          cuentaEspecialId: String(item.cuentaEspecialId || '').trim(),
-          nombreCuentaEspecial: String(item.nombreCuentaEspecial || '').trim(),
-          tipoRegistro: item.tipoRegistro || 'ADMINISTRATIVO_SORTEO'
+          creditos: Number(item.creditos) || 0
         })),
         colaboradores: colaboradores.map(item=>({
           gmail: cpNormalizarEmail(item.gmail || ''),
@@ -2034,10 +1976,6 @@
         if(idx >= 0) pagosAdminActivos[idx] = registro;
         else pagosAdminActivos.push(registro);
       });
-      const sorteoActivo = cpObtenerSorteoIdObjetivo();
-      if(sorteoActivo && sorteoActivo !== sorteoId){
-        return;
-      }
       renderPremios();
       renderPagos();
     }
@@ -2420,16 +2358,8 @@
       tbody.innerHTML = filas;
     }
 
-    function cpCoincideSorteoSeleccionado(item){
-      const sorteoObjetivo = cpObtenerSorteoIdObjetivo();
-      if(!sorteoObjetivo) return true;
-      return (item?.sorteoId || '') === sorteoObjetivo;
-    }
-
     function aplicarFiltrosPremios(origen){
-      const sorteoObjetivo = cpObtenerSorteoIdObjetivo();
       return origen.filter(item=>{
-        if(sorteoObjetivo && item.sorteoId !== sorteoObjetivo) return false;
         const jugador = `${item.gmail || ''} ${item.alias || ''} ${item.nombre || ''}`.toLowerCase();
         if(filtrosPremios.jugador && !jugador.includes(filtrosPremios.jugador)) return false;
         if(filtrosPremios.fecha && !(item.fechaMostrar || '').toLowerCase().includes(filtrosPremios.fecha)) return false;
@@ -2439,9 +2369,7 @@
     }
 
     function aplicarFiltrosPagos(origen){
-      const sorteoObjetivo = cpObtenerSorteoIdObjetivo();
       return origen.filter(item=>{
-        if(sorteoObjetivo && item.sorteoId !== sorteoObjetivo) return false;
         const jugador = `${item.gmail || ''} ${item.alias || ''} ${item.nombre || ''}`.toLowerCase();
         if(filtrosPagos.jugador && !jugador.includes(filtrosPagos.jugador)) return false;
         if(filtrosPagos.fecha && !(item.fechaMostrar || '').toLowerCase().includes(filtrosPagos.fecha)) return false;
@@ -2474,7 +2402,7 @@
     function renderPremios(){
       const lista = mostrarPremiosArchivo ? aplicarFiltrosPremios(premiosArchivados) : aplicarFiltrosPremios(premiosActivos);
       renderTabla(lista, 'tabla-premios', { mostrarArchivo: mostrarPremiosArchivo, tipo: 'premios' });
-      actualizarBadge('premios', premiosActivos.filter(item=>item.estado === 'PENDIENTE' && cpCoincideSorteoSeleccionado(item)).length);
+      actualizarBadge('premios', premiosActivos.filter(item=>item.estado === 'PENDIENTE').length);
       actualizarEstadoBotones();
       reconciliarIndicadorPagos().catch(err=>console.warn('No se pudo actualizar el indicador tras renderizar premios', err));
     }
@@ -2482,7 +2410,7 @@
     function renderPagos(){
       const lista = mostrarPagosArchivo ? aplicarFiltrosPagos(pagosAdminArchivados) : aplicarFiltrosPagos(pagosAdminActivos);
       renderTabla(lista, 'tabla-pagos', { mostrarArchivo: mostrarPagosArchivo, tipo: 'pagos' });
-      actualizarBadge('pagos', pagosAdminActivos.filter(item=>item.estado === 'PENDIENTE' && cpCoincideSorteoSeleccionado(item)).length);
+      actualizarBadge('pagos', pagosAdminActivos.filter(item=>item.estado === 'PENDIENTE').length);
       actualizarEstadoBotones();
       reconciliarIndicadorPagos().catch(err=>console.warn('No se pudo actualizar el indicador tras renderizar pagos', err));
     }
@@ -2956,12 +2884,6 @@
     }
     function configurarBotones(){
       const selectorSorteo = document.getElementById('cp-sorteo-selector');
-      if(selectorSorteo){
-        selectorSorteo.addEventListener('change', ()=>{
-          renderPremios();
-          renderPagos();
-        });
-      }
       const botonGenerarSolicitudes = document.getElementById('cp-generar-solicitudes');
       if(botonGenerarSolicitudes){
         botonGenerarSolicitudes.addEventListener('click', async()=>{

--- a/public/editarsorte.html
+++ b/public/editarsorte.html
@@ -308,31 +308,6 @@
   let formaSeleccionadaId=null;
   let premioInicialBase=0;
   let totalPremiosBase=0;
-  let porcentajePremioConfigurado=0;
-
-  function normalizarPorcentaje(valor){
-    const numero=Number(valor);
-    if(!Number.isFinite(numero)) return 0;
-    if(numero<0) return 0;
-    if(numero>100) return 100;
-    return numero;
-  }
-
-  async function cargarPorcentajePremioDesdeParametros(){
-    if(!db){
-      porcentajePremioConfigurado=0;
-      return porcentajePremioConfigurado;
-    }
-    try{
-      const doc=await db.collection('Variablesglobales').doc('Parametros').get();
-      const data=doc.exists?(doc.data()||{}):{};
-      porcentajePremioConfigurado=normalizarPorcentaje(data.porcentajepremio);
-    }catch(error){
-      console.error('No se pudo cargar el porcentaje premio desde parámetros',error);
-      porcentajePremioConfigurado=0;
-    }
-    return porcentajePremioConfigurado;
-  }
 
   function mostrarConfirmacion(mensaje){
     const modal=document.getElementById('confirm-modal');
@@ -531,18 +506,15 @@
     setCookie(cookieKey,JSON.stringify(data));
   }
 
-  async function iniciarSesionYEstadoLocal(){
-    await initFirebase();
-    auth.onAuthStateChanged(async u=>{
-      if(!u) return;
+firebase.auth().onAuthStateChanged(u=>{
+    if(u){
       cookieKey='editarsorteo_'+sorteoId+'_'+u.email.replace(/[^\w]/g,'_');
-      await cargarPorcentajePremioDesdeParametros();
       cargarDatos().then(()=>{
         loadState();
         setupSaveListeners();
       });
-    });
-  }
+    }
+  });
 
   function formatearHora(hora){
     if(!hora) return '';
@@ -738,10 +710,6 @@
   async function cargarFormasModal(idx){
     const grid=document.getElementById('formas-grid');
     if(!grid) return;
-    if(!db){
-      grid.innerHTML='<div class="formas-empty">Firebase aún no está listo. Reintenta en unos segundos.</div>';
-      return;
-    }
     grid.innerHTML='<div class="formas-empty">Cargando...</div>';
     formasModalDatos=[];
     formaSeleccionadaId=null;
@@ -1011,21 +979,8 @@
     return data.url;
   }
 
-  async function iniciarPaginaEditarSorteo(){
-    try{
-      await initFirebase();
-      await cargarPorcentajePremioDesdeParametros();
-    }catch(error){
-      console.error('No se pudo inicializar Firebase en Editar Sorteo',error);
-      alert('No se pudo inicializar la conexión con Firebase. Recarga la página e intenta nuevamente.');
-      return;
-    }
-    crearFormas();
-    actualizarTotales();
-    iniciarSesionYEstadoLocal().catch(err=>console.error('No se pudo iniciar el estado local de sesión',err));
-  }
-
-  iniciarPaginaEditarSorteo();
+  crearFormas();
+  actualizarTotales();
 
   document.getElementById('cerrar-formas-modal').addEventListener('click',cerrarFormasModal);
   document.getElementById('formas-modal').addEventListener('click',e=>{if(e.target.id==='formas-modal') cerrarFormasModal();});
@@ -1188,8 +1143,7 @@
     try{
       const premioInicialFinal=premioInicialVal??0;
       const totalPremiosNuevo=Math.max(0,totalPremiosBase-premioInicialBase+premioInicialFinal);
-      const porcentajePremioFinal=normalizarPorcentaje(porcentajePremioConfigurado);
-      const updateData={nombre,tipo,fecha,hora,horacierre:cierre,valorCarton:valor,estado,condicion,totalPremios:totalPremiosNuevo,porcentajepremio:porcentajePremioFinal};
+      const updateData={nombre,tipo,fecha,hora,horacierre:cierre,valorCarton:valor,estado,condicion,totalPremios:totalPremiosNuevo};
       if(premioInicialVal!==null){
         updateData.premioInicial=premioInicialVal;
       }else{

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -100,15 +100,7 @@ async function initFirebase(){
     appleProvider.addScope('name');
     await auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL);
     return app;
-  })().catch(error=>{
-    app = null;
-    auth = null;
-    db = null;
-    provider = null;
-    appleProvider = null;
-    firebaseInitPromise = null;
-    throw error;
-  });
+  })();
 
   return firebaseInitPromise;
 }

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -8586,37 +8586,6 @@
     return resultado;
   }
 
-  function obtenerCantosActivosSet(){
-    const activos=new Set();
-    if(!Array.isArray(cantosOrdenados) || !cantosOrdenados.length){
-      return activos;
-    }
-    cantosOrdenados.forEach(numero=>{
-      const normalizado=Number(numero);
-      if(Number.isFinite(normalizado) && esCantoGanador(normalizado)){
-        activos.add(normalizado);
-      }
-    });
-    return activos;
-  }
-
-  function contarAciertosCarton(carton, cantosActivosSet=obtenerCantosActivosSet()){
-    if(!carton || !(cantosActivosSet instanceof Set) || !cantosActivosSet.size){
-      return 0;
-    }
-    const valores=carton.valorPorPos instanceof Map
-      ? Array.from(carton.valorPorPos.values())
-      : [];
-    let aciertos=0;
-    valores.forEach(valor=>{
-      const numero=Number(valor);
-      if(Number.isFinite(numero) && cantosActivosSet.has(numero)){
-        aciertos++;
-      }
-    });
-    return aciertos;
-  }
-
   function actualizarEtiquetaMisCartones(){
     if(!misCartonesLabelEl) return;
     misCartonesLabelEl.textContent = modoSimulacionCartones
@@ -10317,13 +10286,11 @@
       return;
     }
     cartonesMensajeEl.textContent='';
-    const cantosActivosSet=obtenerCantosActivosSet();
     const decorados=lista.map(carton=>{
       const formasGanadas=mapaFormasActivo.get(carton.id)||[];
       const primerPaso=formasGanadas.length?Math.min(...formasGanadas.map(f=>f.paso)):Infinity;
       const resumenGanancias=obtenerResumenGananciasCarton(carton,5);
-      const totalAciertos=contarAciertosCarton(carton, cantosActivosSet);
-      return {...carton, formasGanadas, primerPaso, resumenGanancias, totalAciertos};
+      return {...carton, formasGanadas, primerPaso, resumenGanancias};
     });
     totalGananciasJugador=decorados.reduce((acum,carton)=>{
       const total=Number(carton?.resumenGanancias?.total)||0;
@@ -10335,9 +10302,6 @@
       const aGan=a.formasGanadas.length>0;
       const bGan=b.formasGanadas.length>0;
       if(aGan!==bGan) return aGan?-1:1;
-      const aciertosA=Number(a.totalAciertos)||0;
-      const aciertosB=Number(b.totalAciertos)||0;
-      if(aciertosA!==aciertosB) return aciertosB-aciertosA;
       if(aGan && bGan){
         if(a.primerPaso!==b.primerPaso) return a.primerPaso-b.primerPaso;
       }

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -637,8 +637,6 @@
     .carton-center-info{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px;line-height:1;font-weight:bold;text-transform:none;}
     #carton-num-max{font-size:1.2rem;color:#006400;text-shadow:0 0 4px #fff,0 0 6px rgba(0,0,0,0.2);font-family:'Poppins',sans-serif;display:block;animation:wiggle 1s infinite;}
     .carton td.error{border:2px solid red;}
-    .carton td.azar-resaltado-verde{background:#1ca14c !important;color:#fff !important;text-shadow:none !important;transition:background-color .2s ease,color .2s ease;}
-    .carton td.azar-resaltado-azul{background:#1f4fbf !important;color:#fff !important;text-shadow:none !important;transition:background-color .2s ease,color .2s ease;}
     .carton-back{position:absolute;top:0;left:0;right:0;bottom:0;border-radius:10px;backface-visibility:hidden;transform:rotateY(180deg);background:linear-gradient(white,gray);display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:5px;overflow:hidden;}
     .carton-back img{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:80%;height:auto;opacity:0.15;object-fit:contain;pointer-events:none;z-index:0;}
     .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;z-index:1000;padding:12px;box-sizing:border-box;}
@@ -3527,30 +3525,8 @@ function toggleForma(idx){
     validateBoard();
   }
 
-  function obtenerEstadoCartonAzar(){
-    const celdasNoFree=[...document.querySelectorAll('#bingo-board td:not(.free)')];
-    const total=celdasNoFree.length;
-    let llenas=0;
-    celdasNoFree.forEach(td=>{
-      if((td.dataset.value||'').toString().trim()!=='') llenas++;
-    });
-    if(llenas===0) return 'vacio';
-    if(llenas===total) return 'lleno';
-    return 'parcial';
-  }
-
-  function resaltarCeldasModificadas(celdas=[],modo='verde'){
-    if(!Array.isArray(celdas) || celdas.length===0) return;
-    const clase=modo==='azul'?'azar-resaltado-azul':'azar-resaltado-verde';
-    celdas.forEach(td=>{
-      td.classList.remove('azar-resaltado-verde','azar-resaltado-azul');
-      td.classList.add(clase);
-      setTimeout(()=>td.classList.remove(clase),2000);
-    });
-  }
-
-  function cargarAzar({reemplazoTotal=false}={}){
-    const celdasModificadas=[];
+  function cargarAzar(){
+    limpiarcarton();
     for(let c=0;c<5;c++){
       const [start,end]=ranges[c];
       const nums=[];
@@ -3559,29 +3535,13 @@ function toggleForma(idx){
       for(let r=0;r<5;r++){
         if(r===2&&c===2) continue;
         const td=document.querySelector(`#bingo-board td[data-row="${r}"][data-col="${c}"]`);
-        const actual=(td.dataset.value||'').toString().trim();
-        if(!reemplazoTotal && actual!=='') continue;
         const val=nums.pop();
         td.dataset.value=val;
         td.textContent=val;
-        celdasModificadas.push(td);
       }
     }
-    resaltarCeldasModificadas(celdasModificadas,reemplazoTotal?'azul':'verde');
     validateBoard();
     saveToCookie();
-  }
-
-  async function manejarAzarContextual(){
-    const estado=obtenerEstadoCartonAzar();
-    let mensaje='¿Quieres cargar jugadas al azar?';
-    if(estado==='parcial'){
-      mensaje='¿Deseas elegir al azar los números restantes en el cartón?';
-    }else if(estado==='lleno'){
-      mensaje='¿Deseas cambiar todas las jugadas al azar en el cartón?';
-    }
-    if(!(await confirm(mensaje))) return;
-    cargarAzar({reemplazoTotal:estado==='lleno'});
   }
 
   async function actualizarDatosSorteo(){
@@ -3921,19 +3881,8 @@ function toggleForma(idx){
     const valor=toNumberSafe(sorteoData.valorCarton,0);
     const maxGratis=toNumberSafe(sorteoData.maxcartongratis,0);
     const vars=await db.collection('Variablesglobales').doc('Parametros').get();
-    const varsData=vars.data()||{};
     const porcentaje=toNumberSafe(vars.data()?.porcentaje,0);
     const porcentajesu=toNumberSafe(vars.data()?.porcentajesu,0);
-    const cuentasEspecialesRaw=Array.isArray(varsData.cuentasFondosEspeciales)
-      ? varsData.cuentasFondosEspeciales
-      : (Array.isArray(varsData.cuentasEspecialesFondos) ? varsData.cuentasEspecialesFondos : []);
-    const porcentajeCuentasActivas=cuentasEspecialesRaw
-      .filter(cuenta=>Boolean(cuenta?.activa))
-      .reduce((acc,cuenta)=>acc+toNumberSafe(cuenta?.porcentaje,0),0);
-    const porcentajePremioConfigurado=toNumberSafe(
-      sorteoData?.porcentajepremio,
-      toNumberSafe(varsData.porcentajepremio,0)
-    );
     let jugarGratis=false;
     const gratisJugandoJugador=gratisUsadosJugador;
     if(gratis>0 && (maxGratis<=0 || gratisJugandoJugador<maxGratis)){
@@ -3981,18 +3930,11 @@ function toggleForma(idx){
         if(!Number.isFinite(valorCartonActual) || valorCartonActual<0){
           throw new Error('VALOR_CARTON_INVALIDO');
         }
-        const porcentajeTx=Math.max(0,toNumberSafe(porcentaje,0));
-        const porcentajeSuTx=Math.max(0,toNumberSafe(porcentajesu,0));
-        const porcentajePremioBase=Math.max(0,toNumberSafe(
-          sorteoDataTx?.porcentajepremio,
-          porcentajePremioConfigurado
-        ));
-        const porcentajePremioTx=porcentajePremioBase>0
-          ? porcentajePremioBase
-          : Math.max(0,100-porcentajeTx-porcentajeSuTx-porcentajeCuentasActivas);
+        const porcentajeTx=toNumberSafe(porcentaje,0);
+        const porcentajeSuTx=toNumberSafe(porcentajesu,0);
         const porcentajeValTx=valorCartonActual*porcentajeTx/100;
         const porcentajeSuValTx=valorCartonActual*porcentajeSuTx/100;
-        const paraPremioTx=valorCartonActual*porcentajePremioTx/100;
+        const paraPremioTx=valorCartonActual-porcentajeValTx-porcentajeSuValTx;
         const creditosActual=toNumberSafe(billeteraSnap.data()?.creditos,0);
         const creditosTransitoActual=Math.max(0,toNumberSafe(billeteraSnap.data()?.creditostransito,0));
         const gratisActual=toNumberSafe(billeteraSnap.data()?.CartonesGratis,0);
@@ -4794,7 +4736,7 @@ document.getElementById('gratis-label').addEventListener('click',()=>{
   document.getElementById('premio-valor').addEventListener('click',mostrarPremiosModal);
   document.getElementById('premios-aceptar').addEventListener('click',()=>{document.getElementById('premios-modal').style.display='none';});
   document.getElementById('limpiar-btn').addEventListener('click',async()=>{if(await confirm('¿Deseas limpiar todas las jugadas del carton?')) limpiarcarton();});
-  document.getElementById('azar-btn').addEventListener('click',manejarAzarContextual);
+  document.getElementById('azar-btn').addEventListener('click',async()=>{if(await confirm('¿Quieres cargar jugadas al azar?')) cargarAzar();});
   document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='player.html';});
   document.getElementById('guardar-check').addEventListener('change',e=>{
     const show=e.target.checked;

--- a/public/nuevosorteo.html
+++ b/public/nuevosorteo.html
@@ -306,31 +306,6 @@
   let modalFormaIdx=null;
   let formasModalDatos=[];
   let formaSeleccionadaId=null;
-  let porcentajePremioConfigurado=0;
-
-  function normalizarPorcentaje(valor){
-    const numero=Number(valor);
-    if(!Number.isFinite(numero)) return 0;
-    if(numero<0) return 0;
-    if(numero>100) return 100;
-    return numero;
-  }
-
-  async function cargarPorcentajePremioDesdeParametros(){
-    if(!db){
-      porcentajePremioConfigurado=0;
-      return porcentajePremioConfigurado;
-    }
-    try{
-      const doc=await db.collection('Variablesglobales').doc('Parametros').get();
-      const data=doc.exists?(doc.data()||{}):{};
-      porcentajePremioConfigurado=normalizarPorcentaje(data.porcentajepremio);
-    }catch(error){
-      console.error('No se pudo cargar el porcentaje premio desde parámetros',error);
-      porcentajePremioConfigurado=0;
-    }
-    return porcentajePremioConfigurado;
-  }
 
   function mostrarConfirmacion(mensaje){
     const modal=document.getElementById('confirm-modal');
@@ -509,16 +484,13 @@
     if(btn) btn.click();
   }
 
-  async function iniciarSesionYEstadoLocal(){
-    await initFirebase();
-    auth.onAuthStateChanged(async u=>{
-      if(!u) return;
+  firebase.auth().onAuthStateChanged(u=>{
+    if(u){
       cookieKey='nuevosorteo_'+u.email.replace(/[^\w]/g,'_');
-      await cargarPorcentajePremioDesdeParametros();
       loadState();
       setupSaveListeners();
-    });
-  }
+    }
+  });
 
   function formatearHora(hora){
     if(!hora) return '';
@@ -714,10 +686,6 @@
   async function cargarFormasModal(idx){
     const grid=document.getElementById('formas-grid');
     if(!grid) return;
-    if(!db){
-      grid.innerHTML='<div class="formas-empty">Firebase aún no está listo. Reintenta en unos segundos.</div>';
-      return;
-    }
     grid.innerHTML='<div class="formas-empty">Cargando...</div>';
     formasModalDatos=[];
     formaSeleccionadaId=null;
@@ -987,21 +955,8 @@
     return data.url;
   }
 
-  async function iniciarPaginaNuevoSorteo(){
-    try{
-      await initFirebase();
-      await cargarPorcentajePremioDesdeParametros();
-    }catch(error){
-      console.error('No se pudo inicializar Firebase en Nuevo Sorteo',error);
-      alert('No se pudo inicializar la conexión con Firebase. Recarga la página e intenta nuevamente.');
-      return;
-    }
-    crearFormas();
-    actualizarTotales();
-    iniciarSesionYEstadoLocal().catch(err=>console.error('No se pudo iniciar el estado local de sesión',err));
-  }
-
-  iniciarPaginaNuevoSorteo();
+  crearFormas();
+  actualizarTotales();
 
   document.getElementById('cerrar-formas-modal').addEventListener('click',cerrarFormasModal);
   document.getElementById('formas-modal').addEventListener('click',e=>{if(e.target.id==='formas-modal') cerrarFormasModal();});
@@ -1163,7 +1118,6 @@
     if(conPorcentaje>0 && total!==100){alert('La suma de porcentajes debe ser exactamente 100%');return;}
     try{
       const premioInicialFinal=premioInicialVal??0;
-      const porcentajePremioFinal=normalizarPorcentaje(porcentajePremioConfigurado);
       const sorteoData={
         nombre,
         tipo,
@@ -1174,8 +1128,7 @@
         valorCarton:valor,
         estado,
         condicion,
-        totalPremios:premioInicialFinal,
-        porcentajepremio:porcentajePremioFinal
+        totalPremios:premioInicialFinal
       };
       if(premioInicialVal!==null){
         sorteoData.premioInicial=premioInicialVal;

--- a/public/parametros.html
+++ b/public/parametros.html
@@ -84,7 +84,7 @@
       max-width: 600px;
       display: none;
       flex-direction: column;
-      gap: 6px;
+      gap: 8px;
       font-family: Calibri, Arial, sans-serif;
       font-size: 0.9rem;
       align-items: center;
@@ -93,17 +93,16 @@
       display: flex;
       align-items: center;
       width: 100%;
-      gap: 8px;
     }
     .form-row label {
-      flex: 0 0 138px;
+      flex: 0 0 150px;
       font-weight: bold;
       text-align: right;
-      margin-right: 4px;
+      margin-right: 10px;
     }
     .form-row input {
       flex: 1;
-      padding: 4px 6px;
+      padding: 5px;
       border-radius: 5px;
       border: 1px solid #ccc;
       text-align: left;
@@ -115,18 +114,17 @@
     }
     .small-row {
       flex-wrap: wrap;
-      gap: 8px;
-      justify-content: space-between;
+      gap: 10px;
+      justify-content: center;
     }
     .small-row .field {
       display: flex;
       align-items: center;
-      gap: 4px;
     }
     .small-row .field label {
       flex: none;
       width: auto;
-      margin-right: 0;
+      margin-right: 5px;
       text-align: left;
     }
     .small-row .field input {
@@ -137,290 +135,6 @@
     .small-row .field .percent {
       margin-left: 4px;
       font-weight: bold;
-    }
-    .fondos-especiales-section {
-      width: 100%;
-      border: 1px solid #d9d9d9;
-      border-radius: 10px;
-      padding: 10px;
-      box-sizing: border-box;
-      background: rgba(255, 255, 255, 0.9);
-    }
-    .fondos-header {
-      display: flex;
-      align-items: flex-start;
-      justify-content: space-between;
-      gap: 8px;
-      margin-bottom: 8px;
-    }
-    .fondos-especiales-section h3 {
-      margin: 0;
-      font-size: 1.05rem;
-      text-align: left;
-    }
-    .fondos-resumen {
-      text-align: right;
-      line-height: 1.15;
-    }
-    .fondos-resumen-principal {
-      display: inline-flex;
-      align-items: center;
-      gap: 5px;
-      font-weight: 600;
-    }
-    .fondos-resumen-label {
-      font-weight: 700;
-    }
-    .fondos-resumen-valor {
-      font-weight: 700;
-    }
-    .fondos-resumen-estado {
-      margin-top: 2px;
-      font-size: 0.66rem;
-      font-weight: 700;
-    }
-    .fondos-controls {
-      display: flex;
-      align-items: flex-end;
-      gap: 8px;
-      flex-wrap: wrap;
-      margin-bottom: 8px;
-    }
-    .fondos-fields {
-      display: flex;
-      align-items: flex-end;
-      gap: 8px;
-      flex: 1;
-      flex-wrap: wrap;
-    }
-    .fondos-fields-top {
-      display: grid;
-      grid-template-columns: minmax(180px, 1fr) minmax(120px, 140px);
-      gap: 8px;
-      width: 100%;
-    }
-    .fondos-fields-bottom {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      width: 100%;
-      flex-wrap: wrap;
-    }
-    .fondos-fields-bottom .field {
-      display: inline-flex;
-      align-items: center;
-      gap: 4px;
-    }
-    .fondos-fields-bottom-extra {
-      margin-top: 4px;
-    }
-    .fondos-fields-bottom .field label {
-      font-weight: 700;
-      text-align: left;
-    }
-    .fondos-fields-bottom .field input {
-      width: 72px;
-      padding: 4px 6px;
-      text-align: center;
-      border-radius: 5px;
-      border: 1px solid #ccc;
-      background: #fff;
-    }
-    .fondos-fields-bottom .field .percent {
-      font-weight: 700;
-    }
-    .fondos-field {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 3px;
-    }
-    .fondos-field input[type="text"],
-    .fondos-field input[type="number"] {
-      width: 100%;
-      min-width: 120px;
-      padding: 4px 6px;
-      border-radius: 5px;
-      border: 1px solid #ccc;
-      box-sizing: border-box;
-      background: #fff;
-    }
-    .fondos-checkbox {
-      flex-direction: row;
-      align-items: center;
-      gap: 6px;
-      margin-bottom: 8px;
-    }
-    .fondos-checkbox input[type="checkbox"],
-    .fondos-table input[type="checkbox"] {
-      width: 20px;
-      height: 20px;
-    }
-    .icon-btn-group {
-      display: flex;
-      gap: 6px;
-      flex-wrap: wrap;
-    }
-    .icon-btn {
-      width: 36px;
-      height: 36px;
-      border-radius: 8px;
-      border: 1px solid #bdbdbd;
-      background: #fff;
-      font-size: 18px;
-      line-height: 1;
-      cursor: pointer;
-    }
-    .icon-btn:disabled {
-      cursor: not-allowed;
-      opacity: 0.5;
-    }
-    .fondos-table-wrap {
-      width: 100%;
-      overflow-x: auto;
-    }
-    .fondos-table {
-      width: 100%;
-      min-width: 500px;
-      border-collapse: collapse;
-      font-size: 0.85rem;
-    }
-    .fondos-table th,
-    .fondos-table td {
-      border: 1px solid #d8d8d8;
-      padding: 5px 6px;
-      text-align: left;
-      white-space: nowrap;
-    }
-    .fondos-table th:last-child,
-    .fondos-table td:last-child {
-      text-align: center;
-    }
-    .fondos-table th:nth-child(3),
-    .fondos-table td:nth-child(3) {
-      width: 1%;
-      min-width: 42px;
-      text-align: center;
-      font-weight: 600;
-    }
-    .fondos-table th:nth-child(4),
-    .fondos-table td:nth-child(4) {
-      width: 1%;
-      min-width: 62px;
-      text-align: center;
-      font-weight: 600;
-    }
-    @media (max-width: 768px) {
-      #parametros-form {
-        width: min(95vw, 560px);
-      }
-      .form-row {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 6px;
-      }
-      .form-row label {
-        text-align: left;
-        margin-right: 0;
-      }
-      .small-row {
-        justify-content: flex-start;
-      }
-      .small-row .field {
-        width: 100%;
-      }
-      .small-row .field input,
-      .small-row .field select {
-        flex: 1;
-        width: auto;
-      }
-      .fondos-controls {
-        flex-direction: column;
-        align-items: stretch;
-      }
-      .fondos-header {
-        flex-direction: column;
-        align-items: flex-start;
-      }
-      .fondos-resumen {
-        text-align: left;
-      }
-      .fondos-fields-top {
-        grid-template-columns: 1fr;
-      }
-      .fondos-fields-bottom {
-        gap: 8px;
-      }
-      .fondos-fields-bottom .field {
-        width: auto;
-        min-width: 260px;
-        justify-content: flex-start;
-      }
-      .icon-btn-group {
-        width: 100%;
-      }
-    }
-    @media (max-width: 768px) and (orientation: portrait) {
-      body {
-        padding-top: 72px;
-      }
-      #volver-btn {
-        width: auto;
-        min-height: 44px;
-        padding: 0 12px;
-        z-index: 1000;
-      }
-      h2 {
-        margin-top: 10px !important;
-      }
-      .fondos-controls,
-      .fondos-fields {
-        flex-direction: column;
-        align-items: flex-start;
-      }
-      .fondos-field,
-      .fondos-field input[type="text"],
-      .fondos-field input[type="number"] {
-        width: min(100%, 420px);
-        min-width: 0;
-      }
-      .fondos-checkbox {
-        min-height: 44px;
-        margin-bottom: 0;
-      }
-      .fondos-checkbox input[type="checkbox"],
-      .fondos-table input[type="checkbox"] {
-        width: 24px;
-        height: 24px;
-      }
-      .icon-btn-group {
-        display: flex;
-        flex-wrap: nowrap;
-        justify-content: space-between;
-        align-items: center;
-        gap: 6px;
-        padding: 6px;
-        border: 1px solid #d9d9d9;
-        border-radius: 8px;
-        background: #f7f7f7;
-      }
-      .icon-btn {
-        flex: 1;
-        min-width: 44px;
-        min-height: 44px;
-      }
-      .fondos-table-wrap {
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-      }
-      .fondos-table th,
-      .fondos-table td {
-        font-size: 0.82rem;
-      }
-      .fondos-table td:last-child {
-        min-width: 44px;
-        min-height: 44px;
-      }
     }
   </style>
   <link rel="stylesheet" href="css/desktopFrame.css">
@@ -467,6 +181,16 @@
         <select id="pais"></select>
       </div>
       <div class="field">
+        <label for="porcentaje">Porcentaje Agencia:</label>
+        <input type="number" id="porcentaje" placeholder="0" />
+        <span class="percent">%</span>
+      </div>
+      <div class="field">
+        <label for="porcentajesu">Porcentaje Superadmin:</label>
+        <input type="number" id="porcentajesu" placeholder="0" />
+        <span class="percent">%</span>
+      </div>
+      <div class="field">
         <label for="porcentajeretiro">Porcentaje de Retiros:</label>
         <input type="number" id="porcentajeretiro" placeholder="0" step="0.01" />
         <span class="percent">%</span>
@@ -475,74 +199,6 @@
         <label for="porcentajeadministra">Porcentaje Administrativo:</label>
         <input type="number" id="porcentajeadministra" placeholder="0" step="0.01" />
         <span class="percent">%</span>
-      </div>
-    </div>
-    <div class="fondos-especiales-section">
-      <div class="fondos-header">
-        <h3>Cuentas especiales de fondos</h3>
-        <div class="fondos-resumen" aria-live="polite">
-          <div class="fondos-resumen-principal">
-            <span class="fondos-resumen-label">%</span>
-            <span id="fondos-total-porcentaje" class="fondos-resumen-valor">0.00</span>
-          </div>
-          <div id="fondos-total-estado" class="fondos-resumen-estado">Porcentaje válido</div>
-        </div>
-      </div>
-      <div class="fondos-controls">
-        <div class="fondos-fields">
-          <div class="fondos-fields-bottom">
-            <div class="field">
-              <label for="porcentaje">Porcentaje Agencia:</label>
-              <input type="number" id="porcentaje" placeholder="0" />
-              <span class="percent">%</span>
-            </div>
-            <div class="field">
-              <label for="porcentajesu">Porcentaje Superadmin:</label>
-              <input type="number" id="porcentajesu" placeholder="0" />
-              <span class="percent">%</span>
-            </div>
-            <div class="field">
-              <label for="porcentajepremio">Porcentaje premio:</label>
-              <input type="number" id="porcentajepremio" placeholder="0" step="0.01" />
-              <span class="percent">%</span>
-            </div>
-          </div>
-          <div class="fondos-fields-top fondos-fields-bottom-extra">
-            <div class="fondos-field">
-              <label for="fondo-nombre">Nombre cuenta</label>
-              <input type="text" id="fondo-nombre" placeholder="Nombre de cuenta">
-            </div>
-            <div class="fondos-field">
-              <label for="fondo-porcentaje">Porcentaje</label>
-              <input type="number" id="fondo-porcentaje" placeholder="0" step="0.01">
-            </div>
-          </div>
-          <div class="fondos-fields-bottom">
-            <label class="fondos-field fondos-checkbox">
-              <input type="checkbox" id="fondo-activa">
-              Activa
-            </label>
-          </div>
-        </div>
-        <div class="icon-btn-group">
-          <button type="button" id="fondo-nuevo-btn" class="icon-btn" title="Nuevo" aria-label="Nuevo" style="color:#0a7a26;">➕</button>
-          <button type="button" id="fondo-editar-btn" class="icon-btn" title="Editar" disabled>✏️</button>
-          <button type="button" id="fondo-eliminar-btn" class="icon-btn" title="Eliminar" disabled style="color:#c0392b;">➖</button>
-        </div>
-      </div>
-      <div class="fondos-table-wrap">
-        <table class="fondos-table">
-          <thead>
-            <tr>
-              <th>N°</th>
-              <th>Nombre cuenta</th>
-              <th>%</th>
-              <th>Estado</th>
-              <th>Sel.</th>
-            </tr>
-          </thead>
-          <tbody id="fondos-table-body"></tbody>
-        </table>
       </div>
     </div>
     <button id="editar-btn" class="menu-btn">Editar</button>
@@ -558,14 +214,6 @@
     ensureAuth('Superadmin');
     const EMAIL_PERMITIDO_PARAMETROS = 'jhoseph.q@gmail.com';
     const camposContrasenaLegacy = ['contrasenasu','contrasenaSu','contrasenaSU','Contrasenasu','ContrasenaSu','ContrasenaSU'];
-    let cuentasEspecialesFondos = [];
-    let cuentaEspecialSeleccionadaId = null;
-    function generarIdCuentaEspecial(){
-      if(window.crypto && typeof window.crypto.randomUUID === 'function'){
-        return window.crypto.randomUUID();
-      }
-      return `cuenta-${Date.now()}-${Math.floor(Math.random() * 100000)}`;
-    }
 
     function usuarioPuedeGestionarParametros(user){
       const emailActual = String(user?.email || '').trim().toLowerCase();
@@ -630,188 +278,18 @@
       if(data.Pais){ document.getElementById('pais').value = data.Pais; }
       document.getElementById('porcentaje').value = data.porcentaje || '';
       document.getElementById('porcentajesu').value = data.porcentajesu || '';
-      document.getElementById('porcentajepremio').value = data.porcentajepremio || '';
       document.getElementById('porcentajeretiro').value = data.porcentajeretiro || '';
       document.getElementById('porcentajeadministra').value = data.porcentajeadministra || '';
-      const cuentasFondosRaw = Array.isArray(data.cuentasFondosEspeciales)
-        ? data.cuentasFondosEspeciales
-        : (Array.isArray(data.cuentasEspecialesFondos) ? data.cuentasEspecialesFondos : []);
-      cuentasEspecialesFondos = cuentasFondosRaw
-        .map(item => ({
-            id: item.id || generarIdCuentaEspecial(),
-            nombre: String(item.nombre || '').trim(),
-            porcentaje: Number(item.porcentaje) || 0,
-            activa: Boolean(item.activa),
-            updatedAt: item.updatedAt || null
-          }));
-      cuentaEspecialSeleccionadaId = null;
-      renderizarTablaFondos();
-      limpiarFormularioFondos();
-      actualizarEstadoAccionesFondos();
-      actualizarResumenPorcentajesFondos();
       /* Habilitar edición por defecto para permitir la selección inmediata del país */
       toggleEdicion(false);
     }
-    function obtenerValorNumericoSeguro(valor){
-      const numero = Number.parseFloat(valor);
-      return Number.isFinite(numero) ? numero : 0;
-    }
-    function calcularPorcentajeTotalFondos(){
-      const porcentajeAgencia = obtenerValorNumericoSeguro(document.getElementById('porcentaje')?.value);
-      const porcentajeSuperadmin = obtenerValorNumericoSeguro(document.getElementById('porcentajesu')?.value);
-      const porcentajePremio = obtenerValorNumericoSeguro(document.getElementById('porcentajepremio')?.value);
-      const porcentajeCuentasActivas = cuentasEspecialesFondos
-        .filter(cuenta => cuenta && cuenta.activa)
-        .reduce((acumulado, cuenta) => acumulado + obtenerValorNumericoSeguro(cuenta.porcentaje), 0);
-      return porcentajeAgencia + porcentajeSuperadmin + porcentajePremio + porcentajeCuentasActivas;
-    }
-    function actualizarResumenPorcentajesFondos(){
-      const total = calcularPorcentajeTotalFondos();
-      const esValido = total >= 0 && total <= 100;
-      const elementoTotal = document.getElementById('fondos-total-porcentaje');
-      const elementoEstado = document.getElementById('fondos-total-estado');
-      if(!elementoTotal || !elementoEstado){
-        return { total, esValido };
-      }
-      elementoTotal.textContent = total.toFixed(2);
-      elementoTotal.style.color = esValido ? '#0a7a26' : '#c0392b';
-      elementoEstado.textContent = esValido ? 'Porcentaje válido' : 'Porcentaje excedido';
-      elementoEstado.style.color = esValido ? '#0a7a26' : '#c0392b';
-      return { total, esValido };
-    }
-    function mostrarErrorValidacionPorcentajes(total){
-      alert(`⚠️ No se pudo guardar.\n\nLa suma de porcentajes en "Cuentas especiales de fondos" es ${total.toFixed(2)}% y debe mantenerse entre 0% y 100%.\n\nAjusta Porcentaje Agencia, Porcentaje Superadmin o las cuentas activas antes de guardar.`);
-    }
-    function limpiarFormularioFondos(){
-      document.getElementById('fondo-nombre').value = '';
-      document.getElementById('fondo-porcentaje').value = '';
-      document.getElementById('fondo-activa').checked = true;
-    }
-    function renderizarTablaFondos(){
-      const body = document.getElementById('fondos-table-body');
-      body.innerHTML = '';
-      cuentasEspecialesFondos.forEach((cuenta, index)=>{
-        const tr = document.createElement('tr');
-        const checked = cuentaEspecialSeleccionadaId === cuenta.id ? 'checked' : '';
-        tr.innerHTML = `
-          <td>${index + 1}</td>
-          <td>${cuenta.nombre}</td>
-          <td>${cuenta.porcentaje}%</td>
-          <td>${cuenta.activa ? 'Activa' : 'Inactiva'}</td>
-          <td><input type="radio" name="fondo-seleccion" data-cuenta-id="${cuenta.id}" ${checked}></td>
-        `;
-        body.appendChild(tr);
-      });
-      actualizarResumenPorcentajesFondos();
-      body.querySelectorAll('input[name="fondo-seleccion"]').forEach(radio=>{
-        radio.addEventListener('change', (event)=>{
-          cuentaEspecialSeleccionadaId = event.target.dataset.cuentaId || null;
-          const seleccionada = obtenerCuentaSeleccionada();
-          if(seleccionada){
-            document.getElementById('fondo-nombre').value = seleccionada.nombre;
-            document.getElementById('fondo-porcentaje').value = seleccionada.porcentaje;
-            document.getElementById('fondo-activa').checked = seleccionada.activa;
-          }
-          actualizarEstadoAccionesFondos();
-        });
-      });
-    }
-    function actualizarEstadoAccionesFondos(){
-      const haySeleccion = Boolean(cuentaEspecialSeleccionadaId);
-      document.getElementById('fondo-editar-btn').disabled = !haySeleccion;
-      document.getElementById('fondo-eliminar-btn').disabled = !haySeleccion;
-    }
-    function obtenerCuentaSeleccionada(){
-      if(!cuentaEspecialSeleccionadaId){
-        return null;
-      }
-      return cuentasEspecialesFondos.find(c => c.id === cuentaEspecialSeleccionadaId) || null;
-    }
-    function leerCuentaDesdeFormulario(){
-      const nombre = document.getElementById('fondo-nombre').value.trim();
-      const porcentaje = parseFloat(document.getElementById('fondo-porcentaje').value);
-      const activa = document.getElementById('fondo-activa').checked;
-      if(!nombre){
-        alert('Debes indicar el nombre de la cuenta especial.');
-        return null;
-      }
-      return {
-        nombre,
-        porcentaje: Number.isFinite(porcentaje) ? porcentaje : 0,
-        activa
-      };
-    }
-    document.getElementById('fondo-nuevo-btn').addEventListener('click', ()=>{
-      const nuevaCuenta = leerCuentaDesdeFormulario();
-      if(!nuevaCuenta){
-        return;
-      }
-      cuentasEspecialesFondos.push({
-        id: generarIdCuentaEspecial(),
-        ...nuevaCuenta,
-        updatedAt: new Date().toISOString()
-      });
-      cuentaEspecialSeleccionadaId = null;
-      renderizarTablaFondos();
-      limpiarFormularioFondos();
-      actualizarEstadoAccionesFondos();
-      actualizarResumenPorcentajesFondos();
-    });
-    document.getElementById('fondo-editar-btn').addEventListener('click', ()=>{
-      const cuentaSeleccionada = obtenerCuentaSeleccionada();
-      if(!cuentaSeleccionada){
-        return;
-      }
-      const datos = leerCuentaDesdeFormulario();
-      if(!datos){
-        return;
-      }
-      cuentaSeleccionada.nombre = datos.nombre;
-      cuentaSeleccionada.porcentaje = datos.porcentaje;
-      cuentaSeleccionada.activa = datos.activa;
-      cuentaSeleccionada.updatedAt = new Date().toISOString();
-      renderizarTablaFondos();
-      actualizarEstadoAccionesFondos();
-      actualizarResumenPorcentajesFondos();
-    });
-    document.getElementById('fondo-eliminar-btn').addEventListener('click', ()=>{
-      if(!cuentaEspecialSeleccionadaId){
-        return;
-      }
-      cuentasEspecialesFondos = cuentasEspecialesFondos.filter(c=>c.id !== cuentaEspecialSeleccionadaId);
-      cuentaEspecialSeleccionadaId = null;
-      renderizarTablaFondos();
-      limpiarFormularioFondos();
-      actualizarEstadoAccionesFondos();
-      actualizarResumenPorcentajesFondos();
-    });
     function toggleEdicion(disabled){
       document.querySelectorAll('#parametros-form input, #parametros-form select').forEach(inp=>inp.disabled = disabled);
-      document.getElementById('fondo-nuevo-btn').disabled = disabled;
-      if(disabled){
-        document.getElementById('fondo-editar-btn').disabled = true;
-        document.getElementById('fondo-eliminar-btn').disabled = true;
-      }else{
-        actualizarEstadoAccionesFondos();
-      }
       document.getElementById('editar-btn').style.display = disabled ? 'block':'none';
       document.getElementById('guardar-btn').style.display = disabled ? 'none':'block';
     }
     document.getElementById('editar-btn').addEventListener('click', ()=>{ toggleEdicion(false); });
     document.getElementById('guardar-btn').addEventListener('click', async ()=>{
-      const estadoPorcentaje = actualizarResumenPorcentajesFondos();
-      if(!estadoPorcentaje.esValido){
-        mostrarErrorValidacionPorcentajes(estadoPorcentaje.total);
-        return;
-      }
-      const timestampActualizacion = new Date().toISOString();
-      const cuentasNormalizadas = cuentasEspecialesFondos.map(({id, nombre, porcentaje, activa, updatedAt})=>({
-        id,
-        nombre,
-        porcentaje,
-        activa,
-        updatedAt: updatedAt || timestampActualizacion
-      }));
       const data={
         Aplicacion: document.getElementById('aplicacion').value.trim(),
         Cliente: document.getElementById('cliente').value.trim(),
@@ -824,22 +302,13 @@
         ZonaHoraria: document.getElementById('pais').selectedOptions[0]?.dataset.timezone || '',
         porcentaje: parseFloat(document.getElementById('porcentaje').value)||0,
         porcentajesu: parseFloat(document.getElementById('porcentajesu').value)||0,
-        porcentajepremio: parseFloat(document.getElementById('porcentajepremio').value)||0,
         porcentajeretiro: parseFloat(document.getElementById('porcentajeretiro').value)||0,
-        porcentajeadministra: parseFloat(document.getElementById('porcentajeadministra').value)||0,
-        cuentasFondosEspeciales: cuentasNormalizadas,
-        cuentasEspecialesFondos: cuentasNormalizadas
+        porcentajeadministra: parseFloat(document.getElementById('porcentajeadministra').value)||0
       };
       const limpiezaLegacy = Object.fromEntries(camposContrasenaLegacy.map(campo=>[campo, firebase.firestore.FieldValue.delete()]));
       await db.collection('Variablesglobales').doc('Parametros').set({ ...data, ...limpiezaLegacy },{merge:true});
       alert('Parámetros guardados');
       toggleEdicion(true);
-    });
-    ['porcentaje','porcentajesu','porcentajepremio'].forEach(idCampo=>{
-      const campo = document.getElementById(idCampo);
-      if(campo){
-        campo.addEventListener('input', actualizarResumenPorcentajesFondos);
-      }
     });
     document.getElementById('volver-btn').addEventListener('click',()=>{window.location.href='super.html';});
     async function iniciarParametros(){


### PR DESCRIPTION
### Motivation
- Volver la UI y los flujos frontend al estado estable conocido previo a los PRs #1139–#1149 para aislar regresiones detectadas en pagos, sorteos y experiencia de juego. 
- Restaurar comportamiento de inicialización de autenticación y handlers de juego para evitar efectos secundarios introducidos por cambios posteriores. 
- Reducir el alcance de la investigación dejando una línea base controlada equivalente al punto funcional referenciado (PR #1138). 

### Description
- Se revirtió la lógica introducida por los PRs posteriores en los siguientes archivos del frontend: `public/centropagos.html`, `public/editarsorte.html`, `public/js/auth.js`, `public/juegoactivo.html`, `public/jugarcartones.html`, `public/nuevosorteo.html` y `public/parametros.html`. 
- Cambios clave: restaurado el placeholder "Jugador" en centro de pagos y la carga/simple selección de sorteos en el selector; se eliminó el filtrado por estado "finalizado" en la carga de nombres y el helper `cpEstadoFinalizado`; se devolvieron los cálculos/estructuras previas para badges y renderizado de premios/pagos sin filtrar por sorteo. 
- En formularios de creación/edición de sorteos se reestableció el flujo previo de inicialización y sesión (se removieron las llamadas automáticas a la carga del `porcentajepremio` desde parámetros y se devolvió el patrón de `auth.onAuthStateChanged` usado anteriormente). 
- En `auth.js` se restauró el comportamiento de inicialización del SDK evitando el reset explícito de variables en el `catch` interno; en el juego se restituyeron las versiones anteriores de: carga aleatoria de cartones (`cargarAzar`), ordenamiento/visualización de cartones y la lógica de conteo de aciertos que había sido modificada. 
- Rollback rápido: si se detecta incidencia en producción, revertir este PR para volver a la línea previa (deshacer la restauración aplicada por esta PR). 

### Testing
- Ejecutado `npm test` localmente y todos los suites pasaron: `npm test` → PASS (11 suites, 35 tests, suites y tests en PASS). 
- No se modificaron scripts de generación de configuración ni manifiestos; si se tocan parámetros o imágenes en PR futuros, ejecutar además `npm run generate:firebase-config` y `npm run generate:loterias-manifest` según convenga.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e7230c9c832690c771e96028d44f)