### PR TITLE
Follow-up: ignore .env.dev for Firebase dev setup in PR #1180

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 serviceAccountKey.json
 public/firebase-config.js
 .env
+.env.dev


### PR DESCRIPTION
### Motivation
- The new dev configuration flow instructs creating a local `.env.dev` file that contains credentials and must not be tracked by git to avoid accidental secret commits.

### Description
- Add `.env.dev` to `.gitignore` so local Firebase dev environment files created by the README workflow are ignored by git.

### Testing
- Ran `npm test -- --runInBand` and the test suite passed (`PASS __tests__/player.test.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb58748948326baa58b5a9408fd57)