### PR TITLE
fix(cantos): mejora autoazar, toasts y legibilidad del cartón destacado

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -77,6 +77,14 @@
       #salir-btn { width: 40px; }
       #salir-btn .label { display: none; }
       #detalle-container { margin-left: 5px; margin-right: 5px; }
+      #acciones-sorteo {
+        padding-top: 48px;
+      }
+      #auto-canto-btn {
+        top: 8px;
+        right: 8px;
+        min-width: 100px;
+      }
     }
     #sorteo-btn {
       width: 240px;
@@ -376,6 +384,7 @@
       justify-content: center;
       gap: 8px;
       flex-wrap: wrap;
+      position: relative;
     }
     #acciones-sorteo {
       margin-top: 14px;
@@ -384,6 +393,9 @@
       align-items: flex-end;
       gap: 12px;
       flex-wrap: wrap;
+      position: relative;
+      padding: 40px 8px 0;
+      min-height: 96px;
     }
     #modo-toggle-container {
       display: inline-flex;
@@ -484,19 +496,41 @@
       background: linear-gradient(165deg,#1d4ed8,#60a5fa);
       color: #fff;
       font-size: 0.8rem;
-      padding: 6px 10px;
+      padding: 7px 12px;
       min-height: 34px;
       display: inline-flex;
       align-items: center;
       gap: 6px;
       cursor: pointer;
       box-shadow: 0 4px 12px rgba(0,0,0,.2);
+      width: max-content;
+      min-width: 104px;
+      white-space: nowrap;
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      z-index: 4;
+      transition: transform .25s ease, box-shadow .25s ease, filter .25s ease, opacity .2s ease;
     }
     #auto-canto-btn:disabled { opacity:.55; cursor:not-allowed; }
-    #auto-canto-btn .dado-icon { display:inline-flex; transform-origin:center; }
+    #auto-canto-btn .dado-icon {
+      display:inline-flex;
+      transform-origin:center;
+      font-size: 1.3rem;
+      line-height: 1;
+    }
+    #auto-canto-btn.activo {
+      animation: autoCantoPulso 1.2s ease-in-out infinite;
+      box-shadow: 0 8px 20px rgba(29, 78, 216, .45);
+      filter: saturate(1.12);
+    }
     #auto-canto-btn.activo .dado-icon { animation: giroDado 2.8s linear infinite; }
-    .auto-canto-label { font-family: "Bangers", cursive; letter-spacing: .6px; font-size: 1rem; }
+    .auto-canto-label { font-family: "Bangers", cursive; letter-spacing: .6px; font-size: 1rem; line-height: 1; }
     @keyframes giroDado { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }
+    @keyframes autoCantoPulso {
+      0%, 100% { transform: scale(1); }
+      50% { transform: scale(1.08); }
+    }
     .estado-btn img,
     .estado-btn svg { width: 24px; height: 24px; }
     .estado-btn .pdf-floating-icon {
@@ -1075,18 +1109,31 @@
       left: 50%;
       transform: translateX(-50%);
       z-index: 1900;
-      background: rgba(17,24,39,.94);
       color: #fff;
-      border-radius: 10px;
-      padding: 10px 16px;
-      box-shadow: 0 10px 22px rgba(0,0,0,.28);
+      border-radius: 14px;
+      padding: 11px 16px;
+      box-shadow: 0 12px 24px rgba(0,0,0,.34);
+      border: 1px solid rgba(255,255,255,.28);
+      backdrop-filter: blur(6px);
       opacity: 0;
       pointer-events: none;
       transition: opacity .25s ease, transform .25s ease;
       font-weight: 600;
+      max-width: min(92vw, 460px);
+      text-align: center;
+      letter-spacing: .25px;
+      font-size: clamp(.84rem, 2.4vw, 1rem);
     }
-    #toast-canto-azar { bottom: 16px; transform: translate(-50%, 22px);}
-    #toast-ganador-forma { top: 14px; transform: translate(-50%, -20px); background: rgba(22,101,52,.95);}
+    #toast-canto-azar {
+      bottom: 16px;
+      transform: translate(-50%, 22px);
+      background: linear-gradient(145deg, rgba(30,64,175,.96), rgba(59,130,246,.95));
+    }
+    #toast-ganador-forma {
+      top: 14px;
+      transform: translate(-50%, -20px);
+      background: linear-gradient(145deg, rgba(22,101,52,.97), rgba(34,197,94,.94));
+    }
     #toast-canto-azar.visible, #toast-ganador-forma.visible { opacity: 1; }
     #toast-canto-azar.visible { transform: translate(-50%, 0);}
     #toast-ganador-forma.visible { transform: translate(-50%, 0);}
@@ -1728,7 +1775,7 @@
     </div>
   </section>
   <section id="detalle-container">
-    <div id="sorteo-nombre-row"><div id="sorteo-nombre">Selecciona un sorteo para ver los detalles</div><button id="auto-canto-btn" type="button" title="Cantos automáticos al azar" aria-label="Cantos automáticos al azar" disabled><span class="dado-icon" aria-hidden="true">🎲</span><span class="auto-canto-label">Cantar</span></button></div>
+    <div id="sorteo-nombre-row"><div id="sorteo-nombre">Selecciona un sorteo para ver los detalles</div></div>
     <div id="estado-actual">
       <span id="tipo-estado" class="tipo-estado"></span>
       <span class="estado-etiqueta">ESTADO:</span>
@@ -1745,6 +1792,7 @@
       <div id="tipo-sorteo"></div>
     </div>
     <div id="acciones-sorteo">
+      <button id="auto-canto-btn" type="button" title="Cantos automáticos al azar" aria-label="Cantos automáticos al azar" disabled><span class="dado-icon" aria-hidden="true">🎲</span><span class="auto-canto-label">CANTAR</span></button>
       <button id="sellar-btn" class="estado-btn" title="Sellar sorteo">
         <span class="stop-icon">STOP</span>
       </button>
@@ -2090,6 +2138,7 @@
   let toastCantoAzarTimer = null;
   let toastGanadorTimer = null;
   let formasGanadorasNotificadas = new Set();
+  let contadorToastGanadorPorForma = new Map();
   let evaluandoCantoActual = false;
   const advertenciasGanadorSinEmail = new Set();
   function manejarAceptarConfirmacionCanto(){
@@ -2141,6 +2190,17 @@
     toastGanadorTimer = setTimeout(()=>{
       toastGanadorFormaEl.classList.remove('visible');
     }, 2000);
+  }
+
+  function registrarToastGanadorForma(idx){
+    const actual = Number(contadorToastGanadorPorForma.get(idx) || 0);
+    const siguiente = actual + 1;
+    contadorToastGanadorPorForma.set(idx, siguiente);
+    return siguiente;
+  }
+
+  function puedeMostrarToastGanadorForma(idx){
+    return Number(contadorToastGanadorPorForma.get(idx) || 0) < 3;
   }
 
   function mostrarAvisoSimple(mensaje, titulo = 'Aviso'){
@@ -3904,11 +3964,12 @@
       }
     });
     formasConGanadorActual.forEach(idx=>{
-      if(!formasGanadorasNotificadas.has(idx)){
+      if(!formasGanadorasNotificadas.has(idx) && puedeMostrarToastGanadorForma(idx)){
         const forma = formasActivas.find(item=>Number(item?.idx) === idx);
         const nombreForma = (forma?.nombre || '').toString().trim();
         const etiqueta = nombreForma ? `Forma ${String(idx).padStart(2,'0')} - ${nombreForma}` : `Forma ${String(idx).padStart(2,'0')}`;
         mostrarToastGanador(`Hay ganador en ${etiqueta}`);
+        registrarToastGanadorForma(idx);
         formasGanadorasNotificadas.add(idx);
       }
     });
@@ -4680,6 +4741,12 @@
   function actualizarEstadoBotonAutoCanto(){
     if(!autoCantoBtn) return;
     const habilitado = obtenerEstadoActualNormalizado() === 'jugando';
+    const etiquetaEl = autoCantoBtn.querySelector('.auto-canto-label');
+    const textoBoton = autoCantoAzarActivo ? 'CANTANDO' : 'CANTAR';
+    if(etiquetaEl){
+      etiquetaEl.textContent = textoBoton;
+    }
+    autoCantoBtn.setAttribute('aria-label', autoCantoAzarActivo ? 'Desactivar cantos automáticos al azar' : 'Activar cantos automáticos al azar');
     autoCantoBtn.disabled = !habilitado;
     autoCantoBtn.classList.toggle('activo', autoCantoAzarActivo);
   }
@@ -5355,6 +5422,7 @@
     indiceUltimoGanador = null;
     notificacionComplementariosMostrada = false;
     formasGanadorasNotificadas.clear();
+    contadorToastGanadorPorForma.clear();
     cantosInicializados = false;
     mostrarComplementariosPendiente = false;
     evaluandoCantoActual = false;

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -1055,11 +1055,11 @@
           top: 50%;
           left: 50%;
           transform: translate(-50%, -50%) scale(0.9);
-          background: linear-gradient(145deg, rgba(255,255,255,0.98), rgba(230,255,238,0.96));
+          background: linear-gradient(145deg, rgba(255,255,255,0.98), rgba(220,252,231,0.96));
           border-radius: 18px;
           padding: 10px 14px;
-          box-shadow: 0 14px 32px rgba(0,0,0,0.26);
-          border: 2px solid rgba(0,200,83,0.6);
+          box-shadow: 0 16px 34px rgba(0,0,0,0.3);
+          border: 2px solid rgba(34,197,94,0.62);
           display: none;
           flex-direction: column;
           gap: 10px;
@@ -1081,12 +1081,13 @@
           color: #1a1a1a;
           font-weight: 700;
           font-family: 'Poppins', sans-serif;
+          letter-spacing: .35px;
       }
       .ultimo-canto-popup .popup-numero {
           font-family: 'Poppins', sans-serif;
           font-size: clamp(1.6rem, 4.8vw, 2.4rem);
-          color: #003a87;
-          text-shadow: 0 0 18px rgba(0,255,120,0.8);
+          color: #0b3b8f;
+          text-shadow: 0 0 16px rgba(52,211,153,0.72);
           animation: zoomPulse 1.6s ease-in-out infinite;
           font-weight: 700;
       }
@@ -1094,7 +1095,7 @@
           padding: 6px 18px;
           border-radius: 999px;
           border: none;
-          background: linear-gradient(135deg, rgba(0,200,83,0.92), rgba(0,150,60,0.96));
+          background: linear-gradient(135deg, rgba(22,163,74,0.95), rgba(21,128,61,0.96));
           color: #ffffff;
           font-weight: 600;
           cursor: pointer;
@@ -1218,7 +1219,7 @@
           color: #4a1f00;
       }
       .ultimo-canto-popup.complementarios-activos {
-          background: linear-gradient(145deg, rgba(255,255,255,0.98), rgba(255,228,196,0.95));
+          background: linear-gradient(145deg, rgba(255,252,243,0.98), rgba(255,220,168,0.95));
           border-color: rgba(255,145,0,0.7);
       }
       .ultimo-canto-popup.complementarios-activos .popup-numero {
@@ -2403,9 +2404,12 @@
           font-weight: 700;
           text-shadow: 0 0 6px rgba(255,255,255,0.9);
           letter-spacing: 0.5px;
-          font-size: clamp(0.85rem, 2.4vw, 1.15rem);
+          font-size: calc(clamp(0.82rem, calc(var(--principal-cell-size, var(--cell-size)) * 0.34), 1.14rem) * var(--numero-carton-scale, 1));
           line-height: 1.05;
           word-break: keep-all;
+          max-width: 92%;
+          white-space: nowrap;
+          overflow: hidden;
       }
       .carton-tabla .estrella {
           font-size: 1.2em;
@@ -3488,7 +3492,7 @@
               text-align: center;
           }
           #carton-destacado .carton-tabla--principal td.free .cell-content.numero-carton {
-              font-size: clamp(0.9rem, calc(var(--destacado-cell-size) * 0.24), 1.18rem);
+              font-size: calc(clamp(0.9rem, calc(var(--destacado-cell-size) * 0.24), 1.18rem) * var(--numero-carton-scale, 1));
           }
           #cantos-conducto-grid {
               width: min(100%, calc(var(--canto-cell-size) * 5.08));
@@ -4005,7 +4009,7 @@
               line-height: 1.05;
           }
           #carton-destacado .carton-tabla--principal td.free .cell-content.numero-carton {
-              font-size: clamp(0.72rem, calc(var(--destacado-cell-size) * 0.22), 0.98rem);
+              font-size: calc(clamp(0.72rem, calc(var(--destacado-cell-size) * 0.22), 0.98rem) * var(--numero-carton-scale, 1));
               letter-spacing: 0.4px;
           }
           #carton-destacado .carton-back-total {
@@ -8469,6 +8473,16 @@
           if(modo==='principal'){
             icono.classList.add('numero-carton');
             icono.textContent=numeroCartonCentral && numeroCartonCentral!=='--'?numeroCartonCentral:'★';
+            const longitudNumero = icono.textContent.trim().length;
+            let escalaNumero = 1;
+            if(longitudNumero >= 5){
+              escalaNumero = 0.7;
+            }else if(longitudNumero === 4){
+              escalaNumero = 0.8;
+            }else if(longitudNumero === 3){
+              escalaNumero = 0.9;
+            }
+            icono.style.setProperty('--numero-carton-scale', String(escalaNumero));
           }else{
             icono.textContent='★';
           }


### PR DESCRIPTION
### Motivation
- Mejorar la UX del modo de cantos automáticos desplazando el botón al contenedor de acciones y dar feedback visual claro (texto y animación) cuando el modo azar está activo.
- Evitar la repetición excesiva de notificaciones de ganador por forma limitando su aparición para reducir ruido durante el juego.
- Aumentar la legibilidad del número central del cartón destacado en `juegoactivo` mediante escalado dinámico para adaptarse a distintos tamaños y dispositivos.
- Refinar la presentación de popups/toasts (números cantados y ganadores) para una apariencia más coherente y legible sin cambiar lógica de datos ni reglas de seguridad.

### Description
- Reubiqué el botón de auto-canto dentro del bloque de acciones (`public/cantarsorteos.html`) y apliqué estilos para anclarlo en la esquina superior derecha con ancho dinámico, márgenes pequeños y responsive para portrait; el icono del dado se aumentó con `font-size` sin alterar el tamaño externo del botón y se agregó una animación de pulso cuando está activo.
- Cambié la etiqueta del botón dinámicamente en `actualizarEstadoBotonAutoCanto` para mostrar `CANTAR` / `CANTANDO` según `autoCantoAzarActivo` y actualicé el `aria-label` correspondiente.
- Implementé un contador por forma (`contadorToastGanadorPorForma` / `registrarToastGanadorForma` / `puedeMostrarToastGanadorForma`) en `public/cantarsorteos.html` que limita a 3 la cantidad de toasts de ganador mostrados por cada forma y se limpia al reiniciar los datos del sorteo; la llamada a `mostrarToastGanador` ahora está condicionada por este contador.
- Mejoré estilos de los toasts y del popup de último canto (gradientes, borde, `backdrop-filter`, tamaño máximo, tipografía y sombras) en `public/cantarsorteos.html` y `public/juegoactivo.html` para mayor contraste y consistencia visual.
- Hice que el número central del cartón destacado escale dinámicamente: añadí la variable CSS `--numero-carton-scale` aplicada al `font-size` calculado y lógica en la generación del DOM del cartón en `public/juegoactivo.html` que ajusta la escala según la longitud del número central (3,4,>=5 dígitos) para mantener legibilidad.
- Aseguré que el contador de toasts por forma se reinicie en `reiniciarDatosJuego` para no persistir entre sorteos.

### Testing
- Ejecuté `npm test` y todas las pruebas automatizadas pasaron: `11` suites, `35` tests — `PASS`.
- No se hicieron cambios en backend ni en reglas de Firestore, por lo que las pruebas existentes cubren integridad del proyecto y no se produjeron fallos en CI local (`npm test` ✅).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ae75aca883268fbb1b3e4b172854)