### PR TITLE
fix(pwa): actualiza display del manifiesto y versión de caché

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,7 +3,7 @@
   "short_name": "Bingo",
   "start_url": "/index.html",
   "scope": "/",
-  "display": "browser",
+  "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#7a00cc",
   "icons": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v3';
+const CACHE_VERSION = 'v4';
 const APP_SHELL_CACHE = `bingo-app-shell-${CACHE_VERSION}`;
 const AUDIO_CACHE = `bingo-audio-runtime-${CACHE_VERSION}`;
 


### PR DESCRIPTION
### Motivation
- Forzar que la PWA se comporte como aplicación instalable y forzar la renovación del manifiesto/cache en clientes existentes cambiando el modo de visualización y la versión del Service Worker.

### Description
- Se cambió `"display": "browser"` a `"display": "standalone"` en `public/manifest.webmanifest`, se mantuvieron `start_url: "/index.html"` y `scope: "/"`, y se verificó que los íconos referenciados (`/img/android-chrome-192x192.png`, `/img/android-chrome-512x512.png`) existen en `public/img/`; además se incrementó `CACHE_VERSION` en `public/sw.js` de `v3` a `v4` para invalidar cachés previos.

### Testing
- Se ejecutó `npm test` y pasó completamente (12 suites, 39 tests, TODOS PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2324cc2b88326b4b98bc2689030da)