### PR TITLE
fix(pwa): corrige flujo del botón Instalar con beforeinstallprompt

### DIFF
--- a/public/js/installPrompt.js
+++ b/public/js/installPrompt.js
@@ -3,6 +3,18 @@
     installed: 'installPromptInstalled'
   };
   const STYLE_ID = 'bo-install-prompt-style';
+  let globalDeferredInstallPrompt = null;
+
+  window.addEventListener('beforeinstallprompt', function (event) {
+    event.preventDefault();
+    globalDeferredInstallPrompt = event;
+    window.dispatchEvent(new CustomEvent('bo-install-prompt-ready'));
+  });
+
+  window.addEventListener('appinstalled', function () {
+    globalDeferredInstallPrompt = null;
+    localStorage.setItem(STORAGE_KEYS.installed, '1');
+  });
 
   function isStandalone() {
     return Boolean(
@@ -56,7 +68,7 @@
       mode: options?.mode === 'modal' ? 'modal' : 'banner'
     };
 
-    let deferredPrompt = null;
+    let deferredPrompt = globalDeferredInstallPrompt;
     let root = document.getElementById(settings.containerId);
     if (!root) {
       root = document.createElement('div');
@@ -136,6 +148,7 @@
         return;
       }
       deferredPrompt = null;
+      globalDeferredInstallPrompt = null;
     }
 
     if (isStandalone() || shouldPausePrompt()) {
@@ -184,14 +197,12 @@
       await solicitarInstalacionDirecta();
     });
 
-    window.addEventListener('beforeinstallprompt', function (event) {
-      event.preventDefault();
-      deferredPrompt = event;
+    window.addEventListener('bo-install-prompt-ready', function () {
+      deferredPrompt = globalDeferredInstallPrompt;
       showEntry();
     });
 
     window.addEventListener('appinstalled', function () {
-      localStorage.setItem(STORAGE_KEYS.installed, '1');
       hideAll();
     });
 


### PR DESCRIPTION
### Motivation
- El prompt de instalación PWA se perdía cuando el navegador emitía `beforeinstallprompt` antes de inicializar la UI, provocando que el botón **Instalar** mostrara solo instrucciones manuales en lugar del diálogo nativo. 
- La intención es garantizar que el evento diferido se capture y reutilice para que `prompt()` pueda invocarse cuando el usuario pulse el botón.

### Description
- Se modificó `public/js/installPrompt.js` para centralizar la captura del evento `beforeinstallprompt` en una variable global `globalDeferredInstallPrompt`. 
- Se expone un evento interno `bo-install-prompt-ready` que notifica al componente visual cuando el evento diferido está disponible y permite mostrar la UI adecuada. 
- Se ajustó `initInstallPrompt()` para inicializar su `deferredPrompt` desde la variable global, y se limpia `globalDeferredInstallPrompt` tras completar la instalación o cancelar el prompt. 
- No se tocaron otras áreas de la app, contratos de Firestore, reglas de seguridad ni la lógica de backend; el cambio está acotado a mejorar el flujo PWA en navegadores compatibles.

### Testing
- Ejecuté `npm test` y todas las suites automatizadas pasaron: 12 suites, 39 tests — `PASS`.
- Las pruebas unitarias no cuben el comportamiento del navegador para `beforeinstallprompt`, por lo que se recomienda validación manual en Chrome/Edge Android y desktop (verificar que al cumplir requisitos PWA el botón **Instalar** abre el prompt nativo). 
- Resultado automático mostrado: `npm test` ✅ (12 suites / 39 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22af2f1f48326b7b6ac6954cb6097)