### PR TITLE
fix(pwa): corrige flujo de instalación PWA solo en player

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -194,13 +194,6 @@
     // Cerrar el manejador de DOMContentLoaded
   });
   </script>
-  <script src="js/installPrompt.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      if (typeof window.initInstallPrompt === 'function') {
-        window.initInstallPrompt({ containerId: 'install-prompt-index', mode: 'banner' });
-      }
-    });
-  </script>
+
 </body>
 </html>

--- a/public/js/installPrompt.js
+++ b/public/js/installPrompt.js
@@ -1,10 +1,7 @@
 (function () {
   const STORAGE_KEYS = {
-    dismissedUntil: 'installPromptDismissedUntil',
-    installed: 'installPromptInstalled',
-    accepted: 'installPromptAccepted'
+    installed: 'installPromptInstalled'
   };
-  const DISMISS_DAYS = 7;
   const STYLE_ID = 'bo-install-prompt-style';
 
   function isStandalone() {
@@ -24,15 +21,8 @@
   }
 
   function shouldPausePrompt() {
-    const dismissedUntil = Number(localStorage.getItem(STORAGE_KEYS.dismissedUntil) || 0);
     const installed = localStorage.getItem(STORAGE_KEYS.installed) === '1';
-    const accepted = localStorage.getItem(STORAGE_KEYS.accepted) === '1';
-    return installed || accepted || Date.now() < dismissedUntil;
-  }
-
-  function markDismissed() {
-    const until = Date.now() + DISMISS_DAYS * 24 * 60 * 60 * 1000;
-    localStorage.setItem(STORAGE_KEYS.dismissedUntil, String(until));
+    return installed;
   }
 
   function ensureStyles() {
@@ -80,8 +70,7 @@
     bannerWrap.className = 'bo-install-prompt';
     bannerWrap.innerHTML = `
       <div class="bo-install-prompt__banner">
-        <span>Instala la app en tu dispositivo</span>
-        <button type="button" class="bo-install-open">Instalar</button>
+                <button type="button" class="bo-install-open">Instalar</button>
         <button type="button" class="bo-install-dismiss">Ahora no</button>
       </div>
     `;
@@ -144,7 +133,6 @@
         bannerWrap.style.display = 'block';
       }
       iosHint.querySelector('button').addEventListener('click', function () {
-        markDismissed();
         iosHint.style.display = 'none';
       });
     } else {
@@ -164,31 +152,30 @@
     });
 
     bannerWrap.querySelector('.bo-install-dismiss').addEventListener('click', function () {
-      markDismissed();
       hideAll();
     });
 
     modal.querySelector('.bo-install-close').addEventListener('click', function () {
-      markDismissed();
       hideAll();
     });
 
     modal.addEventListener('click', function (event) {
       if (event.target === modal) {
-        markDismissed();
         hideAll();
       }
     });
 
     modal.querySelector('.bo-install-confirm').addEventListener('click', async function () {
-      if (!deferredPrompt) return;
+      if (!deferredPrompt) {
+        mostrarAyudaInstalacionManual();
+        return;
+      }
       modal.style.display = 'none';
       deferredPrompt.prompt();
       const choiceResult = await deferredPrompt.userChoice;
-      if (choiceResult.outcome === 'accepted') {
-        localStorage.setItem(STORAGE_KEYS.accepted, '1');
-      } else {
-        markDismissed();
+      if (choiceResult.outcome !== 'accepted') {
+        showEntry();
+        return;
       }
       hideAll();
       deferredPrompt = null;

--- a/public/player.html
+++ b/public/player.html
@@ -2428,11 +2428,18 @@
     document.addEventListener('DOMContentLoaded', () => {
       if (typeof window.initInstallPrompt !== 'function') return;
       const postRegistroInstallPromptKey = 'bo_show_install_prompt_after_signup';
+      const installPromptEnabledKey = 'bo_install_prompt_enabled';
       const mostrarPromptPostRegistro = sessionStorage.getItem(postRegistroInstallPromptKey) === '1';
       if (mostrarPromptPostRegistro) {
+        localStorage.setItem(installPromptEnabledKey, '1');
         sessionStorage.removeItem(postRegistroInstallPromptKey);
       }
-      window.initInstallPrompt({ containerId: 'install-prompt-player', mode: 'banner' });
+      window.addEventListener('appinstalled', () => {
+        localStorage.removeItem(installPromptEnabledKey);
+      });
+      if (localStorage.getItem(installPromptEnabledKey) === '1') {
+        window.initInstallPrompt({ containerId: 'install-prompt-player', mode: 'banner' });
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
### Motivation
- Restringir y corregir el prompt de instalación PWA para que solo aparezca en la vista de `player.html` después de un registro exitoso y no en la pantalla de inicio; además garantizar que el botón de "Instalar" invoque correctamente la API nativa cuando esté disponible. 
- Mantener que si el usuario elige "Ahora no" el prompt reaparezca al volver a la ventana de jugador hasta que la app quede instalada, y evitar que el banner muestre texto adicional no deseado.

### Description
- Se actualizó `public/js/installPrompt.js` para quitar la pausa por días y las banderas de `dismissedUntil`/`accepted`, hacer que `shouldPausePrompt()` solo considere si la app ya está instalada y eliminar el texto del banner para dejar únicamente los botones `Instalar` y `Ahora no`.
- Se corrigió la acción del botón del modal `Instalar` para que llame a `deferredPrompt.prompt()` cuando exista el evento `beforeinstallprompt`, y cuando no exista muestre la ayuda manual con `mostrarAyudaInstalacionManual()`; además se restaurará el banner si el usuario no acepta la instalación.
- Se modificó `public/player.html` para activar el prompt solo después del registro exitoso mediante la combinación de `sessionStorage` (ya existente) y una clave persistente `bo_install_prompt_enabled` en `localStorage`, inicializando `initInstallPrompt()` únicamente cuando esa clave esté activa y removiéndola al recibir `appinstalled`.
- Se eliminó la inicialización del prompt desde `public/index.html` para que no aparezca en la pantalla de login/inicio; archivos modificados: `public/js/installPrompt.js`, `public/player.html`, `public/index.html`.

### Testing
- Ejecuté `npm test` y todas las suites automatizadas pasaron: `12 suites, 39 tests` con estado `PASS`.
- Validación estática rápida: se verificó que la función `initInstallPrompt` sigue exportándose como `window.initInstallPrompt` y que los cambios no rompen otros scripts cargados en `index.html` ni en `player.html`.
- Recomendación de pruebas manuales (no automatizadas) para reviewer: validar en Android Chrome la aparición del banner tras registro, que el modal instala la app nativa, que "Ahora no" permita re-mostrar el prompt al volver a `player.html`, y comprobar la ayuda manual en iOS Safari.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2051a5dcc832680e8d6c9c9e4ffb5)