### PR TITLE
chore(config): integra variables de Firebase para staging (measurementId y secretos STG)

### DIFF
--- a/.github/workflows/deploy-by-branch.yml
+++ b/.github/workflows/deploy-by-branch.yml
@@ -20,7 +20,8 @@ jobs:
         secrets.FIREBASE_PROJECT_ID != '' &&
         secrets.FIREBASE_STORAGE_BUCKET != '' &&
         secrets.FIREBASE_MESSAGING_SENDER_ID != '' &&
-        secrets.FIREBASE_APP_ID != '' }}
+        secrets.FIREBASE_APP_ID != '' &&
+        secrets.FIREBASE_MEASUREMENT_ID != '' }}
     steps:
       - name: Aviso por falta de credenciales
         if: env.HAS_FIREBASE_SECRETS != 'true'
@@ -43,6 +44,7 @@ jobs:
           sed -i "s|__FIREBASE_STORAGE_BUCKET__|${FIREBASE_STORAGE_BUCKET}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_MESSAGING_SENDER_ID__|${FIREBASE_MESSAGING_SENDER_ID}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_APP_ID__|${FIREBASE_APP_ID}|g" public/firebase-config.js
+          sed -i "s|__FIREBASE_MEASUREMENT_ID__|${FIREBASE_MEASUREMENT_ID}|g" public/firebase-config.js
         env:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
@@ -51,6 +53,7 @@ jobs:
           FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
 
       - name: Deploy to Firebase Hosting
         if: env.HAS_FIREBASE_SECRETS == 'true'
@@ -67,13 +70,14 @@ jobs:
     if: github.ref == 'refs/heads/staging'
     env:
       HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD != '' &&
-        secrets.FIREBASE_WEB_API_KEY != '' &&
-        secrets.FIREBASE_AUTH_DOMAIN != '' &&
-        secrets.FIREBASE_DATABASE_URL != '' &&
-        secrets.FIREBASE_PROJECT_ID != '' &&
-        secrets.FIREBASE_STORAGE_BUCKET != '' &&
-        secrets.FIREBASE_MESSAGING_SENDER_ID != '' &&
-        secrets.FIREBASE_APP_ID != '' }}
+        secrets.FIREBASE_WEB_API_KEY_STG != '' &&
+        secrets.FIREBASE_AUTH_DOMAIN_STG != '' &&
+        secrets.FIREBASE_DATABASE_URL_STG != '' &&
+        secrets.FIREBASE_PROJECT_ID_STG != '' &&
+        secrets.FIREBASE_STORAGE_BUCKET_STG != '' &&
+        secrets.FIREBASE_MESSAGING_SENDER_ID_STG != '' &&
+        secrets.FIREBASE_APP_ID_STG != '' &&
+        secrets.FIREBASE_MEASUREMENT_ID_STG != '' }}
     steps:
       - name: Aviso por falta de credenciales
         if: env.HAS_FIREBASE_SECRETS != 'true'
@@ -96,14 +100,16 @@ jobs:
           sed -i "s|__FIREBASE_STORAGE_BUCKET__|${FIREBASE_STORAGE_BUCKET}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_MESSAGING_SENDER_ID__|${FIREBASE_MESSAGING_SENDER_ID}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_APP_ID__|${FIREBASE_APP_ID}|g" public/firebase-config.js
+          sed -i "s|__FIREBASE_MEASUREMENT_ID__|${FIREBASE_MEASUREMENT_ID}|g" public/firebase-config.js
         env:
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
-          FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
-          FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
-          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
-          FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
-          FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
-          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY_STG }}
+          FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN_STG }}
+          FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL_STG }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID_STG }}
+          FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET_STG }}
+          FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID_STG }}
+          FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID_STG }}
+          FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID_STG }}
 
       - name: Deploy to Firebase Hosting
         if: env.HAS_FIREBASE_SECRETS == 'true'
@@ -126,7 +132,8 @@ jobs:
         secrets.FIREBASE_PROJECT_ID != '' &&
         secrets.FIREBASE_STORAGE_BUCKET != '' &&
         secrets.FIREBASE_MESSAGING_SENDER_ID != '' &&
-        secrets.FIREBASE_APP_ID != '' }}
+        secrets.FIREBASE_APP_ID != '' &&
+        secrets.FIREBASE_MEASUREMENT_ID != '' }}
     steps:
       - name: Aviso por falta de credenciales
         if: env.HAS_FIREBASE_SECRETS != 'true'
@@ -149,6 +156,7 @@ jobs:
           sed -i "s|__FIREBASE_STORAGE_BUCKET__|${FIREBASE_STORAGE_BUCKET}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_MESSAGING_SENDER_ID__|${FIREBASE_MESSAGING_SENDER_ID}|g" public/firebase-config.js
           sed -i "s|__FIREBASE_APP_ID__|${FIREBASE_APP_ID}|g" public/firebase-config.js
+          sed -i "s|__FIREBASE_MEASUREMENT_ID__|${FIREBASE_MEASUREMENT_ID}|g" public/firebase-config.js
         env:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
@@ -157,6 +165,7 @@ jobs:
           FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
 
       - name: Deploy to Firebase Hosting
         if: env.HAS_FIREBASE_SECRETS == 'true'

--- a/README.md
+++ b/README.md
@@ -100,8 +100,34 @@ Los flujos definidos en `.github/workflows/` generan `public/firebase-config.js`
 - `FIREBASE_STORAGE_BUCKET`
 - `FIREBASE_MESSAGING_SENDER_ID`
 - `FIREBASE_APP_ID`
+- `FIREBASE_MEASUREMENT_ID`
 
 Cada secreto debe contener el valor correspondiente del proyecto de Firebase. Si utiliza otras herramientas de despliegue, replique el mismo proceso de copiado y reemplazo de marcadores antes de publicar los archivos.
+
+#### Variables para entorno `staging`
+
+La rama `staging` utiliza secretos dedicados con sufijo `_STG` en el workflow `deploy-by-branch.yml` para evitar mezclar credenciales entre ambientes:
+
+- `FIREBASE_WEB_API_KEY_STG`
+- `FIREBASE_AUTH_DOMAIN_STG`
+- `FIREBASE_DATABASE_URL_STG`
+- `FIREBASE_PROJECT_ID_STG`
+- `FIREBASE_STORAGE_BUCKET_STG`
+- `FIREBASE_MESSAGING_SENDER_ID_STG`
+- `FIREBASE_APP_ID_STG`
+- `FIREBASE_MEASUREMENT_ID_STG`
+
+Valores de STG proporcionados para cargar en esos secretos:
+
+- `FIREBASE_WEB_API_KEY_STG=AIzaSyB10dWsnd3p4bJb16MrXgwDs15jmREZSTI`
+- `FIREBASE_AUTH_DOMAIN_STG=bingo-online-stg.firebaseapp.com`
+- `FIREBASE_PROJECT_ID_STG=bingo-online-stg`
+- `FIREBASE_STORAGE_BUCKET_STG=bingo-online-stg.firebasestorage.app`
+- `FIREBASE_MESSAGING_SENDER_ID_STG=651184549228`
+- `FIREBASE_APP_ID_STG=1:651184549228:web:2c73f9c759b2efb0ec1749`
+- `FIREBASE_MEASUREMENT_ID_STG=G-WMMR4YWSWC`
+
+> Nota: complete también `FIREBASE_DATABASE_URL_STG` según su Realtime Database en STG. El workflow requiere que ese secreto exista para permitir el despliegue.
 
 ## Directrices de desarrollo
 

--- a/public/firebase-config.template.js
+++ b/public/firebase-config.template.js
@@ -7,5 +7,6 @@ window.__FIREBASE_CONFIG__ = {
   projectId: "__FIREBASE_PROJECT_ID__",
   storageBucket: "__FIREBASE_STORAGE_BUCKET__",
   messagingSenderId: "__FIREBASE_MESSAGING_SENDER_ID__",
-  appId: "__FIREBASE_APP_ID__"
+  appId: "__FIREBASE_APP_ID__",
+  measurementId: "__FIREBASE_MEASUREMENT_ID__"
 };


### PR DESCRIPTION
### Motivation
- Aislar la configuración de Firebase para el entorno `staging` usando secretos dedicados y permitir que la plantilla incluya `measurementId` para soporte de Analytics.
- Evitar mezclar credenciales entre ambientes y proporcionar una ruta CI clara para generar `public/firebase-config.js` por rama.

### Description
- Se agregó `measurementId` a `public/firebase-config.template.js` para que `public/firebase-config.js` pueda generarse con `measurementId` desde CI.
- Se modificó `.github/workflows/deploy-by-branch.yml` para requerir y propagar `FIREBASE_MEASUREMENT_ID` en `dev` y `main` y para usar variables con sufijo `_STG` en la rama `staging` (incluyendo `FIREBASE_*_STG` y `FIREBASE_MEASUREMENT_ID_STG`).
- Se actualizó `README.md` para documentar los nuevos secretos y añadir una sección explícita con los nombres de variables para `staging` y los valores STG compartidos proporcionados.

### Testing
- Ejecuté `npm test` y la suite pasó correctamente (`PASS __tests__/player.test.js`).
- Intenté `npm run generate:firebase-config` y falló porque no existe ese script en `package.json` (documentado como `WARN` en este PR y la generación sigue realizándose desde el workflow de GitHub Actions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb2bfe5188326b95d5d18958a17ac)