### PR TITLE
fix(juegoactivo): serializa cola de cantos y evita drenado concurrente

### DIFF
--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4543,6 +4543,9 @@
     [AUDIO_EVENTS.TIE]: { manifestKey: 'sfx.win', critical: true, duckAmount: 0.3, duckDurationMs: 1800 }
   });
   const AUDIO_CANTO_EVENT_PREFIX = 'CANTO_NUM_';
+  const AUDIO_CANTO_FALLBACK_MS = 1400;
+  const AUDIO_CANTO_MIN_GAP_MS = 120;
+  const AUDIO_CANTO_REINTENTO_MS = 180;
   let audioJuegoInicializado = false;
   let audioJuegoInitPromise = null;
   let audioJuegoDesbloqueoRegistrado = false;
@@ -4550,6 +4553,7 @@
   const audioJuegoEventosRegistrados = new Set();
   const audioJuegoCantosCola = [];
   const audioJuegoUltimoEventoPorNombre = new Map();
+  const audioJuegoDuracionEventoMs = new Map();
 
   function obtenerMarcaTiempoAudioMs(){
     if(typeof performance !== 'undefined' && typeof performance.now === 'function'){
@@ -4560,6 +4564,54 @@
 
   function esErrorAudioBloqueado(err){
     return err && (err.code === 'AUDIO_CONTEXT_BLOCKED' || /bloqueado/i.test(String(err?.message || '')));
+  }
+
+  function esperarAudioJuegoMs(durationMs){
+    const normalizado = Number(durationMs);
+    const ms = Number.isFinite(normalizado) ? Math.max(0, normalizado) : 0;
+    if(ms <= 0) return Promise.resolve();
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  async function obtenerDuracionEventoAudioMs(eventName){
+    if(audioJuegoDuracionEventoMs.has(eventName)){
+      return audioJuegoDuracionEventoMs.get(eventName);
+    }
+    if(!window.audioManager || !window.audioManager.sfxEvents || typeof window.audioManager.loadBufferBySource !== 'function'){
+      return null;
+    }
+    const eventConfig = window.audioManager.sfxEvents.get(eventName);
+    if(!eventConfig?.source){
+      return null;
+    }
+    try{
+      const buffer = await window.audioManager.loadBufferBySource(eventConfig.source);
+      const durationMs = Number(buffer?.duration) * 1000;
+      if(Number.isFinite(durationMs) && durationMs > 0){
+        audioJuegoDuracionEventoMs.set(eventName, durationMs);
+        return durationMs;
+      }
+    }catch(_){}
+    return null;
+  }
+
+  async function reproducirCantoSerializado(eventName){
+    const activeBefore = Number(window.audioManager?.activeSfxNodes?.size);
+    const durationPromise = obtenerDuracionEventoAudioMs(eventName);
+    await window.audioManager.playSfx(eventName);
+    const activeAfter = Number(window.audioManager?.activeSfxNodes?.size);
+    const started = Number.isFinite(activeBefore) && Number.isFinite(activeAfter)
+      ? activeAfter > activeBefore
+      : true;
+    if(!started){
+      return false;
+    }
+    const durationMs = await durationPromise;
+    const waitMs = Number.isFinite(durationMs)
+      ? (durationMs + AUDIO_CANTO_MIN_GAP_MS)
+      : AUDIO_CANTO_FALLBACK_MS;
+    await esperarAudioJuegoMs(waitMs);
+    return true;
   }
 
   function registrarAudioEventosBase(){
@@ -4648,7 +4700,11 @@
           continue;
         }
         try{
-          await window.audioManager.playSfx(eventName);
+          const reproducido = await reproducirCantoSerializado(eventName);
+          if(!reproducido){
+            await esperarAudioJuegoMs(AUDIO_CANTO_REINTENTO_MS);
+            continue;
+          }
           audioJuegoCantosCola.shift();
         }catch(err){
           if(esErrorAudioBloqueado(err)){


### PR DESCRIPTION
### Motivation
- Corregir un bug donde `procesarColaAudioCantos` drenaba la cola inmediatamente porque `playSfx` resolvía al iniciar la reproducción en vez de al terminar, provocando cantos solapados y pérdida de anuncios cuando `maxSfxConcurrency` estaba lleno. 
- Garantizar que los cantos se reproduzcan de forma secuencial y fiable durante snapshots o reconexiones sin cambiar el contrato de bloqueo/autoplay existente.

### Description
- Se añadió la función `reproducirCantoSerializado(eventName)` que inicia un SFX y espera su duración real (obtenida mediante `loadBufferBySource`) más un pequeño espacio antes de continuar. 
- Se introdujeron constantes de temporización (`AUDIO_CANTO_FALLBACK_MS`, `AUDIO_CANTO_MIN_GAP_MS`, `AUDIO_CANTO_REINTENTO_MS`) y el helper `esperarAudioJuegoMs` para controlar fallback, gap y reintentos. 
- Se agregó caché de duraciones por evento con `audioJuegoDuracionEventoMs` y la función `obtenerDuracionEventoAudioMs` para evitar recalcular la duración del buffer en cada reproducción. 
- Se actualizó `procesarColaAudioCantos` para usar la reproducción serializada y reintentar en caso de que el SFX no llegue a arrancar (p. ej. por límite de concurrencia), manteniendo el manejo de errores de audio bloqueado (`AUDIO_CONTEXT_BLOCKED`).

### Testing
- Se ejecutó `npm test -- --runInBand` y todos los tests pasaron (11 suites, 35 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cdf53e908326a6ae319f8448d173)