### PR TITLE
fix(ui): retirar controles de audio de usuario en vistas de juego

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -12,7 +12,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Juego Activo</title>
   <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/audioControls.css">
   <style>
       :root {
           --panel-bg: rgba(255, 255, 255, 0.88);
@@ -4494,43 +4493,7 @@
     </div>
   </div>
 
-  <div id="audio-control-game" class="audio-control audio-control--left">
-    <div class="audio-control__volume" hidden aria-hidden="true">
-      <div id="audio-status-game" class="audio-control__status" role="status" aria-live="polite">🔊 Audio activo</div>
-      <div class="audio-control__rows">
-        <div class="audio-control__row">
-          <label for="audio-volume-master-game">General</label>
-          <input id="audio-volume-master-game" class="audio-control__range" type="range" min="0" max="1" step="0.05" value="1" aria-label="Volumen general">
-          <span id="audio-value-master-game" class="audio-control__value">100%</span>
-        </div>
-        <div class="audio-control__row">
-          <label for="audio-volume-game">Música</label>
-          <input id="audio-volume-game" class="audio-control__range" type="range" min="0" max="1" step="0.05" value="0.22" aria-label="Volumen de música">
-          <span id="audio-value-game" class="audio-control__value">22%</span>
-        </div>
-        <div class="audio-control__row">
-          <label for="audio-volume-sfx-game">Efectos</label>
-          <input id="audio-volume-sfx-game" class="audio-control__range" type="range" min="0" max="1" step="0.05" value="1" aria-label="Volumen de efectos">
-          <span id="audio-value-sfx-game" class="audio-control__value">100%</span>
-        </div>
-      </div>
-      <div class="audio-control__actions">
-        <button id="audio-reset-game" class="audio-control__reset" type="button" aria-label="Restablecer audio a valores por defecto">Restablecer</button>
-      </div>
-    </div>
-    <button id="audio-toggle-game" class="audio-control__toggle" type="button" aria-pressed="true" aria-label="Activar o silenciar todo el audio">
-      <svg class="audio-control__icon audio-control__icon--on" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M4 10v4h4l5 4V6l-5 4H4z" fill="currentColor"></path>
-        <path d="M16.5 8.5a4.5 4.5 0 0 1 0 7" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"></path>
-        <path d="M18.8 6a7.5 7.5 0 0 1 0 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.8"></path>
-      </svg>
-      <svg class="audio-control__icon audio-control__icon--off" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M4 10v4h4l5 4V6l-5 4H4z" fill="currentColor"></path>
-        <path d="M18.5 8.5l-7 7" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
-        <path d="M11.5 8.5l7 7" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
-      </svg>
-    </button>
-  </div>
+
 
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-firestore-compat.js"></script>
@@ -4542,7 +4505,6 @@
   <script src="js/timezone.js"></script>
   <script src="js/audioManifest.js"></script>
   <script src="js/audioManager.js"></script>
-  <script src="js/audioControls.js"></script>
   <script src="js/serviceWorkerRegistration.js"></script>
   <script>
   ensureAuth();
@@ -4561,30 +4523,6 @@
   const sorteoResumenEl = document.getElementById('sorteo-resumen');
   const sorteoDetallesEl = document.getElementById('sorteo-detalles');
 
-  initBingoAudioControl({
-    containerId: 'audio-control-game',
-    toggleId: 'audio-toggle-game',
-    volumeId: 'audio-volume-game',
-    masterVolumeId: 'audio-volume-master-game',
-    sfxVolumeId: 'audio-volume-sfx-game',
-    resetId: 'audio-reset-game',
-    statusId: 'audio-status-game',
-    masterValueId: 'audio-value-master-game',
-    musicValueId: 'audio-value-game',
-    sfxValueId: 'audio-value-sfx-game',
-    musicManifestKey: 'music.backgroundMain',
-    defaultVolume: 0.22,
-    musicTrackId: 'game-background',
-    sfxEvents: {
-      winner: {
-        manifestKey: 'sfx.win',
-        critical: true,
-        duckAmount: 0.3,
-        duckDurationMs: 2200,
-        duckFadeMs: 260,
-      },
-    },
-  });
 
   const AUDIO_EVENTS = Object.freeze({
     DRAW_NUMBER: 'DRAW_NUMBER',

--- a/public/player.html
+++ b/public/player.html
@@ -17,7 +17,6 @@
   <title>Bingo Online</title>
   <!-- Fuentes -->
   <link href="https://fonts.googleapis.com/css2?family=Bangers&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="css/audioControls.css">
   <style>
      		
       body {
@@ -1191,43 +1190,7 @@
   <div id="fecha-hora"></div>
   <div id="derechos">Todos los derechos reservados ® Hexaservice <span class="current-year"></span></div>
 
-  <div id="audio-control-player" class="audio-control audio-control--right">
-    <div class="audio-control__volume" hidden aria-hidden="true">
-      <div id="audio-status-player" class="audio-control__status" role="status" aria-live="polite">🔊 Audio activo</div>
-      <div class="audio-control__rows">
-        <div class="audio-control__row">
-          <label for="audio-volume-master-player">General</label>
-          <input id="audio-volume-master-player" class="audio-control__range" type="range" min="0" max="1" step="0.05" value="1" aria-label="Volumen general">
-          <span id="audio-value-master-player" class="audio-control__value">100%</span>
-        </div>
-        <div class="audio-control__row">
-          <label for="audio-volume-player">Música</label>
-          <input id="audio-volume-player" class="audio-control__range" type="range" min="0" max="1" step="0.05" value="0.22" aria-label="Volumen de música">
-          <span id="audio-value-player" class="audio-control__value">22%</span>
-        </div>
-        <div class="audio-control__row">
-          <label for="audio-volume-sfx-player">Efectos</label>
-          <input id="audio-volume-sfx-player" class="audio-control__range" type="range" min="0" max="1" step="0.05" value="1" aria-label="Volumen de efectos">
-          <span id="audio-value-sfx-player" class="audio-control__value">100%</span>
-        </div>
-      </div>
-      <div class="audio-control__actions">
-        <button id="audio-reset-player" class="audio-control__reset" type="button" aria-label="Restablecer audio a valores por defecto">Restablecer</button>
-      </div>
-    </div>
-    <button id="audio-toggle-player" class="audio-control__toggle" type="button" aria-pressed="true" aria-label="Activar o silenciar todo el audio">
-      <svg class="audio-control__icon audio-control__icon--on" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M4 10v4h4l5 4V6l-5 4H4z" fill="currentColor"></path>
-        <path d="M16.5 8.5a4.5 4.5 0 0 1 0 7" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"></path>
-        <path d="M18.8 6a7.5 7.5 0 0 1 0 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.8"></path>
-      </svg>
-      <svg class="audio-control__icon audio-control__icon--off" viewBox="0 0 24 24" aria-hidden="true">
-        <path d="M4 10v4h4l5 4V6l-5 4H4z" fill="currentColor"></path>
-        <path d="M18.5 8.5l-7 7" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
-        <path d="M11.5 8.5l7 7" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
-      </svg>
-    </button>
-  </div>
+
 
   <!-- Importar el SDK de Firebase (compatibilidad para evitar problemas de CORS al abrir el archivo localmente) -->
   <script src="https://www.gstatic.com/firebasejs/11.5.0/firebase-app-compat.js"></script>
@@ -1284,7 +1247,6 @@
   <script src="js/timezone.js"></script>
   <script src="js/audioManifest.js"></script>
   <script src="js/audioManager.js"></script>
-  <script src="js/audioControls.js"></script>
   <script src="js/serviceWorkerRegistration.js"></script>
 <script>
 (function(){
@@ -2494,21 +2456,6 @@
     }
   }
 
-  initBingoAudioControl({
-    containerId: 'audio-control-player',
-    toggleId: 'audio-toggle-player',
-    volumeId: 'audio-volume-player',
-    masterVolumeId: 'audio-volume-master-player',
-    sfxVolumeId: 'audio-volume-sfx-player',
-    resetId: 'audio-reset-player',
-    statusId: 'audio-status-player',
-    masterValueId: 'audio-value-master-player',
-    musicValueId: 'audio-value-player',
-    sfxValueId: 'audio-value-sfx-player',
-    musicManifestKey: 'music.backgroundMain',
-    defaultVolume: 0.22,
-    musicTrackId: 'player-background',
-  });
 
   inicializarVistaJugador();
 })();


### PR DESCRIPTION
### Motivation
- Quitar únicamente la UI de controles de audio de usuario en `player.html` y `juegoactivo.html` para simplificar la interfaz sin afectar la reproducción de la transmisión en vivo.
- Mantener intactos los bloques y la lógica de `live-stream-*` para evitar regresiones en la reproducción del stream.
- Realizar un cambio mínimo y localizado respetando los flujos operativos y la arquitectura del proyecto (frontend estático + backend Express) descritos en `README.md`.

### Description
- Se eliminaron los bloques HTML de UI de audio de usuario (toggle, sliders, reset y estado visual) en `public/player.html` y `public/juegoactivo.html`.
- Se removió la carga de `css/audioControls.css` en ambas vistas porque dejó de ser necesaria tras quitar los controles visuales.
- Se removió la inclusión de `js/audioControls.js` y las llamadas a `initBingoAudioControl(...)` en ambos archivos para evitar referencias a elementos eliminados, mientras se conservaron `audioManifest.js` y `audioManager.js` para la reproducción programática y SFX.
- Se preservaron todas las referencias estructurales relacionadas con la transmisión en vivo (`live-stream-toggle`, `live-stream-window`, `live-stream-iframe`, permiso de audio del stream, etc.) para no provocar regresiones en el stream.

### Testing
- Ejecutado `npm test` y todos los suites pasaron: `PASS` (11 suites, 35 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e806daa4d0832697d8f7f8019a13d4)