### PR TITLE
fix(audio): corrige carga de sonidos en despliegues bajo subruta

### DIFF
--- a/__tests__/audioManager.test.js
+++ b/__tests__/audioManager.test.js
@@ -56,6 +56,11 @@ describe('AudioManager autoplay queue', () => {
     runtimeWindow = {
       AudioContext: FakeAudioContext,
       webkitAudioContext: FakeAudioContext,
+      location: {
+        origin: 'https://bingo-online-231fd.web.app',
+        href: 'https://bingo-online-231fd.web.app/app/juegoactivo.html',
+        protocol: 'https:',
+      },
       setTimeout,
       clearTimeout,
     };
@@ -120,5 +125,12 @@ describe('AudioManager autoplay queue', () => {
     const manager = new AudioManager();
     expect(manager.isAllowedAudioUrl('https://raw.githubusercontent.com/org/repo/file.ogg')).toBe(true);
     expect(manager.isAllowedAudioUrl('https://example.com/music.ogg')).toBe(false);
+  });
+
+  test('acepta audios locales en despliegues bajo subruta', () => {
+    const manager = new AudioManager();
+    const urlSubruta = 'https://bingo-online-231fd.web.app/Bingo-Online/sonidos/1.wav';
+    expect(manager.isAllowedAudioUrl(urlSubruta)).toBe(true);
+    expect(manager.normalizeAudioCacheKey(urlSubruta)).toBe('/Bingo-Online/sonidos/1.wav');
   });
 });

--- a/public/js/audioManager.js
+++ b/public/js/audioManager.js
@@ -145,13 +145,6 @@
       if (!value) return false;
       if (value.startsWith('/sonidos/')) return true;
       if (value.startsWith('sonidos/')) return true;
-      return false;
-    }
-
-    isAllowedRemoteAudioUrl(url) {
-      if (!url || typeof url !== 'string') return false;
-      const value = url.trim();
-      if (!value) return false;
 
       let parsed;
       try {
@@ -159,73 +152,41 @@
       } catch (_) {
         return false;
       }
+      if (!parsed) return false;
 
-      if (!parsed || (parsed.protocol !== 'https:' && parsed.protocol !== 'http:')) return false;
-      if (!/^https?:/i.test(value)) return false;
-
-      const manifestPolicy = this.getManifestNode('globalAudioPolicy');
-      const allowedHosts = Array.isArray(manifestPolicy?.allowedRemoteHosts)
-        ? manifestPolicy.allowedRemoteHosts.map((host) => String(host || '').trim().toLowerCase()).filter(Boolean)
-        : [];
-
-      if (!allowedHosts.length) return false;
-      return allowedHosts.includes(String(parsed.hostname || '').toLowerCase());
-    }
-
-    isAllowedAudioUrl(url) {
-      return this.isLocalAudioUrl(url) || this.isAllowedRemoteAudioUrl(url);
+      const currentOrigin = window.location?.origin || '';
+      if (currentOrigin && parsed.origin !== currentOrigin) return false;
+      return /(^|\/)sonidos\/.+/i.test(parsed.pathname || '');
     }
 
     normalizeAudioUrl(url) {
       const value = String(url || '').trim();
       if (!value) return null;
       if (/^https?:\/\//i.test(value)) return value;
-      if (value.startsWith('/')) return value;
-      return `/${value.replace(/^\/+/, '')}`;
+      if (value.startsWith('//')) {
+        const protocol = window.location?.protocol || 'https:';
+        return `${protocol}${value}`;
+      }
+      try {
+        return new URL(value, window.location?.href || 'http://localhost/').toString();
+      } catch (_) {
+        return value.startsWith('/') ? value : `/${value.replace(/^\/+/, '')}`;
+      }
     }
 
-    resolveSources(node = {}) {
-      const preferredFormats = Array.isArray(node.preferredFormats) && node.preferredFormats.length
-        ? node.preferredFormats
-        : ['wav'];
-
-      const candidates = [];
-      if (Array.isArray(node.sources)) {
-        node.sources.forEach((source) => {
-          if (!source?.url || !this.isAllowedAudioUrl(source.url)) return;
-          candidates.push({
-            url: this.normalizeAudioUrl(source.url),
-            format: (source.format || '').toLowerCase() || null,
-          });
-        });
+    normalizeAudioCacheKey(url) {
+      const normalized = this.normalizeAudioUrl(url);
+      if (!normalized) return null;
+      try {
+        const parsed = new URL(normalized);
+        const currentOrigin = window.location?.origin || '';
+        if (currentOrigin && parsed.origin === currentOrigin) {
+          return `${parsed.pathname}${parsed.search || ''}`;
+        }
+      } catch (_) {
+        return normalized;
       }
-
-      if (node.urlPrimary && this.isAllowedAudioUrl(node.urlPrimary)) {
-        candidates.push({ url: this.normalizeAudioUrl(node.urlPrimary), format: (node.formatPrimary || '').toLowerCase() || null });
-      }
-      if (node.urlFallback && this.isAllowedAudioUrl(node.urlFallback)) {
-        candidates.push({ url: this.normalizeAudioUrl(node.urlFallback), format: (node.formatFallback || '').toLowerCase() || null });
-      }
-
-      const dedup = new Set();
-      const ordered = [];
-
-      preferredFormats.forEach((format) => {
-        candidates.forEach((candidate) => {
-          if (!candidate?.url || dedup.has(candidate.url)) return;
-          if (candidate.format && candidate.format !== format) return;
-          dedup.add(candidate.url);
-          ordered.push(candidate.url);
-        });
-      });
-
-      candidates.forEach((candidate) => {
-        if (!candidate?.url || dedup.has(candidate.url)) return;
-        dedup.add(candidate.url);
-        ordered.push(candidate.url);
-      });
-
-      return ordered;
+      return normalized;
     }
 
     normalizeSourceDescriptor(source) {
@@ -272,6 +233,78 @@
         preload: source.preload || null,
         preloadCritical: !!source.preloadCritical,
       };
+    }
+    
+    isAllowedRemoteAudioUrl(url) {
+      if (!url || typeof url !== 'string') return false;
+      const value = url.trim();
+      if (!value) return false;
+
+      let parsed;
+      try {
+        parsed = new URL(value, window.location?.origin || 'http://localhost');
+      } catch (_) {
+        return false;
+      }
+
+      if (!parsed || (parsed.protocol !== 'https:' && parsed.protocol !== 'http:')) return false;
+      if (!/^https?:/i.test(value)) return false;
+
+      const manifestPolicy = this.getManifestNode('globalAudioPolicy');
+      const allowedHosts = Array.isArray(manifestPolicy?.allowedRemoteHosts)
+        ? manifestPolicy.allowedRemoteHosts.map((host) => String(host || '').trim().toLowerCase()).filter(Boolean)
+        : [];
+
+      if (!allowedHosts.length) return false;
+      return allowedHosts.includes(String(parsed.hostname || '').toLowerCase());
+    }
+
+    isAllowedAudioUrl(url) {
+      return this.isLocalAudioUrl(url) || this.isAllowedRemoteAudioUrl(url);
+    }
+
+    resolveSources(node = {}) {
+      const preferredFormats = Array.isArray(node.preferredFormats) && node.preferredFormats.length
+        ? node.preferredFormats
+        : ['wav'];
+
+      const candidates = [];
+      if (Array.isArray(node.sources)) {
+        node.sources.forEach((source) => {
+          if (!source?.url || !this.isAllowedAudioUrl(source.url)) return;
+          candidates.push({
+            url: this.normalizeAudioUrl(source.url),
+            format: (source.format || '').toLowerCase() || null,
+          });
+        });
+      }
+
+      if (node.urlPrimary && this.isAllowedAudioUrl(node.urlPrimary)) {
+        candidates.push({ url: this.normalizeAudioUrl(node.urlPrimary), format: (node.formatPrimary || '').toLowerCase() || null });
+      }
+      if (node.urlFallback && this.isAllowedAudioUrl(node.urlFallback)) {
+        candidates.push({ url: this.normalizeAudioUrl(node.urlFallback), format: (node.formatFallback || '').toLowerCase() || null });
+      }
+
+      const dedup = new Set();
+      const ordered = [];
+
+      preferredFormats.forEach((format) => {
+        candidates.forEach((candidate) => {
+          if (!candidate?.url || dedup.has(candidate.url)) return;
+          if (candidate.format && candidate.format !== format) return;
+          dedup.add(candidate.url);
+          ordered.push(candidate.url);
+        });
+      });
+
+      candidates.forEach((candidate) => {
+        if (!candidate?.url || dedup.has(candidate.url)) return;
+        dedup.add(candidate.url);
+        ordered.push(candidate.url);
+      });
+
+      return ordered;
     }
 
     registerMusicTrack(trackId, source) {
@@ -413,7 +446,8 @@
       }
 
       const decoded = await this.audioContext.decodeAudioData(data);
-      this.buffers.set(src, decoded);
+      const cacheKey = this.normalizeAudioCacheKey(src);
+      if (cacheKey) this.buffers.set(cacheKey, decoded);
       return decoded;
     }
 
@@ -425,17 +459,24 @@
 
       for (let i = 0; i < urls.length; i += 1) {
         const url = urls[i];
-        if (this.buffers.has(url)) {
-          if (urls[0] && !this.buffers.has(urls[0])) {
-            this.buffers.set(urls[0], this.buffers.get(url));
+        const cacheKey = this.normalizeAudioCacheKey(url);
+        if (cacheKey && this.buffers.has(cacheKey)) {
+          if (urls[0]) {
+            const primaryCacheKey = this.normalizeAudioCacheKey(urls[0]);
+            if (primaryCacheKey && !this.buffers.has(primaryCacheKey)) {
+              this.buffers.set(primaryCacheKey, this.buffers.get(cacheKey));
+            }
           }
-          return this.buffers.get(url);
+          return this.buffers.get(cacheKey);
         }
 
         try {
           const decoded = await this.fetchAndDecode(url, descriptor);
           if (urls[0] && url !== urls[0]) {
-            this.buffers.set(urls[0], decoded);
+            const primaryCacheKey = this.normalizeAudioCacheKey(urls[0]);
+            if (primaryCacheKey) {
+              this.buffers.set(primaryCacheKey, decoded);
+            }
           }
           return decoded;
         } catch (err) {

--- a/public/sw.js
+++ b/public/sw.js
@@ -46,7 +46,8 @@ self.addEventListener('activate', (event) => {
 
 function isAudioRequest(request) {
   const url = new URL(request.url);
-  if (!url.pathname.startsWith('/sonidos/')) return false;
+  const esRutaSonidos = /(^|\/)sonidos\/.+/i.test(url.pathname);
+  if (!esRutaSonidos) return false;
   if (request.destination === 'audio') return true;
   return /\.wav(\?|$)/i.test(url.pathname);
 }


### PR DESCRIPTION
### Motivation
- En despliegues donde la app no vive en la raíz del dominio, las referencias forzadas a `/sonidos/...` producían 404 y evitaban la descarga/decodificación de los WAV, causando que el audio no sonara en el navegador.
- Se busca garantizar que las URLs de audio se resuelvan respecto al contexto real de ejecución (subruta o subcarpeta) sin relajar la política de seguridad de fuentes.

### Description
- Se actualizó `public/js/audioManager.js` para resolver y normalizar URLs de audio con `window.location.href` y aceptar rutas `sonidos/` same-origin que vivan dentro de subrutas; además se añadió `normalizeAudioCacheKey` para claves de cache consistentes y evitar duplicados entre formas absolutas/relativas.
- Se modificó `public/sw.js` para detectar peticiones de audio cuando la ruta contiene `sonidos/` en cualquier subruta (no solo cuando empieza en `/sonidos/`), evitando que el service worker deje pasar solicitudes en despliegues no-root.
- Se agregó una prueba en `__tests__/audioManager.test.js` que valida la aceptación y normalización de una URL local servida desde una subruta (ej. `https://.../Bingo-Online/sonidos/1.wav`).
- Archivos modificados: `public/js/audioManager.js`, `public/sw.js`, `__tests__/audioManager.test.js`; plan de rollback: revertir el cambio y volver a publicar el frontend/SW y limpiar caché de clientes si fuera necesario.

### Testing
- Ejecutado: `npm test` y todas las suites pasaron; resultado: "PASS 12 suites, 39 tests" (estatus: PASS).
- Tests unitarios relevantes: `__tests__/audioManager.test.js` (incluye nuevo caso para subruta) — pasó correctamente.
- Nota de despliegue: después de publicar se debe forzar actualización del service worker (hard refresh / unregister SW) para evitar clientes con la versión anterior del `sw.js` (esto no afecta los tests automatizados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec25065f94832682f035a55955ff00)