### PR TITLE
fix(audio): deshabilita initBingoAudioControl manteniendo compatibilidad

### DIFF
--- a/public/js/audioControls.js
+++ b/public/js/audioControls.js
@@ -14,6 +14,10 @@
     consent: 'audio:enabledByUser',
   });
 
+  const DEPRECATED_STORAGE_KEYS = Object.freeze([
+    STORAGE_KEYS.consent,
+  ]);
+
   function clamp01(value, fallback) {
     const parsed = Number(value);
     if (!Number.isFinite(parsed)) return fallback;
@@ -35,6 +39,12 @@
   function guardarConsentimientoAudio() {
     try {
       localStorage.setItem(STORAGE_KEYS.consent, 'true');
+    } catch (_) {}
+  }
+
+  function limpiarClavesObsoletasAudio() {
+    try {
+      DEPRECATED_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key));
     } catch (_) {}
   }
 
@@ -165,6 +175,19 @@
 
   function initBingoAudioControl(config) {
     if (!config || !window.audioManager) return;
+
+    // Inicialización de controles deshabilitada temporalmente.
+    // Conservamos la API pública para compatibilidad con páginas existentes.
+    limpiarClavesObsoletasAudio();
+    const estado = leerEstadoAudio();
+    try {
+      window.audioManager.setVolume('master', estado.masterVolume);
+      window.audioManager.setVolume('music', estado.musicVolume);
+      window.audioManager.setVolume('sfx', estado.sfxVolume);
+      window.audioManager.setMuted(estado.muted);
+    } catch (_) {}
+    window.bingoAudioState = estado;
+    return;
 
     const {
       containerId,


### PR DESCRIPTION
### Motivation
- Evitar que la UI/logic legacy de controles de audio monte listeners y elementos DOM mientras se avanza a una nueva implementación de audio.  
- Mantener la compatibilidad con llamadas existentes para que las páginas que aún invocan `initBingoAudioControl` no fallen y sigan teniendo acceso al estado de audio persistido.

### Description
- Se añadió `DEPRECATED_STORAGE_KEYS` y la función `limpiarClavesObsoletasAudio()` que elimina de forma segura claves de `localStorage` obsoletas (actualmente `audio:enabledByUser`).
- `initBingoAudioControl(config)` ahora realiza un retorno temprano: limpia las claves obsoletas, carga el estado persistido mediante `leerEstadoAudio()`, intenta aplicar volúmenes/mute sobre `window.audioManager` y expone `window.bingoAudioState`, pero no monta la UI ni los listeners legacy; la API pública `window.initBingoAudioControl` se conserva para compatibilidad.
- No se eliminan otras APIs públicas (por ejemplo `window.reproducirSonidoGanador`) ni se tocan reglas de Firestore/Storage ni secretos en el repositorio.
- Riesgo e impacto: cambio acotado y de bajo riesgo al frontend estático; si se requiere rollback basta con restaurar la lógica previa en `initBingoAudioControl`.

### Testing
- Ejecutado `npm test` y todas las suites pasaron: `PASS` (11 suites, 35 tests) con el comando `npm test` (resultado: todas las pruebas unitarias en verde).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e809e7ecd0832687b55ac26a1524ad)