### PR TITLE
fix(firebase): unifica databaseURL por entorno y agrega guardas dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,52 @@ FIREBASE_ENV_FILE=.env.dev npm run generate:firebase-config
 
 3. Verifique que se creó `public/firebase-config.js` y luego levante la app.
 
+
+Variables recomendadas para scripts/backend (aplican a `uploadServer.js`, `initUsers.js`, `initBanks.js`, `initRoles.js` y `cronActualizarEstadosSorteos.js`):
+
+```dotenv
+GOOGLE_APPLICATION_CREDENTIALS=./serviceAccountKey.dev.json
+FIREBASE_DATABASE_URL=https://<tu-proyecto-dev>-default-rtdb.firebaseio.com
+# Guardas de seguridad para desarrollo
+FIREBASE_DEV_PROJECT_ID=bingo-online-dev
+FIREBASE_DEV_DATABASE_URL=https://<tu-proyecto-dev>-default-rtdb.firebaseio.com
+# Solo uploadServer.js
+FIREBASE_STORAGE_BUCKET=<tu-bucket-dev>
+```
+
+
 > `public/firebase-config.js` está excluido del control de versiones por `.gitignore`, por lo que cada entorno (dev/staging/prod) puede generar su propio archivo sin mezclar configuraciones.
 
 > **Nota sobre Storage**: Si en la consola de Firebase el bucket aparece con el dominio `*.firebasestorage.app`, utilice ese valor sin modificarlo. La interfaz convierte automáticamente ese formato al identificador clásico (`*.appspot.com`) al inicializar el SDK para garantizar la compatibilidad con `firebase-storage-compat` y permitir la subida de los PDFs generados.
+
+
+#### Entorno `stg` (staging)
+
+Cree un archivo local `.env.stg` con los valores de staging y genere la configuración:
+
+```dotenv
+FIREBASE_API_KEY=...
+FIREBASE_AUTH_DOMAIN=...
+FIREBASE_PROJECT_ID=...
+FIREBASE_STORAGE_BUCKET=...
+FIREBASE_MESSAGING_SENDER_ID=...
+FIREBASE_APP_ID=...
+FIREBASE_DATABASE_URL=https://<tu-proyecto-stg>-default-rtdb.firebaseio.com
+FIREBASE_MEASUREMENT_ID=
+
+# Backend/scripts en staging
+GOOGLE_APPLICATION_CREDENTIALS=./serviceAccountKey.stg.json
+```
+
+```bash
+FIREBASE_ENV_FILE=.env.stg npm run generate:firebase-config
+```
+
+> Importante: para scripts/local dev nunca reutilice credenciales ni `FIREBASE_DATABASE_URL` de producción.
+
+#### Guardas de arranque para desarrollo
+
+Cuando `NODE_ENV=development`, los scripts backend validan que `projectId` y `FIREBASE_DATABASE_URL` coincidan con los valores dev esperados (`FIREBASE_DEV_PROJECT_ID` y `FIREBASE_DEV_DATABASE_URL`). Si no coinciden, el proceso termina con error explícito para evitar operar accidentalmente contra prod.
 
 ### Dominio y cookies
 

--- a/cronActualizarEstadosSorteos.js
+++ b/cronActualizarEstadosSorteos.js
@@ -1,14 +1,12 @@
-const admin = require('firebase-admin');
+require('dotenv').config();
+const { initializeFirebaseAdmin } = require('./firebaseAdminConfig');
 
-// Verificar variable de entorno para credenciales
-if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-  console.error('Falta la variable de entorno GOOGLE_APPLICATION_CREDENTIALS');
+let admin;
+try {
+  admin = initializeFirebaseAdmin();
+} catch (error) {
+  console.error(error.message);
   process.exit(1);
-}
-
-// Inicializa Firebase Admin
-if (!admin.apps.length) {
-  admin.initializeApp();
 }
 
 const db = admin.firestore();

--- a/firebaseAdminConfig.js
+++ b/firebaseAdminConfig.js
@@ -1,0 +1,66 @@
+const admin = require('firebase-admin');
+const fs = require('fs');
+const path = require('path');
+
+function loadServiceAccountFromEnv() {
+  const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS || './serviceAccountKey.json';
+  const absolutePath = path.resolve(credentialsPath);
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Service account credentials not found at ${absolutePath}`);
+  }
+  // eslint-disable-next-line import/no-dynamic-require, global-require
+  return require(absolutePath);
+}
+
+function validateDevelopmentProjectGuard({ projectId, databaseURL }) {
+  if (process.env.NODE_ENV !== 'development') return;
+
+  const expectedProjectId = process.env.FIREBASE_DEV_PROJECT_ID;
+  const expectedDatabaseURL = process.env.FIREBASE_DEV_DATABASE_URL;
+
+  if (!expectedProjectId || !expectedDatabaseURL) {
+    throw new Error('En desarrollo debes definir FIREBASE_DEV_PROJECT_ID y FIREBASE_DEV_DATABASE_URL para validar el entorno.');
+  }
+
+  if (projectId !== expectedProjectId || databaseURL !== expectedDatabaseURL) {
+    throw new Error(
+      `Guard de entorno activado: NODE_ENV=development requiere projectId/databaseURL de dev. ` +
+      `Actual=${projectId} | ${databaseURL}. Esperado=${expectedProjectId} | ${expectedDatabaseURL}`
+    );
+  }
+}
+
+function initializeFirebaseAdmin({ requireStorageBucket = false } = {}) {
+  const serviceAccount = loadServiceAccountFromEnv();
+  const databaseURL = process.env.FIREBASE_DATABASE_URL;
+
+  if (!databaseURL) {
+    throw new Error('Falta la variable de entorno FIREBASE_DATABASE_URL');
+  }
+
+  if (requireStorageBucket && !process.env.FIREBASE_STORAGE_BUCKET) {
+    throw new Error('Falta la variable de entorno FIREBASE_STORAGE_BUCKET');
+  }
+
+  validateDevelopmentProjectGuard({
+    projectId: serviceAccount.project_id,
+    databaseURL
+  });
+
+  if (!admin.apps.length) {
+    const options = {
+      credential: admin.credential.cert(serviceAccount),
+      databaseURL
+    };
+
+    if (requireStorageBucket) {
+      options.storageBucket = process.env.FIREBASE_STORAGE_BUCKET;
+    }
+
+    admin.initializeApp(options);
+  }
+
+  return admin;
+}
+
+module.exports = { initializeFirebaseAdmin };

--- a/initBanks.js
+++ b/initBanks.js
@@ -1,15 +1,13 @@
-const admin = require('firebase-admin');
-const fs = require('fs');
+require('dotenv').config();
+const { initializeFirebaseAdmin } = require('./firebaseAdminConfig');
 
-let credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS || './serviceAccountKey.json';
-if (!fs.existsSync(credentialsPath)) {
-  console.error('Service account credentials not found at', credentialsPath);
+let admin;
+try {
+  admin = initializeFirebaseAdmin();
+} catch (error) {
+  console.error(error.message);
   process.exit(1);
 }
-
-admin.initializeApp({
-  credential: admin.credential.cert(require(credentialsPath)),
-});
 
 const db = admin.firestore();
 

--- a/initRoles.js
+++ b/initRoles.js
@@ -1,15 +1,13 @@
-const admin = require('firebase-admin');
-const fs = require('fs');
+require('dotenv').config();
+const { initializeFirebaseAdmin } = require('./firebaseAdminConfig');
 
-let credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS || './serviceAccountKey.json';
-if (!fs.existsSync(credentialsPath)) {
-  console.error('Service account credentials not found at', credentialsPath);
+let admin;
+try {
+  admin = initializeFirebaseAdmin();
+} catch (error) {
+  console.error(error.message);
   process.exit(1);
 }
-
-admin.initializeApp({
-  credential: admin.credential.cert(require(credentialsPath)),
-});
 
 const db = admin.firestore();
 

--- a/initUsers.js
+++ b/initUsers.js
@@ -1,15 +1,13 @@
-const admin = require('firebase-admin');
-const fs = require('fs');
+require('dotenv').config();
+const { initializeFirebaseAdmin } = require('./firebaseAdminConfig');
 
-let credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS || './serviceAccountKey.json';
-if (!fs.existsSync(credentialsPath)) {
-  console.error('Service account credentials not found at', credentialsPath);
+let admin;
+try {
+  admin = initializeFirebaseAdmin();
+} catch (error) {
+  console.error(error.message);
   process.exit(1);
 }
-
-admin.initializeApp({
-  credential: admin.credential.cert(require(credentialsPath)),
-});
 
 const db = admin.firestore();
 

--- a/uploadServer.js
+++ b/uploadServer.js
@@ -3,22 +3,14 @@ const express = require('express');
 const cors = require('cors');
 const multer = require('multer');
 const path = require('path');
-const admin = require('firebase-admin');
+const { initializeFirebaseAdmin } = require('./firebaseAdminConfig');
 
-// Verificar variables de entorno necesarias antes de inicializar Firebase
-const requiredEnv = ['GOOGLE_APPLICATION_CREDENTIALS', 'FIREBASE_STORAGE_BUCKET', 'SENDGRID_API_KEY'];
-for (const name of requiredEnv) {
-  if (!process.env[name]) {
-    console.error(`Falta la variable de entorno ${name}`);
-    process.exit(1);
-  }
-}
-
-// Inicializa Firebase Admin especificando el bucket de Storage
-if (!admin.apps.length) {
-  admin.initializeApp({
-    storageBucket: process.env.FIREBASE_STORAGE_BUCKET
-  });
+let admin;
+try {
+  admin = initializeFirebaseAdmin({ requireStorageBucket: true });
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
 }
 
 const app = express();


### PR DESCRIPTION
### Motivation
- Evitar inicializaciones heterogéneas o implícitas de Firebase Admin y prevenir ejecuciones accidentales sobre el proyecto de producción al ejecutar scripts/backend.
- Forzar que `databaseURL` sea provisto por entorno (`FIREBASE_DATABASE_URL`) y exigir credenciales separadas por entorno para reducir riesgo operativo.
- Añadir validaciones de arranque en `development` para detectar si las credenciales/URL no corresponden al proyecto `dev` y abortar con un error claro.

### Description
- Se añadió `firebaseAdminConfig.js` que centraliza la inicialización de Firebase Admin y exige `FIREBASE_DATABASE_URL`, carga credenciales desde `GOOGLE_APPLICATION_CREDENTIALS` y permite `requireStorageBucket` para servicios que lo necesiten.
- Se actualizaron `uploadServer.js`, `initUsers.js`, `initBanks.js`, `initRoles.js` y `cronActualizarEstadosSorteos.js` para usar `require('dotenv').config()` y `initializeFirebaseAdmin(...)` en lugar de inicializaciones locales con valores implícitos o hardcodeados.
- Implementé una guarda que, cuando `NODE_ENV=development`, valida que `serviceAccount.project_id` y `FIREBASE_DATABASE_URL` coincidan con `FIREBASE_DEV_PROJECT_ID` y `FIREBASE_DEV_DATABASE_URL`, abortando con mensaje explícito si no coinciden.
- Se actualizó `README.md` con ejemplos explícitos de `.env.dev` y `.env.stg` y las variables recomendadas para scripts/backend (`GOOGLE_APPLICATION_CREDENTIALS`, `FIREBASE_DATABASE_URL`, `FIREBASE_DEV_*`, `FIREBASE_STORAGE_BUCKET`) y la explicación de la guarda de arranque.

### Testing
- `npm test` — PASS (suite de tests unitarios locales con `jest`).
- `npm run generate:firebase-config` — FAIL (esperado en el entorno de CI/local porque faltan variables frontend: `FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, `FIREBASE_PROJECT_ID`, `FIREBASE_MESSAGING_SENDER_ID`, `FIREBASE_APP_ID`).
- Nota: las pruebas automatizadas que dependen de credenciales de Firebase no se ejecutaron porque requieren variables de entorno reales (`GOOGLE_APPLICATION_CREDENTIALS`, `FIREBASE_DATABASE_URL`, etc.), y en `NODE_ENV=development` la nueva guarda exige definir `FIREBASE_DEV_PROJECT_ID` y `FIREBASE_DEV_DATABASE_URL`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f299bc0d888326b459f5359f53903f)