### PR TITLE
[PR #1170 Follow-up] Fix audio defaults and canto queue playback completion

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4853,23 +4853,22 @@
   async function reproducirCantoAudioYEsperar(eventName){
     if(!eventName || !window.audioManager || typeof window.audioManager.playSfx !== 'function') return false;
     const sfxActivos = window.audioManager.activeSfxNodes;
-    const totalAntes = sfxActivos && typeof sfxActivos.size === 'number' ? sfxActivos.size : null;
+    const activosAntes = sfxActivos instanceof Set ? new Set(sfxActivos) : null;
 
     await window.audioManager.playSfx(eventName);
 
-    const totalDespues = sfxActivos && typeof sfxActivos.size === 'number' ? sfxActivos.size : null;
-    const inicioConfirmado = Number.isFinite(totalAntes) && Number.isFinite(totalDespues)
-      ? totalDespues > totalAntes
-      : true;
+    const fuenteCanto = sfxActivos instanceof Set
+      ? Array.from(sfxActivos).find((source)=>!activosAntes?.has(source))
+      : null;
+    const inicioConfirmado = sfxActivos instanceof Set ? !!fuenteCanto : true;
 
     if(!inicioConfirmado){
       return false;
     }
 
-    if(Number.isFinite(totalDespues)){
-      const objetivo = Math.max(0, totalDespues - 1);
+    if(sfxActivos instanceof Set && fuenteCanto){
       const inicioEspera = obtenerMarcaTiempoAudioMs();
-      while(sfxActivos.size > objetivo){
+      while(sfxActivos.has(fuenteCanto)){
         await new Promise((resolve)=>setTimeout(resolve, 40));
         if((obtenerMarcaTiempoAudioMs() - inicioEspera) > 5000){
           break;

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4635,6 +4635,8 @@
   }
 
   function clampAudioValor(valor, fallback = 1){
+    if(valor === null || typeof valor === 'undefined') return fallback;
+    if(typeof valor === 'string' && valor.trim() === '') return fallback;
     const numero = Number(valor);
     if(!Number.isFinite(numero)) return fallback;
     return Math.max(0, Math.min(1, numero));
@@ -4820,8 +4822,12 @@
           continue;
         }
         try{
-          await window.audioManager.playSfx(eventName);
-          audioJuegoCantosCola.shift();
+          const reproducido = await reproducirCantoAudioYEsperar(eventName);
+          if(reproducido){
+            audioJuegoCantosCola.shift();
+          }else{
+            await new Promise((resolve)=>setTimeout(resolve, 120));
+          }
         }catch(err){
           if(esErrorAudioBloqueado(err)){
             break;
@@ -4842,6 +4848,36 @@
     registrarDesbloqueoAudioJuegoPorInteraccion();
     audioJuegoCantosCola.push(normalizado);
     void procesarColaAudioCantos();
+  }
+
+  async function reproducirCantoAudioYEsperar(eventName){
+    if(!eventName || !window.audioManager || typeof window.audioManager.playSfx !== 'function') return false;
+    const sfxActivos = window.audioManager.activeSfxNodes;
+    const totalAntes = sfxActivos && typeof sfxActivos.size === 'number' ? sfxActivos.size : null;
+
+    await window.audioManager.playSfx(eventName);
+
+    const totalDespues = sfxActivos && typeof sfxActivos.size === 'number' ? sfxActivos.size : null;
+    const inicioConfirmado = Number.isFinite(totalAntes) && Number.isFinite(totalDespues)
+      ? totalDespues > totalAntes
+      : true;
+
+    if(!inicioConfirmado){
+      return false;
+    }
+
+    if(Number.isFinite(totalDespues)){
+      const objetivo = Math.max(0, totalDespues - 1);
+      const inicioEspera = obtenerMarcaTiempoAudioMs();
+      while(sfxActivos.size > objetivo){
+        await new Promise((resolve)=>setTimeout(resolve, 40));
+        if((obtenerMarcaTiempoAudioMs() - inicioEspera) > 5000){
+          break;
+        }
+      }
+    }
+
+    return true;
   }
 
   async function playGameAudioEvent(eventName, options={}){


### PR DESCRIPTION
### Motivation
- Prevent first-time users from getting silent audio due to `localStorage` returning `null`/empty values that were coerced to `0` when loading audio preferences.  
- Ensure queued canto audio is only removed after real playback starts and completes so numbers are not dropped or overlapped during burst catch-up.

### Description
- Treat `null`, `undefined`, and empty-string values as missing in `clampAudioValor` so fallback defaults are applied when loading `localStorage` preferences in `public/juegoactivo.html`.  
- Add `reproducirCantoAudioYEsperar(eventName)` and update `procesarColaAudioCantos` to confirm playback start via `window.audioManager.activeSfxNodes` and wait for the canto to finish (with a bounded wait) before dequeuing.  
- When playback does not start (e.g., concurrency saturation), keep the canto in queue and retry shortly instead of dropping it, preserving order and avoiding overlaps.

### Testing
- Ran the project test suite with `npm test -- --runInBand` and all tests passed (11 suites, 35 tests).  
- Verified the changed file is `public/juegoactivo.html` and modifications are limited to audio preference handling and canto queue playback logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c8372a5883268bf55d4baa28c6c8)