### PR TITLE
AudioManager: enqueue autoplay-blocked plays, allowlist remote audio hosts, and register background music

### DIFF
--- a/__tests__/audioManager.test.js
+++ b/__tests__/audioManager.test.js
@@ -1,0 +1,124 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+class FakeAudioContext {
+  constructor() {
+    this.state = 'suspended';
+    this.currentTime = 0;
+    this.sampleRate = 44100;
+    this.destination = {};
+  }
+
+  async resume() {
+    this.state = 'running';
+  }
+
+  createGain() {
+    return {
+      gain: {
+        value: 1,
+        setValueAtTime(v) { this.value = v; },
+        cancelScheduledValues() {},
+        linearRampToValueAtTime(v) { this.value = v; },
+      },
+      connect() {},
+      disconnect() {},
+    };
+  }
+
+  createBuffer() {
+    return {};
+  }
+
+  createBufferSource() {
+    return {
+      buffer: null,
+      loop: false,
+      onended: null,
+      connect() {},
+      disconnect() {},
+      start: jest.fn(),
+      stop: jest.fn(),
+    };
+  }
+
+  async decodeAudioData() {
+    return { duration: 1 };
+  }
+}
+
+describe('AudioManager autoplay queue', () => {
+  let AudioManager;
+  let runtimeWindow;
+
+  beforeAll(() => {
+    runtimeWindow = {
+      AudioContext: FakeAudioContext,
+      webkitAudioContext: FakeAudioContext,
+      setTimeout,
+      clearTimeout,
+    };
+    const source = fs.readFileSync(path.join(__dirname, '..', 'public/js/audioManager.js'), 'utf8');
+    vm.runInNewContext(source, {
+      window: runtimeWindow,
+      console,
+      setTimeout,
+      clearTimeout,
+      fetch: jest.fn(),
+      localStorage: {
+        getItem: jest.fn(() => null),
+        setItem: jest.fn(),
+      },
+      Date,
+      URL,
+    });
+    AudioManager = runtimeWindow.AudioManager;
+  });
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('encola SFX cuando el contexto está bloqueado', async () => {
+    const manager = new AudioManager();
+    manager.registerSfxEvent('DRAW', { sources: [{ format: 'wav', url: '/sonidos/1.wav' }] });
+
+    jest.spyOn(manager, 'ensureRunningContext').mockRejectedValueOnce(manager.createBlockedAudioError());
+
+    await expect(manager.playSfx('DRAW')).rejects.toMatchObject({ code: 'AUDIO_CONTEXT_BLOCKED' });
+    expect(manager.pendingPlayRequests).toHaveLength(1);
+    expect(manager.pendingPlayRequests[0]).toMatchObject({ type: 'sfx', payload: { eventName: 'DRAW' } });
+  });
+
+  test('reintenta cola de SFX al desbloquear contexto', async () => {
+    const manager = new AudioManager();
+    await manager.init();
+    manager.registerSfxEvent('DRAW', { sources: [{ format: 'wav', url: '/sonidos/1.wav' }] });
+
+    manager.pendingPlayRequests.push({ type: 'sfx', payload: { eventName: 'DRAW' }, at: Date.now() });
+    jest.spyOn(manager, 'loadBufferBySource').mockResolvedValue({ duration: 1 });
+
+    await manager.ensureRunningContext();
+
+    expect(manager.pendingPlayRequests).toHaveLength(0);
+    expect(manager.activeSfxNodes.size).toBe(1);
+  });
+
+  test('acepta fuentes remotas solo en hosts permitidos del manifiesto', () => {
+    runtimeWindow.BINGO_AUDIO_MANIFEST = {
+      manifestVersion: 'test',
+      globalAudioPolicy: {
+        allowedRemoteHosts: ['raw.githubusercontent.com'],
+      },
+    };
+    const manager = new AudioManager();
+    expect(manager.isAllowedAudioUrl('https://raw.githubusercontent.com/org/repo/file.ogg')).toBe(true);
+    expect(manager.isAllowedAudioUrl('https://example.com/music.ogg')).toBe(false);
+  });
+});

--- a/public/js/audioManager.js
+++ b/public/js/audioManager.js
@@ -29,11 +29,68 @@
       this.pendingInitPromise = null;
       this.autoplayBlocked = false;
       this.autoplayProbeDone = false;
+      this.pendingPlayRequests = [];
+      this.maxPendingPlayRequests = 40;
+      this.debugEnabled = false;
 
       this.manifestStorageKey = 'bingoAudioManifestCache';
       this.manifest = null;
       this.defaultMaxSfxBytes = 262144;
       this.defaultMaxMusicBytes = 1048576;
+    }
+
+    setDebugEnabled(value) {
+      this.debugEnabled = !!value;
+    }
+
+    logDebug(message, details = null) {
+      if (!this.debugEnabled) return;
+      if (details === null || typeof details === 'undefined') {
+        console.info(`[AudioManager] ${message}`);
+        return;
+      }
+      console.info(`[AudioManager] ${message}`, details);
+    }
+
+    logWarn(message, details = null) {
+      if (details === null || typeof details === 'undefined') {
+        console.warn(`[AudioManager] ${message}`);
+        return;
+      }
+      console.warn(`[AudioManager] ${message}`, details);
+    }
+
+    enqueuePendingPlay(type, payload) {
+      if (!type || !payload) return;
+      this.pendingPlayRequests.push({ type, payload, at: Date.now() });
+      if (this.pendingPlayRequests.length > this.maxPendingPlayRequests) {
+        this.pendingPlayRequests.shift();
+      }
+      this.logDebug('Reproducción encolada por bloqueo/autoplay.', { type, payload, pending: this.pendingPlayRequests.length });
+    }
+
+    async flushPendingPlayRequests() {
+      if (!this.pendingPlayRequests.length) return;
+      const pending = this.pendingPlayRequests.splice(0);
+      this.logDebug('Reintentando reproducciones encoladas.', { pending: pending.length });
+      for (let i = 0; i < pending.length; i += 1) {
+        const item = pending[i];
+        if (!item || !item.type) continue;
+        try {
+          if (item.type === 'sfx' && item.payload?.eventName) {
+            await this.playSfx(item.payload.eventName, { bypassQueueOnBlocked: true });
+          }
+          if (item.type === 'music' && item.payload?.trackId) {
+            await this.playMusic(item.payload.trackId, { ...item.payload.options, bypassQueueOnBlocked: true });
+          }
+        } catch (err) {
+          if (err?.code === 'AUDIO_CONTEXT_BLOCKED') {
+            this.pendingPlayRequests.unshift(item);
+            break;
+          }
+          this.logWarn('Falló reintento de reproducción en cola.', { item, err: String(err?.message || err) });
+        }
+      }
     }
 
     getCachedManifest() {
@@ -86,15 +143,43 @@
       if (!url || typeof url !== 'string') return false;
       const value = url.trim();
       if (!value) return false;
-      if (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('//')) return false;
       if (value.startsWith('/sonidos/')) return true;
       if (value.startsWith('sonidos/')) return true;
       return false;
     }
 
+    isAllowedRemoteAudioUrl(url) {
+      if (!url || typeof url !== 'string') return false;
+      const value = url.trim();
+      if (!value) return false;
+
+      let parsed;
+      try {
+        parsed = new URL(value, window.location?.origin || 'http://localhost');
+      } catch (_) {
+        return false;
+      }
+
+      if (!parsed || (parsed.protocol !== 'https:' && parsed.protocol !== 'http:')) return false;
+      if (!/^https?:/i.test(value)) return false;
+
+      const manifestPolicy = this.getManifestNode('globalAudioPolicy');
+      const allowedHosts = Array.isArray(manifestPolicy?.allowedRemoteHosts)
+        ? manifestPolicy.allowedRemoteHosts.map((host) => String(host || '').trim().toLowerCase()).filter(Boolean)
+        : [];
+
+      if (!allowedHosts.length) return false;
+      return allowedHosts.includes(String(parsed.hostname || '').toLowerCase());
+    }
+
+    isAllowedAudioUrl(url) {
+      return this.isLocalAudioUrl(url) || this.isAllowedRemoteAudioUrl(url);
+    }
+
     normalizeAudioUrl(url) {
       const value = String(url || '').trim();
       if (!value) return null;
+      if (/^https?:\/\//i.test(value)) return value;
       if (value.startsWith('/')) return value;
       return `/${value.replace(/^\/+/, '')}`;
     }
@@ -107,7 +192,7 @@
       const candidates = [];
       if (Array.isArray(node.sources)) {
         node.sources.forEach((source) => {
-          if (!source?.url || !this.isLocalAudioUrl(source.url)) return;
+          if (!source?.url || !this.isAllowedAudioUrl(source.url)) return;
           candidates.push({
             url: this.normalizeAudioUrl(source.url),
             format: (source.format || '').toLowerCase() || null,
@@ -115,10 +200,10 @@
         });
       }
 
-      if (node.urlPrimary && this.isLocalAudioUrl(node.urlPrimary)) {
+      if (node.urlPrimary && this.isAllowedAudioUrl(node.urlPrimary)) {
         candidates.push({ url: this.normalizeAudioUrl(node.urlPrimary), format: (node.formatPrimary || '').toLowerCase() || null });
       }
-      if (node.urlFallback && this.isLocalAudioUrl(node.urlFallback)) {
+      if (node.urlFallback && this.isAllowedAudioUrl(node.urlFallback)) {
         candidates.push({ url: this.normalizeAudioUrl(node.urlFallback), format: (node.formatFallback || '').toLowerCase() || null });
       }
 
@@ -146,7 +231,7 @@
     normalizeSourceDescriptor(source) {
       if (!source) return null;
       if (typeof source === 'string') {
-        if (!this.isLocalAudioUrl(source)) return null;
+        if (!this.isAllowedAudioUrl(source)) return null;
         return {
           urls: [this.normalizeAudioUrl(source)],
           preferredFormats: ['wav'],
@@ -290,6 +375,10 @@
         throw this.createBlockedAudioError();
       }
 
+      if (this.pendingPlayRequests.length) {
+        await this.flushPendingPlayRequests();
+      }
+
       return true;
     }
 
@@ -298,7 +387,7 @@
     }
 
     async fetchAndDecode(src, descriptor = null) {
-      if (!this.isLocalAudioUrl(src)) {
+      if (!this.isAllowedAudioUrl(src)) {
         throw new Error(`Origen de audio no permitido: ${src}`);
       }
       if (!this.audioContext) {
@@ -384,11 +473,19 @@
       if (!trackId) return;
       this.currentMusicTrackId = trackId;
       const fadeInMs = Number.isFinite(options.fadeInMs) ? Math.max(0, options.fadeInMs) : 0;
+      const bypassQueueOnBlocked = !!options.bypassQueueOnBlocked;
 
       const sourceDescriptor = this.musicTracks.get(trackId);
       if (!sourceDescriptor) return;
 
-      await this.ensureRunningContext();
+      try {
+        await this.ensureRunningContext();
+      } catch (err) {
+        if (!bypassQueueOnBlocked && err?.code === 'AUDIO_CONTEXT_BLOCKED') {
+          this.enqueuePendingPlay('music', { trackId, options: { fadeInMs } });
+        }
+        throw err;
+      }
       const buffer = await this.loadBufferBySource(sourceDescriptor);
       if (!buffer) return;
 
@@ -423,13 +520,21 @@
       this.currentMusicSource = source;
     }
 
-    async playSfx(eventName) {
+    async playSfx(eventName, options = {}) {
       if (!eventName) return;
       const eventConfig = this.sfxEvents.get(eventName);
       if (!eventConfig) return;
       if (this.activeSfxNodes.size >= this.maxSfxConcurrency) return;
+      const bypassQueueOnBlocked = !!options.bypassQueueOnBlocked;
 
-      await this.ensureRunningContext();
+      try {
+        await this.ensureRunningContext();
+      } catch (err) {
+        if (!bypassQueueOnBlocked && err?.code === 'AUDIO_CONTEXT_BLOCKED') {
+          this.enqueuePendingPlay('sfx', { eventName });
+        }
+        throw err;
+      }
       const buffer = await this.loadBufferBySource(eventConfig.source);
       if (!buffer) return;
 

--- a/public/js/audioManifest.js
+++ b/public/js/audioManifest.js
@@ -2,29 +2,35 @@
   const manifest = {
     manifestVersion: '2026.03.16-local-only-v1',
     globalAudioPolicy: {
-      allowedSourceType: 'repository-local-files-only',
+      allowedSourceType: 'repository-local-files-and-allowlisted-remote',
+      allowedRemoteHosts: ['raw.githubusercontent.com'],
       preferredFormats: ['wav'],
       musicPreload: 'deferred',
       criticalSfxPreload: 'on-game-enter',
       maxSfxBytes: 262144,
-      maxMusicBytes: 1048576,
+      maxMusicBytes: 6291456,
       normalizationNote: 'Todos los audios deben existir en /public/sonidos y versionarse dentro del repositorio.',
     },
     music: {
       backgroundMain: {
         category: 'music',
-        preferredFormats: ['wav'],
+        preferredFormats: ['ogg', 'wav'],
         preload: 'deferred',
-        maxBytes: 1048576,
-        normalizationGain: 0.55,
+        maxBytes: 6291456,
+        normalizationGain: 0.28,
         sources: [
+          {
+            format: 'ogg',
+            url: 'https://raw.githubusercontent.com/mrdoob/three.js/dev/examples/sounds/358232_j_s_song.ogg',
+            kind: 'remote-open-source',
+          },
           {
             format: 'wav',
             url: '/sonidos/5.wav',
             kind: 'local-primary',
           },
         ],
-        description: 'Pista base local (loop).',
+        description: 'Pista base para pruebas (remota con fallback local).',
       },
     },
     sfx: {

--- a/public/juegoactivo.html
+++ b/public/juegoactivo.html
@@ -4614,10 +4614,14 @@
     [AUDIO_EVENTS.TIE]: { manifestKey: 'sfx.win', critical: true, duckAmount: 0.3, duckDurationMs: 1800 }
   });
   const AUDIO_CANTO_EVENT_PREFIX = 'CANTO_NUM_';
+  const AUDIO_BACKGROUND_TRACK_ID = 'GAMEPLAY_BG_MAIN';
+  const AUDIO_BACKGROUND_MANIFEST_KEY = 'music.backgroundMain';
   let audioJuegoInicializado = false;
   let audioJuegoInitPromise = null;
   let audioJuegoDesbloqueoRegistrado = false;
   let audioJuegoCantosEnProceso = false;
+  let audioJuegoMusicaRegistrada = false;
+  let audioJuegoMusicaIniciada = false;
   const audioJuegoEventosRegistrados = new Set();
   const audioJuegoCantosCola = [];
   const audioJuegoUltimoEventoPorNombre = new Map();
@@ -4668,14 +4672,37 @@
     if(typeof window.audioManager.setVolume === 'function'){
       window.audioManager.setVolume('master', audioJuegoPreferencias.master);
       window.audioManager.setVolume('sfx', audioJuegoPreferencias.sfx);
+      window.audioManager.setVolume('music', 0.22);
     }
     if(typeof window.audioManager.setMuted === 'function'){
       window.audioManager.setMuted(audioJuegoPreferencias.muted);
     }
   }
 
+  function registrarAudioMusicaJuego(){
+    if(audioJuegoMusicaRegistrada) return;
+    if(!window.audioManager || typeof window.audioManager.registerMusicTrack !== 'function') return;
+    window.audioManager.registerMusicTrack(AUDIO_BACKGROUND_TRACK_ID, { manifestKey: AUDIO_BACKGROUND_MANIFEST_KEY });
+    audioJuegoMusicaRegistrada = true;
+  }
+
+  async function intentarIniciarMusicaJuego(){
+    if(audioJuegoMusicaIniciada || audioJuegoPreferencias.muted) return;
+    if(!window.audioManager || typeof window.audioManager.playMusic !== 'function') return;
+    registrarAudioMusicaJuego();
+    try{
+      await window.audioManager.playMusic(AUDIO_BACKGROUND_TRACK_ID, { fadeInMs: 1200 });
+      audioJuegoMusicaIniciada = true;
+    }catch(err){
+      if(!esErrorAudioBloqueado(err)){
+        console.warn('No se pudo iniciar la música de fondo del juego.', err);
+      }
+    }
+  }
+
   function registrarAudioEventosBase(){
     if(!window.audioManager || typeof window.audioManager.registerSfxEvent !== 'function') return;
+    registrarAudioMusicaJuego();
     Object.entries(AUDIO_EVENT_CONFIG).forEach(([eventName, config])=>{
       if(audioJuegoEventosRegistrados.has(eventName)) return;
       window.audioManager.registerSfxEvent(eventName, { manifestKey: config.manifestKey }, config);
@@ -4726,6 +4753,7 @@
     if(!window.audioManager || typeof window.audioManager.ensureRunningContext !== 'function') return false;
     try{
       await window.audioManager.ensureRunningContext();
+      await intentarIniciarMusicaJuego();
       await procesarColaAudioCantos();
       return true;
     }catch(err){
@@ -4796,6 +4824,9 @@
       aplicarPreferenciasAudioJuego();
       guardarPreferenciasAudioJuego();
       actualizarUI();
+      if(!audioJuegoPreferencias.muted){
+        void intentarIniciarMusicaJuego();
+      }
     };
 
     gameAudioToggleBtn.addEventListener('click', ()=>{


### PR DESCRIPTION
### Motivation
- Evitar pérdida de intentos de reproducción cuando el `AudioContext` está bloqueado y reintentar automáticamente tras el desbloqueo.  
- Permitir cargas remotas controladas mediante una lista de hosts en el manifiesto para facilitar pruebas y fallback remoto/ local.  
- Integrar una pista de música de fondo y manejar su registro/inicio desde la UI del juego cuando sea posible.

### Description
- Implementa una cola de solicitudes de reproducción (`pendingPlayRequests`) con `enqueuePendingPlay`, `flushPendingPlayRequests` y un control de tamaño (`maxPendingPlayRequests`) y añade logging de depuración con `setDebugEnabled`, `logDebug` y `logWarn`.  
- Modifica `ensureRunningContext`, `playSfx` y `playMusic` para encolar peticiones cuando el contexto esté bloqueado y reintentar automáticamente al desbloquear; añade la opción `bypassQueueOnBlocked` para evitar reencolado en reintentos internos.  
- Añade validación de URLs remotas usando `isAllowedRemoteAudioUrl` / `isAllowedAudioUrl` y aplica estas comprobaciones en `resolveSources`, `normalizeSourceDescriptor` y `fetchAndDecode` para respetar la política del manifiesto.  
- Actualiza el manifiesto (`public/js/audioManifest.js`) para permitir hosts remotos allowlisteados y ajustar `maxMusicBytes` y preferencias de formatos, incluyendo una fuente remota de prueba con fallback local.  
- Integra la música de fondo en la página del juego (`public/juegoactivo.html`) registrando la pista, ajustando el volumen por defecto de `music`, intentando iniciar la música cuando el audio se desbloquea o al cambiar preferencias, y manejando errores de contexto bloqueado.

### Testing
- Añade pruebas unitarias `__tests__/audioManager.test.js` con un `FakeAudioContext` que cubren: encolado de SFX cuando el contexto está bloqueado, reintento de la cola al desbloquear y validación de hosts remotos permitidos por el manifiesto.  
- Ejecuté las pruebas de Jest para `__tests__/audioManager.test.js` y las pruebas unitarias añadidas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaaeef41c483268ef5e3e81013ad16)