### PR TITLE
chore(audio): agrega capa compat para audioManager

### DIFF
--- a/public/js/audioManagerCompat.js
+++ b/public/js/audioManagerCompat.js
@@ -1,0 +1,49 @@
+(function () {
+  function getManifestNode(path) {
+    if (!path) return null;
+    const manifest = window.BINGO_AUDIO_MANIFEST || null;
+    if (!manifest) return null;
+
+    return String(path)
+      .split('.')
+      .reduce((acc, segment) => (acc && acc[segment] ? acc[segment] : null), manifest);
+  }
+
+  function createAudioManagerStub() {
+    return {
+      audioContext: null,
+      autoplayBlocked: false,
+      registerMusicTrack() {},
+      registerSfxEvent() {},
+      setVolume() {},
+      setMuted() {},
+      toggleMute() {
+        return false;
+      },
+      async probeAutoplayState() {
+        return true;
+      },
+      async ensureRunningContext() {
+        return true;
+      },
+      async playMusic() {
+        return null;
+      },
+      async playSfx() {
+        return null;
+      },
+      isAutoplayBlocked() {
+        return false;
+      },
+      getManifestNode,
+    };
+  }
+
+  window.createAudioManagerStub = window.createAudioManagerStub || createAudioManagerStub;
+
+  if (!window.audioManager) {
+    window.audioManager = createAudioManagerStub();
+  } else if (typeof window.audioManager.getManifestNode !== 'function') {
+    window.audioManager.getManifestNode = getManifestNode;
+  }
+})();

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4505,6 +4505,7 @@
   <script src="js/timezone.js"></script>
   <script src="js/audioManifest.js"></script>
   <script src="js/audioManager.js"></script>
+  <script src="js/audioManagerCompat.js"></script>
   <script src="js/serviceWorkerRegistration.js"></script>
   <script>
   ensureAuth();

--- a/public/player.html
+++ b/public/player.html
@@ -1247,6 +1247,7 @@
   <script src="js/timezone.js"></script>
   <script src="js/audioManifest.js"></script>
   <script src="js/audioManager.js"></script>
+  <script src="js/audioManagerCompat.js"></script>
   <script src="js/serviceWorkerRegistration.js"></script>
 <script>
 (function(){


### PR DESCRIPTION
### Motivation
- Evitar roturas en páginas legacy durante la migración del motor de audio manteniendo `public/sonidos/` y `public/js/audioManifest.js` como fuente de verdad y proveyendo una capa mínima compatible para `audioManager`.

### Description
- Se añadió `public/js/audioManagerCompat.js`, un stub/adaptador que expone `window.audioManager` con métodos no-op y `getManifestNode` para leer `window.BINGO_AUDIO_MANIFEST`, y se incluyó justo después de `js/audioManager.js` en `public/player.html` y `public/juegoactivo.html`; rollback: revertir el cambio o eliminar la inclusión del script.

### Testing
- Ejecutado `npm test` → PASS (11 suites, 35 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80e398a74832683d95580fd4d8b40)