### PR TITLE
fix(cantarsorteos): centrar botón CANTAR debajo de las acciones

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -78,11 +78,7 @@
       #salir-btn .label { display: none; }
       #detalle-container { margin-left: 5px; margin-right: 5px; }
       #acciones-sorteo {
-        padding-top: 48px;
-      }
-      #auto-canto-btn {
-        top: 8px;
-        right: 8px;
+        padding-top: 0;
         min-width: 100px;
       }
     }
@@ -390,12 +386,12 @@
       margin-top: 14px;
       display: flex;
       justify-content: center;
-      align-items: flex-end;
+      align-items: center;
       gap: 12px;
       flex-wrap: wrap;
       position: relative;
-      padding: 40px 8px 0;
-      min-height: 96px;
+      padding: 0 8px;
+      min-height: 0;
     }
     #modo-toggle-container {
       display: inline-flex;
@@ -506,10 +502,9 @@
       width: max-content;
       min-width: 104px;
       white-space: nowrap;
-      position: absolute;
-      top: 6px;
-      right: 6px;
-      z-index: 4;
+      order: 99;
+      flex-basis: 100%;
+      margin: 5px auto;
       transition: transform .25s ease, box-shadow .25s ease, filter .25s ease, opacity .2s ease;
     }
     #auto-canto-btn:disabled { opacity:.55; cursor:not-allowed; }


### PR DESCRIPTION
### Motivation
- Mejorar la visualización en la ventana `cantarsorteos` colocando el botón de cantos automáticos (`CANTAR`) centrado debajo de los botones de acción con márgenes verticales estrechos (~5px), para evitar que esté anclado en la esquina y mejorar la lectura del contenedor.

### Description
- Se modificó `public/cantarsorteos.html` (CSS) eliminando el posicionamiento absoluto del botón `#auto-canto-btn` y su offset en la esquina; ahora usa `order: 99`, `flex-basis: 100%` y `margin: 5px auto` para renderizarse centrado y en una nueva línea debajo de los botones de acción.
- Se ajustó el contenedor `#acciones-sorteo` para usar `align-items: center`, `padding: 0 8px` y `min-height: 0` en lugar del espacio reservado superior anterior, y en `@media (orientation: portrait)` se removió el `padding-top`/offset previo (`padding-top: 0`).
- Cambios enfocados únicamente a estilos; no se tocó lógica JavaScript, reglas de Firestore, endpoints ni contratos de datos.

### Testing
- Ejecutado: `npm test` — Resultado: PASS (11 suites, 35 tests).
- Verificación manual recomendada por reviewer: abrir `cantarsorteos.html` y confirmar que el botón `CANTAR` aparece centrado debajo de la fila de acciones en desktop y en vista portrait.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b5785f6c8326b1c717e80d15759a)