### PR TITLE
fix(sw): prioriza red para audios en /sonidos y elimina caché obsoleta

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -46,8 +46,9 @@ self.addEventListener('activate', (event) => {
 
 function isAudioRequest(request) {
   const url = new URL(request.url);
+  if (!url.pathname.startsWith('/sonidos/')) return false;
   if (request.destination === 'audio') return true;
-  return /\.(mp3|ogg|wav)(\?|$)/i.test(url.pathname);
+  return /\.wav(\?|$)/i.test(url.pathname);
 }
 
 self.addEventListener('fetch', (event) => {
@@ -75,9 +76,6 @@ self.addEventListener('fetch', (event) => {
 
   event.respondWith(
     caches.open(AUDIO_CACHE).then(async (cache) => {
-      const cached = await cache.match(event.request, { ignoreSearch: false });
-      if (cached) return cached;
-
       try {
         const networkResponse = await fetch(event.request);
         if (networkResponse && (networkResponse.ok || networkResponse.type === 'opaque')) {
@@ -85,6 +83,7 @@ self.addEventListener('fetch', (event) => {
         }
         return networkResponse;
       } catch (_) {
+        const cached = await cache.match(event.request, { ignoreSearch: false });
         if (cached) return cached;
         throw _;
       }


### PR DESCRIPTION
### Motivation
- Evitar que el service worker sirva audios stale o provoque 404s por reglas de caché demasiado amplias, manteniendo la accesibilidad de los archivos en `public/sonidos/`.
- Restringir el alcance de la lógica a la ruta operativa actual y a la extensión soportada (`.wav`) para eliminar reglas obsoletas que consideraban `.mp3`/`.ogg`.

### Description
- Modifiqué `public/sw.js` para que solo trate como recursos de audio cacheables las peticiones cuyo `pathname` empieza con `/sonidos/` y explícitamente soporte `.wav`.
- Reemplacé la detección previa basada en múltiples extensiones por una comprobación restringida a `/.wav` y preservé `request.destination === 'audio'` como condición adicional.
- Cambié la política de caché de audio a una estrategia *network-first* (intenta red y en fallo recurre al caché) para evitar servir archivos stale, y solo accede al caché como fallback cuando la red falla.
- No se tocaron archivos de backend, reglas de Firestore ni configuraciones sensibles; el cambio es acotado a `public/sw.js`.

### Testing
- Ejecuté `npm test` y todos los tests pasaron: `PASS` (11 suites, 35 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80fd588788326a48021abaf351898)