### PR TITLE
[PR #1183 follow-up] fix(auth): restore redirect fallback for popup-blocked Google login

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -286,12 +286,17 @@ async function loginGoogle(){
       return;
     }
     const popupErrorMessage = getGoogleAuthErrorMessage(err, 'popup');
-    if(popupErrorMessage){
+    const shouldFallbackToRedirect = err.code === 'auth/popup-blocked';
+    if(popupErrorMessage && !shouldFallbackToRedirect){
       console.error('Error de autenticación con Google (popup)', err);
       alert(popupErrorMessage);
       return;
     }
-    console.warn('Popup login failed, trying redirect', err);
+    if(shouldFallbackToRedirect){
+      console.warn('Google popup bloqueado; se intentará el flujo por redirección', err);
+    } else {
+      console.warn('Popup login failed, trying redirect', err);
+    }
     try {
       await auth.signInWithRedirect(provider);
     } catch(e){


### PR DESCRIPTION
### Motivation

- Restore the previous behavior where a blocked Google popup (`auth/popup-blocked`) falls back to the redirect flow so users with popup blockers can still sign in.
- Preserve early-return, actionable error messages for deterministic configuration errors (e.g. `unauthorized-domain`, `operation-not-allowed`) so those cases remain visible to operators.

### Description

- Updated `public/js/auth.js` in `loginGoogle()` to compute `shouldFallbackToRedirect = err.code === 'auth/popup-blocked'` and only short-circuit when a popup error message is present and the error is not `auth/popup-blocked`.
- Kept `getGoogleAuthErrorMessage(...)`-based messaging for deterministic errors while allowing the redirect fallback to run for `popup-blocked` errors.
- Added clearer warning logging to distinguish the `popup-blocked` fallback path from other popup failures.

### Testing

- Ran unit tests with `npm test -- --runInBand`, which passed (`PASS __tests__/player.test.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efbcd803908326992037e6a4e286bc)