### PR TITLE
fix(auth): mejora diagnóstico de login Google en entorno dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ A partir de las últimas versiones de los navegadores se bloquean las cookies de
 
 Para evitarlo, despliegue el sitio en Firebase Hosting utilizando el dominio del proyecto (`bingo-online-231fd.web.app` o un dominio personalizado asociado). Así las cookies son del mismo sitio y la autenticación funciona de forma correcta.
 
+### Diagnóstico rápido: error al iniciar sesión con Google en `dev`
+
+Si aparece el mensaje "Error al iniciar sesión con Google" en el dominio `https://bingo-online-dev.web.app/`, valide este checklist en orden:
+
+1. **Dominio autorizado en Firebase Auth**  
+   En Firebase Console > Authentication > Settings > Authorized domains, confirme que existe exactamente `bingo-online-dev.web.app`.
+
+2. **Proveedor Google habilitado**  
+   En Authentication > Sign-in method, confirme que el proveedor **Google** está en estado **Enabled** dentro del mismo proyecto `dev`.
+
+3. **Config frontend coherente con `dev`**  
+   Genere nuevamente `public/firebase-config.js` usando el `.env` del entorno dev:
+   ```bash
+   FIREBASE_ENV_FILE=.env.dev npm run generate:firebase-config
+   ```
+   Verifique que `authDomain` y `projectId` apunten al proyecto dev (no staging/prod).
+
+4. **Deploy con archivo actualizado**  
+   Verifique que el deploy de Hosting incluya el `public/firebase-config.js` recién generado y que no haya caché vieja del navegador (probar en incógnito).
+
+5. **Cookies / almacenamiento del navegador**  
+   Revise que el navegador no esté bloqueando almacenamiento para `*.web.app`, y que extensiones de privacidad no bloqueen `accounts.google.com`.
+
+6. **Revisar código de error exacto**  
+   Abra DevTools (Console) y capture el `error.code` devuelto por Firebase (`auth/unauthorized-domain`, `auth/operation-not-allowed`, etc.) para decidir la corrección puntual.
+
 ### Despliegues automáticos (GitHub Actions)
 
 Los flujos definidos en `.github/workflows/` generan `public/firebase-config.js` a partir de la plantilla antes de invocar a Firebase Hosting. Configure los siguientes secretos en el repositorio para que la sustitución se realice correctamente:

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -285,14 +285,24 @@ async function loginGoogle(){
       alert(DISABLED_MSG);
       return;
     }
+    const popupErrorMessage = getGoogleAuthErrorMessage(err, 'popup');
+    if(popupErrorMessage){
+      console.error('Error de autenticación con Google (popup)', err);
+      alert(popupErrorMessage);
+      return;
+    }
     console.warn('Popup login failed, trying redirect', err);
     try {
       await auth.signInWithRedirect(provider);
     } catch(e){
+      const redirectErrorMessage = getGoogleAuthErrorMessage(e, 'redirect');
       if (e.code === 'auth/user-disabled') {
         alert(DISABLED_MSG);
       } else if (e.code === 'auth/web-storage-unsupported') {
         alert('El navegador ha bloqueado las cookies necesarias para continuar. Intenta habilitarlas o abre la aplicación desde un dominio configurado en Firebase.');
+      } else if(redirectErrorMessage){
+        console.error('Error de autenticación con Google (redirect)', e);
+        alert(redirectErrorMessage);
       } else {
         console.error('Error login Google', e);
         alert('Error al iniciar sesión con Google');
@@ -354,10 +364,39 @@ async function handleRedirect(){
       redirectByRole(role);
     }
   } catch(err){
+    const redirectErrorMessage = getGoogleAuthErrorMessage(err, 'redirect');
     if (err.code === 'auth/web-storage-unsupported') {
       alert('El navegador impide usar el almacenamiento necesario para mantener la sesión. Abre la aplicación desde un dominio configurado en Firebase o habilita las cookies.');
+    } else if(redirectErrorMessage){
+      alert(redirectErrorMessage);
     }
     console.error('Error processing redirect login', err);
+  }
+}
+
+function getGoogleAuthErrorMessage(error, flow = 'popup'){
+  if(!error || !error.code) return null;
+  const domain = hasWindow() ? window.location.hostname : '';
+  const flowLabel = flow === 'redirect' ? 'redirección' : 'popup';
+
+  switch(error.code){
+    case 'auth/unauthorized-domain':
+      return `El dominio "${domain}" no está autorizado en Firebase Auth. Agrega este dominio en Authentication > Settings > Authorized domains y vuelve a intentar.`;
+    case 'auth/operation-not-allowed':
+      return 'Google Sign-In no está habilitado en Firebase Authentication > Sign-in method. Activa el proveedor Google para este proyecto.';
+    case 'auth/invalid-api-key':
+    case 'auth/app-not-authorized':
+      return 'La configuración de Firebase del frontend no corresponde con este entorno. Regenera public/firebase-config.js con las variables del proyecto dev y valida authDomain/projectId.';
+    case 'auth/popup-blocked':
+      return 'El navegador bloqueó la ventana emergente de Google. Permite popups para este sitio o usa el flujo de redirección.';
+    case 'auth/popup-closed-by-user':
+      return 'Se cerró la ventana de Google antes de completar el inicio de sesión.';
+    case 'auth/cancelled-popup-request':
+      return `Había otra solicitud de inicio de sesión en curso (${flowLabel}). Espera unos segundos y vuelve a intentarlo.`;
+    case 'auth/network-request-failed':
+      return 'Falló la conexión de red durante el inicio de sesión con Google. Revisa tu conexión e intenta nuevamente.';
+    default:
+      return null;
   }
 }
 


### PR DESCRIPTION
### Motivation

- Detectar y comunicar causas concretas de fallos en el inicio de sesión por Google en el entorno `dev` para acelerar el diagnóstico y soporte. 
- Evitar que el frontend haga fallback a `signInWithRedirect` cuando el error es determinístico (por ejemplo dominio no autorizado), lo que generaba mensajes genéricos y confusión. 
- Reducir tiempo de triage y evitar despliegues innecesarios al proporcionar mensajes accionables al usuario/operación.

### Description

- Se agregó la función `getGoogleAuthErrorMessage(error, flow)` en `public/js/auth.js` que mapea `error.code` de Firebase a mensajes en español para errores comunes (`auth/unauthorized-domain`, `auth/operation-not-allowed`, `auth/invalid-api-key`, `auth/popup-blocked`, `auth/popup-closed-by-user`, `auth/cancelled-popup-request`, `auth/network-request-failed`).
- Se integró esa función en `loginGoogle()` y `handleRedirect()` para mostrar mensajes accionables y evitar reintentos automáticos cuando la causa es de configuración, registrando además errores en `console.error` para facilitar el debugging.
- Se añadió un bloque en `README.md` con un checklist de diagnóstico para `https://bingo-online-dev.web.app/` que incluye verificación de `Authorized domains`, activación del proveedor Google, regenerar `public/firebase-config.js`, deploy/caché y comprobación de cookies/extensiones.
- Riesgos/impacto y rollback: afecta el frontend de autenticación (alto impacto por alcance de login), no modifica reglas de Firestore ni introduce secretos; plan de rollback consistente en revertir los cambios en `public/js/auth.js` y redeploy del frontend si se detecta regresión en logins válidos.

### Testing

- Ejecuté `npm test` y pasó correctamente: `PASS __tests__/player.test.js`.
- Intenté `npm run generate:firebase-config` y devolvió un warning/FAIL por falta de variables de entorno (`FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, `FIREBASE_PROJECT_ID`, `FIREBASE_MESSAGING_SENDER_ID`, `FIREBASE_APP_ID`), lo cual es esperado en un entorno local sin `.env`; se documenta como precondición para validar en `dev` con `FIREBASE_ENV_FILE=.env.dev npm run generate:firebase-config`.
- Recomendación de verificación manual (pendiente): reproducir en `dev` los casos `auth/unauthorized-domain`, `auth/operation-not-allowed` y un login exitoso para confirmar que los mensajes son correctos y que no se altera el flujo exitoso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efb811edd4832688839130195fb5ce)