### PR TITLE
fix(juego-activo): reubica control de audio, dim tras 5s y reproducir bolitas al tocar

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -199,13 +199,17 @@
       }
       .game-audio-control {
           position: fixed;
-          top: clamp(66px, 11vw, 82px);
-          right: clamp(12px, 3vw, 18px);
+          bottom: clamp(12px, 3vw, 18px);
+          left: clamp(12px, 3vw, 18px);
           z-index: 43;
           display: flex;
           flex-direction: column;
-          align-items: flex-end;
+          align-items: flex-start;
           gap: 8px;
+          transition: opacity 0.25s ease;
+      }
+      .game-audio-control.game-audio-control--dimmed {
+          opacity: 0.3;
       }
       .game-audio-toggle {
           width: clamp(44px, 10vw, 54px);
@@ -4586,6 +4590,7 @@
   const cantosConductoGridEl = cantosConductoEl;
   const cantosConductoTrackEl = document.getElementById('cantos-conducto-track');
   const ultimoCantoEl = document.getElementById('ultimo-canto');
+  const gameAudioControlEl = document.querySelector('.game-audio-control');
   const sorteoHeaderEl = document.getElementById('sorteo-header');
   const sorteoResumenEl = document.getElementById('sorteo-resumen');
   const sorteoDetallesEl = document.getElementById('sorteo-detalles');
@@ -4616,6 +4621,7 @@
   const audioJuegoEventosRegistrados = new Set();
   const audioJuegoCantosCola = [];
   const audioJuegoUltimoEventoPorNombre = new Map();
+  const AUDIO_CONTROL_DIM_DELAY_MS = 5000;
   const AUDIO_STORAGE_KEYS = Object.freeze({
     master: 'audio:masterVolume',
     sfx: 'audio:sfxVolume',
@@ -4740,10 +4746,34 @@
   }
 
   function configurarControlesAudioJuego(){
-    if(!gameAudioToggleBtn || !gameAudioPanelEl || !gameAudioMasterInput || !gameAudioSfxInput || !gameAudioMuteBtn) return;
+    if(!gameAudioToggleBtn || !gameAudioPanelEl || !gameAudioMasterInput || !gameAudioSfxInput || !gameAudioMuteBtn || !gameAudioControlEl) return;
     cargarPreferenciasAudioJuego();
     registrarDesbloqueoAudioJuegoPorInteraccion();
     let panelVisible = false;
+    let audioControlDimTimeout = null;
+
+    const limpiarDimAudio = ()=>{
+      if(audioControlDimTimeout){
+        clearTimeout(audioControlDimTimeout);
+        audioControlDimTimeout = null;
+      }
+    };
+
+    const programarDimAudio = ()=>{
+      limpiarDimAudio();
+      if(panelVisible) return;
+      gameAudioControlEl.classList.remove('game-audio-control--dimmed');
+      audioControlDimTimeout = setTimeout(()=>{
+        if(!panelVisible){
+          gameAudioControlEl.classList.add('game-audio-control--dimmed');
+        }
+      }, AUDIO_CONTROL_DIM_DELAY_MS);
+    };
+
+    const mostrarControlAudio = ()=>{
+      gameAudioControlEl.classList.remove('game-audio-control--dimmed');
+      programarDimAudio();
+    };
 
     const actualizarUI = ()=>{
       gameAudioMasterInput.value = audioJuegoPreferencias.master.toFixed(2);
@@ -4774,6 +4804,12 @@
       gameAudioPanelEl.setAttribute('aria-hidden', panelVisible ? 'false' : 'true');
       gameAudioToggleBtn.setAttribute('aria-expanded', panelVisible ? 'true' : 'false');
       if(panelVisible){
+        limpiarDimAudio();
+        gameAudioControlEl.classList.remove('game-audio-control--dimmed');
+      }else{
+        programarDimAudio();
+      }
+      if(panelVisible){
         void inicializarAudioJuego();
         void intentarDesbloquearAudioJuego();
       }
@@ -4783,15 +4819,18 @@
       audioJuegoPreferencias.master = clampAudioValor(event?.target?.value, audioJuegoPreferencias.master);
       audioJuegoPreferencias.muted = false;
       aplicarYGuardar();
+      mostrarControlAudio();
     });
     gameAudioSfxInput.addEventListener('input', (event)=>{
       audioJuegoPreferencias.sfx = clampAudioValor(event?.target?.value, audioJuegoPreferencias.sfx);
       audioJuegoPreferencias.muted = false;
       aplicarYGuardar();
+      mostrarControlAudio();
     });
     gameAudioMuteBtn.addEventListener('click', ()=>{
       audioJuegoPreferencias.muted = !audioJuegoPreferencias.muted;
       aplicarYGuardar();
+      mostrarControlAudio();
     });
 
     document.addEventListener('click', (event)=>{
@@ -4801,10 +4840,15 @@
       gameAudioPanelEl.hidden = true;
       gameAudioPanelEl.setAttribute('aria-hidden', 'true');
       gameAudioToggleBtn.setAttribute('aria-expanded', 'false');
+      programarDimAudio();
     });
+
+    gameAudioControlEl.addEventListener('pointerdown', mostrarControlAudio, { passive: true });
+    gameAudioControlEl.addEventListener('mouseenter', mostrarControlAudio);
 
     aplicarPreferenciasAudioJuego();
     actualizarUI();
+    programarDimAudio();
   }
 
   async function procesarColaAudioCantos(){
@@ -4842,6 +4886,24 @@
     registrarDesbloqueoAudioJuegoPorInteraccion();
     audioJuegoCantosCola.push(normalizado);
     void procesarColaAudioCantos();
+  }
+
+  async function reproducirAudioCantoPorInteraccion(numero){
+    const normalizado = Number(numero);
+    if(!Number.isInteger(normalizado) || normalizado < 1 || normalizado > 75) return;
+    await inicializarAudioJuego();
+    registrarDesbloqueoAudioJuegoPorInteraccion();
+    await intentarDesbloquearAudioJuego();
+    const eventName = registrarAudioCantoNumero(normalizado);
+    if(!eventName || !window.audioManager || typeof window.audioManager.playSfx !== 'function') return;
+    try{
+      await window.audioManager.playSfx(eventName);
+    }catch(err){
+      if(!esErrorAudioBloqueado(err)){
+        console.warn('No se pudo reproducir el audio al interactuar con la bolita.', { numero: normalizado, err });
+      }
+      encolarAudioCantoNumero(normalizado);
+    }
   }
 
   async function playGameAudioEvent(eventName, options={}){
@@ -8009,6 +8071,7 @@
   function manejarInteraccionCantoGanador(numero){
     const valor=Number(numero);
     if(!Number.isFinite(valor)) return;
+    void reproducirAudioCantoPorInteraccion(valor);
     const formas=obtenerFormasGanadorasPorNumero(valor);
     if(!formas.length) return;
     const principal=formas[0]?.forma;


### PR DESCRIPTION
### Motivation
- Ajustar la UI del juego activo colocando el control de audio en la esquina inferior izquierda y aplicar el mismo comportamiento visual de atenuación que el botón de modo tutorial.  
- Permitir que al interactuar con cualquier bolita se reproduzca su audio asociado por número (`/sonidos/<numero>.wav`) para mejorar la experiencia de usuario.  
- Garantizar que la reproducción siga la política de los navegadores (desbloqueo por interacción) y use el mecanismo de cola/fallback existente cuando el audio esté bloqueado.

### Description
- Se modificó `public/juegoactivo.html` para reubicar el contenedor `.game-audio-control` a `bottom/left` y alinear sus elementos a la izquierda, además se añadió la clase `.game-audio-control--dimmed` y transición para opacidad.  
- Se introdujo la constante `AUDIO_CONTROL_DIM_DELAY_MS = 5000` y la lógica JS que programa/limpia el timeout para atenuar el control tras 5s sin interacción y restaurarlo al interactuar con el control (`pointerdown`, `mouseenter`, inputs del panel).  
- Se añadió el helper `reproducirAudioCantoPorInteraccion(numero)` que inicializa/desbloquea el `audioManager`, registra el evento con `registrarAudioCantoNumero(numero)` y reproduce `/sonidos/<numero>.wav`, con fallback a `encolarAudioCantoNumero(numero)` si falla por bloqueo de autoplay.  
- Se invoca `reproducirAudioCantoPorInteraccion` desde `manejarInteraccionCantoGanador(numero)` para que al pulsar una bolita suene inmediatamente su `N.wav` sin alterar el comportamiento existente que abre el modal de ganadores.

### Testing
- Ejecuté `npm test` y todas las suites pasaron: `11 suites, 35 tests` (estado: PASS).  
- Las pruebas existentes no cubren UI visual ni reproducción en navegador; la nueva lógica usa las APIs existentes de `audioManager` y mantiene el flujo de cola/fallback para navegadores que bloqueen autoplay (comportamiento comprobado por consola/manualmente en integración).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83aac58f083269ad423dcc30d6101)