### PR TITLE
fix(auth): corrige fallback de config Firebase al crear sorteos

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -34,8 +34,12 @@ function roleEquals(left, right){
 
 function getConfigFromWindow(){
   if(!hasWindow()) return null;
-  const cfg = window.firebaseConfig || window.__FIREBASE_CONFIG__;
-  if(cfg && Object.keys(cfg).length > 0) return cfg;
+  const candidates = [window.firebaseConfig, window.__FIREBASE_CONFIG__];
+  for(const cfg of candidates){
+    if(cfg && typeof cfg === 'object' && Object.keys(cfg).length > 0){
+      return cfg;
+    }
+  }
   return null;
 }
 


### PR DESCRIPTION
### Motivation
- Se detectó que el flujo de creación de nuevos sorteos fallaba porque `auth.js` tomaba `window.firebaseConfig` aún cuando era un objeto vacío (`{}`) y por tanto no llegaba a leer `window.__FIREBASE_CONFIG__`, provocando error de inicialización de Firebase en páginas como `nuevosorteo.html`.

### Description
- Se actualizó `getConfigFromWindow()` en `public/js/auth.js` para iterar y devolver la primera configuración válida no vacía entre `window.firebaseConfig` y `window.__FIREBASE_CONFIG__`, con lo que se evita quedar bloqueado por un objeto vacío inicial.

### Testing
- Ejecutado `npm test` y todas las suites pasaron (`11 suites`, `35 tests`) — estado: `PASS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f0a0b3d48326a584c9e2a36e3381)