### PR TITLE
chore(firebase): separar configuración por entorno para deploy

### DIFF
--- a/.github/workflows/deploy-by-branch.yml
+++ b/.github/workflows/deploy-by-branch.yml
@@ -13,19 +13,27 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/dev'
     env:
+      DEPLOY_ENV: dev
       HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD != '' &&
-        secrets.FIREBASE_WEB_API_KEY != '' &&
-        secrets.FIREBASE_AUTH_DOMAIN != '' &&
-        secrets.FIREBASE_DATABASE_URL != '' &&
-        secrets.FIREBASE_PROJECT_ID != '' &&
-        secrets.FIREBASE_STORAGE_BUCKET != '' &&
-        secrets.FIREBASE_MESSAGING_SENDER_ID != '' &&
-        secrets.FIREBASE_APP_ID != '' }}
+        secrets.FIREBASE_DEV_API_KEY != '' &&
+        secrets.FIREBASE_DEV_AUTH_DOMAIN != '' &&
+        secrets.FIREBASE_DEV_DATABASE_URL != '' &&
+        secrets.FIREBASE_DEV_PROJECT_ID != '' &&
+        secrets.FIREBASE_DEV_STORAGE_BUCKET != '' &&
+        secrets.FIREBASE_DEV_MESSAGING_SENDER_ID != '' &&
+        secrets.FIREBASE_DEV_APP_ID != '' }}
+      FIREBASE_DEV_API_KEY: ${{ secrets.FIREBASE_DEV_API_KEY }}
+      FIREBASE_DEV_AUTH_DOMAIN: ${{ secrets.FIREBASE_DEV_AUTH_DOMAIN }}
+      FIREBASE_DEV_DATABASE_URL: ${{ secrets.FIREBASE_DEV_DATABASE_URL }}
+      FIREBASE_DEV_PROJECT_ID: ${{ secrets.FIREBASE_DEV_PROJECT_ID }}
+      FIREBASE_DEV_STORAGE_BUCKET: ${{ secrets.FIREBASE_DEV_STORAGE_BUCKET }}
+      FIREBASE_DEV_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_DEV_MESSAGING_SENDER_ID }}
+      FIREBASE_DEV_APP_ID: ${{ secrets.FIREBASE_DEV_APP_ID }}
     steps:
       - name: Aviso por falta de credenciales
         if: env.HAS_FIREBASE_SECRETS != 'true'
         run: |
-          echo "::warning::No se encontraron todas las credenciales de Firebase necesarias."
+          echo "::warning::No se encontraron todas las credenciales de Firebase necesarias para dev."
           echo "::warning::Se omite el despliegue automático para la rama dev."
 
       - uses: actions/checkout@v4
@@ -33,24 +41,7 @@ jobs:
 
       - name: Generar firebase-config.js
         if: env.HAS_FIREBASE_SECRETS == 'true'
-        run: |
-          set -euo pipefail
-          cp public/firebase-config.template.js public/firebase-config.js
-          sed -i "s|__FIREBASE_API_KEY__|${FIREBASE_API_KEY}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_AUTH_DOMAIN__|${FIREBASE_AUTH_DOMAIN}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_DATABASE_URL__|${FIREBASE_DATABASE_URL}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_PROJECT_ID__|${FIREBASE_PROJECT_ID}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_STORAGE_BUCKET__|${FIREBASE_STORAGE_BUCKET}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_MESSAGING_SENDER_ID__|${FIREBASE_MESSAGING_SENDER_ID}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_APP_ID__|${FIREBASE_APP_ID}|g" public/firebase-config.js
-        env:
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
-          FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
-          FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-          FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
-          FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
-          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+        run: node scripts/generateFirebaseConfig.js --env "${DEPLOY_ENV}"
 
       - name: Deploy to Firebase Hosting
         if: env.HAS_FIREBASE_SECRETS == 'true'
@@ -66,19 +57,27 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/staging'
     env:
+      DEPLOY_ENV: stg
       HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD != '' &&
-        secrets.FIREBASE_WEB_API_KEY != '' &&
-        secrets.FIREBASE_AUTH_DOMAIN != '' &&
-        secrets.FIREBASE_DATABASE_URL != '' &&
-        secrets.FIREBASE_PROJECT_ID != '' &&
-        secrets.FIREBASE_STORAGE_BUCKET != '' &&
-        secrets.FIREBASE_MESSAGING_SENDER_ID != '' &&
-        secrets.FIREBASE_APP_ID != '' }}
+        secrets.FIREBASE_STG_API_KEY != '' &&
+        secrets.FIREBASE_STG_AUTH_DOMAIN != '' &&
+        secrets.FIREBASE_STG_DATABASE_URL != '' &&
+        secrets.FIREBASE_STG_PROJECT_ID != '' &&
+        secrets.FIREBASE_STG_STORAGE_BUCKET != '' &&
+        secrets.FIREBASE_STG_MESSAGING_SENDER_ID != '' &&
+        secrets.FIREBASE_STG_APP_ID != '' }}
+      FIREBASE_STG_API_KEY: ${{ secrets.FIREBASE_STG_API_KEY }}
+      FIREBASE_STG_AUTH_DOMAIN: ${{ secrets.FIREBASE_STG_AUTH_DOMAIN }}
+      FIREBASE_STG_DATABASE_URL: ${{ secrets.FIREBASE_STG_DATABASE_URL }}
+      FIREBASE_STG_PROJECT_ID: ${{ secrets.FIREBASE_STG_PROJECT_ID }}
+      FIREBASE_STG_STORAGE_BUCKET: ${{ secrets.FIREBASE_STG_STORAGE_BUCKET }}
+      FIREBASE_STG_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_STG_MESSAGING_SENDER_ID }}
+      FIREBASE_STG_APP_ID: ${{ secrets.FIREBASE_STG_APP_ID }}
     steps:
       - name: Aviso por falta de credenciales
         if: env.HAS_FIREBASE_SECRETS != 'true'
         run: |
-          echo "::warning::No se encontraron todas las credenciales de Firebase necesarias."
+          echo "::warning::No se encontraron todas las credenciales de Firebase necesarias para staging."
           echo "::warning::Se omite el despliegue automático para la rama staging."
 
       - uses: actions/checkout@v4
@@ -86,24 +85,7 @@ jobs:
 
       - name: Generar firebase-config.js
         if: env.HAS_FIREBASE_SECRETS == 'true'
-        run: |
-          set -euo pipefail
-          cp public/firebase-config.template.js public/firebase-config.js
-          sed -i "s|__FIREBASE_API_KEY__|${FIREBASE_API_KEY}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_AUTH_DOMAIN__|${FIREBASE_AUTH_DOMAIN}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_DATABASE_URL__|${FIREBASE_DATABASE_URL}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_PROJECT_ID__|${FIREBASE_PROJECT_ID}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_STORAGE_BUCKET__|${FIREBASE_STORAGE_BUCKET}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_MESSAGING_SENDER_ID__|${FIREBASE_MESSAGING_SENDER_ID}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_APP_ID__|${FIREBASE_APP_ID}|g" public/firebase-config.js
-        env:
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
-          FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
-          FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-          FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
-          FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
-          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+        run: node scripts/generateFirebaseConfig.js --env "${DEPLOY_ENV}"
 
       - name: Deploy to Firebase Hosting
         if: env.HAS_FIREBASE_SECRETS == 'true'
@@ -119,19 +101,27 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     env:
+      DEPLOY_ENV: prod
       HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD != '' &&
-        secrets.FIREBASE_WEB_API_KEY != '' &&
-        secrets.FIREBASE_AUTH_DOMAIN != '' &&
-        secrets.FIREBASE_DATABASE_URL != '' &&
-        secrets.FIREBASE_PROJECT_ID != '' &&
-        secrets.FIREBASE_STORAGE_BUCKET != '' &&
-        secrets.FIREBASE_MESSAGING_SENDER_ID != '' &&
-        secrets.FIREBASE_APP_ID != '' }}
+        secrets.FIREBASE_PROD_API_KEY != '' &&
+        secrets.FIREBASE_PROD_AUTH_DOMAIN != '' &&
+        secrets.FIREBASE_PROD_DATABASE_URL != '' &&
+        secrets.FIREBASE_PROD_PROJECT_ID != '' &&
+        secrets.FIREBASE_PROD_STORAGE_BUCKET != '' &&
+        secrets.FIREBASE_PROD_MESSAGING_SENDER_ID != '' &&
+        secrets.FIREBASE_PROD_APP_ID != '' }}
+      FIREBASE_PROD_API_KEY: ${{ secrets.FIREBASE_PROD_API_KEY }}
+      FIREBASE_PROD_AUTH_DOMAIN: ${{ secrets.FIREBASE_PROD_AUTH_DOMAIN }}
+      FIREBASE_PROD_DATABASE_URL: ${{ secrets.FIREBASE_PROD_DATABASE_URL }}
+      FIREBASE_PROD_PROJECT_ID: ${{ secrets.FIREBASE_PROD_PROJECT_ID }}
+      FIREBASE_PROD_STORAGE_BUCKET: ${{ secrets.FIREBASE_PROD_STORAGE_BUCKET }}
+      FIREBASE_PROD_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_PROD_MESSAGING_SENDER_ID }}
+      FIREBASE_PROD_APP_ID: ${{ secrets.FIREBASE_PROD_APP_ID }}
     steps:
       - name: Aviso por falta de credenciales
         if: env.HAS_FIREBASE_SECRETS != 'true'
         run: |
-          echo "::warning::No se encontraron todas las credenciales de Firebase necesarias."
+          echo "::warning::No se encontraron todas las credenciales de Firebase necesarias para producción."
           echo "::warning::Se omite el despliegue automático para la rama main."
 
       - uses: actions/checkout@v4
@@ -139,24 +129,7 @@ jobs:
 
       - name: Generar firebase-config.js
         if: env.HAS_FIREBASE_SECRETS == 'true'
-        run: |
-          set -euo pipefail
-          cp public/firebase-config.template.js public/firebase-config.js
-          sed -i "s|__FIREBASE_API_KEY__|${FIREBASE_API_KEY}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_AUTH_DOMAIN__|${FIREBASE_AUTH_DOMAIN}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_DATABASE_URL__|${FIREBASE_DATABASE_URL}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_PROJECT_ID__|${FIREBASE_PROJECT_ID}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_STORAGE_BUCKET__|${FIREBASE_STORAGE_BUCKET}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_MESSAGING_SENDER_ID__|${FIREBASE_MESSAGING_SENDER_ID}|g" public/firebase-config.js
-          sed -i "s|__FIREBASE_APP_ID__|${FIREBASE_APP_ID}|g" public/firebase-config.js
-        env:
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
-          FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
-          FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-          FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
-          FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
-          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+        run: node scripts/generateFirebaseConfig.js --env "${DEPLOY_ENV}"
 
       - name: Deploy to Firebase Hosting
         if: env.HAS_FIREBASE_SECRETS == 'true'

--- a/README.md
+++ b/README.md
@@ -105,35 +105,55 @@ El archivo `index.html` contiene toda la lógica de la aplicación. Sólo es nec
 
 ### Configuración de `firebase-config`
 
-El repositorio incluye la plantilla `public/firebase-config.template.js`. Antes de ejecutar el sitio debe copiarse a `public/firebase-config.js` y reemplazar los marcadores `__FIREBASE_*__` por los valores reales de Firebase:
+El repositorio incluye el script `scripts/generateFirebaseConfig.js` para generar `public/firebase-config.js` por entorno sin versionar credenciales. Comando base:
 
 ```bash
-cp public/firebase-config.template.js public/firebase-config.js
+npm run generate:firebase-config -- --env dev
 ```
 
-Luego edite el archivo resultante y actualice cada propiedad (`apiKey`, `authDomain`, `databaseURL`, `projectId`, `storageBucket`, `messagingSenderId`, `appId`). Este archivo contiene credenciales sensibles y está excluido del control de versiones mediante `.gitignore`.
+Entornos soportados:
+
+- `dev` → Hosting target `bingo-online-231fd-dev` y base de datos `dev-db`
+- `stg` → Hosting target `bingo-online-231fd-stg` y base de datos `stg-db`
+- `prod` (o `main`) → Hosting target `bingo-online-231fd` y base de datos default
+
+Variables requeridas por entorno (con fallback a versión global sin prefijo):
+
+- `FIREBASE_<ENV>_API_KEY`
+- `FIREBASE_<ENV>_AUTH_DOMAIN`
+- `FIREBASE_<ENV>_DATABASE_URL`
+- `FIREBASE_<ENV>_PROJECT_ID`
+- `FIREBASE_<ENV>_STORAGE_BUCKET`
+- `FIREBASE_<ENV>_MESSAGING_SENDER_ID`
+- `FIREBASE_<ENV>_APP_ID`
+
+> Ejemplo para staging (`<ENV>=STG`): `FIREBASE_STG_DATABASE_URL=https://bingo-online-231fd-stg-db.firebaseio.com`.
 
 > **Nota sobre Storage**: Si en la consola de Firebase el bucket aparece con el dominio `*.firebasestorage.app`, utilice ese valor sin modificarlo. La interfaz convierte automáticamente ese formato al identificador clásico (`*.appspot.com`) al inicializar el SDK para garantizar la compatibilidad con `firebase-storage-compat` y permitir la subida de los PDFs generados.
 
 ### Dominio y cookies
 
-A partir de las últimas versiones de los navegadores se bloquean las cookies de terceros por defecto. Si la aplicación se aloja en un dominio distinto al configurado en `authDomain` (por ejemplo GitHub Pages), Firebase no puede completar el inicio de sesión y la página queda cargando indefinidamente.
+A partir de las últimas versiones de los navegadores se bloquean las cookies de terceros por defecto. Si la aplicación se aloja en un dominio distinto al configurado en `authDomain`, Firebase no puede completar el inicio de sesión y la página queda cargando indefinidamente.
 
-Para evitarlo, despliegue el sitio en Firebase Hosting utilizando el dominio del proyecto (`bingo-online-231fd.web.app` o un dominio personalizado asociado). Así las cookies son del mismo sitio y la autenticación funciona de forma correcta.
+Para evitarlo, cada entorno debe usar su propio dominio Firebase Hosting como `authDomain`:
+
+- Desarrollo: `bingo-online-231fd-dev.web.app`
+- Pruebas: `bingo-online-231fd-stg.web.app`
+- Producción: `bingo-online-231fd.web.app`
+
+Además, en Firebase Authentication > Settings > Authorized domains agregue estos tres dominios para permitir login en cada ambiente de manera aislada.
 
 ### Despliegues automáticos (GitHub Actions)
 
-Los flujos definidos en `.github/workflows/` generan `public/firebase-config.js` a partir de la plantilla antes de invocar a Firebase Hosting. Configure los siguientes secretos en el repositorio para que la sustitución se realice correctamente:
+El flujo `.github/workflows/deploy-by-branch.yml` genera `public/firebase-config.js` con el script anterior y despliega por rama (`dev`, `staging`, `main`) usando targets de Hosting distintos.
 
-- `FIREBASE_WEB_API_KEY`
-- `FIREBASE_AUTH_DOMAIN`
-- `FIREBASE_DATABASE_URL`
-- `FIREBASE_PROJECT_ID`
-- `FIREBASE_STORAGE_BUCKET`
-- `FIREBASE_MESSAGING_SENDER_ID`
-- `FIREBASE_APP_ID`
+Configure los siguientes secretos por entorno en GitHub:
 
-Cada secreto debe contener el valor correspondiente del proyecto de Firebase. Si utiliza otras herramientas de despliegue, replique el mismo proceso de copiado y reemplazo de marcadores antes de publicar los archivos.
+- Dev: `FIREBASE_DEV_API_KEY`, `FIREBASE_DEV_AUTH_DOMAIN`, `FIREBASE_DEV_DATABASE_URL`, `FIREBASE_DEV_PROJECT_ID`, `FIREBASE_DEV_STORAGE_BUCKET`, `FIREBASE_DEV_MESSAGING_SENDER_ID`, `FIREBASE_DEV_APP_ID`
+- Staging: `FIREBASE_STG_API_KEY`, `FIREBASE_STG_AUTH_DOMAIN`, `FIREBASE_STG_DATABASE_URL`, `FIREBASE_STG_PROJECT_ID`, `FIREBASE_STG_STORAGE_BUCKET`, `FIREBASE_STG_MESSAGING_SENDER_ID`, `FIREBASE_STG_APP_ID`
+- Producción: `FIREBASE_PROD_API_KEY`, `FIREBASE_PROD_AUTH_DOMAIN`, `FIREBASE_PROD_DATABASE_URL`, `FIREBASE_PROD_PROJECT_ID`, `FIREBASE_PROD_STORAGE_BUCKET`, `FIREBASE_PROD_MESSAGING_SENDER_ID`, `FIREBASE_PROD_APP_ID`
+
+Además se mantiene el secreto de cuenta de servicio `FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD` para publicar en Hosting.
 
 ## Mutaciones de Firestore por Pull Request (Bingoanimalito)
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "assign-role": "node scripts/assignRoleClaims.js",
     "apply-firebase-mutations": "node scripts/applyFirestoreMutations.js",
     "test:coverage": "jest --coverage",
-    "reconciliar-premios": "node scripts/reconciliarPremiosPendientes.js"
+    "reconciliar-premios": "node scripts/reconciliarPremiosPendientes.js",
+    "generate:firebase-config": "node scripts/generateFirebaseConfig.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/generateFirebaseConfig.js
+++ b/scripts/generateFirebaseConfig.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ENV_ALIASES = {
+  dev: 'dev',
+  desarrollo: 'dev',
+  development: 'dev',
+  stg: 'stg',
+  stage: 'stg',
+  staging: 'stg',
+  prod: 'prod',
+  production: 'prod',
+  main: 'prod'
+};
+
+const REQUIRED_KEYS = [
+  'FIREBASE_API_KEY',
+  'FIREBASE_AUTH_DOMAIN',
+  'FIREBASE_DATABASE_URL',
+  'FIREBASE_PROJECT_ID',
+  'FIREBASE_STORAGE_BUCKET',
+  'FIREBASE_MESSAGING_SENDER_ID',
+  'FIREBASE_APP_ID'
+];
+
+function parseArgs(argv) {
+  const args = { env: process.env.APP_ENV || process.env.ENV || 'prod', output: 'public/firebase-config.js' };
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const current = argv[index];
+
+    if ((current === '--env' || current === '-e') && argv[index + 1]) {
+      args.env = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if ((current === '--output' || current === '-o') && argv[index + 1]) {
+      args.output = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (current === '--help' || current === '-h') {
+      args.help = true;
+      break;
+    }
+  }
+
+  return args;
+}
+
+function normalizeEnv(rawEnv) {
+  const normalized = String(rawEnv || '').trim().toLowerCase();
+  return ENV_ALIASES[normalized] || normalized;
+}
+
+function resolveValue(key, envKey) {
+  return process.env[envKey] || process.env[key] || '';
+}
+
+function escapeTemplateValue(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function printHelp() {
+  console.log(`Uso:\n  node scripts/generateFirebaseConfig.js --env <dev|stg|prod> [--output public/firebase-config.js]\n\nVariables requeridas por entorno:\n  FIREBASE_<ENV>_API_KEY\n  FIREBASE_<ENV>_AUTH_DOMAIN\n  FIREBASE_<ENV>_DATABASE_URL\n  FIREBASE_<ENV>_PROJECT_ID\n  FIREBASE_<ENV>_STORAGE_BUCKET\n  FIREBASE_<ENV>_MESSAGING_SENDER_ID\n  FIREBASE_<ENV>_APP_ID\n\nTambién acepta fallback sin prefijo de entorno: FIREBASE_API_KEY, FIREBASE_AUTH_DOMAIN, etc.`);
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const environment = normalizeEnv(args.env);
+  if (!['dev', 'stg', 'prod'].includes(environment)) {
+    throw new Error(`Entorno no soportado: ${args.env}. Use dev, stg o prod.`);
+  }
+
+  const prefix = `FIREBASE_${environment.toUpperCase()}_`;
+
+  const config = {};
+  const missing = [];
+
+  for (const key of REQUIRED_KEYS) {
+    const suffix = key.replace('FIREBASE_', '');
+    const envKey = `${prefix}${suffix}`;
+    const value = resolveValue(key, envKey);
+
+    if (!value) {
+      missing.push(`${envKey} (o fallback ${key})`);
+    }
+
+    const targetKey = suffix
+      .toLowerCase()
+      .replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+
+    config[targetKey] = value;
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Faltan variables requeridas para ${environment}:\n- ${missing.join('\n- ')}`);
+  }
+
+  const outputPath = path.resolve(process.cwd(), args.output);
+  const content = `// Archivo generado automáticamente por scripts/generateFirebaseConfig.js\n// Entorno: ${environment}\nwindow.__FIREBASE_CONFIG__ = {\n  apiKey: "${escapeTemplateValue(config.apiKey)}",\n  authDomain: "${escapeTemplateValue(config.authDomain)}",\n  databaseURL: "${escapeTemplateValue(config.databaseUrl)}",\n  projectId: "${escapeTemplateValue(config.projectId)}",\n  storageBucket: "${escapeTemplateValue(config.storageBucket)}",\n  messagingSenderId: "${escapeTemplateValue(config.messagingSenderId)}",\n  appId: "${escapeTemplateValue(config.appId)}"\n};\n`;
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, content, 'utf8');
+  console.log(`firebase-config generado en ${outputPath} para entorno ${environment}`);
+}
+
+main();


### PR DESCRIPTION
### Motivation
- Aislar las configuraciones de Firebase por entorno para evitar que `dev` o `staging` apunten por error a la base de datos o hosting de `main`, evitando contaminación de datos entre `dev-db`, `stg-db` y el entorno por defecto.
- Facilitar generación de `public/firebase-config.js` por entorno en CI/local sin versionar credenciales ni introducir secrets en el repositorio.
- Reducir riesgo operativo al hacer explícitos los secretos por ambiente y documentar los dominios autorizados para Firebase Auth.

### Description
- Se añadió el script `scripts/generateFirebaseConfig.js` que genera `public/firebase-config.js` por entorno (`--env dev|stg|prod`), valida variables requeridas y permite fallbacks globales; el script produce el objeto `window.__FIREBASE_CONFIG__` usado por la app.
- Se actualizó el workflow de despliegue a `.github/workflows/deploy-by-branch.yml` para usar secretos por entorno (`FIREBASE_DEV_*`, `FIREBASE_STG_*`, `FIREBASE_PROD_*`) y ejecutar el script anterior en lugar de `sed` inline, manteniendo los targets de hosting separados (`dev`, `stg`, `prod`).
- Se documentó en `README.md` la nueva estrategia multi-entorno (mapeo hosting ↔ base de datos), la lista de secretos por entorno y los dominios `authDomain` por ambiente que deben añadirse en Firebase Auth.
- Se agregó el script de npm `generate:firebase-config` en `package.json` y no se tocaron `firestore.rules` ni `storage.rules`.

### Testing
- Ejecuté `npm test` y todos los tests unitarios pasaron: `Test Suites: 12 passed, 12 total` y `Tests: 39 passed, 39 total` (estado: PASS).
- Verifiqué la generación local del config con ejemplo de environment vars: `FIREBASE_DEV_API_KEY=dev-key FIREBASE_DEV_AUTH_DOMAIN=bingo-online-231fd-dev.web.app FIREBASE_DEV_DATABASE_URL=https://bingo-online-231fd-dev-db.firebaseio.com FIREBASE_DEV_PROJECT_ID=bingo-online-231fd FIREBASE_DEV_STORAGE_BUCKET=bingo-online-231fd.firebasestorage.app FIREBASE_DEV_MESSAGING_SENDER_ID=123 FIREBASE_DEV_APP_ID=1:123:web:abc npm run generate:firebase-config -- --env dev` (resultado: `firebase-config generado en /workspace/Bingo-Online/public/firebase-config.js para entorno dev`, estado: PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecc0dd0464832693bab4d2809f37e2)