### PR TITLE
chore(firebase): agrega flujo de configuracion para entorno dev

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,10 @@
+# Copie este archivo como .env.dev y reemplace cada valor para su proyecto Firebase de desarrollo.
+FIREBASE_API_KEY=
+FIREBASE_AUTH_DOMAIN=
+FIREBASE_PROJECT_ID=
+FIREBASE_STORAGE_BUCKET=
+FIREBASE_MESSAGING_SENDER_ID=
+FIREBASE_APP_ID=
+# Opcionales
+FIREBASE_DATABASE_URL=
+FIREBASE_MEASUREMENT_ID=

--- a/README.md
+++ b/README.md
@@ -79,13 +79,33 @@ El archivo `index.html` contiene toda la lógica de la aplicación. Sólo es nec
 
 ### Configuración de `firebase-config`
 
-El repositorio incluye la plantilla `public/firebase-config.template.js`. Antes de ejecutar el sitio debe copiarse a `public/firebase-config.js` y reemplazar los marcadores `__FIREBASE_*__` por los valores reales de Firebase:
+El repositorio incluye la plantilla `public/firebase-config.template.js` y el generador `npm run generate:firebase-config` para crear `public/firebase-config.js` sin hardcodear credenciales en el código.
 
-```bash
-cp public/firebase-config.template.js public/firebase-config.js
+#### Entorno `dev` (Firebase project separado)
+
+1. Cree un archivo local `.env.dev` (no versionado) con sus valores de Firebase:
+
+```dotenv
+FIREBASE_API_KEY=...
+FIREBASE_AUTH_DOMAIN=...
+FIREBASE_PROJECT_ID=...
+FIREBASE_STORAGE_BUCKET=...
+FIREBASE_MESSAGING_SENDER_ID=...
+FIREBASE_APP_ID=...
+# Opcionales
+FIREBASE_DATABASE_URL=
+FIREBASE_MEASUREMENT_ID=
 ```
 
-Luego edite el archivo resultante y actualice cada propiedad (`apiKey`, `authDomain`, `databaseURL`, `projectId`, `storageBucket`, `messagingSenderId`, `appId`). Este archivo contiene credenciales sensibles y está excluido del control de versiones mediante `.gitignore`.
+2. Genere el archivo de configuración usado por el frontend:
+
+```bash
+FIREBASE_ENV_FILE=.env.dev npm run generate:firebase-config
+```
+
+3. Verifique que se creó `public/firebase-config.js` y luego levante la app.
+
+> `public/firebase-config.js` está excluido del control de versiones por `.gitignore`, por lo que cada entorno (dev/staging/prod) puede generar su propio archivo sin mezclar configuraciones.
 
 > **Nota sobre Storage**: Si en la consola de Firebase el bucket aparece con el dominio `*.firebasestorage.app`, utilice ese valor sin modificarlo. La interfaz convierte automáticamente ese formato al identificador clásico (`*.appspot.com`) al inicializar el SDK para garantizar la compatibilidad con `firebase-storage-compat` y permitir la subida de los PDFs generados.
 
@@ -106,6 +126,7 @@ Los flujos definidos en `.github/workflows/` generan `public/firebase-config.js`
 - `FIREBASE_STORAGE_BUCKET`
 - `FIREBASE_MESSAGING_SENDER_ID`
 - `FIREBASE_APP_ID`
+- `FIREBASE_MEASUREMENT_ID` (opcional)
 
 Cada secreto debe contener el valor correspondiente del proyecto de Firebase. Si utiliza otras herramientas de despliegue, replique el mismo proceso de copiado y reemplazo de marcadores antes de publicar los archivos.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest",
     "start": "node uploadServer.js",
-    "cron": "node cronActualizarEstadosSorteos.js"
+    "cron": "node cronActualizarEstadosSorteos.js",
+    "generate:firebase-config": "node scripts/generate-firebase-config.js"
   },
   "keywords": [],
   "author": "",

--- a/public/firebase-config.template.js
+++ b/public/firebase-config.template.js
@@ -1,5 +1,5 @@
 // Plantilla para generar la configuración de Firebase durante los despliegues.
-// Los valores __FIREBASE_*__ se reemplazan en los workflows de GitHub Actions.
+// Los valores __FIREBASE_*__ se reemplazan en CI/CD o con npm run generate:firebase-config.
 window.__FIREBASE_CONFIG__ = {
   apiKey: "__FIREBASE_API_KEY__",
   authDomain: "__FIREBASE_AUTH_DOMAIN__",
@@ -7,5 +7,6 @@ window.__FIREBASE_CONFIG__ = {
   projectId: "__FIREBASE_PROJECT_ID__",
   storageBucket: "__FIREBASE_STORAGE_BUCKET__",
   messagingSenderId: "__FIREBASE_MESSAGING_SENDER_ID__",
-  appId: "__FIREBASE_APP_ID__"
+  appId: "__FIREBASE_APP_ID__",
+  measurementId: "__FIREBASE_MEASUREMENT_ID__"
 };

--- a/scripts/generate-firebase-config.js
+++ b/scripts/generate-firebase-config.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+const rootDir = path.resolve(__dirname, '..');
+const envFile = process.env.FIREBASE_ENV_FILE || '.env';
+const envPath = path.resolve(rootDir, envFile);
+
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+} else {
+  dotenv.config();
+}
+
+const templatePath = path.join(rootDir, 'public', 'firebase-config.template.js');
+const outputPath = path.join(rootDir, 'public', 'firebase-config.js');
+
+const requiredEnvVars = [
+  'FIREBASE_API_KEY',
+  'FIREBASE_AUTH_DOMAIN',
+  'FIREBASE_PROJECT_ID',
+  'FIREBASE_STORAGE_BUCKET',
+  'FIREBASE_MESSAGING_SENDER_ID',
+  'FIREBASE_APP_ID'
+];
+
+const optionalEnvVars = ['FIREBASE_DATABASE_URL', 'FIREBASE_MEASUREMENT_ID'];
+
+const missingVars = requiredEnvVars.filter((envVar) => !process.env[envVar]);
+if (missingVars.length > 0) {
+  console.error(
+    `Faltan variables requeridas para Firebase: ${missingVars.join(', ')}. ` +
+      'Defínalas en variables de entorno o en el archivo .env indicado.'
+  );
+  process.exit(1);
+}
+
+const template = fs.readFileSync(templatePath, 'utf8');
+const replacementMap = {
+  '__FIREBASE_API_KEY__': process.env.FIREBASE_API_KEY,
+  '__FIREBASE_AUTH_DOMAIN__': process.env.FIREBASE_AUTH_DOMAIN,
+  '__FIREBASE_DATABASE_URL__': process.env.FIREBASE_DATABASE_URL || '',
+  '__FIREBASE_PROJECT_ID__': process.env.FIREBASE_PROJECT_ID,
+  '__FIREBASE_STORAGE_BUCKET__': process.env.FIREBASE_STORAGE_BUCKET,
+  '__FIREBASE_MESSAGING_SENDER_ID__': process.env.FIREBASE_MESSAGING_SENDER_ID,
+  '__FIREBASE_APP_ID__': process.env.FIREBASE_APP_ID,
+  '__FIREBASE_MEASUREMENT_ID__': process.env.FIREBASE_MEASUREMENT_ID || ''
+};
+
+let output = template;
+for (const [placeholder, value] of Object.entries(replacementMap)) {
+  output = output.replaceAll(placeholder, value);
+}
+
+for (const envVar of optionalEnvVars) {
+  if (!process.env[envVar]) {
+    const propertyName = envVar.replace('FIREBASE_', '').toLowerCase();
+    const jsPropertyName = propertyName.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+    const regex = new RegExp(`\\n\\s*${jsPropertyName}: \\"\\",?`, 'g');
+    output = output.replace(regex, '');
+  }
+}
+
+fs.writeFileSync(outputPath, `${output.trimEnd()}\n`, 'utf8');
+console.log(`Archivo generado: ${path.relative(rootDir, outputPath)} usando ${path.basename(envPath)}`);


### PR DESCRIPTION
### Motivation
- Evitar la edición manual y el versionado de credenciales al enlazar proyectos Firebase por entorno (dev/staging/prod).
- Facilitar la generación reproducible de `public/firebase-config.js` desde variables de entorno para permitir despliegues y pruebas locales del proyecto con proyectos Firebase separados.
- Mantener la seguridad y cumplir la convención del repositorio de no incluir archivos con credenciales en el control de versiones.

### Description
- Se añadió el script `scripts/generate-firebase-config.js` que lee variables de entorno (o un archivo indicado por `FIREBASE_ENV_FILE`) y genera `public/firebase-config.js` a partir de `public/firebase-config.template.js` validando las variables requeridas.
- Se agregó el script de npm `generate:firebase-config` en `package.json` y el ejemplo `.env.dev.example` con las variables necesarias/opcionales para el entorno `dev`.
- Se actualizó `public/firebase-config.template.js` para incluir `measurementId` como propiedad opcional y se documentó en `README.md` el flujo para crear `.env.dev` y ejecutar `FIREBASE_ENV_FILE=.env.dev npm run generate:firebase-config`.
- Rollback: revertir los archivos modificados y eliminar el script `generate:firebase-config` para volver al flujo manual de copia/edición de la plantilla.

### Testing
- Ejecuté `npm test` y pasó correctamente: `PASS __tests__/player.test.js` (estado: PASS).
- Probé la generación del archivo con `FIREBASE_ENV_FILE=.env.dev npm run generate:firebase-config` usando variables en un `.env.dev` local (no versionado); el comando generó `public/firebase-config.js` (estado: PASS).
- Verificación adicional: `public/firebase-config.js` permanece ignorado por `.gitignore` y no se cometieron credenciales en el repositorio (estado: PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8367371c83268d3d2ece03fcfd05)