### PR TITLE
fix(ci): alinea despliegue staging con proyecto bingo-online-stg

### DIFF
--- a/.github/workflows/deploy-by-branch.yml
+++ b/.github/workflows/deploy-by-branch.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/staging'
     env:
-      HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD != '' &&
+      HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_STG != '' &&
         secrets.FIREBASE_WEB_API_KEY_STG != '' &&
         secrets.FIREBASE_AUTH_DOMAIN_STG != '' &&
         secrets.FIREBASE_DATABASE_URL_STG != '' &&
@@ -116,8 +116,8 @@ jobs:
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD }}
-          projectId: bingo-online-231fd
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_STG }}
+          projectId: bingo-online-stg
           target: stg
           channelId: live
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Cada secreto debe contener el valor correspondiente del proyecto de Firebase. Si
 
 La rama `staging` utiliza secretos dedicados con sufijo `_STG` en el workflow `deploy-by-branch.yml` para evitar mezclar credenciales entre ambientes:
 
+- `FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_STG`
 - `FIREBASE_WEB_API_KEY_STG`
 - `FIREBASE_AUTH_DOMAIN_STG`
 - `FIREBASE_DATABASE_URL_STG`
@@ -128,6 +129,7 @@ Valores de STG proporcionados para cargar en esos secretos:
 - `FIREBASE_MEASUREMENT_ID_STG=G-WMMR4YWSWC`
 
 > Nota: complete también `FIREBASE_DATABASE_URL_STG` según su Realtime Database en STG. El workflow requiere que ese secreto exista para permitir el despliegue.
+> Para `staging`, el despliegue de Hosting usa el proyecto `bingo-online-stg`; por eso el service account debe corresponder a ese proyecto.
 
 ## Directrices de desarrollo
 


### PR DESCRIPTION
### Motivation
- Evitar que el pipeline de la rama `staging` utilice credenciales o proyecto de producción/dev y garantizar que el deploy publique en el proyecto correcto `bingo-online-stg`.

### Description
- Se actualizó el job `deploy-staging` en `.github/workflows/deploy-by-branch.yml` para validar y usar el secreto `FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_STG` y para establecer `projectId: bingo-online-stg` durante el despliegue.
- Se documentó en `README.md` la necesidad del nuevo secreto `FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_STG` y se aclaró que el deploy de `staging` apunta al proyecto `bingo-online-stg`.

### Testing
- Ejecuté `npm test` y todos los tests unitarios locales pasaron (`PASS __tests__/player.test.js`).
- Intenté ejecutar `npm run generate:firebase-config` pero el script no existe en `package.json` (resultado: error / no aplicable en este repositorio).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efbfee99b4832688e9a6944551ba12)