### PR TITLE
fix(ci): map staging hosting target for bingo-online-stg

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -15,6 +15,13 @@
           "bingo-online-231fd"
         ]
       }
+    },
+    "bingo-online-stg": {
+      "hosting": {
+        "stg": [
+          "bingo-online-stg"
+        ]
+      }
     }
   },
   "etags": {}


### PR DESCRIPTION
### Motivation
- Prevent the staging workflow from failing when it deploys `hosting:stg` to `projectId: bingo-online-stg` because Firebase deploy targets are project-specific.
- Align repository target mappings to match the workflow which uses `projectId: bingo-online-stg` and `target: stg`.

### Description
- Added a `targets.bingo-online-stg.hosting.stg` entry to `.firebaserc` that maps the `stg` hosting target to the `bingo-online-stg` project.
- Kept the existing GitHub Actions workflow configuration (`projectId: bingo-online-stg` and `target: stg`) unchanged and made the target resolvable by Firebase.
- Updated `.firebaserc` JSON to include the new project-specific hosting target mapping.

### Testing
- Validated `.firebaserc` JSON with `jq . .firebaserc`, which succeeded.
- Ran unit tests with `npm test -- --runInBand` and all tests passed (`PASS __tests__/player.test.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc3b6b7008326a0913eab54337452)