### PR TITLE
fix(referidos): usar dominio correcto de registro en enlaces de referidos

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -1959,8 +1959,9 @@
     }catch(err){
       console.error('No se pudo obtener la campaña activa', err);
     }
+    const REGISTRO_BASE_URL = 'https://www.bingo-juega-online.com/registrarse';
     if(!campana){
-      const registroUrl = 'https://bingoanimalito.juega-online.com/registrarse.html';
+      const registroUrl = REGISTRO_BASE_URL;
       const mensaje = `Epale! estoy jugando a ${APP_NOMBRE}, y es un vasilón! 🤩 si entras en este link: ${registroUrl} 👈 te registras, y al jugar ¡Puedes ganar muchos PREMIOS!`;
       const enlace = `https://wa.me/?text=${encodeURIComponent(mensaje)}`;
       window.location.href = enlace;
@@ -1977,7 +1978,7 @@
     }catch(err){
       console.error('No se pudo obtener la campaña activa', err);
     }
-    const registroUrl = `https://bingoanimalito.juega-online.com/registrarse.html?codigo=${encodeURIComponent(codigo)}`;
+    const registroUrl = `${REGISTRO_BASE_URL}?codigo=${encodeURIComponent(codigo)}`;
     const mensaje = `Epale! estoy jugando a ${APP_NOMBRE}, y es un vasilón! 🤩 si entras en este link: ${registroUrl} 👈 y te registras usando mi código ${codigo} te regalarán ${cartonesNuevo} cartones para que juegues GRATIS!`;
     const enlace = `https://wa.me/?text=${encodeURIComponent(mensaje)}`;
     window.location.href = enlace;


### PR DESCRIPTION
### Motivation
- Corregir enlaces de referidos que apuntaban al dominio antiguo (`bingoanimalito.juega-online.com/registrarse.html`) para garantizar que los usuarios lleguen al flujo de registro correcto en el dominio actual.

### Description
- Se actualizó `public/player.html` para centralizar la URL de registro en la constante `REGISTRO_BASE_URL = 'https://www.bingo-juega-online.com/registrarse'` y se usó en ambos flujos de compartir por WhatsApp (sin campaña y con campaña añadiendo `?codigo=`).

### Testing
- Ejecuté `npm test` y todas las suites automatizadas pasaron correctamente (11 suites, 35 tests, PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d9805a408326afee0173c6a0ad3f)