### PR TITLE
feat(player): permitir jugar con Pago Móvil y agregar CTA de instalación

### DIFF
--- a/public/js/installPrompt.js
+++ b/public/js/installPrompt.js
@@ -40,7 +40,7 @@
     const style = document.createElement('style');
     style.id = STYLE_ID;
     style.textContent = `
-      .bo-install-prompt{position:fixed;right:16px;bottom:16px;z-index:9800;display:none;font-family:'Poppins',sans-serif}
+      .bo-install-prompt{position:fixed;left:50%;transform:translateX(-50%);bottom:16px;z-index:9800;display:none;font-family:'Poppins',sans-serif}
       .bo-install-prompt__banner{display:flex;align-items:center;gap:8px;background:#fff;color:#1f2937;border:1px solid #e5e7eb;border-radius:999px;padding:8px 10px;box-shadow:0 8px 24px rgba(0,0,0,.18)}
       .bo-install-prompt__banner button{border:none;border-radius:999px;padding:7px 12px;cursor:pointer;font-weight:600}
       .bo-install-prompt__banner .bo-install-open{background:#7a00cc;color:#fff}
@@ -80,7 +80,7 @@
     bannerWrap.className = 'bo-install-prompt';
     bannerWrap.innerHTML = `
       <div class="bo-install-prompt__banner">
-        <span>Instala la app</span>
+        <span>Instala la app en tu dispositivo</span>
         <button type="button" class="bo-install-open">Instalar</button>
         <button type="button" class="bo-install-dismiss">Ahora no</button>
       </div>
@@ -128,6 +128,12 @@
       }
     }
 
+    function mostrarAyudaInstalacionManual() {
+      modal.style.display = 'flex';
+      modal.querySelector('h3').textContent = 'Instalar app';
+      modal.querySelector('p').textContent = 'Si no aparece la instalación automática, usa el menú del navegador y elige "Instalar aplicación" o "Añadir a pantalla de inicio".';
+    }
+
     if (isStandalone() || shouldPausePrompt()) {
       hideAll();
       return { destroy: hideAll };
@@ -135,17 +141,26 @@
 
     if (isIosSafari()) {
       if (!hasPriorityOverlay()) {
-        iosHint.style.display = 'block';
+        bannerWrap.style.display = 'block';
       }
       iosHint.querySelector('button').addEventListener('click', function () {
         markDismissed();
         iosHint.style.display = 'none';
       });
+    } else {
+      showEntry();
     }
 
     bannerWrap.querySelector('.bo-install-open').addEventListener('click', function () {
-      if (!deferredPrompt) return;
-      modal.style.display = 'flex';
+      if (deferredPrompt) {
+        modal.style.display = 'flex';
+        return;
+      }
+      if (isIosSafari()) {
+        iosHint.style.display = 'block';
+        return;
+      }
+      mostrarAyudaInstalacionManual();
     });
 
     bannerWrap.querySelector('.bo-install-dismiss').addEventListener('click', function () {

--- a/public/jugarcartones.html
+++ b/public/jugarcartones.html
@@ -2491,11 +2491,6 @@
     const cedula=(data.cedula??'').toString().trim();
     const pagomovil=(data.pagomovil??'').toString().trim();
     if(!banco || !cedula || !pagomovil) return false;
-    const cuenta=(data.cuenta??'').toString().trim();
-    const tipoCuenta=(data.tipoCuenta??'').toString().trim();
-    if((cuenta || tipoCuenta) && (!cuenta || !tipoCuenta)){
-      return false;
-    }
     return true;
   }
 

--- a/public/player.html
+++ b/public/player.html
@@ -2426,14 +2426,13 @@
   <script src="js/installPrompt.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      if (typeof window.initInstallPrompt === 'function') {
-        const postRegistroInstallPromptKey = 'bo_show_install_prompt_after_signup';
-        const mostrarPromptPostRegistro = sessionStorage.getItem(postRegistroInstallPromptKey) === '1';
-        if (mostrarPromptPostRegistro) {
-          sessionStorage.removeItem(postRegistroInstallPromptKey);
-          window.initInstallPrompt({ containerId: 'install-prompt-player', mode: 'banner' });
-        }
+      if (typeof window.initInstallPrompt !== 'function') return;
+      const postRegistroInstallPromptKey = 'bo_show_install_prompt_after_signup';
+      const mostrarPromptPostRegistro = sessionStorage.getItem(postRegistroInstallPromptKey) === '1';
+      if (mostrarPromptPostRegistro) {
+        sessionStorage.removeItem(postRegistroInstallPromptKey);
       }
+      window.initInstallPrompt({ containerId: 'install-prompt-player', mode: 'banner' });
     });
   </script>
 </body>


### PR DESCRIPTION
### Motivation
- Reducir fricción para que un jugador pueda jugar cuando ya tiene completos los datos de Pago Móvil (`banco`, `cedula`, `pagomovil`) sin exigir datos de cuenta bancaria tradicional (`cuenta`/`tipoCuenta`).
- Aumentar la exposición al flujo de instalación PWA mostrando un CTA visible en la vista principal del jugador cuando la app no está instalada.

### Description
- Se cambió la función `datosBancariosEstanCompletos` en `public/jugarcartones.html` para validar únicamente `banco`, `cedula` y `pagomovil`, eliminando la lógica que requería `cuenta` y `tipoCuenta` (ahora si tiene Pago Móvil completo puede jugar). 
- Se modificó `public/player.html` para invocar `window.initInstallPrompt({ containerId: 'install-prompt-player', mode: 'banner' })` en `DOMContentLoaded` de forma consistente (antes solo se activaba en un flujo post-registro). 
- Se mejoró `public/js/installPrompt.js` para mostrar un CTA fijo inferior centrado con botón “Instalar” cuando la app no está instalada, incluir fallback de guía manual (desktop/otros navegadores) y mostrar ayuda específica para iOS; el prompt se oculta si la app ya está instalada, aceptada o se descartó temporalmente.
- No se tocaron reglas de Firestore, contratos de datos ni endpoints backend; los cambios son solo de validación cliente y UI de invitación a instalar la PWA.

### Testing
- Ejecuté los tests automatizados con `npm test` y todos pasaron: `12 suites, 39 tests` (PASS).
- Los cambios de UI/instalación requieren validación manual en navegadores reales: probar `beforeinstallprompt` en Android/Chrome, comprobación de guía iOS/Safari y comportamiento desktop como verificación adicional (no cubierto por tests automatizados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f134e1ca4c8326a0f055d3d067d0dc)