### PR TITLE
fix(hosting): corrige rewrite de dev para no romper login con Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Para evitarlo, despliegue el sitio en Firebase Hosting utilizando el dominio del
 
 Si aparece el mensaje "Error al iniciar sesión con Google" en el dominio `https://bingo-online-dev.web.app/`, valide este checklist en orden:
 
+0. **Hosting `dev` sin redirecciones externas**  
+   En `firebase.json` el target `dev` debe resolver a `"/index.html"` (SPA) y no redirigir (`301`) a otros dominios como `www.juega-online.com`, porque eso rompe el flujo OAuth del proyecto `dev`.
+
 1. **Dominio autorizado en Firebase Auth**  
    En Firebase Console > Authentication > Settings > Authorized domains, confirme que existe exactamente `bingo-online-dev.web.app`.
 

--- a/firebase.json
+++ b/firebase.json
@@ -13,8 +13,7 @@
       "rewrites": [
         {
           "source": "**",
-          "destination": "https://www.juega-online.com",
-          "type": 301
+          "destination": "/index.html"
         }
       ]
     },


### PR DESCRIPTION
### Motivation
- El flujo de autenticación con Google en el entorno `dev` fallaba porque el hosting de `dev` redirigía todas las rutas a un dominio externo, rompiendo el origen de la sesión OAuth y provocando errores al iniciar sesión.

### Description
- Se actualizó `firebase.json` para que el `target: dev` sirva la SPA resolviendo a `/index.html` en lugar de realizar una redirección 301 a `https://www.juega-online.com`.
- Se añadió una verificación explícita en `README.md` (paso 0 del diagnóstico) que alerta sobre redirecciones externas en `dev` que interrumpen el flujo OAuth.
- Cambios mínimos y focalizados que no tocan reglas de Firestore ni de Storage ni introducen secretos en el repositorio.

### Testing
- `npm test` → PASS (tests unitarios con `jest` ejecutados correctamente: `PASS __tests__/player.test.js`).
- `npm run generate:firebase-config` → WARN (falló en este entorno local por falta de variables obligatorias: `FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, `FIREBASE_PROJECT_ID`, `FIREBASE_MESSAGING_SENDER_ID`, `FIREBASE_APP_ID`).
- Validación sintáctica de `firebase.json` con `node -e "JSON.parse(require('fs').readFileSync('firebase.json','utf8'))"` → PASS.

Recomendación para despliegue: publicar el target `dev` y verificar el inicio de sesión de Google en `https://bingo-online-dev.web.app/` en modo incógnito; si persiste un error, revisar en Firebase Console los `Authorized domains` y que el proveedor Google esté habilitado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff009f8b88326a633178ecf68b730)