### PR TITLE
fix(ci): prioriza main como entorno de producción en config firebase

### DIFF
--- a/.github/workflows/deploy-by-branch.yml
+++ b/.github/workflows/deploy-by-branch.yml
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     env:
-      DEPLOY_ENV: prod
+      DEPLOY_ENV: main
       HAS_FIREBASE_SECRETS: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_BINGO_ONLINE_231FD != '' &&
         secrets.FIREBASE_PROD_API_KEY != '' &&
         secrets.FIREBASE_PROD_AUTH_DOMAIN != '' &&

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Entornos soportados:
 
 - `dev` → Hosting target `bingo-online-231fd-dev` y base de datos `dev-db`
 - `stg` → Hosting target `bingo-online-231fd-stg` y base de datos `stg-db`
-- `prod` (o `main`) → Hosting target `bingo-online-231fd` y base de datos default
+- `main` → Producción (Hosting target `bingo-online-231fd` y base de datos default)
+  - Compatibilidad: también acepta `prod` y `production`, normalizados internamente como producción.
 
 Variables requeridas por entorno (con fallback a versión global sin prefijo):
 
@@ -128,6 +129,8 @@ Variables requeridas por entorno (con fallback a versión global sin prefijo):
 - `FIREBASE_<ENV>_APP_ID`
 
 > Ejemplo para staging (`<ENV>=STG`): `FIREBASE_STG_DATABASE_URL=https://bingo-online-231fd-stg-db.firebaseio.com`.
+
+> Para producción en `main` el script utiliza prefijo `FIREBASE_PROD_*` (compatibilidad actual).
 
 > **Nota sobre Storage**: Si en la consola de Firebase el bucket aparece con el dominio `*.firebasestorage.app`, utilice ese valor sin modificarlo. La interfaz convierte automáticamente ese formato al identificador clásico (`*.appspot.com`) al inicializar el SDK para garantizar la compatibilidad con `firebase-storage-compat` y permitir la subida de los PDFs generados.
 
@@ -192,6 +195,5 @@ npm run apply-firebase-mutations -- --files firebase/bingoanimalito/mi-cambio.js
 - El documento `Variablesglobales/Parametros` contiene configuración sensible y se trata como **confidencial**.
 - En `firestore.rules`, su lectura y escritura requieren privilegio fuerte de **Superadmin** (`isStrongSuperadmin()`).
 - La página `public/parametros.html` está diseñada para este mismo nivel de privilegio; usuarios autenticados sin rol fuerte de Superadmin deben recibir denegación de acceso al intentar leer ese documento.
-
 
 

--- a/scripts/generateFirebaseConfig.js
+++ b/scripts/generateFirebaseConfig.js
@@ -67,7 +67,7 @@ function escapeTemplateValue(value) {
 }
 
 function printHelp() {
-  console.log(`Uso:\n  node scripts/generateFirebaseConfig.js --env <dev|stg|prod> [--output public/firebase-config.js]\n\nVariables requeridas por entorno:\n  FIREBASE_<ENV>_API_KEY\n  FIREBASE_<ENV>_AUTH_DOMAIN\n  FIREBASE_<ENV>_DATABASE_URL\n  FIREBASE_<ENV>_PROJECT_ID\n  FIREBASE_<ENV>_STORAGE_BUCKET\n  FIREBASE_<ENV>_MESSAGING_SENDER_ID\n  FIREBASE_<ENV>_APP_ID\n\nTambién acepta fallback sin prefijo de entorno: FIREBASE_API_KEY, FIREBASE_AUTH_DOMAIN, etc.`);
+  console.log(`Uso:\n  node scripts/generateFirebaseConfig.js --env <dev|stg|main> [--output public/firebase-config.js]\n\nEntornos aceptados:\n  dev\n  stg\n  main (producción)\n  prod / production (compatibilidad retroactiva, se normalizan a main)\n\nVariables requeridas por entorno:\n  FIREBASE_<ENV>_API_KEY\n  FIREBASE_<ENV>_AUTH_DOMAIN\n  FIREBASE_<ENV>_DATABASE_URL\n  FIREBASE_<ENV>_PROJECT_ID\n  FIREBASE_<ENV>_STORAGE_BUCKET\n  FIREBASE_<ENV>_MESSAGING_SENDER_ID\n  FIREBASE_<ENV>_APP_ID\n\nPara producción (main) se buscan variables FIREBASE_PROD_*.\nTambién acepta fallback sin prefijo de entorno: FIREBASE_API_KEY, FIREBASE_AUTH_DOMAIN, etc.`);
 }
 
 function main() {
@@ -80,7 +80,7 @@ function main() {
 
   const environment = normalizeEnv(args.env);
   if (!['dev', 'stg', 'prod'].includes(environment)) {
-    throw new Error(`Entorno no soportado: ${args.env}. Use dev, stg o prod.`);
+    throw new Error(`Entorno no soportado: ${args.env}. Use dev, stg o main (prod/production también son válidos por compatibilidad).`);
   }
 
   const prefix = `FIREBASE_${environment.toUpperCase()}_`;


### PR DESCRIPTION
### Motivation
- Unificar la nomenclatura operativa para producción usando `main` en documentación y ayudas de scripts, eliminando ambigüedad entre rama `main` y el alias `prod`.
- Mantener compatibilidad con la configuración existente que usa secretos `FIREBASE_PROD_*` para evitar rotación de credenciales y minimizar riesgo operativo.

### Description
- Actualiza la ayuda de `scripts/generateFirebaseConfig.js` para mostrar `--env <dev|stg|main>` y documentar que `prod`/`production` se normalizan a producción por compatibilidad.
- Ajusta el mensaje de error en `scripts/generateFirebaseConfig.js` para recomendar `main` sin romper aliases previos; la normalización interna sigue resolviendo `main` -> `prod` para leer `FIREBASE_PROD_*`.
- Modifica `README.md` para describir la rama/entorno de producción como `main` y añadir una nota de compatibilidad que indica que el script sigue usando el prefijo `FIREBASE_PROD_*`.
- Cambia `.github/workflows/deploy-by-branch.yml` para ejecutar el generador con `DEPLOY_ENV: main` en el job de producción, preservando la comprobación y uso de secretos `FIREBASE_PROD_*`.

### Testing
- `npm test` — PASS (todas las suites locales pasaron: 12 suites, 39 tests).
- `npm run generate:firebase-config` — WARN (falló localmente por ausencia de variables `FIREBASE_PROD_*`, comportamiento esperado fuera de CI donde los secretos están definidos).
- `FIREBASE_PROD_API_KEY=a FIREBASE_PROD_AUTH_DOMAIN=b FIREBASE_PROD_DATABASE_URL=c FIREBASE_PROD_PROJECT_ID=d FIREBASE_PROD_STORAGE_BUCKET=e FIREBASE_PROD_MESSAGING_SENDER_ID=f FIREBASE_PROD_APP_ID=g node scripts/generateFirebaseConfig.js --env main --output /tmp/firebase-config.test.js` — PASS (generó `/tmp/firebase-config.test.js` correctamente y produjo la configuración esperada).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f002cb77508326a84b6164ae4614ce)