### PR TITLE
fix(audio): reintenta efectos bloqueados por autoplay

### DIFF
--- a/__tests__/audioManager.test.js
+++ b/__tests__/audioManager.test.js
@@ -1,0 +1,111 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+class FakeAudioContext {
+  constructor() {
+    this.state = 'suspended';
+    this.currentTime = 0;
+    this.sampleRate = 44100;
+    this.destination = {};
+  }
+
+  async resume() {
+    this.state = 'running';
+  }
+
+  createGain() {
+    return {
+      gain: {
+        value: 1,
+        setValueAtTime(v) { this.value = v; },
+        cancelScheduledValues() {},
+        linearRampToValueAtTime(v) { this.value = v; },
+      },
+      connect() {},
+      disconnect() {},
+    };
+  }
+
+  createBuffer() {
+    return {};
+  }
+
+  createBufferSource() {
+    return {
+      buffer: null,
+      loop: false,
+      onended: null,
+      connect() {},
+      disconnect() {},
+      start: jest.fn(),
+      stop: jest.fn(),
+    };
+  }
+
+  async decodeAudioData() {
+    return { duration: 1 };
+  }
+}
+
+describe('AudioManager autoplay queue', () => {
+  let AudioManager;
+  let runtimeWindow;
+
+  beforeAll(() => {
+    runtimeWindow = {
+      AudioContext: FakeAudioContext,
+      webkitAudioContext: FakeAudioContext,
+      setTimeout,
+      clearTimeout,
+    };
+    const source = fs.readFileSync(path.join(__dirname, '..', 'public/js/audioManager.js'), 'utf8');
+    vm.runInNewContext(source, {
+      window: runtimeWindow,
+      console,
+      setTimeout,
+      clearTimeout,
+      fetch: jest.fn(),
+      localStorage: {
+        getItem: jest.fn(() => null),
+        setItem: jest.fn(),
+      },
+      Date,
+    });
+    AudioManager = runtimeWindow.AudioManager;
+  });
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('encola SFX cuando el contexto está bloqueado', async () => {
+    const manager = new AudioManager();
+    manager.registerSfxEvent('DRAW', { sources: [{ format: 'wav', url: '/sonidos/1.wav' }] });
+
+    jest.spyOn(manager, 'ensureRunningContext').mockRejectedValueOnce(manager.createBlockedAudioError());
+
+    await expect(manager.playSfx('DRAW')).rejects.toMatchObject({ code: 'AUDIO_CONTEXT_BLOCKED' });
+    expect(manager.pendingPlayRequests).toHaveLength(1);
+    expect(manager.pendingPlayRequests[0]).toMatchObject({ type: 'sfx', payload: { eventName: 'DRAW' } });
+  });
+
+  test('reintenta cola de SFX al desbloquear contexto', async () => {
+    const manager = new AudioManager();
+    await manager.init();
+    manager.registerSfxEvent('DRAW', { sources: [{ format: 'wav', url: '/sonidos/1.wav' }] });
+
+    manager.pendingPlayRequests.push({ type: 'sfx', payload: { eventName: 'DRAW' }, at: Date.now() });
+    jest.spyOn(manager, 'loadBufferBySource').mockResolvedValue({ duration: 1 });
+
+    await manager.ensureRunningContext();
+
+    expect(manager.pendingPlayRequests).toHaveLength(0);
+    expect(manager.activeSfxNodes.size).toBe(1);
+  });
+});

--- a/public/js/audioManager.js
+++ b/public/js/audioManager.js
@@ -29,11 +29,68 @@
       this.pendingInitPromise = null;
       this.autoplayBlocked = false;
       this.autoplayProbeDone = false;
+      this.pendingPlayRequests = [];
+      this.maxPendingPlayRequests = 40;
+      this.debugEnabled = false;
 
       this.manifestStorageKey = 'bingoAudioManifestCache';
       this.manifest = null;
       this.defaultMaxSfxBytes = 262144;
       this.defaultMaxMusicBytes = 1048576;
+    }
+
+    setDebugEnabled(value) {
+      this.debugEnabled = !!value;
+    }
+
+    logDebug(message, details = null) {
+      if (!this.debugEnabled) return;
+      if (details === null || typeof details === 'undefined') {
+        console.info(`[AudioManager] ${message}`);
+        return;
+      }
+      console.info(`[AudioManager] ${message}`, details);
+    }
+
+    logWarn(message, details = null) {
+      if (details === null || typeof details === 'undefined') {
+        console.warn(`[AudioManager] ${message}`);
+        return;
+      }
+      console.warn(`[AudioManager] ${message}`, details);
+    }
+
+    enqueuePendingPlay(type, payload) {
+      if (!type || !payload) return;
+      this.pendingPlayRequests.push({ type, payload, at: Date.now() });
+      if (this.pendingPlayRequests.length > this.maxPendingPlayRequests) {
+        this.pendingPlayRequests.shift();
+      }
+      this.logDebug('Reproducción encolada por bloqueo/autoplay.', { type, payload, pending: this.pendingPlayRequests.length });
+    }
+
+    async flushPendingPlayRequests() {
+      if (!this.pendingPlayRequests.length) return;
+      const pending = this.pendingPlayRequests.splice(0);
+      this.logDebug('Reintentando reproducciones encoladas.', { pending: pending.length });
+      for (let i = 0; i < pending.length; i += 1) {
+        const item = pending[i];
+        if (!item || !item.type) continue;
+        try {
+          if (item.type === 'sfx' && item.payload?.eventName) {
+            await this.playSfx(item.payload.eventName, { bypassQueueOnBlocked: true });
+          }
+          if (item.type === 'music' && item.payload?.trackId) {
+            await this.playMusic(item.payload.trackId, { ...item.payload.options, bypassQueueOnBlocked: true });
+          }
+        } catch (err) {
+          if (err?.code === 'AUDIO_CONTEXT_BLOCKED') {
+            this.pendingPlayRequests.unshift(item);
+            break;
+          }
+          this.logWarn('Falló reintento de reproducción en cola.', { item, err: String(err?.message || err) });
+        }
+      }
     }
 
     getCachedManifest() {
@@ -290,6 +347,10 @@
         throw this.createBlockedAudioError();
       }
 
+      if (this.pendingPlayRequests.length) {
+        await this.flushPendingPlayRequests();
+      }
+
       return true;
     }
 
@@ -384,11 +445,19 @@
       if (!trackId) return;
       this.currentMusicTrackId = trackId;
       const fadeInMs = Number.isFinite(options.fadeInMs) ? Math.max(0, options.fadeInMs) : 0;
+      const bypassQueueOnBlocked = !!options.bypassQueueOnBlocked;
 
       const sourceDescriptor = this.musicTracks.get(trackId);
       if (!sourceDescriptor) return;
 
-      await this.ensureRunningContext();
+      try {
+        await this.ensureRunningContext();
+      } catch (err) {
+        if (!bypassQueueOnBlocked && err?.code === 'AUDIO_CONTEXT_BLOCKED') {
+          this.enqueuePendingPlay('music', { trackId, options: { fadeInMs } });
+        }
+        throw err;
+      }
       const buffer = await this.loadBufferBySource(sourceDescriptor);
       if (!buffer) return;
 
@@ -423,13 +492,21 @@
       this.currentMusicSource = source;
     }
 
-    async playSfx(eventName) {
+    async playSfx(eventName, options = {}) {
       if (!eventName) return;
       const eventConfig = this.sfxEvents.get(eventName);
       if (!eventConfig) return;
       if (this.activeSfxNodes.size >= this.maxSfxConcurrency) return;
+      const bypassQueueOnBlocked = !!options.bypassQueueOnBlocked;
 
-      await this.ensureRunningContext();
+      try {
+        await this.ensureRunningContext();
+      } catch (err) {
+        if (!bypassQueueOnBlocked && err?.code === 'AUDIO_CONTEXT_BLOCKED') {
+          this.enqueuePendingPlay('sfx', { eventName });
+        }
+        throw err;
+      }
       const buffer = await this.loadBufferBySource(eventConfig.source);
       if (!buffer) return;
 


### PR DESCRIPTION
### Motivation
- Se detectó que cuando el navegador bloquea el `AudioContext` por políticas de autoplay los llamados a `playSfx`/`playMusic` fallaban y los eventos se perdían, provocando que no se escucharan efectos en flujos asíncronos del juego. 
- Objetivo: aplicar una corrección mínima y definitiva en la capa de audio cliente para que los efectos no se pierdan y quede una base sólida para música de fondo futura. 
- Mantener cambios locales al frontend sin tocar auth, Firestore ni reglas de seguridad. 

### Description
- Se añadió en `public/js/audioManager.js` una cola segura `pendingPlayRequests` con límite y funciones `enqueuePendingPlay` / `flushPendingPlayRequests` para reintentar reproducciones que fallaron por `AUDIO_CONTEXT_BLOCKED`. 
- `ensureRunningContext` ahora ejecuta un drenaje de la cola cuando el contexto pasa a estado `running`, y `playSfx` / `playMusic` encolan solicitudes en caso de `AUDIO_CONTEXT_BLOCKED` (con flag `bypassQueueOnBlocked` para evitar loops). 
- Se añadió instrumentación no intrusiva (`setDebugEnabled`, `logDebug`, `logWarn`) para diagnóstico de encolado/reintentos sin ruido en producción. 
- Se agregó `__tests__/audioManager.test.js` con pruebas unitarias que validan el encolado al fallar el contexto y el reintento/consumo de la cola al desbloquearse el contexto. 

### Testing
- Ejecuté `npm test -- --runInBand` y todas las suites automáticas pasaron: 12 suites, 37 tests en PASS. 
- Las nuevas pruebas (`__tests__/audioManager.test.js`) pasaron correctamente en el entorno CI local simulado con `FakeAudioContext`. 
- No apliqué `npm run generate:firebase-config` ni `npm run generate:loterias-manifest` porque no se tocaron configuraciones ni assets de loterías. 
- Resultado automatizado principal: `npm test -- --runInBand` => PASS (todas las pruebas unitarias verdes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaaeef41c483268ef5e3e81013ad16)