### PR TITLE
fix(firebase): corrige datos de entornos dev y stg en documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ npm run generate:firebase-config -- --env dev
 
 Entornos soportados:
 
-- `dev` → Hosting target `bingo-online-231fd-dev` y base de datos `dev-db`
-- `stg` → Hosting target `bingo-online-231fd-stg` y base de datos `stg-db`
+- `dev` → Proyecto Firebase `bingo-online-dev` (número `671201853237`), Hosting target `bingo-online-dev` y base de datos **default** (no `dev-db`)
+- `stg` → Proyecto Firebase `bingo-online-stg` (número `651184549228`), Hosting target `bingo-online-stg` y base de datos **default** (no `stg-db`)
 - `main` → Producción (Hosting target `bingo-online-231fd` y base de datos default)
   - Compatibilidad: también acepta `prod` y `production`, normalizados internamente como producción.
 
@@ -128,7 +128,7 @@ Variables requeridas por entorno (con fallback a versión global sin prefijo):
 - `FIREBASE_<ENV>_MESSAGING_SENDER_ID`
 - `FIREBASE_<ENV>_APP_ID`
 
-> Ejemplo para staging (`<ENV>=STG`): `FIREBASE_STG_DATABASE_URL=https://bingo-online-231fd-stg-db.firebaseio.com`.
+> Ejemplo para staging (`<ENV>=STG`): `FIREBASE_STG_DATABASE_URL=https://bingo-online-stg-default-rtdb.firebaseio.com` (base de datos **default**).
 
 > Para producción en `main` el script utiliza prefijo `FIREBASE_PROD_*` (compatibilidad actual).
 
@@ -140,11 +140,11 @@ A partir de las últimas versiones de los navegadores se bloquean las cookies de
 
 Para evitarlo, cada entorno debe usar su propio dominio Firebase Hosting como `authDomain`:
 
-- Desarrollo: `bingo-online-231fd-dev.web.app`
-- Pruebas: `bingo-online-231fd-stg.web.app`
+- Desarrollo: `bingo-online-dev.web.app` y `bingo-online-dev.firebaseapp.com`
+- Pruebas: `bingo-online-stg.web.app` y `bingo-online-stg.firebaseapp.com`
 - Producción: `bingo-online-231fd.web.app`
 
-Además, en Firebase Authentication > Settings > Authorized domains agregue estos tres dominios para permitir login en cada ambiente de manera aislada.
+Además, en Firebase Authentication > Settings > Authorized domains agregue todos los dominios de cada ambiente (`*.web.app` y `*.firebaseapp.com`) para permitir login en cada entorno de manera aislada.
 
 ### Despliegues automáticos (GitHub Actions)
 


### PR DESCRIPTION
### Motivation
- Corregir datos desactualizados de los entornos `dev` y `stg` para evitar errores de configuración y despliegue (projectId, número de proyecto, base de datos y dominios de auth). 
- Aclarar que ambos entornos usan la base de datos `default` y normalizar la guía de dominios autorizados para cada ambiente.

### Description
- Se actualizó `README.md` para reflejar que `dev` apunta al proyecto `bingo-online-dev` (número `671201853237`) y `stg` apunta al proyecto `bingo-online-stg` (número `651184549228`) y que ambas usan la base de datos **default** (se eliminó la mención a `dev-db`/`stg-db`).
- Se corrigió el ejemplo de `FIREBASE_STG_DATABASE_URL` para usar `https://bingo-online-stg-default-rtdb.firebaseio.com` y se ajustó la recomendación de `authDomain`/dominios autorizados para incluir `*.web.app` y `*.firebaseapp.com` por entorno.
- Los cambios son exclusivamente documentales y no modifican lógica, reglas de seguridad ni código que afecte contratos de datos.

### Testing
- Ejecuté `npm test` y todas las suites pasaron correctamente (12 suites, 39 tests en PASS). 
- No se ejecutaron scripts de generación de `firebase-config` ni despliegue automático porque esos pasos requieren secretos/variables de entorno; esto se documenta como precondición para deploy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b3fb40dc8326a795d95c882717bb)