### PR TITLE
fix(sw): corregir rutas de favicon en app shell y renovar cache

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v4';
+const CACHE_VERSION = 'v5';
 const APP_SHELL_CACHE = `bingo-app-shell-${CACHE_VERSION}`;
 const AUDIO_CACHE = `bingo-audio-runtime-${CACHE_VERSION}`;
 
@@ -11,8 +11,8 @@ const APP_SHELL_URLS = [
   '/img/android-chrome-192x192.png',
   '/img/android-chrome-512x512.png',
   '/img/favicon.ico',
-  '/img/favicon-16x16.ico',
-  '/img/favicon-32x32.ico',
+  '/img/favicon-16x16.png',
+  '/img/favicon-32x32.png',
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
### Motivation
- Corregir rutas inválidas en `APP_SHELL_URLS` del service worker para que coincidan con los favicons reales en `public/` y forzar la invalidación del caché antiguo tras el ajuste.

### Description
- Se actualizó `public/sw.js` reemplazando `/img/favicon-16x16.ico` y `/img/favicon-32x32.ico` por `/img/favicon-16x16.png` y `/img/favicon-32x32.png`, y se incrementó `CACHE_VERSION` de `v4` a `v5`.

### Testing
- Verificación de assets en `APP_SHELL_URLS` mediante script Node (comprobación local): `Missing: none` (PASS).
- Tests automatizados: `npm test` (12 suites, 39 tests) — PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f234f5b1b08326b83999b9e8353a3f)