### PR TITLE
chore(ci): alinea despliegues de Firebase por entorno y rama

### DIFF
--- a/.github/workflows/deploy-by-branch.yml
+++ b/.github/workflows/deploy-by-branch.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.ref == 'refs/heads/dev'
     env:
       DEPLOY_ENV: dev
-      HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD != '' &&
+      HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_DEV != '' &&
         secrets.FIREBASE_DEV_API_KEY != '' &&
         secrets.FIREBASE_DEV_AUTH_DOMAIN != '' &&
         secrets.FIREBASE_DEV_DATABASE_URL != '' &&
@@ -48,8 +48,8 @@ jobs:
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD }}
-          projectId: bingo-online-231fd
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_DEV }}
+          projectId: bingo-online-dev
           target: dev
           channelId: live
 
@@ -58,7 +58,7 @@ jobs:
     if: github.ref == 'refs/heads/staging'
     env:
       DEPLOY_ENV: stg
-      HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD != '' &&
+      HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_STG != '' &&
         secrets.FIREBASE_STG_API_KEY != '' &&
         secrets.FIREBASE_STG_AUTH_DOMAIN != '' &&
         secrets.FIREBASE_STG_DATABASE_URL != '' &&
@@ -92,8 +92,8 @@ jobs:
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD }}
-          projectId: bingo-online-231fd
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_STG }}
+          projectId: bingo-online-stg
           target: stg
           channelId: live
 
@@ -138,5 +138,5 @@ jobs:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD }}
           projectId: bingo-online-231fd
-          target: prod
+          target: main
           channelId: live


### PR DESCRIPTION
### Motivación
- El workflow de despliegue compartía una misma cuenta de servicio/proyecto entre entornos lo que podía provocar despliegues cruzados o dependencia de secretos de producción en jobs de `dev`/`staging`.
- Se requiere que cada rama despliegue a su proyecto/target aislado y que la generación de `firebase-config` siga funcionando con `DEPLOY_ENV` (`dev`, `stg`, `prod`/`main`).

### Descripción
- Se actualizó `.github/workflows/deploy-by-branch.yml` para que `deploy-dev` use `FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_DEV`, `projectId: bingo-online-dev` y `target: dev`.
- Se actualizó el job `deploy-staging` para usar `FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_STG`, `projectId: bingo-online-stg` y `target: stg`.
- El job `deploy-prod` (rama `main`) mantiene `projectId: bingo-online-231fd`, conserva la cuenta de servicio `FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD` y cambia `target` de `prod` a `main`.
- Se alinearon las condiciones `HAS_FIREBASE_SECRETS` en cada job para validar el secreto de la cuenta de servicio correspondiente y se preservó `DEPLOY_ENV` por entorno para la generación de `firebase-config`.

### Testing
- Ejecuté `npm test -- --runInBand` y la suite completa pasó (12 suites, 39 tests) — PASS.
- Ejecuté `npm run generate:firebase-config -- --env dev`, `--env stg` y `--env prod` con variables dummy y el archivo `public/firebase-config.js` se generó correctamente en cada caso — PASS.
- Nota automatizada: sólo se modificó el workflow; durante pruebas `public/firebase-config.js` se generó localmente y no se incluyeron secretos ni credenciales en el commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f001e309488326937dbdea5e72588d)