### PR TITLE
fix(hosting): alinea rewrite de dev con stg/prod para preservar login

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -13,8 +13,7 @@
       "rewrites": [
         {
           "source": "**",
-          "destination": "https://www.juega-online.com",
-          "type": 301
+          "destination": "/index.html"
         }
       ]
     },


### PR DESCRIPTION
### Motivation
- Evitar que el hosting `dev` redirija todo a `https://www.juega-online.com`, lo cual rompe el flujo de Firebase Auth por salida de dominio y cookies third-party; la intención es mantener el login en el mismo dominio del entorno `dev`.

### Description
- Se modificó `firebase.json` en el bloque `hosting` con `target: "dev"` para reemplazar la regla `rewrites` que hacía `destination: "https://www.juega-online.com"` (type: 301) por `destination: "/index.html"`, alineando el comportamiento con `stg` y `prod` y dejando el fallback SPA local.

### Testing
- `npm test` — PASS (ejecutó `jest`, 1 suite pasada).
- `npm run generate:firebase-config` y `npm run generate:loterias-manifest` — WARN/FAIL (los scripts no existen en `package.json`).
- `firebase deploy --only hosting:dev` y `npx firebase-tools deploy --only hosting:dev` — FAIL en este entorno: falta CLI global y `npx` intentó instalar pero falló la autenticación (requiere `firebase login` o token CI), por lo que no se pudo desplegar desde aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efcd2ca3ec832699809fcd3742f0ff)