### PR TITLE
chore(firebase): alinea aliases y targets de hosting por entorno

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,18 +1,29 @@
 {
   "projects": {
-    "default": "bingo-online-231fd"
+    "default": "bingo-online-231fd",
+    "main": "bingo-online-231fd",
+    "dev": "bingo-online-dev",
+    "stg": "bingo-online-stg"
   },
   "targets": {
     "bingo-online-231fd": {
       "hosting": {
-        "dev": [
-          "bingo-online-231fd-dev"
-        ],
-        "stg": [
-          "bingo-online-231fd-stg"
-        ],
-        "prod": [
+        "main": [
           "bingo-online-231fd"
+        ]
+      }
+    },
+    "bingo-online-dev": {
+      "hosting": {
+        "dev": [
+          "bingo-online-dev"
+        ]
+      }
+    },
+    "bingo-online-stg": {
+      "hosting": {
+        "stg": [
+          "bingo-online-stg"
         ]
       }
     }


### PR DESCRIPTION
### Motivation
- Alinear la configuración de Firebase CLI con la nueva estrategia de despliegue que usa aliases por entorno (`main`, `dev`, `stg`) en lugar de agrupar targets en un único proyecto.
- Evitar ambigüedades causadas por el target `prod` y facilitar despliegues por ambiente con targets coherentes.
- Mantener compatibilidad CLI conservando `default` apuntando a `bingo-online-231fd` para flujos existentes.

### Description
- Se actualizó el archivo `.firebaserc` para declarar los aliases de proyecto `main`, `dev` y `stg` y conservar `default` apuntando a `bingo-online-231fd` (archivo modificado: `.firebaserc`).
- Se reestructuraron los `targets` para que cada proyecto tenga su target de hosting nombrado por ambiente: `main` → `bingo-online-231fd`, `dev` → `bingo-online-dev`, `stg` → `bingo-online-stg`.
- Se eliminó por completo cualquier referencia al target `prod` dentro de `targets`.
- Se creó la rama `chore/firebase-alias-targets-main` y se registró el cambio con commit en formato Conventional Commits (`chore(firebase): alinea aliases y targets de hosting por entorno`).

### Testing
- `npm test` — PASS (12 suites, 39 tests ejecutados y superados).
- `npm run generate:firebase-config -- --env dev` — WARN (falló localmente por falta de las variables de entorno `FIREBASE_DEV_*` necesarias para generar `public/firebase-config.js`).
- `firebase target:apply hosting main bingo-online-231fd --project bingo-online-231fd` y equivalentes para `dev`/`stg` — WARN (no se pudieron ejecutar en este entorno porque la CLI `firebase` no está instalada: `command not found`).
- No se añadieron secretos ni cambios a reglas de seguridad, y los tests automatizados existentes pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69effff8e4808326a9fda9313a63cc36)