### PR TITLE
feat(juegoactivo): habilita audio por canto y efectos de juego

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4534,14 +4534,167 @@
     TIE: 'TIE',
   });
 
-  // Audio de efectos del juego deshabilitado intencionalmente para mantener
-  // operativa la lógica de UI/estado sin reproducir SFX ni cola de cantos.
-  function encolarAudioCantoNumero(_numero){
-    return;
+  const AUDIO_EVENT_CONFIG = Object.freeze({
+    [AUDIO_EVENTS.DRAW_NUMBER]: { manifestKey: 'sfx.drawNumber' },
+    [AUDIO_EVENTS.MARK_CELL]: { manifestKey: 'sfx.markCell' },
+    [AUDIO_EVENTS.MODAL_OPEN]: { manifestKey: 'sfx.openModal' },
+    [AUDIO_EVENTS.MODAL_CLOSE]: { manifestKey: 'sfx.openModal' },
+    [AUDIO_EVENTS.WINNER]: { manifestKey: 'sfx.win', critical: true, duckAmount: 0.25, duckDurationMs: 2200 },
+    [AUDIO_EVENTS.TIE]: { manifestKey: 'sfx.win', critical: true, duckAmount: 0.3, duckDurationMs: 1800 }
+  });
+  const AUDIO_CANTO_EVENT_PREFIX = 'CANTO_NUM_';
+  let audioJuegoInicializado = false;
+  let audioJuegoInitPromise = null;
+  let audioJuegoDesbloqueoRegistrado = false;
+  let audioJuegoCantosEnProceso = false;
+  const audioJuegoEventosRegistrados = new Set();
+  const audioJuegoCantosCola = [];
+  const audioJuegoUltimoEventoPorNombre = new Map();
+
+  function obtenerMarcaTiempoAudioMs(){
+    if(typeof performance !== 'undefined' && typeof performance.now === 'function'){
+      return performance.now();
+    }
+    return 0;
   }
 
-  function playGameAudioEvent(_eventName, _options={}){
-    return;
+  function esErrorAudioBloqueado(err){
+    return err && (err.code === 'AUDIO_CONTEXT_BLOCKED' || /bloqueado/i.test(String(err?.message || '')));
+  }
+
+  function registrarAudioEventosBase(){
+    if(!window.audioManager || typeof window.audioManager.registerSfxEvent !== 'function') return;
+    Object.entries(AUDIO_EVENT_CONFIG).forEach(([eventName, config])=>{
+      if(audioJuegoEventosRegistrados.has(eventName)) return;
+      window.audioManager.registerSfxEvent(eventName, { manifestKey: config.manifestKey }, config);
+      audioJuegoEventosRegistrados.add(eventName);
+    });
+  }
+
+  function registrarAudioCantoNumero(numero){
+    if(!window.audioManager || typeof window.audioManager.registerSfxEvent !== 'function') return null;
+    const normalizado = Number(numero);
+    if(!Number.isInteger(normalizado) || normalizado < 1 || normalizado > 75) return null;
+    const eventName = `${AUDIO_CANTO_EVENT_PREFIX}${normalizado}`;
+    if(audioJuegoEventosRegistrados.has(eventName)) return eventName;
+    window.audioManager.registerSfxEvent(eventName, {
+      category: 'sfx',
+      preferredFormats: ['wav'],
+      normalizationGain: 1,
+      sources: [{ format: 'wav', url: `/sonidos/${normalizado}.wav` }]
+    });
+    audioJuegoEventosRegistrados.add(eventName);
+    return eventName;
+  }
+
+  async function inicializarAudioJuego(){
+    if(audioJuegoInicializado) return true;
+    if(audioJuegoInitPromise) return audioJuegoInitPromise;
+    if(!window.audioManager){
+      return false;
+    }
+    audioJuegoInitPromise = (async ()=>{
+      registrarAudioEventosBase();
+      if(typeof window.audioManager.setVolume === 'function'){
+        window.audioManager.setVolume('master', 1);
+        window.audioManager.setVolume('sfx', 1);
+      }
+      if(typeof window.audioManager.probeAutoplayState === 'function'){
+        try{
+          await window.audioManager.probeAutoplayState();
+        }catch(_){}
+      }
+      audioJuegoInicializado = true;
+      return true;
+    })().finally(()=>{
+      audioJuegoInitPromise = null;
+    });
+    return audioJuegoInitPromise;
+  }
+
+  async function intentarDesbloquearAudioJuego(){
+    if(!window.audioManager || typeof window.audioManager.ensureRunningContext !== 'function') return false;
+    try{
+      await window.audioManager.ensureRunningContext();
+      await procesarColaAudioCantos();
+      return true;
+    }catch(err){
+      if(!esErrorAudioBloqueado(err)){
+        console.warn('No se pudo desbloquear el contexto de audio del juego.', err);
+      }
+      return false;
+    }
+  }
+
+  function registrarDesbloqueoAudioJuegoPorInteraccion(){
+    if(audioJuegoDesbloqueoRegistrado) return;
+    audioJuegoDesbloqueoRegistrado = true;
+    const handler = ()=>{ void intentarDesbloquearAudioJuego(); };
+    window.addEventListener('pointerdown', handler, { passive: true });
+    window.addEventListener('keydown', handler, { passive: true });
+    window.addEventListener('touchstart', handler, { passive: true });
+  }
+
+  async function procesarColaAudioCantos(){
+    if(audioJuegoCantosEnProceso || !audioJuegoCantosCola.length) return;
+    if(!window.audioManager || typeof window.audioManager.playSfx !== 'function') return;
+    audioJuegoCantosEnProceso = true;
+    try{
+      while(audioJuegoCantosCola.length){
+        const numero = audioJuegoCantosCola[0];
+        const eventName = registrarAudioCantoNumero(numero);
+        if(!eventName){
+          audioJuegoCantosCola.shift();
+          continue;
+        }
+        try{
+          await window.audioManager.playSfx(eventName);
+          audioJuegoCantosCola.shift();
+        }catch(err){
+          if(esErrorAudioBloqueado(err)){
+            break;
+          }
+          console.warn('No se pudo reproducir el audio del canto.', { numero, err });
+          audioJuegoCantosCola.shift();
+        }
+      }
+    }finally{
+      audioJuegoCantosEnProceso = false;
+    }
+  }
+
+  function encolarAudioCantoNumero(numero){
+    const normalizado = Number(numero);
+    if(!Number.isInteger(normalizado) || normalizado < 1 || normalizado > 75) return;
+    void inicializarAudioJuego();
+    registrarDesbloqueoAudioJuegoPorInteraccion();
+    audioJuegoCantosCola.push(normalizado);
+    void procesarColaAudioCantos();
+  }
+
+  async function playGameAudioEvent(eventName, options={}){
+    if(!eventName || !window.audioManager || typeof window.audioManager.playSfx !== 'function') return;
+    await inicializarAudioJuego();
+    registrarDesbloqueoAudioJuegoPorInteraccion();
+
+    const throttleMs = Number(options?.throttleMs);
+    const force = !!options?.force;
+    if(!force && Number.isFinite(throttleMs) && throttleMs > 0){
+      const now = obtenerMarcaTiempoAudioMs();
+      const ultimo = Number(audioJuegoUltimoEventoPorNombre.get(eventName) || 0);
+      if((now - ultimo) < throttleMs){
+        return;
+      }
+      audioJuegoUltimoEventoPorNombre.set(eventName, now);
+    }
+
+    try{
+      await window.audioManager.playSfx(eventName);
+    }catch(err){
+      if(!esErrorAudioBloqueado(err)){
+        console.warn(`No se pudo reproducir el efecto de audio: ${eventName}`, err);
+      }
+    }
   }
 
   const sinSorteoContenedorEl = document.getElementById('sin-sorteo-contenedor');


### PR DESCRIPTION
## Resumen de cambios
- Se activó la capa de audio en `public/juegoactivo.html`, reemplazando stubs no operativos por implementación real.
- Se agregó una cola de reproducción para cantos nuevos (`encolarAudioCantoNumero`) que mapea cada número cantado (1-75) a su archivo local `public/sonidos/{n}.wav`.
- Se registraron efectos de sonido base del juego (modal, marcado, ganador/empate) usando el `audioManager` y `audioManifest` existentes.
- Se incorporó manejo de desbloqueo de audio por interacción del usuario (pointer/teclado/touch) para navegadores con restricciones de autoplay.
- Se añadió control de `throttle` para eventos repetitivos de SFX (`playGameAudioEvent`).

## Motivación / problema que resuelve
La ventana `juegoactivo` tenía los métodos de audio desactivados (no-op), por lo que no se reproducían efectos ni el canto por número. Este PR permite que los jugadores escuchen el audio correspondiente a cada número cantado y recupera feedback sonoro clave de la interfaz.

## Riesgos / impacto
- **Frontend únicamente** en `public/juegoactivo.html`.
- No cambia contratos de Firestore, reglas de seguridad ni backend (`uploadServer.js`).
- Riesgo moderado de UX en navegadores con políticas estrictas de autoplay: mitigado con desbloqueo por interacción y cola pendiente.

## Plan de rollback
1. Revertir commit `54c647a`.
2. Validar que `encolarAudioCantoNumero` y `playGameAudioEvent` vuelvan a comportamiento anterior (sin audio).
3. Redesplegar hosting estático.

## Evidencia de pruebas
- `npm test` ✅ PASS (11 suites, 35 tests)

## Checklist de seguridad
- [x] No se agregaron secretos ni credenciales hardcodeadas.
- [x] No se modificaron `firestore.rules` ni `storage.rules`.
- [x] No se alteraron endpoints administrativos ni validaciones de auth.

## Orden recomendado de PRs para esta funcionalidad
Este cambio puede ir como **PR único** porque es acotado y menor a 400 líneas netas.

Si se desea estrategia secuencial para minimizar riesgo en producción:
1. **PR 1 (este PR):** motor de reproducción y cola en `juegoactivo`.
2. **PR 2 (opcional):** controles UI de volumen/mute específicos de `juegoactivo`.
3. **PR 3 (opcional):** observabilidad (logs/telemetría de fallas de autoplay y carga de archivos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8281bf7048326b23be66250f250cc)