### PR TITLE
fix(ui): ajusta azar de cartones y visualización de cuentas especiales en centro de pagos

### DIFF
--- a/public/centropagos.html
+++ b/public/centropagos.html
@@ -110,6 +110,11 @@
     #pagos-section table td {
       color: #7a3f00;
     }
+    #tabla-pagos tr.registro-cuenta-especial td.gmail,
+    #tabla-pagos tr.registro-cuenta-especial td.creditos,
+    #tabla-pagos tr.registro-cuenta-especial td.fecha {
+      color: #0d47a1 !important;
+    }
     #colaboradores-section {
       color: #6a1b9a;
     }
@@ -2226,6 +2231,12 @@
       return `<span class="gmail-cell"><span class="gmail-full">${largoSeguro}</span><span class="gmail-short">${cortoSeguro}</span></span>`;
     }
 
+    function esRegistroCuentaEspecial(item = {}){
+      const tipoRegistro = (item.tipoRegistro || '').toString().toUpperCase();
+      const rolInterno = (item.rolInterno || '').toString().toLowerCase();
+      return tipoRegistro === 'FONDO_ESPECIAL_SORTEO' || rolInterno === 'fondo_especial';
+    }
+
     function normalizarTipoUsuario(valor){
       const texto = (valor || '').toString().trim();
       if(!texto) return 'Colaborador';
@@ -2408,11 +2419,19 @@
             <td><input type="checkbox" data-id="${item.id}" ${disabled}></td>
           </tr>`;
         }
-        return `<tr data-id="${item.id}">
+        const esCuentaEspecial = esRegistroCuentaEspecial(item);
+        const usuarioVisible = esCuentaEspecial
+          ? (item.alias || item.nombre || item.nombreCuentaEspecial || item.cuentaEspecialId || '').toString()
+          : (item.gmail || '').toString();
+        const usuarioHtml = esCuentaEspecial
+          ? `<span class="gmail-cell"><span class="gmail-full">${escapeHtml(usuarioVisible)}</span><span class="gmail-short">${escapeHtml(usuarioVisible)}</span></span>`
+          : construirGmailHtml(usuarioVisible);
+        const claseEspecial = esCuentaEspecial ? ' registro-cuenta-especial' : '';
+        return `<tr data-id="${item.id}" class="${claseEspecial.trim()}">
           <td>${numero}</td>
-          <td class="gmail" data-gmail="${gmailAttr}" data-nombre="${nombreAttr}">${construirGmailHtml(item.gmail)}</td>
+          <td class="gmail" data-gmail="${gmailAttr}" data-nombre="${nombreAttr}">${usuarioHtml}</td>
           <td class="creditos">${formatNumberEntero.format(Math.round(item.creditos))}</td>
-          <td>${escapeHtml(item.fechaMostrar)}</td>
+          <td class="fecha">${escapeHtml(item.fechaMostrar)}</td>
           <td class="estado">${estadoHtml}</td>
           <td><input type="checkbox" data-id="${item.id}" ${disabled}></td>
         </tr>`;

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -631,14 +631,14 @@
     .carton th,.carton td{background:transparent;border:2px solid gray;width:60px;height:60px;aspect-ratio:1/1;text-align:center;font-weight:bold;padding:0 3px;margin:0;box-sizing:border-box;}
     .carton th{font-size:2.5rem;color:#ff6600;background:radial-gradient(circle,#ffffff,#ffffff 60%,#00aa00);text-shadow:2px 2px 0 #000;}
     .forma-header{display:flex;flex-direction:column;align-items:center;justify-content:center;width:100%;height:100%;font-family:'Bangers',cursive;font-size:0.8rem;line-height:1;text-shadow:1px 1px 0 #000;}
-    .carton td{cursor:pointer;font-size:1.8rem;text-shadow:0 0 3px green;}
+    .carton td{cursor:pointer;font-size:1.8rem;color:#000;text-shadow:0 0 3px green;}
     .carton td[data-tutorial-temp="1"]{color:#7a7a7a;text-shadow:none;}
     .carton td.free{background:#ffeb3b;display:flex;align-items:center;justify-content:center;font-size:1.2rem;color:#4B0082;box-shadow:inset 0 0 6px rgba(0,0,0,0.18);}
     .carton-center-info{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:2px;line-height:1;font-weight:bold;text-transform:none;}
     #carton-num-max{font-size:1.2rem;color:#006400;text-shadow:0 0 4px #fff,0 0 6px rgba(0,0,0,0.2);font-family:'Poppins',sans-serif;display:block;animation:wiggle 1s infinite;}
     .carton td.error{border:2px solid red;}
-    .carton td.azar-resaltado-verde{background:#1ca14c !important;color:#fff !important;text-shadow:none !important;transition:background-color .2s ease,color .2s ease;}
-    .carton td.azar-resaltado-azul{background:#1f4fbf !important;color:#fff !important;text-shadow:none !important;transition:background-color .2s ease,color .2s ease;}
+    .carton td.azar-resaltado-verde{color:#39ff14 !important;text-shadow:0 0 2px #000,0 0 4px #000 !important;transition:color .2s ease,text-shadow .2s ease;}
+    .carton td.azar-resaltado-azul{color:#39ff14 !important;text-shadow:0 0 2px #000,0 0 4px #000 !important;transition:color .2s ease,text-shadow .2s ease;}
     .carton-back{position:absolute;top:0;left:0;right:0;bottom:0;border-radius:10px;backface-visibility:hidden;transform:rotateY(180deg);background:linear-gradient(white,gray);display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:5px;overflow:hidden;}
     .carton-back img{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:80%;height:auto;opacity:0.15;object-fit:contain;pointer-events:none;z-index:0;}
     .modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.8);justify-content:center;align-items:center;z-index:1000;padding:12px;box-sizing:border-box;}
@@ -3545,7 +3545,7 @@ function toggleForma(idx){
     celdas.forEach(td=>{
       td.classList.remove('azar-resaltado-verde','azar-resaltado-azul');
       td.classList.add(clase);
-      setTimeout(()=>td.classList.remove(clase),2000);
+      setTimeout(()=>td.classList.remove(clase),1000);
     });
   }
 
@@ -3553,8 +3553,20 @@ function toggleForma(idx){
     const celdasModificadas=[];
     for(let c=0;c<5;c++){
       const [start,end]=ranges[c];
-      const nums=[];
-      for(let n=start;n<=end;n++) nums.push(n);
+      const numsDisponibles=[];
+      for(let n=start;n<=end;n++) numsDisponibles.push(n);
+      if(!reemplazoTotal){
+        for(let r=0;r<5;r++){
+          if(r===2&&c===2) continue;
+          const tdActual=document.querySelector(`#bingo-board td[data-row="${r}"][data-col="${c}"]`);
+          const valorActual=Number((tdActual?.dataset?.value||'').toString().trim());
+          if(Number.isFinite(valorActual) && valorActual>=start && valorActual<=end){
+            const idx=numsDisponibles.indexOf(valorActual);
+            if(idx>=0) numsDisponibles.splice(idx,1);
+          }
+        }
+      }
+      const nums=[...numsDisponibles];
       for(let i=nums.length-1;i>0;i--){const j=Math.floor(Math.random()*(i+1));[nums[i],nums[j]]=[nums[j],nums[i]];}
       for(let r=0;r<5;r++){
         if(r===2&&c===2) continue;


### PR DESCRIPTION
### Motivation
- Evitar que el botón de azar introduzca números ya presentes en un cartón parcial, previniendo duplicados dentro de la misma columna.
- Cambiar la retroalimentación visual al azar para usar color de fuente (verde fluorescente) con resplandor negro durante 1 segundo y luego volver al estilo habitual.
- Mejorar la legibilidad en la sección `PAGOS ADMINISTRACION` mostrando un identificador humano (alias/nombre) para cuentas especiales y resaltando estas filas en azul en columnas clave.

### Description
- Jugarcartones: modifiqué la función de generación aleatoria para que, en caso de `reemplazoTotal === false`, construya la lista de números disponibles por columna excluyendo los valores ya seleccionados en ese rango y así no reutilizarlos; los cambios están en `public/jugarcartones.html` (lógica de `cargarAzar` y `resaltarCeldasModificadas`).
- Jugarcartones: cambié estilos CSS para que el resaltado use color de fuente verde fluorescente con resplandor negro en lugar de cambiar el fondo, y reduje la duración del resaltado a `1000ms` (1s). (CSS y temporización en `public/jugarcartones.html`).
- Centropagos: añadí detección de registros de cuenta especial (`tipoRegistro === 'FONDO_ESPECIAL_SORTEO'` o `rolInterno === 'fondo_especial'`), muestro alias/nombre visible en la columna Usuario en vez del correo/ID interno y marco las filas con clase `registro-cuenta-especial` para aplicar color azul en las columnas Usuario, Créditos y Fecha; cambios en `public/centropagos.html` (función `esRegistroCuentaEspecial`, renderizado de tabla y reglas CSS).
- Mantengo el filtrado por sorteo existente: las funciones de filtro por selector de sorteo no fueron alteradas y siguen aplicando la visión por sorteo en premios/pagos.
- Rama y commit: cambios realizados en la rama `fix/jugarcartones-centropagos-ajustes` y commit con mensaje `fix(ui): ajusta azar de cartones y visualización de cuentas especiales en centro de pagos`.

### Testing
- Ejecuté `npm test`; todos los tests automáticos pasaron: `11 suites, 35 tests` (estado: PASS). (Comando ejecutado: `npm test` — Resultado: PASS).
- Verifiqué localmente que los archivos modificados son `public/jugarcartones.html` y `public/centropagos.html` y que no se tocan reglas de Firestore ni backends.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ca01e0748326b59dbec63b88f5cf)