### PR TITLE
fix(registro): evitar writes a campanasReferidos durante registro sin referido

### DIFF
--- a/public/registrarse.html
+++ b/public/registrarse.html
@@ -401,18 +401,20 @@
       setTimeout(()=>toast.classList.remove('mostrar'), 3500);
     }
 
-    async function obtenerCampanaActiva(){
+    async function obtenerCampanaActiva({ actualizarEstado = true } = {}){
       const snapshot = await db.collection('campanasReferidos').where('estado','==','ACTIVA').get();
       const hoy = hoySinHora();
       let activa = null;
-      const batch = db.batch();
+      const batch = actualizarEstado ? db.batch() : null;
       let cambios = 0;
       snapshot.forEach(doc => {
         const data = doc.data() || {};
         const fin = parseFecha(data.fechaFin);
         if(fin && fin < hoy){
-          batch.update(db.collection('campanasReferidos').doc(doc.id), { estado:'INACTIVA' });
-          cambios += 1;
+          if(actualizarEstado){
+            batch.update(db.collection('campanasReferidos').doc(doc.id), { estado:'INACTIVA' });
+            cambios += 1;
+          }
           return;
         }
         const inicio = parseFecha(data.fechaInicio);
@@ -420,7 +422,7 @@
           activa = { id: doc.id, ...data };
         }
       });
-      if(cambios){ await batch.commit(); }
+      if(actualizarEstado && cambios){ await batch.commit(); }
       return activa;
     }
 
@@ -666,7 +668,7 @@
           }
           campanaActiva = await obtenerCampanaActiva();
         }else{
-          campanaActiva = await obtenerCampanaActiva();
+          campanaActiva = await obtenerCampanaActiva({ actualizarEstado: false });
           modalidadRegistroDirecto = obtenerConfiguracionRegistroDirecto(campanaActiva);
         }
         await db.collection('users').doc(user.email).set({


### PR DESCRIPTION
### Motivation
- Evitar que el flujo principal de registro (sin `codigoReferido`) intente realizar escrituras en `campanasReferidos`, operación que está restringida a admins por las reglas de Firestore y que estaba bloqueando registros cuando existían campañas `ACTIVA` vencidas.
- Mantener intacto el comportamiento del flujo de referidos por código de usuario y permitir que la funcionalidad de registro directo por campaña siga leyendo la configuración sin provocar writes no autorizados.

### Description
- Se modificó `obtenerCampanaActiva` para aceptar una opción `{ actualizarEstado = true }` y permitir ejecución en modo lectura cuando se requiera (archivo `public/registrarse.html`).
- Se añadió una guardia para que `batch.update` / `batch.commit` sólo se ejecuten si `actualizarEstado` es `true`, evitando writes en modo lectura.
- En `completarRegistroConDatos`, la rama de registro sin `codigoReferido` ahora llama a `obtenerCampanaActiva({ actualizarEstado: false })` para leer la campaña activa sin intentar marcar campañas vencidas como `INACTIVA`.
- El flujo con `codigoReferido` mantiene el comportamiento previo (writes permitidos) porque sigue llamando a `obtenerCampanaActiva()` con el modo por defecto.

### Testing
- Ejecutado: `npm test -- --runInBand`.
- Resultado: Todas las pruebas unitarias pasaron: **12 suites passed, 39 tests passed**.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22dd2b8fc8326a4f948e3beb30c5f)