### PR TITLE
fix(configuracion): carga robusta de parámetros y toasts solo en sorteo jugando

### DIFF
--- a/public/cantarsorteos.html
+++ b/public/cantarsorteos.html
@@ -2215,6 +2215,7 @@
   }
 
   function mostrarToastGanador(mensaje){
+    if(obtenerEstadoActualNormalizado() !== 'jugando') return;
     if(!toastGanadorFormaEl) return;
     toastGanadorFormaEl.textContent = mensaje;
     toastGanadorFormaEl.classList.add('visible');
@@ -3999,8 +4000,9 @@
         if(paso > pasoMaximo) pasoMaximo = paso;
       }
     });
+    const sorteoJugando = obtenerEstadoActualNormalizado() === 'jugando';
     formasConGanadorActual.forEach(idx=>{
-      if(!formasGanadorasNotificadas.has(idx) && puedeMostrarToastGanadorForma(idx)){
+      if(sorteoJugando && !formasGanadorasNotificadas.has(idx) && puedeMostrarToastGanadorForma(idx)){
         const forma = formasActivas.find(item=>Number(item?.idx) === idx);
         const nombreForma = (forma?.nombre || '').toString().trim();
         const etiqueta = nombreForma ? `Forma ${String(idx).padStart(2,'0')} - ${nombreForma}` : `Forma ${String(idx).padStart(2,'0')}`;

--- a/public/configuraciones.html
+++ b/public/configuraciones.html
@@ -1705,6 +1705,41 @@
     function construirListadoWhatsapp(){
       return numerosWhatsappList.map(item=>valorCompuestoNumero(item)).filter(Boolean);
     }
+    function extraerListaWhatsapp(rawLista){
+      if(!Array.isArray(rawLista)) return [];
+      return rawLista
+        .map(item=>{
+          if(typeof item === 'string' || typeof item === 'number'){
+            return normalizarNumeroWhatsapp(item);
+          }
+          if(item && typeof item === 'object'){
+            const prefijo = normalizarNumeroWhatsapp(item.prefijo ?? item.codigo ?? item.code ?? '');
+            const local = (item.local ?? item.numero ?? item.phone ?? item.telefono ?? '').toString().replace(/\D/g,'');
+            return normalizarNumeroWhatsapp(`${prefijo}${local}`);
+          }
+          return '';
+        })
+        .filter(Boolean);
+    }
+    function obtenerNumeroDesdeParametros(data){
+      return normalizarNumeroWhatsapp(
+        data.numeroWhatsapp
+        ?? data.numero_whatsapp
+        ?? data.numeroWhatsappAplicacion
+        ?? data.whatsappNumero
+        ?? ''
+      );
+    }
+    function obtenerEnteroNoNegativoDesdeClaves(data,claves){
+      for(const clave of claves){
+        if(!(clave in data)) continue;
+        const valor = Number(data[clave]);
+        if(Number.isFinite(valor)){
+          return Math.max(0, Math.floor(valor));
+        }
+      }
+      return 0;
+    }
     function marcarFilaSeleccionada(valor){
       if(!tablaWhatsapp) return;
       const filas=tablaWhatsapp.querySelectorAll('tr[data-valor]');
@@ -1887,9 +1922,9 @@
           if(nombreApp){
             etiquetaNumeroWhatsapp.textContent=`Número WhatsApp para ${nombreApp}`;
           }
-          const listaGuardada=Array.isArray(data.numerosWhatsapp)?data.numerosWhatsapp:[];
-          const numeroGuardado=normalizarNumeroWhatsapp(data.numeroWhatsapp??data.numero_whatsapp??'');
-          const listaNormalizada=listaGuardada.length>0?listaGuardada.map(normalizarNumeroWhatsapp):[];
+          const listaGuardada=extraerListaWhatsapp(data.numerosWhatsapp);
+          const numeroGuardado=obtenerNumeroDesdeParametros(data);
+          const listaNormalizada=listaGuardada.length>0?listaGuardada:[];
           const baseLista=listaNormalizada.length>0?listaNormalizada:[numeroGuardado].filter(Boolean);
           numerosWhatsappList=baseLista.map(valor=>{
             const {prefijo,local}=descomponerNumeroWhatsapp(valor);
@@ -1901,17 +1936,22 @@
           numeroSeleccionado=numeroGuardado|| (numerosWhatsappList[0] ? `${numerosWhatsappList[0].prefijo}${numerosWhatsappList[0].local}` : '');
           renderDropdownWhatsapp();
           registrarEstadoBaseWhatsapp(baseLista.length>0?baseLista:numerosWhatsappList.map(valorCompuestoNumero));
-          const linkGuardado=data.linkWhatsapp??data.linkwhatsapp??'';
-          if(linkGuardado){
-            campoLinkWhatsapp.value=linkGuardado;
-          }
-          const segundosCierre = Number(data.segundosCierreCantos ?? data.segundosParaCierreCantos ?? data.cierreCantosSegundos ?? data.duracionCantoManualSegundos ?? data.tiempoCantoManualSegundos ?? data.manualBingoDuracionSegundos ?? 0);
+          const linkGuardado=(data.linkWhatsapp??data.linkwhatsapp??data.link_whatsapp??'').toString().trim();
+          campoLinkWhatsapp.value=linkGuardado;
+          const segundosCierre = obtenerEnteroNoNegativoDesdeClaves(data,[
+            'segundosCierreCantos','segundosParaCierreCantos','cierreCantosSegundos',
+            'duracionCantoManualSegundos','tiempoCantoManualSegundos','manualBingoDuracionSegundos',
+            'segundos_cierre_cantos'
+          ]);
           if(campoSegundosCierreCantos){
-            campoSegundosCierreCantos.value = Number.isFinite(segundosCierre) && segundosCierre >= 0 ? String(Math.floor(segundosCierre)) : '0';
+            campoSegundosCierreCantos.value = String(segundosCierre);
           }
-          const segundosAzar = Number(data.segundosIntervaloCantoAzar ?? data.intervaloCantoAzarSegundos ?? data.segundosCantoAzar ?? 0);
+          const segundosAzar = obtenerEnteroNoNegativoDesdeClaves(data,[
+            'segundosIntervaloCantoAzar','intervaloCantoAzarSegundos','segundosCantoAzar',
+            'segundos_intervalo_canto_azar'
+          ]);
           if(campoSegundosIntervaloCantoAzar){
-            campoSegundosIntervaloCantoAzar.value = Number.isFinite(segundosAzar) && segundosAzar >= 0 ? String(Math.floor(segundosAzar)) : '0';
+            campoSegundosIntervaloCantoAzar.value = String(segundosAzar);
           }
           const linkPublicidadPrimario=(data.linkPublicidadSorteos1??data.linkPublicidadSorteos??data.linkpublicidadsorteos??data.linkPublicidad??'').toString();
           const linkPublicidadSecundario=(data.linkPublicidadSorteos2??data.linkpublicidadsorteos2??data.linkPublicidad2??'').toString();


### PR DESCRIPTION
### Motivation
- Resolver que en la ventana de Configuraciones no se mostraban valores guardados para el número de WhatsApp (dropdown), link de grupo y los campos de segundos de cierre/intervalo por variantes históricas de las claves y formatos en `Variablesglobales/Parametros`.
- Evitar que las notificaciones tipo toast de "formas ganadoras" aparezcan al refrescar la vista cuando el sorteo está en estado `finalizado`, mostrando esos toasts solo mientras el sorteo está `jugando`.
- Mantener cambios mínimos y con bajo impacto, sin tocar contratos de Firestore ni reglas de seguridad.

### Description
- Añadidas utilidades en `public/configuraciones.html`: `extraerListaWhatsapp`, `obtenerNumeroDesdeParametros` y `obtenerEnteroNoNegativoDesdeClaves` para normalizar listas heterogéneas de números y diferentes aliases de claves numéricas.
- Mejorada la función `cargarParametrosWhatsapp()` en `public/configuraciones.html` para poblar correctamente: el dropdown de número (`numero-whatsapp`), el campo `link-whatsapp`, `segundos-cierre-cantos` y `segundos-intervalo-canto-azar` usando múltiples aliases y normalización robusta.
- Ajustada la lógica de toasts en `public/cantarsorteos.html`: se agregó una verificación en `mostrarToastGanador` y se condicionó el disparo de toasts dentro de `evaluarEstadoFormasGanadoras()` para que solo se muestren cuando `obtenerEstadoActualNormalizado() === 'jugando'`.
- Archivos modificados: `public/configuraciones.html` y `public/cantarsorteos.html`.

### Testing
- Ejecutado `npm test` y todas las suites pasaron: 11 suites, 35 tests (PASS).
- Resultado de comando: `npm test` → PASS (todas las pruebas unitarias locales exitosas).
- Recomendación de verificación manual tras deploy: comprobar en UI que el dropdown de WhatsApp y los campos de segundos se hidratan desde `Variablesglobales/Parametros` con documentos que usen claves legacy, y confirmar en `cantarsorteos.html` que los toasts de ganadores no aparecen al refrescar con sorteo `finalizado` pero sí cuando está `jugando`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7be8f48fc8326937442e45dd20ce5)