### PR TITLE
fix(sw): registrar explícitamente el service worker

### DIFF
--- a/public/js/serviceWorkerRegistration.js
+++ b/public/js/serviceWorkerRegistration.js
@@ -3,10 +3,9 @@
 
   window.addEventListener('load', async () => {
     try {
-      const registrations = await navigator.serviceWorker.getRegistrations();
-      await Promise.all(registrations.map((registration) => registration.unregister()));
-    } catch (_) {
-      // Intencionalmente silencioso para no afectar el flujo principal de la app.
+      await navigator.serviceWorker.register('/sw.js');
+    } catch (error) {
+      console.warn('No se pudo registrar el service worker.', error);
     }
   });
 })();


### PR DESCRIPTION
### Motivation
- Evitar la desregistración masiva de Service Workers que podía romper la PWA/caché y garantizar que la aplicación registre explícitamente el SW requerido (`/sw.js`).

### Description
- Se actualizó `public/js/serviceWorkerRegistration.js` para eliminar la llamada a `navigator.serviceWorker.getRegistrations()` y `unregister()`, y en su lugar usar `navigator.serviceWorker.register('/sw.js')` con manejo de errores via `console.warn`; se mantiene la protección `if (!('serviceWorker' in navigator)) return;` y se confirmó que `js/serviceWorkerRegistration.js` sigue incluido en `public/index.html`, `public/player.html` y `public/juegoactivo.html`, sin otros scripts que vuelvan a desregistrar SW.

### Testing
- Ejecuté `npm test` (resultado: PASS — 12 suites, 39 tests) y validé con `rg` que no existan llamadas a `getRegistrations()`/`unregister()` y que `serviceWorkerRegistration.js` esté referenciado en las tres páginas; ambos checks pasaron (PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f230e4b82c83269262800ab377f041)