### PR TITLE
feat(referidos): soporte registro directo por campaña (código + cartones)

### DIFF
--- a/public/nuevacampana.html
+++ b/public/nuevacampana.html
@@ -180,6 +180,16 @@
       <input id="cartones-nuevo" type="number" inputmode="numeric" min="0" placeholder="Cartones nuevo">
     </div>
   </div>
+  <div class="row row--premios">
+    <div class="field-inline">
+      <span class="field-label label-nuevo">CARTONES NUEVO USUARIO</span>
+      <input id="cartones-nuevo-campana" type="number" inputmode="numeric" min="0" placeholder="Cartones nuevo usuario">
+    </div>
+    <div class="field-inline">
+      <span class="field-label label-referidos">CÓDIGO DE CAMPAÑA</span>
+      <input id="codigo-campana" type="text" maxlength="24" placeholder="Código de campaña" style="text-transform:uppercase;">
+    </div>
+  </div>
   <div id="estado-group" class="toggle-group">
     <button data-value="ACTIVA">ACTIVA</button>
     <button data-value="INACTIVA">INACTIVA</button>
@@ -216,6 +226,8 @@
         cartonesPremio: document.getElementById('cartones-premio').value,
         referidosMin: document.getElementById('referidos-min').value,
         cartonesNuevo: document.getElementById('cartones-nuevo').value,
+        cartonesNuevoCampana: document.getElementById('cartones-nuevo-campana').value,
+        codigoCampana: document.getElementById('codigo-campana').value.trim().toUpperCase(),
         estado: estadoSeleccionado,
       };
     }
@@ -231,6 +243,8 @@
         actualizoValor(a.cartonesPremio) === actualizoValor(b.cartonesPremio) &&
         actualizoValor(a.referidosMin) === actualizoValor(b.referidosMin) &&
         actualizoValor(a.cartonesNuevo) === actualizoValor(b.cartonesNuevo) &&
+        actualizoValor(a.cartonesNuevoCampana) === actualizoValor(b.cartonesNuevoCampana) &&
+        actualizoValor(a.codigoCampana) === actualizoValor(b.codigoCampana) &&
         actualizoValor(a.estado) === actualizoValor(b.estado)
       );
     }
@@ -304,6 +318,8 @@
         document.getElementById('cartones-premio').value = data.cartonesPremio ?? '';
         document.getElementById('referidos-min').value = data.referidosMin ?? '';
         document.getElementById('cartones-nuevo').value = data.cartonesNuevo ?? '';
+        document.getElementById('cartones-nuevo-campana').value = data.cartonesNuevoCampana ?? '';
+        document.getElementById('codigo-campana').value = (data.codigoCampana || '').toString().toUpperCase();
         setEstado((data.estado || 'INACTIVA').toUpperCase());
         snapshotInicial = obtenerEstadoFormulario();
         actualizarBotonGuardar();
@@ -317,7 +333,7 @@
       btn.addEventListener('click', () => setEstado(btn.dataset.value));
     });
     setEstado(estadoSeleccionado);
-    ['nombre-campana','fecha-inicio','fecha-fin','cartones-premio','referidos-min','cartones-nuevo'].forEach(id=>{
+    ['nombre-campana','fecha-inicio','fecha-fin','cartones-premio','referidos-min','cartones-nuevo','cartones-nuevo-campana','codigo-campana'].forEach(id=>{
       const campo = document.getElementById(id);
       if(campo){
         campo.addEventListener('input', actualizarBotonGuardar);
@@ -332,6 +348,9 @@
       const cartonesPremio = toNumero(document.getElementById('cartones-premio').value);
       const referidosMin = toNumero(document.getElementById('referidos-min').value);
       const cartonesNuevo = toNumero(document.getElementById('cartones-nuevo').value);
+      const cartonesNuevoCampanaInput = document.getElementById('cartones-nuevo-campana').value.trim();
+      const codigoCampana = document.getElementById('codigo-campana').value.trim().toUpperCase();
+      const cartonesNuevoCampana = cartonesNuevoCampanaInput === '' ? NaN : toNumero(cartonesNuevoCampanaInput);
 
       if(!nombre){ alert('Debes colocar el nombre de la campaña'); return; }
       if(!fechaInicio){ alert('Debes seleccionar la fecha de inicio'); return; }
@@ -343,6 +362,12 @@
       if(!Number.isFinite(cartonesPremio) || cartonesPremio < 0){ alert('El número de cartones debe ser válido'); return; }
       if(!Number.isFinite(referidosMin) || referidosMin < 1){ alert('El número de referidos debe ser válido'); return; }
       if(!Number.isFinite(cartonesNuevo) || cartonesNuevo < 0){ alert('El número de cartones para el nuevo usuario debe ser válido'); return; }
+      if(cartonesNuevoCampanaInput !== '' && !codigoCampana){ alert('Falta el código de Referido de Campaña'); return; }
+      if(codigoCampana && cartonesNuevoCampanaInput === ''){ alert('Falta cantidad de cartones para registro de usuario'); return; }
+      if(cartonesNuevoCampanaInput !== '' && (!Number.isFinite(cartonesNuevoCampana) || cartonesNuevoCampana < 0)){
+        alert('El número de cartones para registro directo debe ser válido');
+        return;
+      }
 
       let estadoFinal = estadoSeleccionado;
       const hoy = hoySinHora();
@@ -371,6 +396,8 @@
         cartonesPremio,
         referidosMin,
         cartonesNuevo,
+        cartonesNuevoCampana: Number.isFinite(cartonesNuevoCampana) ? cartonesNuevoCampana : null,
+        codigoCampana: codigoCampana || '',
         estado: estadoFinal,
         actualizadoEn: new Date().toISOString()
       };

--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -468,6 +468,14 @@
       return { premioReferidor };
     }
 
+    function obtenerConfiguracionRegistroDirecto(campana){
+      if(!campana) return null;
+      const codigoCampana = (campana.codigoCampana || '').toString().trim().toUpperCase();
+      const cartonesNuevoCampana = Number(campana.cartonesNuevoCampana || 0) || 0;
+      if(!codigoCampana || cartonesNuevoCampana <= 0) return null;
+      return { codigoCampana, cartonesNuevoCampana };
+    }
+
     const selectCodigoPais=document.getElementById('codigo-pais');
     poblarSelectCodigos(selectCodigoPais);
     const REGISTRO_PENDIENTE_KEY = 'registroPendienteBingoOnline';
@@ -645,6 +653,7 @@
         const codigoReferido = (datos.codigoReferido || '').trim().toUpperCase();
         let campanaActiva = null;
         let usuarioReferidor = null;
+        let modalidadRegistroDirecto = null;
         if(codigoReferido){
           usuarioReferidor = await buscarUsuarioPorCodigo(codigoReferido);
           if(!usuarioReferidor){
@@ -656,13 +665,18 @@
             throw new Error('codigo_propio');
           }
           campanaActiva = await obtenerCampanaActiva();
+        }else{
+          campanaActiva = await obtenerCampanaActiva();
+          modalidadRegistroDirecto = obtenerConfiguracionRegistroDirecto(campanaActiva);
         }
         await db.collection('users').doc(user.email).set({
           name:datos.nombre, apellido:datos.apellido, alias:datos.alias,
           celular:numeroCompleto, numerocel:numeroCompleto, email:user.email,
           photoURL:user.photoURL, role:'Jugador', aceptoNotificaciones:'NO',
           codigoPromocional, codigoReferidoUsado: codigoReferido || '',
-          referidoPorEmail: usuarioReferidor ? (usuarioReferidor.email || usuarioReferidor.id || '') : '',
+          referidoPorEmail: usuarioReferidor
+            ? (usuarioReferidor.email || usuarioReferidor.id || '')
+            : (modalidadRegistroDirecto ? modalidadRegistroDirecto.codigoCampana : ''),
           campanaReferidosId: campanaActiva ? campanaActiva.id : '',
           fechaRegistro: new Date().toISOString()
         });
@@ -674,6 +688,9 @@
           }
           const { premioReferidor } = await registrarReferido({ campana: campanaActiva, nuevoEmail: user.email, referidoEmail: usuarioReferidor.email || usuarioReferidor.id });
           if(premioReferidor > 0){ await actualizarBilletera(usuarioReferidor.email || usuarioReferidor.id, premioReferidor); }
+        }else if(modalidadRegistroDirecto){
+          await actualizarBilletera(user.email, modalidadRegistroDirecto.cartonesNuevoCampana);
+          alert(`Ganaste ${modalidadRegistroDirecto.cartonesNuevoCampana} cartones por haberte registrado.`);
         }
         limpiarRegistroPendiente();
         trackEvent('registro_exito',{email:user.email});


### PR DESCRIPTION
### Motivation
- Permitir que una campaña de referidos otorgue cartones a usuarios que se registran directamente sin usar el código de otro usuario mediante un `código de campaña` y una cantidad configurable de cartones. 
- Habilitar la configuración de esta modalidad desde el formulario de creación/edición de campañas para que funcione simultáneamente con el flujo actual de referidos. 
- Mantener compatibilidad con campañas existentes cuando los nuevos campos no estén presentes.

### Description
- Se agregan dos campos en `public/nuevacampana.html`: `cartones-nuevo-campana` (cantidad) y `codigo-campana` (código, uppercase) y se persisten como `cartonesNuevoCampana` y `codigoCampana` en el documento de `campanasReferidos`.
- Se incorporan validaciones de formulario al guardar/editar campaña que obligan a completar ambos campos juntos, mostrando los mensajes: `Falta cantidad de cartones para registro de usuario` o `Falta el código de Referido de Campaña` según falte el valor.
- Se añade en `public/registrarse.html` la función `obtenerConfiguracionRegistroDirecto` y la lógica que, cuando el usuario NO provee `codigoReferido` y la campaña activa tiene `codigoCampana` + `cartonesNuevoCampana` válidos, acredita `cartonesNuevoCampana` a la billetera del nuevo usuario y muestra el popup `Ganaste <cantidad> cartones por haberte registrado.`
- La lógica actual de referidos por código de usuario se preserva sin cambios y ambas modalidades (referido por usuario y registro directo por campaña) pueden coexistir; los nuevos campos son opcionales y retrocompatible.

### Testing
- Ejecutado: `npm test` y todos los tests unitarios pasaron correctamente.
- Resultado: 12 suites, 39 tests — TODO PASS (12 suites passed, 39 tests passed).
- Pruebas manuales recomendadas en staging: registrar con (1) código de referido de usuario, (2) sin código pero con campaña que tenga ambos campos, y (3) sin código con campaña sin los campos, para validar billetera y mensajes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f210a571e083269176ef2bf3bf06ad)